### PR TITLE
Bongo: Fix multiple update does not work bug. (All fields of the model

### DIFF
--- a/go/src/github.com/koding/bongo/model.go
+++ b/go/src/github.com/koding/bongo/model.go
@@ -143,14 +143,12 @@ func (b *Bongo) UpdateMulti(i Modellable, rest ...map[string]interface{}) error 
 		return errors.New("Update partial parameter list is wrong")
 	}
 
-	query := b.DB.Model(i)
-
-	query = query.Table(i.TableName())
+	query := b.DB.Table(i.TableName())
 
 	//add selector
 	query = addWhere(query, selector)
 
-	if err := query.Update(set).Error; err != nil {
+	if err := query.Updates(set).Error; err != nil {
 		return err
 	}
 


### PR DESCRIPTION
expected query is this: 
UPDATE notification.notification SET "glanced" = true  WHERE ("glanced" = false) AND ("account_id" = 1)

After we add model, the query is: 
UPDATE notification.notification SET "account_id" = 1, "notification_content_id" = 0, "glanced" = true, "activated_at" = date, "subscribed_at" = '0001-01-01 00:00:00+00', "unsubscribed_at" = '0001-01-01 00:00:00+00' WHERE ("glanced" = false) AND ("account_id" = 1)
