### PR TITLE
Subdomain create, de/activate functionality is completed

### DIFF
--- a/client/Environments/styl/app.environments.styl
+++ b/client/Environments/styl/app.environments.styl
@@ -846,11 +846,20 @@ section.resources-container
 
 
 .environments-add-domain-form
+
   input.kdinput
     background      #fff !important
 
     &.text
-      padding-left  14px
+      font-weight   500
+
+  .suffix-domain
+    top     13px
+    right   10px
+    z-index 1
+    width   auto
+    color   #999
+    abs()
 
   label
     font-size       14px
@@ -865,6 +874,7 @@ section.resources-container
       line-height   32px !important
       max-width     100px
       text-overflow ellipsis
+
 
 
 /*--- Scene -----*/

--- a/client/Environments/styl/app.environments.styl
+++ b/client/Environments/styl/app.environments.styl
@@ -1247,8 +1247,6 @@ div.environments-item
 
     &.verified
       opacity         1
-      button
-        display       none !important
 
     &:hover
       opacity         1

--- a/client/Environments/views/domains/commondomaincreateform.coffee
+++ b/client/Environments/views/domains/commondomaincreateform.coffee
@@ -8,6 +8,8 @@ class CommonDomainCreateForm extends KDFormViewWithFields
         domainName          :
           name              : "domainInput"
           cssClass          : "domain-input"
+          attributes        :
+            spellcheck      : false
           label             : options.label        ? "Subdomain"
           placeholder       : options.placeholder or "Type your domain"
           validate          :
@@ -18,9 +20,16 @@ class CommonDomainCreateForm extends KDFormViewWithFields
               itemClass     : KDSelectBox
               cssClass      : "main-domain-select"
               selectOptions : options.selectOptions
+            suffixDomain    :
+              itemClass     : KDView
+              cssClass      : "suffix-domain"
+              partial       : ".#{options.suffixDomain}"
 
+    if options.noDomainSelector
+      delete o.fields.domainName.nextElement.domains
 
-    delete o.fields.domainName.nextElement  if options.noDomainSelector
+    unless options.suffixDomain
+      delete o.fields.domainName.nextElement.suffixDomain
 
     super o, data
 

--- a/client/Environments/views/domains/domaincreateform.coffee
+++ b/client/Environments/views/domains/domaincreateform.coffee
@@ -89,8 +89,8 @@ class DomainCreateForm extends KDCustomHTMLView
       createButton.hideLoader()
       return notifyUser "#{domain} is an invalid subdomain."
 
-    domain =
-      Encoder.XSSEncode "#{domain}.#{domains.getValue()}"
+    domain = Encoder.XSSEncode \
+      "#{domain}.#{KD.nick()}.#{KD.config.userSitesDomain}"
 
     @createJDomain domain, (err, domain)=>
       createButton.hideLoader()

--- a/client/Environments/views/domains/domaincreateform.coffee
+++ b/client/Environments/views/domains/domaincreateform.coffee
@@ -27,25 +27,28 @@ class DomainCreateForm extends KDCustomHTMLView
       type : "subdomain"
       view : @subdomainForm = new SubdomainCreateForm
 
-    @tabView.addPane dom = new KDTabPaneView
-      name               : "Route own domain"
-      type               : "redirect"
-      view               : @domainForm = new CommonDomainCreateForm
-        label            : ""
-        placeholder      : "Type your domain name..."
-        noDomainSelector : yes
-
-    nickname = KD.whoami().profile.nickname
-
-    dom.addSubView @redirectNotice = (new KDCustomHTMLView
-      tagName  : "p"
-      cssClass : "status-message"
-      partial  : """
-        Before adding your domain, you need to create a <strong>CNAME RECORD</strong> pointing to: <strong>#{nickname}.kd.io</strong> or an <br/>
-        <strong>A RECORD</strong> which is pointing to: <strong>68.68.97.66</strong>
-        Otherwise Koding won't be able to add your domain. <a href="http://learn.koding.com/add-cname-records-to-your-domain/" target="_blank">Learn how</a>
-        """
-    ), null, yes
+    # Custom domains commented-out for now ~ GG
+    #
+    # @tabView.addPane dom = new KDTabPaneView
+    #   name               : "Route own domain"
+    #   type               : "redirect"
+    #   view               : @domainForm = new CommonDomainCreateForm
+    #     label            : ""
+    #     placeholder      : "Type your domain name..."
+    #     noDomainSelector : yes
+    #
+    # nickname = KD.whoami().profile.nickname
+    #
+    # dom.addSubView @redirectNotice = (new KDCustomHTMLView
+    #   tagName  : "p"
+    #   cssClass : "status-message"
+    #   partial  : """
+    #     Before adding your domain, you need to create a <strong>CNAME RECORD</strong> pointing to: <strong>#{nickname}.kd.io</strong> or an <br/>
+    #     <strong>A RECORD</strong> which is pointing to: <strong>68.68.97.66</strong>
+    #     Otherwise Koding won't be able to add your domain. <a href="http://learn.koding.com/add-cname-records-to-your-domain/" target="_blank">Learn how</a>
+    #     """
+    # ), null, yes
+    # ##
 
     @tabView.showPane sub
 
@@ -72,7 +75,7 @@ class DomainCreateForm extends KDCustomHTMLView
         @showError err.message
       else
         @showSuccess domain, @domainForm
-        @updateDomains()
+
 
   createSubDomain: ->
 
@@ -151,39 +154,6 @@ class DomainCreateForm extends KDCustomHTMLView
 
     @emit 'CloseClicked'
 
-  updateDomains: ->
-
-    domainList = []
-    pushDomainOption = (context) ->
-      domain = "#{context}.kd.io"
-      domainList.push {title:".#{domain}", value: domain}
-
-    {JDomain} = KD.remote.api
-    JDomain.fetchDomains (err, userDomains)=>
-
-      return warn "Failed to update domains:", err  if err
-
-      if userDomains
-        for domain in userDomains
-          if not domain.regYears > 0
-            domainList.push {title:".#{domain.domain}", value:domain.domain}
-
-      group = KD.getSingleton("groupsController").currentGroupName
-      # adds group root domain to domain selections
-      unless group is "koding"
-        pushDomainOption group
-      else
-        slug = KD.whoami().profile.nickname              # if user domain root does not exist, it is added
-        rootDomain = userDomains.filter (domain) ->      # here. actually it is not possible to delete a root
-          domain.domain is "#{slug}.kd.io"               # domain, but defensive checks are always good.
-        pushDomainOption slug  unless rootDomain.length
-
-      {domains, domainName} = @subdomainForm.inputs
-      domainName.setValue ""
-      domains.removeSelectOptions()
-      domains.setSelectOptions domainList
-
   viewAppended:->
-    @updateDomains()
-    KD.getSingleton("vmController").on 'VMListChanged', @bound 'updateDomains'
+
     @subdomainForm.inputs.domainName.setFocus()

--- a/client/Environments/views/domains/subdomaincreateform.coffee
+++ b/client/Environments/views/domains/subdomaincreateform.coffee
@@ -3,7 +3,9 @@ class SubdomainCreateForm extends CommonDomainCreateForm
   constructor:(options = {}, data)->
 
     super
-      label       : ""
-      placeholder : "Type your subdomain name..."
-      buttonTitle : "Create subdomain"
+      label            : ""
+      placeholder      : "Type your subdomain "
+      buttonTitle      : "Create subdomain"
+      suffixDomain     : "#{KD.nick()}.#{KD.config.userSitesDomain}"
+      noDomainSelector : yes
     , data

--- a/client/Environments/views/scene/environmentdomaincontainer.coffee
+++ b/client/Environments/views/scene/environmentdomaincontainer.coffee
@@ -33,7 +33,7 @@ class EnvironmentDomainContainer extends EnvironmentContainer
         title          : "Add Domain"
         cssClass       : "domain-creation"
         view           : domainCreateForm
-        width          : 700
+        width          : 600
         overlay        : yes
         buttons        :
           createButton :

--- a/client/Environments/views/scene/environmentdomainitem.coffee
+++ b/client/Environments/views/scene/environmentdomainitem.coffee
@@ -24,19 +24,47 @@ class EnvironmentDomainItem extends EnvironmentItem
     @deletionModal = new DomainDeletionModal {}, @domain
     @deletionModal.on "domainRemoved", @bound 'destroy'
 
+  getState:->
 
-  activateDomain:->
+    states = ["Activate", "Deactivate"]
 
-    new KDNotificationView title: "FIXME GG~"
+    if @domain.domain
+      title        : states[1]
+      newTitle     : states[0]
+      newData      : null
+      notification : "Deactivating..."
+      command      : "deactivateDomain"
+    else
+      title        : states[0]
+      newTitle     : states[1]
+      newData      : @domain.proposedDomain
+      notification : "Activating..."
+      command      : "activateDomain"
+
+  toggleDomainState:->
+
+    state = @getState()
+
+    new KDNotificationView
+      title : state.notification
+      type  : "tray"
+
+    @domain[state.command] (err)=>
+      unless err
+        @activateButton.setTitle state.newTitle
+        @domain.domain = state.newData
+        @updateStateStyle()
+
 
   viewAppended:->
 
+    state = @getState()
     @updateStateStyle()
 
     @activateButton = new KDButtonView
-      title    : "Activate"
+      title    : state.title
       cssClass : "solid green mini"
-      callback : @bound 'activateDomain'
+      callback : @bound 'toggleDomainState'
 
     super
 

--- a/workers/social/lib/social/models/domain.coffee
+++ b/workers/social/lib/social/models/domain.coffee
@@ -53,6 +53,10 @@ module.exports = class JDomain extends jraphical.Module
           (signature String, Function)
         unbindMachine :
           (signature String, Function)
+        activateDomain:
+          (signature Function)
+        deactivateDomain:
+          (signature Function)
         remove        :
           (signature Function)
 
@@ -271,6 +275,37 @@ module.exports = class JDomain extends jraphical.Module
       }, (err, domain)->
 
         if err? then console.error err  unless err.code is 11000
+
+
+  updateState: (state, callback)->
+
+    if state
+
+      domain = @proposedDomain
+
+      checkExistence domain, (err)=>
+        return callback err  if err
+        @update $set: { domain }, callback
+
+    else
+
+      @update $unset: domain: 1, callback
+
+
+  activateDomain: permit
+    advanced    : [
+      { permission: "edit own domains", validateWith: Validators.own }
+    ]
+    success: (client, callback)->
+      @updateState yes, callback
+
+
+  deactivateDomain: permit
+    advanced    : [
+      { permission: "edit own domains", validateWith: Validators.own }
+    ]
+    success: (client, callback)->
+      @updateState no, callback
 
 
   bindMachine: (target, callback)->

--- a/workers/social/lib/social/models/domain.coffee
+++ b/workers/social/lib/social/models/domain.coffee
@@ -2,6 +2,9 @@
 # NOTE: All domain registry related stuff removed
 # you can look at them from 745b4914f14fa424a3e38db68e09a1bc832be7f4
 
+{argv}   = require 'optimist'
+KONFIG   = require('koding-config-manager').load("main.#{argv.c}")
+
 jraphical = require 'jraphical'
 module.exports = class JDomain extends jraphical.Module
 
@@ -123,6 +126,8 @@ module.exports = class JDomain extends jraphical.Module
 
   parseDomain = (domain)->
 
+    { userSitesDomain } = KONFIG
+
     # Custom error
     err = (message = "Invalid domain: #{domain}")->
       err: new KodingError message, "INVALIDDOMAIN"
@@ -132,19 +137,19 @@ module.exports = class JDomain extends jraphical.Module
       /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}$/i.test domain
 
     # Return domain type as custom and keep the domain as is
-    return {type: 'custom', domain}  unless /\.kd\.io$/.test domain
+    unless ///\.#{userSitesDomain}$///.test domain
+      return { type: 'custom', domain }
 
     # Basic check
-    unless /([a-z0-9\-]+)\.kd\.io$/.test domain
-      return err()
+    return err()  unless ///([a-z0-9\-]+)\.#{userSitesDomain}$///.test domain
 
     # Check for shared|vm prefix
     if /^shared|vm[\-]?([0-9]+)?/.test prefix
       return err "Domain name cannot start with shared|vm"
 
     # Parse domain
-    match = domain.match /([a-z0-9\-]+)\.([a-z0-9\-]+)\.kd\.io$/
-    return err "Invalid domain: #{domain}."  unless match
+    match = domain.match ///([a-z0-9\-]+)\.([a-z0-9\-]+)\.#{userSitesDomain}$///
+    return err "Invalid domain: #{domain}"  unless match
     [rest..., prefix, slug] = match
 
     # Return type as internal and slug and domain

--- a/workers/social/lib/social/models/domain.coffee
+++ b/workers/social/lib/social/models/domain.coffee
@@ -144,8 +144,8 @@ module.exports = class JDomain extends jraphical.Module
     return err()  unless ///([a-z0-9\-]+)\.#{userSitesDomain}$///.test domain
 
     # Check for shared|vm prefix
-    if /^shared|vm[\-]?([0-9]+)?/.test prefix
-      return err "Domain name cannot start with shared|vm"
+    # if /^shared|vm[\-]?([0-9]+)?/.test prefix
+    #   return err "Domain name cannot start with shared|vm"
 
     # Parse domain
     match = domain.match ///([a-z0-9\-]+)\.([a-z0-9\-]+)\.#{userSitesDomain}$///

--- a/workers/social/lib/social/models/domain.coffee
+++ b/workers/social/lib/social/models/domain.coffee
@@ -215,6 +215,19 @@ module.exports = class JDomain extends jraphical.Module
             callback err, domain
 
 
+  checkExistence = (domain, callback)->
+
+    JDomain.count { domain }, (err, count)->
+
+      return callback err  if err
+
+      if count > 0
+        callback new KodingError \
+          "The domain #{domain} already exists", "DUPLICATEDOMAIN"
+      else
+        callback null
+
+
   @createDomain$: permit 'create domains', success: (client, data, callback)->
 
     { domain, stack } = data
@@ -232,10 +245,8 @@ module.exports = class JDomain extends jraphical.Module
     {err, domain, type, slug, prefix} = parseDomain domain, { nickname, group }
     return callback err  if err
 
-    JDomain.one {domain}, (err, model)->
+    checkExistence domain, (err)->
       return callback err  if err
-      if model
-        return error "The domain #{domain} already exists", "DUPLICATEDOMAIN"
 
       resolveDomain domain, (err)->
         return callback err  if err


### PR DESCRIPTION
Users can create subdomains for user domains like `gokmen.kd.io` which `gokmen` comes from user nickname and `kd.io` from `KD.config.userSitesDomain` and also in this batch users can activate or deactivate their domains which is in the backend updates `JDomain.domain` field with `JDomain.proposedDomain`. It also checks existence of domain before activating it.
