### PR TITLE
sockjs: avoid invalid state errors

### DIFF
--- a/client/Bongo/sockjs-0.3-patched.js
+++ b/client/Bongo/sockjs-0.3-patched.js
@@ -1021,6 +1021,7 @@ SockJS.prototype._setHeartbeatTimeout = function(data) {
 
 SockJS.prototype._didClose = function(code, reason, force) {
     var that = this;
+    clearTimeout(that.heartbeatTimeoutTimer);
     if (that.readyState !== SockJS.CONNECTING &&
         that.readyState !== SockJS.OPEN &&
         that.readyState !== SockJS.CLOSING)


### PR DESCRIPTION
There can be a condition where close is called while the connection is already closing, which will result in `_didClose` being called twice. This to avoid that 
