### PR TITLE
npm install: faster solution than rm -r node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "main": "server/index.js",
   "scripts": {
-    "preinstall": "rm -rf node_modules; mkdir node_modules; cd node_modules; ln -sf ../node_modules_koding/* .; cd ..",
-    "install": "patch -p1 < patches/mongodb.patch; patch -p1 < patches/newrelic.patch"
+    "preinstall": "./scripts/reset-node-modules.sh",
+    "install": "./scripts/patch-node-modules.sh"
   },
   "dependencies": {
     "async": "0.2.5",

--- a/scripts/patch-node-modules.sh
+++ b/scripts/patch-node-modules.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+PATCHES=$(ls patches)
+PATCHED=$(less node_modules/.patched 2>/dev/null)
+
+for i in $PATCHES; do
+  if ! [[ $PATCHED =~ $i ]]; then
+     patch -N -p1 < patches/$i
+     echo $i >> node_modules/.patched
+  fi
+done

--- a/scripts/reset-node-modules.sh
+++ b/scripts/reset-node-modules.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+DIR=$(cd $(dirname "${BASH_SOURCE[0]}"); pwd)
+NODE_MODULES=$DIR/../node_modules
+MATCHES=$(ls "$NODE_MODULES"_koding)
+
+for i in $MATCHES; do
+  rm -r $NODE_MODULES/$i 2>/dev/null
+  mkdir $NODE_MODULES 2>/dev/null
+  cd $NODE_MODULES
+  ln -sf ../node_modules_koding/$i $i
+done


### PR DESCRIPTION
This replaces the method that we were previously using to merge the package.json node_modules with the modules found in node_modules_koding, and also idempotently patch the former.  Tested, and seems to work. cc @devrim @sinan 
