### PR TITLE
Social: remove reference to `ModalTopicsListItem` since code for

### DIFF
--- a/client/Main/CommonViews/ShowMoreDataModalView.coffee
+++ b/client/Main/CommonViews/ShowMoreDataModalView.coffee
@@ -12,7 +12,6 @@ class ShowMoreDataModalView extends KDModalView
 
   listItemMap = ->
     account : MembersListItemView
-    tag     : ModalTopicsListItem
     app     : ModalAppsListItemView
 
   constructor:(options = {}, data)->


### PR DESCRIPTION
it was removed in 94eb165
