### PR TITLE
Use modular templates for email notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "node-sockjs-client": "1.0.7",
     "cli-table": "^0.3.0",
     "read": "^1.0.5",
-    "juice": "0.4.0"
+    "juice": "0.4.0",
+    "swig": "1.4.1"
   },
   "devDependencies": {},
   "optionalDependencies": {},

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "amqplib": "^0.2.0",
     "node-sockjs-client": "1.0.7",
     "cli-table": "^0.3.0",
-    "read": "^1.0.5"
+    "read": "^1.0.5",
+    "juice": "0.4.0"
   },
   "devDependencies": {},
   "optionalDependencies": {},

--- a/workers/emailnotifications/main.coffee
+++ b/workers/emailnotifications/main.coffee
@@ -62,14 +62,15 @@ sendDailyEmail = (details, content)->
   unless content or details.email
     log "Content not found, notification postponed"
   else
-    Emailer.send
-      From      : 'Koding <hello@koding.com>'
-      To        : emailWorker.forcedRecipient or details.email
-      Subject   : template.dailyHeader details
-      HtmlBody  : template.dailyMail details, content
-    , (err, status)->
-      log "An error occured: #{err}" if err
-      log "Daily e-mail sent to #{details.email}"
+    template.dailyMail details, content, (err, body, subject)->
+      Emailer.send
+        From      : 'Koding <hello@koding.com>'
+        To        : emailWorker.forcedRecipient or details.email
+        Subject   : subject
+        HtmlBody  : body
+      , (err, status)->
+        log "An error occured: #{err}" if err
+        log "Daily e-mail sent to #{details.email}"
 
 sendInstantEmail = (details)->
   {notification} = details

--- a/workers/emailnotifications/templates.coffee
+++ b/workers/emailnotifications/templates.coffee
@@ -3,6 +3,7 @@
 {uri}       = require('koding-config-manager').load("main.#{argv.c}")
 dateFormat  = require 'dateformat'
 htmlify     = require 'koding-htmlify'
+juice       = require 'juice'
 
 flags =
   comment                 :

--- a/workers/emailnotifications/templates.coffee
+++ b/workers/emailnotifications/templates.coffee
@@ -4,6 +4,7 @@
 dateFormat  = require 'dateformat'
 htmlify     = require 'koding-htmlify'
 juice       = require 'juice'
+swig        = require 'swig'
 
 flags =
   comment                 :
@@ -41,6 +42,16 @@ gravatar  = (m, size = 20) ->
           src="https://gravatar.com/avatar/#{m.sender.profile?.hash}?size=#{size}&d=https%3A%2F%2Fapi.koding.com%2Fimages%2Fdefaultavatar%2Fdefault.avatar.#{size}.png" />"""
 
 Templates =
+
+  render : (tpl, m, data) ->
+    template = swig.compileFile "#{__dirname}/templates/"+tpl;
+    data = _.extend {
+      m: m,
+      currentDate: dateFormat m.notification.dateIssued, "mmm dd"
+      turnOffLink: "#{uri.address}/Unsubscribe/#{m.notification.unsubscribeId}"
+    }, data
+
+    template(data)
 
   linkStyle    : """ style="text-decoration:none; color:#1AAF5D;" """
   mainTemplate : (m, content, footer, description)->
@@ -206,12 +217,10 @@ Templates =
       Templates.singleEvent(m), Templates.footerTemplate turnOffLink
 
   dailyMail    : (m, content)->
-    turnOffLink = "#{uri.address}/Unsubscribe/#{m.notification.unsubscribeId}/#{encodeURIComponent m.email}"
-    turnOffDailyURL = link "#{turnOffLink}/daily", "daily emails"
-    turnOffAllEmailsURL = link "#{turnOffLink}/all", "all"
-    turnOffLink = """Unsubscribe from #{turnOffDailyURL} or Unsubscribe from #{turnOffAllEmailsURL} emails from Koding."""
-    description = "Here what's happened in Koding today!"
-    Templates.mainTemplate m, content, Templates.footerTemplate(turnOffLink), description
+    Templates.render "daily", m, {
+      turnOffLink:  "#{uri.address}/Unsubscribe/#{m.notification.unsubscribeId}/#{encodeURIComponent m.email}",
+      content: content
+    }
 
   commonHeader : (m)->
     eventFlag = flags[m.notification.eventFlag][m.event] ? flags[m.notification.eventFlag]

--- a/workers/emailnotifications/templates/daily.html
+++ b/workers/emailnotifications/templates/daily.html
@@ -1,0 +1,5 @@
+{% extend "layout.html" %}
+
+{% block description %}Here what's happened in Koding today!{% endblock %}
+
+{% block content %}{{ content }}{% endblock %}

--- a/workers/emailnotifications/templates/layout.html
+++ b/workers/emailnotifications/templates/layout.html
@@ -3,9 +3,7 @@
   <html>
   <head>
     <title>[Koding]</title>
-    <style>
-
-    </style>
+    <link rel="stylesheet" href="style/base.css">
   </head>
   <body style="margin: 10px;">
     <table style="font-size: 13px; font-family: 'Open Sans', sans-serif;

--- a/workers/emailnotifications/templates/layout.html
+++ b/workers/emailnotifications/templates/layout.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"
+  "http://www.w3.org/TR/REC-html40/loose.dtd">
+  <html>
+  <head>
+    <title>[Koding]</title>
+    <style>
+
+    </style>
+  </head>
+  <body style="margin: 10px;">
+    <table style="font-size: 13px; font-family: 'Open Sans', sans-serif;
+                  height:100%; color: #666; width:100%;" cellspacing="0">
+      <!-- HEADER -->
+      <tr>
+        <td style="width: 58px; text-align:right; border-right: 1px
+                   solid #CCC; margin-left:12px; vertical-align:top;">
+          <!-- Koding Logo with pure table -->
+          <table width="40px" height="40px" style="margin-left:12px; width:40px; text-align:right; height:40px; border:none; font-size:0px; background-color:#1AAF5D; padding:9px;" cellspacing="2" cellpadding="2">
+            <tr>
+                <td height="1px" style="max-height:1px;height:1px; background-color:white;" colspan="3">&nbsp;</td>
+            </tr>
+            <tr>
+                <td height="1px" style="max-height:1px;height:1px; background-color:white;  width: 75%;" >&nbsp;</td>
+                <td height="1px" style="max-height:1px;height:1px; background-color:#1AAF5D; width: 25%;" colspan="2">&nbsp;</td>
+            </tr>
+            <tr>
+                <td height="1px" style="max-height:1px;height:1px; background-color:white;" colspan="3">&nbsp;</td>
+            </tr>
+          </table><br/>
+        </td>
+        <td style="padding: 6px 0 0 10px; padding-bottom:20px; margin-top: 0;">
+          <h2 style="margin-top:0; ">Hello {{ m.receiver.profile.firstName }},</h2>
+          <p>{% block description %}{% endblock %}</p>
+        </td>
+        <td style="text-align:center; width:90px; vertical-align:top;">
+          <p style="font-size: 11px; color: #999;
+                    padding: 0 0 2px 0; margin-top: 4px;">{{ currentDate }}</p>
+        </td>
+      </tr>
+      {% block content %}{% endblock %}
+      <!-- FOOTER -->
+      <tr height="90%" style="height: 90%; ">
+        <td style="width: 15px; border-right: 1px solid #CCC;"></td>
+        <td height="40px" style="height:40px; padding-left: 10px;" colspan="2"></td>
+      </tr>
+      <tr style="font-size:11px; height: 30px; color: #999;">
+        <td style="border-right: 1px solid #CCC; text-align:right;
+                   padding-right:10px;"></td>
+        <td style="padding-left: 10px;" colspan="2">
+          Unsubscribe from <a href="{{ turnOffLink }}/daily">daily emails</a> or Unsubscribe from <a href="{{ turnOffLink }}/all">all</a> emails from Koding.<br/>
+          <a href="https://koding.com">Koding"</a>, Inc. 358 Brannan, San Francisco, CA 94107
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/workers/emailnotifications/templates/style/base.css
+++ b/workers/emailnotifications/templates/style/base.css
@@ -1,0 +1,4 @@
+a {
+    text-decoration:none;
+    color:#1AAF5D;
+}


### PR DESCRIPTION
# :warning: Not yet ready to be merged or tested
#### The goal of this PR is to:
- Make it more easy to write emails with a unified design
- Make it more easy to design emails
- Refine UI for all email notifications
#### In this PR, I will:
- [x] Improve the templating system for emails using: [swig](https://www.npmjs.org/package/swig) and [juice](https://www.npmjs.org/package/juice) (since html in email need inlined css)
- [ ] Externalise stylesheet in a css file instead of inlined css by hand
- [ ] Move all current emails to templates 
  - [ ] Move template to async rendering
    - [x] Daily email
    - [ ] Instant email
- [ ] Refine UI for all email notifications

Let me know if I'm doing something wrong or if I'm not respecting your code style guide. :beers:
