### PR TITLE
oskite: various fixes around the updater

### DIFF
--- a/go/src/koding/oskite/usage.go
+++ b/go/src/koding/oskite/usage.go
@@ -201,8 +201,8 @@ func (p *Plan) prepareLimits(username, groupId string) (*Limit, error) {
 		return nil, errors.New("plan doesn't exist")
 	}
 
-	log.Debug("total usage:   %+v username: %s groups %s", plan, username, groupId)
-	log.Debug("current usage: %+v username: %s group: %s", *p, username, groupId)
+	log.Info("total usage:   %+v username: %s group %s", plan, username, groupId)
+	log.Info("current usage: %+v username: %s group: %s", *p, username, groupId)
 
 	lim := NewLimit()
 
@@ -228,7 +228,6 @@ func (p *Plan) prepareLimits(username, groupId string) (*Limit, error) {
 func (l *Limit) check() error {
 	if l.CPU == LimitQuotaExceeded {
 		return &kitelib.Error{Message: "CPU limit reached", CodeVal: ErrQuotaExceeded.Error()}
-
 	}
 
 	if l.Disk == LimitQuotaExceeded {

--- a/go/src/koding/oskite/vm.go
+++ b/go/src/koding/oskite/vm.go
@@ -177,7 +177,7 @@ func vmStart(vos *virt.VOS) (interface{}, error) {
 		return nil, err
 	}
 
-	if _, err := updateState(vos.VM.Id, vos.VM.State); err != nil {
+	if _, err := checkAndUpdateState(vos.VM.Id, vos.VM.State); err != nil {
 		return nil, err
 	}
 
@@ -193,7 +193,7 @@ func vmShutdown(vos *virt.VOS) (interface{}, error) {
 		return nil, err
 	}
 
-	if _, err := updateState(vos.VM.Id, vos.VM.State); err != nil {
+	if _, err := checkAndUpdateState(vos.VM.Id, vos.VM.State); err != nil {
 		return nil, err
 	}
 
@@ -209,7 +209,7 @@ func vmStop(vos *virt.VOS) (interface{}, error) {
 		return nil, err
 	}
 
-	if _, err := updateState(vos.VM.Id, vos.VM.State); err != nil {
+	if _, err := checkAndUpdateState(vos.VM.Id, vos.VM.State); err != nil {
 		return nil, err
 	}
 
@@ -339,7 +339,6 @@ func (o *Oskite) vmPrepareAndStart(args *dnode.Partial, channel *kite.Channel, v
 }
 
 func (o *Oskite) prepareAndStart(vos *virt.VOS, username, groupId string, pre Preparer) (interface{}, error) {
-
 	dlocksMu.Lock()
 	dlock, ok := dlocks[username]
 	if !ok {
@@ -475,8 +474,7 @@ func unprepareProgress(t tracer.Tracer, vm *virt.VM, destroy bool) error {
 		return fmt.Errorf("unprepareProgress hostKite nil setting: %v", err)
 	}
 
-	// mark it as stopped in mongodb
-	if _, err := updateState(vm.Id, "STOPPED"); err != nil {
+	if _, err := checkAndUpdateState(vm.Id, vm.State); err != nil {
 		return err
 	}
 
@@ -488,7 +486,7 @@ func prepareProgress(t tracer.Tracer, vm *virt.VM) error {
 		return err
 	}
 
-	if _, err := updateState(vm.Id, vm.State); err != nil {
+	if _, err := checkAndUpdateState(vm.Id, vm.State); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
1. Fixes a bug that was introduced last week. Mainly we weren't
   updating the state to `STOPPED` and it was causing `hostkite=null` and
   `state=RUNNING`. Basically the updateState() function was comparing the
   passed state with the LXC state. If they are the same it wouldn't update
   the DB state. That's why we were passing `STOPPED` explicitly and LXC
   would give us `STOPPED`, causing the state in DB not the be updated.
   Instead we need to pass the DB's current state.  I've changed the
   function name to avoid further confusions and fixed it by passing the
   DB state for comparing.
2. There is a potential race condition during an updateState session and
   an individual prepare/unprepare that would cause another DB updateState.
   Basically they weren't protected, which could cause to a race condition.
   I've fixed it by adding  a `waitgroup`, basically a `waitgroup` waits
   until some work is finished. All the queues are waiting for the
   `waitgroup` to be finished. If there is no work they continue, however if
   the `updaterState` function starts (every 30 second), each of the queues
   waits until the updater has been finished. Therefore they never cross
   the line together and there is no more race condition.
