### PR TITLE
oskite: wait for stopped state on unprepare

### DIFF
--- a/go/src/koding/oskite/oskite.go
+++ b/go/src/koding/oskite/oskite.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	OSKITE_NAME    = "oskite"
-	OSKITE_VERSION = "0.4.3"
+	OSKITE_VERSION = "0.4.4"
 )
 
 var (
@@ -421,8 +421,9 @@ func (o *Oskite) releaseVMs(selector bson.M) error {
 		_, err := c.UpdateAll(
 			selector,
 			bson.M{"$set": bson.M{
-				"hostKite": nil,
-				"state":    "STOPPED",
+				"hostKite":      nil,
+				"state":         "STOPPED",
+				"__updatedBy__": "releaseVMs",
 			}})
 		return err
 	}

--- a/go/src/koding/oskite/oskite.go
+++ b/go/src/koding/oskite/oskite.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	OSKITE_NAME    = "oskite"
-	OSKITE_VERSION = "0.4.2"
+	OSKITE_VERSION = "0.4.3"
 )
 
 var (

--- a/go/src/koding/oskite/oskite.go
+++ b/go/src/koding/oskite/oskite.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	OSKITE_NAME    = "oskite"
-	OSKITE_VERSION = "0.4.4"
+	OSKITE_VERSION = "0.4.5"
 )
 
 var (

--- a/go/src/koding/oskite/vm.go
+++ b/go/src/koding/oskite/vm.go
@@ -475,7 +475,10 @@ func unprepareProgress(t tracer.Tracer, vm *virt.VM, destroy bool) error {
 	}
 
 	if err := mongodbConn.Run("jVMs", func(c *mgo.Collection) error {
-		return c.Update(bson.M{"_id": vm.Id}, bson.M{"$set": bson.M{"hostKite": nil}})
+		return c.Update(bson.M{"_id": vm.Id},
+			bson.M{"$set": bson.M{
+				"hostKite":      nil,
+				"__updatedBy__": "unprepareProgress"}})
 	}); err != nil {
 		return fmt.Errorf("unprepareProgress hostKite nil setting: %v", err)
 	}

--- a/go/src/koding/oskite/vm.go
+++ b/go/src/koding/oskite/vm.go
@@ -468,6 +468,12 @@ func unprepareProgress(t tracer.Tracer, vm *virt.VM, destroy bool) error {
 		return err
 	}
 
+	// we'll wait indefinitely (up to 24 hours) for the VM state to actually be
+	// "STOPPED" before we set the hostKite to nil.
+	if err := vm.WaitForState("STOPPED", time.Hour*24); err != nil {
+		return err
+	}
+
 	if err := mongodbConn.Run("jVMs", func(c *mgo.Collection) error {
 		return c.Update(bson.M{"_id": vm.Id}, bson.M{"$set": bson.M{"hostKite": nil}})
 	}); err != nil {

--- a/go/src/koding/oskite/vm.go
+++ b/go/src/koding/oskite/vm.go
@@ -474,11 +474,15 @@ func unprepareProgress(t tracer.Tracer, vm *virt.VM, destroy bool) error {
 		return err
 	}
 
+	getterState, _ := vm.GetState()
+
 	if err := mongodbConn.Run("jVMs", func(c *mgo.Collection) error {
 		return c.Update(bson.M{"_id": vm.Id},
 			bson.M{"$set": bson.M{
-				"hostKite":      nil,
-				"__updatedBy__": "unprepareProgress"}})
+				"hostKite":          nil,
+				"__updatedBy__":     "unprepareProgress",
+				"__stateProperty__": vm.State,
+				"__stateGetter__":   getterState}})
 	}); err != nil {
 		return fmt.Errorf("unprepareProgress hostKite nil setting: %v", err)
 	}


### PR DESCRIPTION
DO NOT MERGE
This is yet another attempt to solve the `hostKite: null, state: "RUNNING"` bug
