### PR TITLE
Activity: remove embedly preview from activity input

### DIFF
--- a/client/Social/Activity/views/inputwidget.coffee
+++ b/client/Social/Activity/views/inputwidget.coffee
@@ -346,7 +346,7 @@ class ActivityInputWidget extends KDView
     # @addSubView @avatar
     @addSubView @input
     @addSubView @buttonBar
-    @addSubView @embedBox
+    # @addSubView @embedBox
     @addSubView @bugNotification
     @addSubView @helpContainer
     @buttonBar.addSubView @submitButton


### PR DESCRIPTION
I didn't remove references to `embedBox` because the embedded preview for post itself is being generated from it. I just hided it from dom.

ping @sinan 
