### PR TITLE
activity: update client-side follow state when a user's post receives a comment

### DIFF
--- a/client/Main/socialapicontroller.coffee
+++ b/client/Main/socialapicontroller.coffee
@@ -23,6 +23,9 @@ class SocialApiController extends KDController
     return fn(data) or []
 
 
+  eachCached: (id, fn) ->
+    fn section[id]  for own name, section of @_cache when id of section
+
   openGroupChannel: ->
     # to - do refactor this part to use same functions with other parts
     groupsController = KD.singleton "groupsController"

--- a/client/Social/Activity/sidebar/activitysidebar.coffee
+++ b/client/Social/Activity/sidebar/activitysidebar.coffee
@@ -102,8 +102,9 @@ class ActivitySidebar extends KDCustomScrollView
 
       return KD.showError err  if err
 
-      # when someone replies to a user's post, we mark that post as "followed" by that user.
-      data.isFollowed = yes
+      # when someone replies to a user's post, we locally mark that post, and
+      # any cached copies as "followed" by that user.
+      socialapi.eachCached data.getId(), (it) -> it.isFollowed = yes
       # and add to the sidebar
       # (if the item is already on sidebar, it's handled on @addItem)
       item = @addItem data, yes

--- a/client/Social/Activity/sidebar/activitysidebar.coffee
+++ b/client/Social/Activity/sidebar/activitysidebar.coffee
@@ -102,6 +102,8 @@ class ActivitySidebar extends KDCustomScrollView
 
       return KD.showError err  if err
 
+      # when someone replies to a user's post, we mark that post as "followed" by that user.
+      data.isFollowed = yes
       # and add to the sidebar
       # (if the item is already on sidebar, it's handled on @addItem)
       item = @addItem data, yes


### PR DESCRIPTION
This solution relies on the `MessageAddedToChannel` event properly dispatching only to the original author of the post while he has not yet "unfollowed" it, and other users who are following the post.

Corresponding issue on Pivotal:
https://www.pivotaltracker.com/s/projects/1082076/stories/75228096
