### PR TITLE
Social: remove reference to remove `followTopic` and `unfollowTopic`

### DIFF
--- a/workers/social/lib/social/models/socialapi/requests.coffee
+++ b/workers/social/lib/social/models/socialapi/requests.coffee
@@ -223,10 +223,10 @@ glanceNotifications = (accountId, callback)->
   post url, {accountId}, callback
 
 followUser = (data, callback)->
-  followHelper data, followTopic, callback
+  followHelper data, addParticipants, callback
 
 unfollowUser = (data, callback)->
-  followHelper data, unfollowTopic, callback
+  followHelper data, removeParticipants, callback
 
 followHelper = (data, followFn, callback) ->
   unless data.accountId and data.creatorId


### PR DESCRIPTION
ping @cihangir It no longer crashes the server and state changes 'follow' to 'unfollow', although i'm not sure if we actually show following user posts in ui
