### PR TITLE
klient: first draft of reporting a random kloud usage metrics

### DIFF
--- a/go/src/koding/kites/klient/kloud.go
+++ b/go/src/koding/kites/klient/kloud.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/koding/kite"
+	"github.com/koding/kite/protocol"
+	"github.com/koding/kloud"
+)
+
+// Kloud represents a remote kloud instance
+type Kloud struct {
+	client *kite.Client
+}
+
+// Kloud returns a new connected kloud instance. The kloud is ready to use.
+// It's connected and will redial if there is any disconnections.
+func NewKloud(k *kite.Kite) (*Kloud, error) {
+	kontrolQuery := protocol.KontrolQuery{
+		Username:    "koding",
+		Environment: "vagrant",
+		Name:        "kloud",
+	}
+
+	timeout := time.After(time.Minute)
+
+	k.Log.Info("Querying for Kloud: %+v", kontrolQuery)
+	for {
+		select {
+		case <-time.Tick(time.Second * 2):
+			kites, err := k.GetKites(kontrolQuery)
+			if err != nil {
+				// still not up, try again until the kite is ready
+				continue
+			}
+
+			remoteKite := kites[0]
+
+			connected, err := remoteKite.DialForever()
+			if err != nil {
+				return nil, err
+			}
+
+			select {
+			case <-connected:
+			case <-time.After(time.Minute):
+				return nil, kloud.NewError(kloud.ErrNoKiteConnection)
+			}
+
+			// Kloud connection is ready now
+			return &Kloud{
+				client: remoteKite,
+			}, nil
+		case <-timeout:
+			return nil, fmt.Errorf("timeout while connection for kite")
+		}
+	}
+}
+
+// Report reports machine and usage metrics to a random kloud.
+func (k *Kloud) Report() error {
+	resp, err := k.client.Tell("report")
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("resp.MustString() %+v\n", resp.MustString())
+	return nil
+}

--- a/go/src/koding/kites/klient/usage.go
+++ b/go/src/koding/kites/klient/usage.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"time"
+
+	"github.com/koding/kite"
+)
+
+// Plan defines the environment on which klient is going to act and work. A
+// plan has limitations. Those limitiations are different for different plan
+// kinds.
+type Plan struct {
+	// name is the plan name, "free", "micro", etc...
+	name string
+
+	// timeout defines the limit in which a machine can be RUNNING at most.
+	// After the timeout is being reached, the machine is closed immediately.
+	timeout time.Duration
+}
+
+type Usage struct {
+	// plan stores a reference to the current plan
+	plan *Plan
+
+	// lastActivity stores the time in which the latest activity was done.
+	lastActivity time.Time
+
+	// methodcalls stores the number of method calls
+	methodCalls int32
+}
+
+func newUsage() *Usage {
+	return &Usage{
+		// start with free, can be upgraded, downgraded later
+		plan: &Plan{
+			name:    "free",
+			timeout: time.Minute * 30,
+		},
+	}
+}
+
+// counter resets the current usage and counts the incoming calls.
+func (u *Usage) counter(r *kite.Request) (interface{}, error) {
+	// reset the latest activity
+	u.lastActivity = time.Now()
+
+	// incrase the method calls
+	u.methodCalls += 1
+	return nil, nil
+}
+
+// current returns the current acvitiy usage
+func (u *Usage) current(r *kite.Request) (interface{}, error) {
+	// don't allow to proceed if there is no activity for 30 minutes
+	return u.lastActivity.Add(u.plan.timeout).Before(time.Now()), nil
+}

--- a/go/src/koding/kites/kloud/deploy.go
+++ b/go/src/koding/kites/kloud/deploy.go
@@ -176,16 +176,16 @@ func (k *KodingDeploy) Deploy(artifact *protocol.Artifact) (*protocol.DeployArti
 
 	// TODO: enable this later in production, currently it's just slowing down
 	// local development.
-	// k.Log.Info("Connecting to remote Klient instance")
-	// klient, err := k.Klient(query.String())
-	// if err != nil {
-	// 	k.Log.Warning("Connecting to remote Klient instance err: %s", err)
-	// } else {
-	// 	k.Log.Info("Sending a ping message")
-	// 	if err := klient.Ping(); err != nil {
-	// 		k.Log.Warning("Sending a ping message err:", err)
-	// 	}
-	// }
+	k.Log.Info("Connecting to remote Klient instance")
+	klient, err := k.Klient(query.String())
+	if err != nil {
+		k.Log.Warning("Connecting to remote Klient instance err: %s", err)
+	} else {
+		k.Log.Info("Sending a ping message")
+		if err := klient.Ping(); err != nil {
+			k.Log.Warning("Sending a ping message err:", err)
+		}
+	}
 
 	return &protocol.DeployArtifact{
 		KiteQuery: query.String(),

--- a/go/src/koding/kites/kloud/koding/check.go
+++ b/go/src/koding/kites/kloud/koding/check.go
@@ -2,7 +2,6 @@ package koding
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/koding/kloud/api/amazon"
 	"github.com/mitchellh/goamz/ec2"
@@ -18,12 +17,6 @@ type concurrentLimit struct {
 	concurrent int
 }
 
-type timeoutLimit struct {
-	// timeout defines the limit in which a machine can be RUNNING at most.
-	// After the timeout is being reached, the machine is closed immediately.
-	timeout time.Duration
-}
-
 var (
 	// limits contains the various limitations for each plan
 	limits = map[string]Limiter{
@@ -35,11 +28,9 @@ var (
 func freeLimiter() Limiter {
 	// Non-paid user cannot create more than 3 VMs
 	// Non-paid user cannot start more than 1 VM simultaneously
-	// Non-paid user VM shuts down after 30 minutes without activity
 	return newMultiLimiter(
 		&totalLimit{total: 1},
 		&concurrentLimit{concurrent: 1},
-		&timeoutLimit{timeout: 30 * time.Minute},
 	)
 }
 
@@ -74,9 +65,5 @@ func (t *totalLimit) Check(ctx *CheckContext) error {
 }
 
 func (c *concurrentLimit) Check(ctx *CheckContext) error {
-	return nil
-}
-
-func (t *timeoutLimit) Check(ctx *CheckContext) error {
 	return nil
 }

--- a/go/src/koding/kites/kloud/koding/limiter.go
+++ b/go/src/koding/kites/kloud/koding/limiter.go
@@ -36,7 +36,8 @@ func newMultiLimiter(limiter ...Limiter) Limiter {
 	return multiLimiter(limiter)
 }
 
-// Limit implements the kloud.Limiter interface
+// Limit implements the kloud.Limiter interface. This is called for every
+// incoming method before the execution.
 func (p *Provider) Limit(opts *protocol.MachineOptions, method string) error {
 	// only check for build method, all other's are ok to be used without any
 	// restriction.

--- a/go/src/koding/kites/kloud/koding/provider.go
+++ b/go/src/koding/kites/kloud/koding/provider.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	// DefaultAMI = "ami-80778be8" // Ubuntu 14.0.4 EBS backed, amd64,  PV
-	DefaultAMI          = "ami-a6926dce" // Ubuntu 14.04 EBS backed, amd64, HVM
+	DefaultAMI          = "ami-864d84ee" // Ubuntu 14.04 EBS backed, amd64, HVM
 	DefaultInstanceType = "t2.micro"
 	DefaultRegion       = "us-east-1"
 

--- a/go/src/koding/kites/kloud/main.go
+++ b/go/src/koding/kites/kloud/main.go
@@ -112,6 +112,10 @@ func newKite() *kite.Kite {
 	k.HandleFunc("info", kld.Info)
 	k.HandleFunc("destroy", kld.Destroy)
 	k.HandleFunc("event", kld.Event)
+	k.HandleFunc("report", func(r *kite.Request) (interface{}, error) {
+		k.Log.Info("Klient is reporting!!! %v", r.Client.Kite)
+		return "I've got your message", nil
+	})
 
 	return k
 }


### PR DESCRIPTION
### DO NOT MERGE YET

There are several ways to measure an 30 minutes non activity. In this approach each klient kite searches for a kloud and reports the usage metrics, such as latest activity (reading file, executing command, opening terminal..). Kloud decides than what to do with those metrics. In our case we are going to lookup the plan and constraint the features according the plan.

Say the klient belongs to a free user, than Kloud will check the latest activity time, if it's more than 30 mins it will shut down the machine.
