### PR TITLE
kloud: update default AMI, old one is removed from Amazon Marketplace

### DIFF
--- a/go/src/koding/kites/kloud/koding/provider.go
+++ b/go/src/koding/kites/kloud/koding/provider.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	// DefaultAMI = "ami-80778be8" // Ubuntu 14.0.4 EBS backed, amd64,  PV
-	DefaultAMI          = "ami-a6926dce" // Ubuntu 14.04 EBS backed, amd64, HVM
+	DefaultAMI          = "ami-864d84ee" // Ubuntu 14.04 EBS backed, amd64, HVM
 	DefaultInstanceType = "t2.micro"
 	DefaultRegion       = "us-east-1"
 


### PR DESCRIPTION
This is an hotfix that @gokmen, @fatihacet and me is already using hotfix. Merging it. 
