### PR TITLE
Activity: add instant feedback of comment deletion, show error if necessary

### DIFF
--- a/client/Social/Activity/views/comments/deletemodal.coffee
+++ b/client/Social/Activity/views/comments/deletemodal.coffee
@@ -21,12 +21,16 @@ class CommentDeleteModal extends KDModalView
 
   submit: ->
 
-    {id} = @getData()
+    { id } = @getData()
+
+    # Emit this event so that
+    # listeners do things without waiting
+    # server response.
+    @emit "DeleteClicked"
+    @buttons.Delete.hideLoader()
+    @hide()
 
     KD.singleton('appManager').tell 'Activity', 'delete', {id}, (err) =>
-
-      @buttons.Delete.hideLoader()
-      @destroy()
 
       if err
         return new KDNotificationView
@@ -34,4 +38,14 @@ class CommentDeleteModal extends KDModalView
           cssClass : 'error editor'
           title    : 'Error, please try again later!'
 
-      @emit "Deleted"
+        # with the emit of this event
+        # we are giving a way to recover
+        # if something goes wrong.
+        @emit "DeleteError"
+        @show()
+
+      # and finally emit this event so that
+      # it is confirmed that it is deleted.
+      @emit "DeleteConfirmed"
+      @destroy()
+

--- a/client/Social/Activity/views/comments/listitemview.coffee
+++ b/client/Social/Activity/views/comments/listitemview.coffee
@@ -47,7 +47,9 @@ class CommentListItemView extends KDListItemView
   showDeleteModal: ->
 
     modal = new CommentDeleteModal {}, @getData()
-    modal.once "Deleted", @bound "destroy"
+    modal.once "DeleteClicked"   , @bound "hide"
+    modal.once "DeleteConfirmed" , @bound "destroy"
+    modal.once "DeleteError"     , @bound "show"
 
 
   createReplyLink: ->


### PR DESCRIPTION
This PR creates a series of hooks for comment deletion to create a more user friendly way of comment deletion.
- Hide comment's dom element first when the delete is clicked.
- When it gets a confirmation from modal that is deleted (which comes from server) destroys the dom element.
- If there is an error, it still shows an error but the comment's dom element will be visible again.

This way when an error happens, user doesn't need to refresh the page.

ping @sinan 
