### PR TITLE
activity: preserve feed input content

### DIFF
--- a/client/Social/Activity/views/inputview.coffee
+++ b/client/Social/Activity/views/inputview.coffee
@@ -111,15 +111,20 @@ class ActivityInputView extends KDTokenizedInput
 
     return position + startOffset
 
+
   focus: ->
+
     super
-    value = @getValue()
-    unless value
-      content = @prefixDefaultTokens()
-      return  unless content
-      @setContent content
-      {childNodes} = @getEditableElement()
-      @utils.selectEnd childNodes[childNodes.length - 1]
+
+    return @utils.selectEnd()  if value = @getValue()
+
+    content = @prefixDefaultTokens()
+    return  unless content
+
+    @setContent content
+    {childNodes} = @getEditableElement()
+    @utils.selectEnd childNodes[childNodes.length - 1]
+
 
   # contentEditable elements cannot be
   # triggered to be blurred. This method

--- a/client/Social/Activity/views/inputwidget.coffee
+++ b/client/Social/Activity/views/inputwidget.coffee
@@ -337,7 +337,6 @@ class ActivityInputWidget extends KDView
   focus: ->
 
     @input.focus()
-    @input.setPlaceholder()
 
 
   viewAppended: ->


### PR DESCRIPTION
[Preserve the feed input content during section switches](https://www.pivotaltracker.com/story/show/74013674)
