### PR TITLE
activity: remove multiple event registration for topic pane

### DIFF
--- a/client/Social/Activity/views/topicmessagepane.coffee
+++ b/client/Social/Activity/views/topicmessagepane.coffee
@@ -2,8 +2,6 @@ class TopicMessagePane extends MessagePane
 
   bindChannelEvents: ->
 
-    super
-
     KD.singletons.socialapi
       .on 'MessageAdded',   @bound 'prependMessage'
       .on 'MessageRemoved', @bound 'removeMessage'


### PR DESCRIPTION
super class was already registered to the same event. calling super before registering to that event was causing multiple registrations to the same event.

ping @szkl 
