### PR TITLE
Algolia: Add api credentials to config files

### DIFF
--- a/config/main.sandbox.coffee
+++ b/config/main.sandbox.coffee
@@ -137,6 +137,9 @@ module.exports =
     staticFilesBaseUrl: "http://sandbox.koding.com"
     runtimeOptions:
       kites: require './kites.coffee'
+      algolia: #TODO change these credentials
+        appId: '8KD9RHY1OA'
+        apiKey: 'e4a8ebe91bf848b67c9ac31a6178c64b'
       osKitePollingMs: 1000 * 60 # 1 min
       userIdleMs: 1000 * 60 * 5 # 5 min
       sessionCookie :

--- a/config/main.sjc-production.coffee
+++ b/config/main.sjc-production.coffee
@@ -142,6 +142,9 @@ module.exports =
     staticFilesBaseUrl: "https://koding.com"
     runtimeOptions:
       kites: require './kites.coffee'
+      algolia: #TODO change these credentials
+        appId: '8KD9RHY1OA'
+        apiKey: 'e4a8ebe91bf848b67c9ac31a6178c64b'
       osKitePollingMs: 1000 * 60 # 1 min
       userIdleMs: 1000 * 60 * 5 # 5 min
       sessionCookie :

--- a/config/main.sl-production.coffee
+++ b/config/main.sl-production.coffee
@@ -138,6 +138,9 @@ module.exports =
     staticFilesBaseUrl: "https://koding.com"
     runtimeOptions:
       kites: require './kites.coffee'
+      algolia: #TODO change these credentials
+        appId: '8KD9RHY1OA'
+        apiKey: 'e4a8ebe91bf848b67c9ac31a6178c64b'
       osKitePollingMs: 1000 * 60 # 1 min
       userIdleMs: 1000 * 60 * 5 # 5 min
       sessionCookie :

--- a/config/main.staging.coffee
+++ b/config/main.staging.coffee
@@ -139,6 +139,9 @@ module.exports =
     staticFilesBaseUrl: "https://koding.com"
     runtimeOptions:
       kites: require './kites.coffee'
+      algolia: #TODO change these credentials
+        appId: '8KD9RHY1OA'
+        apiKey: 'e4a8ebe91bf848b67c9ac31a6178c64b'
       osKitePollingMs: 1000 * 60 # 1 min
       userIdleMs: 1000 * 60 * 5 # 5 min
       sessionCookie :


### PR DESCRIPTION
@humanchimp Since I was having `[KONFIG][ERROR] [ Property Mismatch : client.runtimeOptions.algolia ] Not found in file but it's required in schema, please define before proceeding.  [paths: [config/main.sandbox.coffee] [./config.schema.coffee]]`, I have added the development environment credentials to all configuration files, just for suppressing the error. These credentials must be changed. 
