### PR TITLE
KodingKontrol: use "klient" as default kite name for baseKite of Machine

### DIFF
--- a/client/Main/kite/kodingkontrol.coffee
+++ b/client/Main/kite/kodingkontrol.coffee
@@ -96,7 +96,8 @@ class KodingKontrol extends (require 'kontrol')
     # If queryString provided try to split it first
     # and if successful, use it as query
     if queryString? and queryObject = KD.utils.splitKiteQuery queryString
-      { name } = query = queryObject
+      query    = queryObject
+      { name } = queryObject  if query.name
 
     # Check for cached version of requested kite with correlationName
     return kite  if (kite = @getCachedKite name, correlationName)?

--- a/client/Main/providers/machine.coffee
+++ b/client/Main/providers/machine.coffee
@@ -54,7 +54,7 @@ class Machine extends KDObject
 
     if @queryString? and createIfNotExists
 
-      kontrol.getKite { @queryString, correlationName: @uid }
+      kontrol.getKite { name: "klient", @queryString, correlationName: @uid }
 
     else
 


### PR DESCRIPTION
since we can query kites by only using the ID we need to give a kite name when
requesting the corresponding kite.
