### PR TITLE
Add kloud "-test" flag for development

### DIFF
--- a/go/src/koding/kites/kloud/koding/mongodb.go
+++ b/go/src/koding/kites/kloud/koding/mongodb.go
@@ -99,7 +99,7 @@ func (p *Provider) Get(id, username string) (*protocol.Machine, error) {
 	}
 
 	// check for user permissions
-	if err := p.checkUser(username, machine.Users); err != nil && !p.NoAuth {
+	if err := p.checkUser(username, machine.Users); err != nil && !p.Test {
 		return nil, err
 	}
 

--- a/go/src/koding/kites/kloud/koding/mongodb.go
+++ b/go/src/koding/kites/kloud/koding/mongodb.go
@@ -99,7 +99,7 @@ func (p *Provider) Get(id, username string) (*protocol.Machine, error) {
 	}
 
 	// check for user permissions
-	if err := p.checkUser(username, machine.Users); err != nil {
+	if err := p.checkUser(username, machine.Users); err != nil && !p.NoAuth {
 		return nil, err
 	}
 

--- a/go/src/koding/kites/kloud/koding/provider.go
+++ b/go/src/koding/kites/kloud/koding/provider.go
@@ -48,7 +48,7 @@ type Provider struct {
 
 	// A flag saying if user permissions should be ignored
 	// store negation so default value is aligned with most common use case
-	NoAuth bool
+	Test bool
 }
 
 func (p *Provider) NewClient(machine *protocol.Machine) (*amazon.AmazonClient, error) {

--- a/go/src/koding/kites/kloud/koding/provider.go
+++ b/go/src/koding/kites/kloud/koding/provider.go
@@ -45,6 +45,10 @@ type Provider struct {
 	AssigneeName string
 	Log          logging.Logger
 	Push         func(string, int, machinestate.State)
+
+	// A flag saying if user permissions should be ignored
+	// store negation so default value is aligned with most common use case
+	NoAuth bool
 }
 
 func (p *Provider) NewClient(machine *protocol.Machine) (*amazon.AmazonClient, error) {

--- a/go/src/koding/kites/kloud/main.go
+++ b/go/src/koding/kites/kloud/main.go
@@ -43,7 +43,7 @@ var (
 	flagProxy       = flag.Bool("proxy", false, "Start klient behind a proxy")
 
 	// Development related flags
-	flagNoAuth = flag.Bool("noauth", false, "Disable VM authentication checks (useful for development)")
+	flagTest = flag.Bool("test", false, "Activate test mode (Disables VM authentication checks [useful for development], etc ..)")
 )
 
 func main() {
@@ -117,7 +117,7 @@ func newKite() *kite.Kite {
 		Log:          newLogger("koding"),
 		AssigneeName: id,
 		Session:      db,
-		NoAuth:       *flagNoAuth,
+		Test:         *flagTest,
 	}
 
 	if err := kodingProvider.CleanupOldData(); err != nil {

--- a/go/src/koding/kites/kloud/main.go
+++ b/go/src/koding/kites/kloud/main.go
@@ -41,6 +41,9 @@ var (
 	flagPublic      = flag.Bool("public", false, "Start klient in local environment.")
 	flagRegisterURL = flag.String("register-url", "", "Change register URL to kontrol")
 	flagProxy       = flag.Bool("proxy", false, "Start klient behind a proxy")
+
+	// Development related flags
+	flagNoAuth = flag.Bool("noauth", false, "Disable VM authentication checks (useful for development)")
 )
 
 func main() {
@@ -114,6 +117,7 @@ func newKite() *kite.Kite {
 		Log:          newLogger("koding"),
 		AssigneeName: id,
 		Session:      db,
+		NoAuth:       *flagNoAuth,
 	}
 
 	if err := kodingProvider.CleanupOldData(); err != nil {


### PR DESCRIPTION
This avoids needing a `jUsers` collection and the whole 99 yards. Thus
making development a little bit easier.

If you don’t agree with it @fatih we can remove it.

It's not intrusive and by default leaves the current behavior as is.
