### PR TITLE
Kite operations should check existence of kite before sending any command to it.

### DIFF
--- a/client/Main/kite/kodingkite.coffee
+++ b/client/Main/kite/kodingkite.coffee
@@ -28,7 +28,21 @@ class KodingKite extends KDObject
     @emit 'ready'
 
   tell: (rpcMethod, params, callback) ->
-    @ready().then => @transport.tell rpcMethod, [params], callback
+
+    unless @_invalid
+
+      @ready().then => @transport.tell rpcMethod, [params], callback
+
+    else
+
+      { name } = @getOptions()
+
+      Promise.reject
+        name    : "KiteInvalid"
+        message : """Kite is invalid. This kite (#{name}) not exists
+                     or there is a problem with connection."""
+        err     : @_invalid
+
 
   @createMethod = (ctx, { method, rpcMethod }) ->
     ctx[method] = (payload) -> @tell rpcMethod, payload

--- a/client/Main/kite/kodingkite.coffee
+++ b/client/Main/kite/kodingkite.coffee
@@ -29,7 +29,7 @@ class KodingKite extends KDObject
 
   tell: (rpcMethod, params, callback) ->
 
-    unless @_invalid
+    unless @invalid
 
       @ready().then => @transport.tell rpcMethod, [params], callback
 

--- a/client/Main/kite/kodingkontrol.coffee
+++ b/client/Main/kite/kodingkontrol.coffee
@@ -122,6 +122,11 @@ class KodingKontrol extends (require 'kontrol')
 
       warn "[KodingKontrol] ", err
 
+      # Instead parsing message we need to define a code or different
+      # name for `No kite found` error in kite.js ~ FIXME GG
+      if err and err.name is "KiteError" and /^No kite found/.test err.message
+        kite._invalid = err
+
       @setCachedKite name, correlationName, null
 
       {message} = err

--- a/client/Main/kite/kodingkontrol.coffee
+++ b/client/Main/kite/kodingkontrol.coffee
@@ -125,7 +125,7 @@ class KodingKontrol extends (require 'kontrol')
       # Instead parsing message we need to define a code or different
       # name for `No kite found` error in kite.js ~ FIXME GG
       if err and err.name is "KiteError" and /^No kite found/.test err.message
-        kite._invalid = err
+        kite.invalid = err
 
       @setCachedKite name, correlationName, null
 

--- a/client/Main/navigation/navigationmachineitem.coffee
+++ b/client/Main/navigation/navigationmachineitem.coffee
@@ -16,7 +16,7 @@ class NavigationMachineItem extends KDListItemView
 
     options.tagName    = 'a'
     options.type     or= 'main-nav'
-    options.cssClass   = 'vm'
+    options.cssClass   = "vm #{machine.status.state.toLowerCase()}"
     options.attributes =
       href             : path
       # title            : "Go to your VM #{@alias}"

--- a/client/Main/navigation/navigationmachineitem.coffee
+++ b/client/Main/navigation/navigationmachineitem.coffee
@@ -54,7 +54,7 @@ class NavigationMachineItem extends KDListItemView
   click: (event)->
 
     if event.target.tagName.toLowerCase() isnt 'span'
-      return yes  if @machine.status.state in [Running, Stopped]
+      return yes  if @machine.status.state is Running
 
     KD.utils.stopDOMEvent event
 

--- a/client/Main/providers/computecontroller.coffee
+++ b/client/Main/providers/computecontroller.coffee
@@ -2,7 +2,7 @@ class ComputeController extends KDController
 
   @providers = KD.config.providers
 
-  @timeout = 7000
+  @timeout = 20000
 
   constructor:->
     super
@@ -139,6 +139,7 @@ class ComputeController extends KDController
       @info machine for machine in @machines
       @emit "renderStacks"
 
+
   errorHandler = (task, eventListener, machine)->
 
     ComputeErrors = {
@@ -148,6 +149,8 @@ class ComputeController extends KDController
     { timeout }   = ComputeController
 
     retryIfNeeded = (task, machine)->
+
+      return # FIXME ~ GG
 
       if task in ['info', 'stop', 'start']
         info "Trying again to do '#{task}' in #{timeout}ms..."
@@ -162,7 +165,6 @@ class ComputeController extends KDController
 
         when ComputeErrors.TimeoutError
 
-          warn "Task timedout."
           retryIfNeeded task, machine
 
         when ComputeErrors.KiteError
@@ -187,12 +189,12 @@ class ComputeController extends KDController
 
       @kloud.destroy { machineId: machine._id }
 
-      .timeout ComputeController.timeout
-
       .then (res)=>
 
         @eventListener.addListener 'destroy', machine._id
         log "destroy res:", res
+
+      .timeout ComputeController.timeout
 
       .catch errorHandler 'destroy', @eventListener, machine
 
@@ -207,12 +209,12 @@ class ComputeController extends KDController
 
     @kloud.build { machineId: machine._id }
 
-    .timeout ComputeController.timeout
-
     .then (res)=>
 
       @eventListener.addListener 'build', machine._id
       log "build res:", res
+
+    .timeout ComputeController.timeout
 
     .catch errorHandler 'build', @eventListener, machine
 
@@ -225,12 +227,12 @@ class ComputeController extends KDController
 
     @kloud.start { machineId: machine._id }
 
-    .timeout ComputeController.timeout
-
     .then (res)=>
 
       @eventListener.addListener 'start', machine._id
       log "start res:", res
+
+    .timeout ComputeController.timeout
 
     .catch errorHandler 'start', @eventListener, machine
 
@@ -245,12 +247,12 @@ class ComputeController extends KDController
 
     @kloud.stop { machineId: machine._id }
 
-    .timeout ComputeController.timeout
-
     .then (res)=>
 
       @eventListener.addListener 'stop', machine._id
       log "stop res:", res
+
+    .timeout ComputeController.timeout
 
     .catch errorHandler 'stop', @eventListener, machine
 
@@ -277,8 +279,6 @@ class ComputeController extends KDController
 
     @kloud.info { machineId: machine._id }
 
-    .timeout ComputeController.timeout
-
     .then (response)=>
 
       log "info response:", response
@@ -286,7 +286,11 @@ class ComputeController extends KDController
         status      : response.state
         percentage  : 100
 
+    .timeout ComputeController.timeout
+
     .catch errorHandler 'info', @eventListener, machine
+
+
 
 
   requireMachine: (options = {}, callback = noop)-> @ready =>
@@ -320,6 +324,9 @@ class ComputeController extends KDController
           @storage.setValue identifier, machine.uid
 
         callback err, machine
+
+
+
 
 
   @reviveProvisioner = (machine, callback)->


### PR DESCRIPTION
When kodingKontrol catches `No kite found` error it marks it as invalid with the original error. And in the `::tell` wrapper we are checking that mark. So, all requests will be rejected if kite is invalid. Not urgent but for later we need to define a unique error name for `No kite found` error since I'm checking the error message now https://github.com/gokmen/koding/compare/koding:kodingme...kodingme#diff-a4c56c225420e0021ee61674157288d8R127 which is not good.
