### PR TITLE
controller: fix querystring for start artifacts

### DIFF
--- a/go/src/github.com/koding/kloud/controller.go
+++ b/go/src/github.com/koding/kloud/controller.go
@@ -250,7 +250,7 @@ func (k *Kloud) start(r *kite.Request, c *Controller) (interface{}, error) {
 		}
 
 		err = k.Storage.Update(c.MachineId, &StorageData{
-			Type: "build",
+			Type: "start",
 			Data: map[string]interface{}{
 				"ipAddress":    resp.IpAddress,
 				"instanceId":   resp.InstanceId,


### PR DESCRIPTION
This fixes empty querystring storing to MongoDB while doing a stop/start for a machine.
