### PR TITLE
activity: reset input widget immediately in async callback

### DIFF
--- a/client/Social/Activity/views/inputwidget.coffee
+++ b/client/Social/Activity/views/inputwidget.coffee
@@ -207,9 +207,10 @@ class ActivityInputWidget extends KDView
 
   submissionCallback: (err, activity) ->
 
+    @reset yes
+
     return @showError err  if err
 
-    @reset yes
     @emit "Submit", activity
 
     KD.mixpanel "Status update create, success", { length: activity?.body?.length }


### PR DESCRIPTION
[if socialapi is under maintenance, when it backs-up we are not able to post another message](https://www.pivotaltracker.com/story/show/76406124)
