### PR TITLE
activity: hide location from activity items

### DIFF
--- a/client/Social/Activity/views/activitylistitem.coffee
+++ b/client/Social/Activity/views/activitylistitem.coffee
@@ -224,7 +224,7 @@ class ActivityListItemView extends KDListItemView
       {{> @avatar}}
       <div class='meta'>
         {{> @author}}
-        {{> @timeAgoView}} <span class="location"> from San Francisco</span>
+        {{> @timeAgoView}} <span class="location hidden"> from San Francisco</span>
       </div>
       {{> @editWidgetWrapper}}
       {article{@formatContent #(body)}}


### PR DESCRIPTION
Fixes [Hide the "from San Francisco" message in posts](https://www.pivotaltracker.com/story/show/76463218)

Didn't remove it from dom because it will be placed over there when it is need to be implemented and it can remain as a reference to css classes and where to put that location so that it can be continued from here easily.

ping @szkl @sinan 
