### PR TITLE
Kloud/apache setup

### DIFF
--- a/go/src/koding/kites/kloud/deploy.go
+++ b/go/src/koding/kites/kloud/deploy.go
@@ -32,7 +32,7 @@ type KodingDeploy struct {
 
 const (
 	// Port to bind apache to by default
-	apachePort = 7000
+	apachePort = 80
 )
 
 func (k *KodingDeploy) ServeKite(r *kite.Request) (interface{}, error) {

--- a/go/src/koding/kites/kloud/deploy.go
+++ b/go/src/koding/kites/kloud/deploy.go
@@ -171,6 +171,13 @@ func (k *KodingDeploy) ServeKite(r *kite.Request) (interface{}, error) {
 		return nil, err
 	}
 
+	log("Setting up users' Web/ directory to be served by apache")
+	out, err = client.StartCommand(webSetupCommand(username))
+	if err != nil {
+		fmt.Println("out", out)
+		return nil, err
+	}
+
 	query := kiteprotocol.Kite{ID: tknID.String()}
 
 	// TODO: enable this later in production, currently it's just slowing down
@@ -203,6 +210,14 @@ gpasswd -a %s sudo  && \
 echo '%s    ALL = NOPASSWD: ALL' > /etc/sudoers.d/%s
  `, username, username, username, username, username, username)
 
+}
+
+// webSetupCommand generates a bash command configuring apache for a given user
+func webSetupCommand(username string) string {
+	return fmt.Sprintf(`
+rm -rf /var/www; \
+ln -s /home/%s/Web /var/www
+`, username)
 }
 
 // Build the klient.conf patching command

--- a/go/src/koding/kites/kloud/deploy.go
+++ b/go/src/koding/kites/kloud/deploy.go
@@ -287,5 +287,16 @@ func changeApacheConf(client *sshutil.SSHClient, port int) error {
 		return err
 	}
 
-	return apacheTemplate.Execute(apacheFile, port)
+	// Write conf file
+	if err := apacheTemplate.Execute(apacheFile, port); err != nil {
+		return err
+	}
+
+	apachePortsFile, err := client.Create("/etc/apache2/ports.conf")
+	if err != nil {
+		return err
+	}
+
+	// Write /etc/apache2/ports.conf file
+	return apachePortsTemplate.Execute(apachePortsFile, port)
 }

--- a/go/src/koding/kites/kloud/deploy.go
+++ b/go/src/koding/kites/kloud/deploy.go
@@ -282,7 +282,7 @@ func changeHostname(client *sshutil.SSHClient, hostname string) error {
 // so that it listens on the port of our choice and serves /var/www
 // rather than /var/www/html (/var/www is symlinked to user's ~/Web)
 func changeApacheConf(client *sshutil.SSHClient, port int) error {
-	apacheFile, err := client.Create("/etc/apache2/sites-enabled/000-default")
+	apacheFile, err := client.Create("/etc/apache2/sites-available/000-default.conf")
 	if err != nil {
 		return err
 	}

--- a/go/src/koding/kites/kloud/deploy.go
+++ b/go/src/koding/kites/kloud/deploy.go
@@ -239,11 +239,12 @@ func patchConfCommand(username string) string {
 // and creates them if they don't
 func makeDirectoriesCommand(username string) string {
 	return fmt.Sprintf(`
-mkdir -p /home/%s/Applications && \
-mkdir -p /home/%s/Backup && \
-mkdir -p /home/%s/Documents && \
-mkdir -p /home/%s/Web
-`, username, username, username, username)
+sudo -u %s mkdir -p /home/%s/Applications && \
+sudo -u %s mkdir -p /home/%s/Backup && \
+sudo -u %s mkdir -p /home/%s/Documents && \
+sudo -u %s mkdir -p /home/%s/Web
+`, username, username, username, username,
+		username, username, username, username)
 }
 
 // changeHostname is used to change the remote machines hostname by modifying

--- a/go/src/koding/kites/kloud/deploy.go
+++ b/go/src/koding/kites/kloud/deploy.go
@@ -159,6 +159,12 @@ func (k *KodingDeploy) ServeKite(r *kite.Request) (interface{}, error) {
 		return nil, err
 	}
 
+	log("Making user's default directories")
+	out, err = client.StartCommand(makeDirectoriesCommand(username))
+	if err != nil {
+		return nil, err
+	}
+
 	log("Tweaking apache config")
 	if err := changeApacheConf(client, apachePort); err != nil {
 		return nil, err
@@ -221,6 +227,17 @@ func patchConfCommand(username string) string {
 		"sed -i 's/\\.\\/klient/sudo -E -u %s \\.\\/klient/g' /etc/init/klient.conf",
 		username,
 	)
+}
+
+// makeDirectoriesCommand ensures that all the user's default folders exist
+// and creates them if they don't
+func makeDirectoriesCommand(username string) string {
+	return fmt.Sprintf(`
+mkdir -p /home/%s/Applications && \
+mkdir -p /home/%s/Backup && \
+mkdir -p /home/%s/Documents && \
+mkdir -p /home/%s/Web
+`, username, username, username, username)
 }
 
 // changeHostname is used to change the remote machines hostname by modifying

--- a/go/src/koding/kites/kloud/deploy.go
+++ b/go/src/koding/kites/kloud/deploy.go
@@ -177,6 +177,12 @@ func (k *KodingDeploy) ServeKite(r *kite.Request) (interface{}, error) {
 		return nil, err
 	}
 
+	log("Restarting apache2 with new config")
+	out, err = client.StartCommand("service apache2 restart")
+	if err != nil {
+		return nil, err
+	}
+
 	query := kiteprotocol.Kite{ID: tknID.String()}
 
 	// TODO: enable this later in production, currently it's just slowing down

--- a/go/src/koding/kites/kloud/deploy.go
+++ b/go/src/koding/kites/kloud/deploy.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"html/template"
 	"path/filepath"
 	"strings"
 	"time"
@@ -30,22 +29,6 @@ type KodingDeploy struct {
 
 	Bucket *Bucket
 }
-
-var (
-	t = template.Must(template.New("hosts").Parse(hosts))
-
-	// default ubuntu /etc/hosts file which is used to replace with our custom
-	// hostname later
-	hosts = `127.0.0.1       localhost
-127.0.1.1       {{.}} {{.}}
-
-# The following lines are desirable for IPv6 capable hosts
-::1     ip6-localhost ip6-loopback
-fe00::0 ip6-localnet
-ff00::0 ip6-mcastprefix
-ff02::1 ip6-allnodes
-ff02::2 ip6-allrouters`
-)
 
 func (k *KodingDeploy) ServeKite(r *kite.Request) (interface{}, error) {
 	data, err := r.Context.Get("buildArtifact")
@@ -238,7 +221,7 @@ func changeHostname(client *sshutil.SSHClient, hostname string) error {
 		return err
 	}
 
-	if err := t.Execute(hostFile, hostname); err != nil {
+	if err := hostsTemplate.Execute(hostFile, hostname); err != nil {
 		return err
 	}
 

--- a/go/src/koding/kites/kloud/deploy_templates.go
+++ b/go/src/koding/kites/kloud/deploy_templates.go
@@ -27,11 +27,11 @@ ff02::2 ip6-allrouters`
 
   DocumentRoot /var/www
   <Directory />
-    Options FollowSymLinks
+    Options +FollowSymLinks
     AllowOverride None
   </Directory>
   <Directory /var/www/>
-    Options Indexes FollowSymLinks MultiViews +ExecCGI
+    Options +Indexes +FollowSymLinks +MultiViews +ExecCGI
     AddHandler cgi-script .cgi .pl .rb .py
     AllowOverride All
     Order allow,deny

--- a/go/src/koding/kites/kloud/deploy_templates.go
+++ b/go/src/koding/kites/kloud/deploy_templates.go
@@ -18,4 +18,42 @@ fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters`
+
+	apacheTemplate = template.Must(template.New("apache").Parse(apache))
+
+	apache = `
+<VirtualHost *:{{.}}>
+  ServerAdmin webmaster@localhost
+
+  DocumentRoot /var/www
+  <Directory />
+    Options FollowSymLinks
+    AllowOverride None
+  </Directory>
+  <Directory /var/www/>
+    Options Indexes FollowSymLinks MultiViews +ExecCGI
+    AddHandler cgi-script .cgi .pl .rb .py
+    AllowOverride All
+    Order allow,deny
+    Allow from all
+  </Directory>
+
+  ScriptAlias /cgi-bin/ /usr/lib/cgi-bin/
+  <Directory "/usr/lib/cgi-bin">
+    AllowOverride None
+    Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch
+    Order allow,deny
+    Allow from all
+  </Directory>
+
+  ErrorLog ${APACHE_LOG_DIR}/error.log
+
+  # Possible values include: debug, info, notice, warn, error, crit,
+  # alert, emerg.
+  LogLevel warn
+
+  CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>
+`
+
 )

--- a/go/src/koding/kites/kloud/deploy_templates.go
+++ b/go/src/koding/kites/kloud/deploy_templates.go
@@ -55,5 +55,4 @@ ff02::2 ip6-allrouters`
   CustomLog ${APACHE_LOG_DIR}/access.log combined
 </VirtualHost>
 `
-
 )

--- a/go/src/koding/kites/kloud/deploy_templates.go
+++ b/go/src/koding/kites/kloud/deploy_templates.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"html/template"
+)
+
+var (
+	hostsTemplate = template.Must(template.New("hosts").Parse(hosts))
+
+	// default ubuntu /etc/hosts file which is used to replace with our custom
+	// hostname later
+	hosts = `127.0.0.1       localhost
+127.0.1.1       {{.}} {{.}}
+
+# The following lines are desirable for IPv6 capable hosts
+::1     ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters`
+)

--- a/go/src/koding/kites/kloud/deploy_templates.go
+++ b/go/src/koding/kites/kloud/deploy_templates.go
@@ -5,7 +5,9 @@ import (
 )
 
 var (
-	hostsTemplate = template.Must(template.New("hosts").Parse(hosts))
+	hostsTemplate       = template.Must(template.New("hosts").Parse(hosts))
+	apacheTemplate      = template.Must(template.New("apache").Parse(apache))
+	apachePortsTemplate = template.Must(template.New("apachePorts").Parse(apachePorts))
 
 	// default ubuntu /etc/hosts file which is used to replace with our custom
 	// hostname later
@@ -18,8 +20,6 @@ fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters`
-
-	apacheTemplate = template.Must(template.New("apache").Parse(apache))
 
 	apache = `
 <VirtualHost *:{{.}}>
@@ -54,5 +54,9 @@ ff02::2 ip6-allrouters`
 
   CustomLog ${APACHE_LOG_DIR}/access.log combined
 </VirtualHost>
+`
+
+	apachePorts = `
+Listen {{.}}
 `
 )

--- a/go/src/koding/kites/kloud/deploy_templates.go
+++ b/go/src/koding/kites/kloud/deploy_templates.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"html/template"
+	"text/template"
 )
 
 var (

--- a/go/src/koding/kites/kloud/provisioner/provisioner.go
+++ b/go/src/koding/kites/kloud/provisioner/provisioner.go
@@ -15,7 +15,7 @@ var shellProvisioner = map[string]interface{}{
 		// Refresh package entries
 		"sudo apt-get update",
 		// Install system software & CLI Tools
-		"sudo apt-get install -y ubuntu-standard ubuntu-minimal htop git net-tools aptitude apache2 php5 libapache2-mod-php5 php5-cgi ruby screen fish sudo emacs mc iotop iftop software-properties-common libgd2-xpm",
+		"sudo apt-get install -y ubuntu-standard ubuntu-minimal htop git net-tools aptitude apache2 php5 libapache2-mod-php5 php5-cgi ruby screen fish sudo emacs mc iotop iftop software-properties-common",
 		// Install NodeJS 0.10.26
 		"wget -O - http://nodejs.org/dist/v0.10.26/node-v0.10.26-linux-x64.tar.gz | sudo tar -C /usr/local/ --strip-components=1 -zxv",
 		// Install programming language runtimes/compilers


### PR DESCRIPTION
This PR does the following :
- Fixes an issue with installing the `apache2` package (and others) (`libgd2-xpm` was not available, thus breaking that install line)
- Sets up (and creates) the user's default directories
- Symlinks `~/Web` to `/var/www`
- Configures `apache2` programmatically (we can run apache on a custom port etc ...)

This is tested and works as expected. @fatih @devrim Ready to merge when you want.

**P.S:** This doesn't do https://www.pivotaltracker.com/story/show/76492880 (which should be easy to and is rather separate to the `apache` setup).
