### PR TITLE
activity: fix confusing follow/unfollow button states [fixes #75486014]

### DIFF
--- a/client/Social/Activity/styl/activity.styl
+++ b/client/Social/Activity/styl/activity.styl
@@ -351,13 +351,11 @@ styleScrollBars()
       padding       0
       borderBox()
       &:hover
-        border-color    transparent
-        bg              color #777
+        border          none
         .icon
           r-sprite      activity 'check-gray'
 
       .icon
-        r-sprite        activity 'check-gray'
         margin          0 6px 0 0
         padding         0
         fr()
@@ -371,6 +369,11 @@ styleScrollBars()
 
         .icon
           r-sprite      activity 'check-gray'
+
+        &:hover
+          border        1px solid #b1b1b1
+          .icon
+            display     none
 
   .kdlistitemview-sidebar-item.selected
     background          #15171A
@@ -396,15 +399,14 @@ styleScrollBars()
       &.follow:before
         color           #d1efdf
 
-      .icon
-        r-sprite      activity 'check-gray'
-
       &.following
         bg              color transparent
         border-color    transparent
 
-        .icon
-          r-sprite      activity 'check-gray'
+        &:hover
+          border          1px solid #b1b1b1
+          .icon
+            display       none
 
   .conversations
   .messages


### PR DESCRIPTION
before:
follow: https://www.dropbox.com/s/1121o05mce0cyam/Screenshot%202014-08-07%2016.45.22.png
unfollow: https://www.dropbox.com/s/494iz9yjowkhspy/Screenshot%202014-08-07%2016.45.31.png

after:
follow: https://www.dropbox.com/s/n4gqwfnn1t5ub96/Screenshot%202014-08-07%2016.44.24.png
unfollow: https://www.dropbox.com/s/81h9vc49xlz500s/Screenshot%202014-08-07%2016.44.51.png

On hover, we show the state of action, i.e. if not followed, hovering will show tick mark.
