### PR TITLE
kloud: enable auto-update of klient binary  [Completes #73743240]

### DIFF
--- a/go/src/github.com/fatih/structure/.travis.yml
+++ b/go/src/github.com/fatih/structure/.travis.yml
@@ -1,3 +1,11 @@
 language: go
 go: 1.3
-
+before_install:
+- go get github.com/axw/gocov/gocov
+- go get github.com/mattn/goveralls
+- go get code.google.com/p/go.tools/cmd/cover
+script:
+- $HOME/gopath/bin/goveralls -repotoken $COVERALLS_TOKEN
+env:
+  global:
+    secure: TQBWcnkeQqgqxeNazuMz8/u15jFCwUtiF6z4VCgbCcwPqUyaS1Xf1xtSisfgqFRUGKC7j+yGXC9F1BkGVkz5fKXm5nQxTZvNzjg/JALQZZaw4yHzcy+3lE/2hOQouwAZVsgi1yfu+renNmThdwbRzsQM4se6ENIO/zh16oY/Jbs=

--- a/go/src/github.com/fatih/structure/README.md
+++ b/go/src/github.com/fatih/structure/README.md
@@ -1,8 +1,10 @@
-# Structure [![GoDoc](https://godoc.org/github.com/fatih/structure?status.svg)](http://godoc.org/github.com/fatih/structure) [![Build Status](https://travis-ci.org/fatih/structure.svg)](https://travis-ci.org/fatih/structure)
+# Structure [![GoDoc](https://godoc.org/github.com/fatih/structure?status.svg)](http://godoc.org/github.com/fatih/structure) [![Build Status](https://travis-ci.org/fatih/structure.svg)](https://travis-ci.org/fatih/structure) [![Coverage Status](https://img.shields.io/coveralls/fatih/structure.svg)](https://coveralls.io/r/fatih/structure)
 
-Structure contains various utilities to work with Go (Golang) structs.
-
-**WIP, Use with care until it's finished and announced**
+Structure contains various utilities to work with Go (Golang) structs. It was
+initially used by me to convert a struct into a `map[string]interface{}`. With
+time I've added other utilities for structs.  It's basically a high level
+package based on primitives from the reflect package. Feel free to add new
+functions or improve the existing code.
 
 ## Install
 
@@ -34,11 +36,11 @@ s := &Server{
 m := structure.Map(s)
 
 // Convert the values of a struct to a []interface{}
-// => [true, 123456, "gopher"]
+// => [123456, "gopher", true]
 v := structure.Values(s)
 
 // Convert the fields of a struct to a []string. 
-// => ["Enabled", "ID", "Name"]
+// => ["Name", "ID", "Enabled"]
 f := structure.Fields(s)
 
 // Return the struct name
@@ -47,11 +49,16 @@ n := structure.Name(s)
 
 // Check if field name exists
 // => true
-n := structure.Has(s, "Enabled")
+h := structure.Has(s, "Enabled")
 
-// Check if the fields of a struct is initialized or not.
-if !structure.IsZero(s) {
-    fmt.Println("s is initialized")
+// Check if any field of a struct is initialized or not.
+if structure.HasZero(s) {
+    fmt.Println("s has a zero value field")
+}
+
+// Check if all fields of a struct is initialized or not.
+if structure.IsZero(s) {
+    fmt.Println("all fields of s is zero value")
 }
 
 // Check if it's a struct or a pointer to struct
@@ -60,4 +67,14 @@ if structure.IsStruct(s) {
 }
 
 ```
+
+## Credits
+
+ * [Fatih Arslan](https://github.com/fatih)
+ * [Cihangir Savas](https://github.com/cihangir)
+
+## License
+
+The MIT License (MIT) - see LICENSE.md for more details
+
 

--- a/go/src/github.com/fatih/structure/tags.go
+++ b/go/src/github.com/fatih/structure/tags.go
@@ -1,0 +1,32 @@
+package structure
+
+import "strings"
+
+// tagOptions contains a slice of tag options
+type tagOptions []string
+
+// Has returns true if the given optiton is available in tagOptions
+func (t tagOptions) Has(opt string) bool {
+	for _, tagOpt := range t {
+		if tagOpt == opt {
+			return true
+		}
+	}
+
+	return false
+}
+
+// parseTag splits a struct field's tag into its name and a list of options
+// which comes after a name. A tag is in the form of: "name,option1,option2".
+// The name can be neglectected.
+func parseTag(tag string) (string, tagOptions) {
+	// tag is one of followings:
+	// ""
+	// "name"
+	// "name,opt"
+	// "name,opt,opt2"
+	// ",opt"
+
+	res := strings.Split(tag, ",")
+	return res[0], res[1:]
+}

--- a/go/src/github.com/fatih/structure/tags_test.go
+++ b/go/src/github.com/fatih/structure/tags_test.go
@@ -1,0 +1,46 @@
+package structure
+
+import "testing"
+
+func TestParseTag_Name(t *testing.T) {
+	tags := []struct {
+		tag string
+		has bool
+	}{
+		{"", false},
+		{"name", true},
+		{"name,opt", true},
+		{"name , opt, opt2", false}, // has a single whitespace
+		{", opt, opt2", false},
+	}
+
+	for _, tag := range tags {
+		name, _ := parseTag(tag.tag)
+
+		if (name != "name") && tag.has {
+			t.Errorf("Parse tag should return name: %#v", tag)
+		}
+	}
+}
+
+func TestParseTag_Opts(t *testing.T) {
+	tags := []struct {
+		opts string
+		has  bool
+	}{
+		{"name", false},
+		{"name,opt", true},
+		{"name , opt, opt2", false}, // has a single whitespace
+		{",opt, opt2", true},
+		{", opt3, opt4", false},
+	}
+
+	// search for "opt"
+	for _, tag := range tags {
+		_, opts := parseTag(tag.opts)
+
+		if opts.Has("opt") != tag.has {
+			t.Errorf("Tag opts should have opt: %#v", tag)
+		}
+	}
+}

--- a/go/src/koding/kites/klient/klient.go
+++ b/go/src/koding/kites/klient/klient.go
@@ -11,7 +11,6 @@ import (
 	"log"
 	"net/url"
 	"os"
-	"time"
 
 	"github.com/koding/kite"
 	"github.com/koding/kite/config"
@@ -111,18 +110,20 @@ func main() {
 		}
 	}
 
-	go func() {
-		kloud, err := NewKloud(k)
-		if err != nil {
-			k.Log.Warning(err.Error())
-		}
+	// go func() {
+	// 	kloud, err := NewKloud(k)
+	// 	if err != nil {
+	// 		k.Log.Warning(err.Error())
+	// 	}
+	//
+	// 	for _ = range time.Tick(time.Second * 5) {
+	// 		err := kloud.Report()
+	// 		fmt.Printf("err %+v\n", err)
+	// 	}
+	//
+	// }()
 
-		for _ = range time.Tick(time.Second * 5) {
-			err := kloud.Report()
-			fmt.Printf("err %+v\n", err)
-		}
-
-	}()
+	go backgroundUpdater()
 
 	k.Run()
 }

--- a/go/src/koding/kites/klient/klient.go
+++ b/go/src/koding/kites/klient/klient.go
@@ -32,7 +32,8 @@ var (
 	NAME    = protocol.Name
 
 	// this is our main reference to count and measure metrics for the klient
-	usg = usage.NewUsage()
+	usg  = usage.NewUsage()
+	klog kite.Logger
 )
 
 func main() {
@@ -48,6 +49,8 @@ func main() {
 	k.Config.Port = *flagPort
 	k.Config.Environment = *flagEnvironment
 	k.Config.Region = *flagRegion
+
+	klog = k.Log
 
 	// always boot up with the same id in the kite.key
 	k.Id = conf.Id

--- a/go/src/koding/kites/klient/klient.go
+++ b/go/src/koding/kites/klient/klient.go
@@ -57,6 +57,7 @@ func main() {
 
 	// this provides us to get the current usage whenever we want
 	k.HandleFunc("klient.usage", usg.Current)
+	k.HandleFunc("klient.update", updater)
 
 	k.HandleFunc("fs.readDirectory", fs.ReadDirectory)
 	k.HandleFunc("fs.glob", fs.Glob)

--- a/go/src/koding/kites/klient/klient.go
+++ b/go/src/koding/kites/klient/klient.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/koding/kite"
 	"github.com/koding/kite/config"
@@ -26,6 +27,11 @@ var (
 	flagEnvironment = flag.String("env", protocol.Environment, "Change environment")
 	flagRegion      = flag.String("region", protocol.Region, "Change region")
 	flagRegisterURL = flag.String("register-url", "", "Change register URL to kontrol")
+
+	flagUpdateInterval = flag.Duration("update-interval", time.Minute*5,
+		"Change interval for checking for new updates")
+	flagUpdateURL = flag.String("update-url", "https://s3.amazonaws.com/koding-kites/klient/latest.txt",
+		"Change update endpoint for latest version")
 
 	VERSION = protocol.Version
 	NAME    = protocol.Name
@@ -123,7 +129,12 @@ func main() {
 	//
 	// }()
 
-	go backgroundUpdater()
+	if *flagUpdateInterval < time.Minute {
+		klog.Warning("Update interval can't be less than one minute. Setting to one minute.")
+		*flagUpdateInterval = time.Minute
+	}
+
+	go backgroundUpdater(*flagUpdateInterval)
 
 	k.Run()
 }

--- a/go/src/koding/kites/klient/klient.go
+++ b/go/src/koding/kites/klient/klient.go
@@ -72,6 +72,7 @@ func main() {
 	k.PreHandleFunc(func(r *kite.Request) (interface{}, error) {
 		updatingMu.Lock()
 		defer updatingMu.Unlock()
+
 		if updating {
 			return nil, errors.New("Updating klient. Can't accept any method.")
 		}

--- a/go/src/koding/kites/klient/update.go
+++ b/go/src/koding/kites/klient/update.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/inconshreveable/go-update"
+	"github.com/koding/kite"
+	"github.com/mitchellh/osext"
+)
+
+var (
+	AuthenticatedUser = "koding"
+)
+
+type UpdateData struct {
+	KlientURL string
+}
+
+func updater(r *kite.Request) (interface{}, error) {
+	if r.Username != AuthenticatedUser {
+		return nil, fmt.Errorf("Not authenticated to make an update: %s", r.Username)
+	}
+
+	var params UpdateData
+	if err := r.Args.One().Unmarshal(&params); err != nil {
+		return nil, err
+	}
+
+	if params.KlientURL == "" {
+		return nil, errors.New("Can't update myself, incoming URL is empty")
+	}
+
+	// can't return the result during update
+	go func() {
+		if err := updateBinary(params.KlientURL); err != nil {
+			r.LocalKite.Log.Warning("Update fail: %v", err)
+		}
+	}()
+
+	return true, nil
+}
+
+func updateBinary(url string) error {
+	u := update.New()
+	err := u.CanUpdate()
+	if err != nil {
+		return err
+	}
+
+	self, err := osext.Executable()
+	if err != nil {
+		return err
+	}
+
+	err, errRecover := u.FromUrl(url)
+	if err != nil {
+		if errRecover != nil {
+			return errRecover
+		}
+
+		return err
+	}
+
+	env := os.Environ()
+
+	execErr := syscall.Exec(self, []string{self}, env)
+	if execErr != nil {
+		return err
+	}
+
+	return nil
+}

--- a/go/src/koding/kites/klient/update.go
+++ b/go/src/koding/kites/klient/update.go
@@ -38,7 +38,7 @@ func (u *Updater) ServeKite(r *kite.Request) (interface{}, error) {
 	go func() {
 		r.LocalKite.Log.Info("klient.Update is called. Updating binary via latest version")
 		if err := u.checkAndUpdate(); err != nil {
-			klog.Warning("klient.update error report: %s", err)
+			klog.Warning("klient.update: %s", err)
 		}
 	}()
 
@@ -190,7 +190,7 @@ func (u *Updater) Run() {
 
 	for _ = range time.Tick(u.Interval) {
 		if err := u.checkAndUpdate(); err != nil {
-			klog.Warning("Self-update error report: %s", err)
+			klog.Warning("Self-update: %s", err)
 		}
 	}
 }

--- a/go/src/koding/kites/klient/update.go
+++ b/go/src/koding/kites/klient/update.go
@@ -91,6 +91,7 @@ func (u *Updater) checkAndUpdate() error {
 
 func updateBinary(url string) error {
 	u := update.New()
+	klog.Info("Checking if I can update myself and have the necessary permissions")
 	err := u.CanUpdate()
 	if err != nil {
 		return err

--- a/go/src/koding/kites/kloud/deploy.go
+++ b/go/src/koding/kites/kloud/deploy.go
@@ -165,6 +165,13 @@ func (k *KodingDeploy) ServeKite(r *kite.Request) (interface{}, error) {
 		return nil, err
 	}
 
+	log("Chowning /opt/kite/klient to user's permisison")
+	out, err = client.StartCommand(fmt.Sprintf("chown %s:%s -R /opt/kite/klient", username, username))
+	if err != nil {
+		fmt.Println("out", out)
+		return nil, err
+	}
+
 	log("Restarting klient with kite.key")
 	out, err = client.StartCommand("service klient restart")
 	if err != nil {

--- a/go/src/koding/kites/kloud/deploy.go
+++ b/go/src/koding/kites/kloud/deploy.go
@@ -122,7 +122,7 @@ func (k *KodingDeploy) ServeKite(r *kite.Request) (interface{}, error) {
 	}
 
 	log("Fetching latest klient.deb binary")
-	latestDeb, err := k.Bucket.Latest()
+	latestDeb, err := k.Bucket.LatestDeb()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This enables self-update of remote klient binaries. The process is:
- If a new Klient is deployed to `klientkite.development` or `klientkite.production` branch a new klient with the name `klient-version.gz` is updated to S3.
- For the first deployment of a machine Kloud deploys the `klient` kite in `.deb` form which also installs the upstart script. It also chowns the folder `/opt/kite/klient.` to `user:user` to let the self-update working without any problem.
- The file https://s3.amazonaws.com/koding-kites/klient/development/latest-version.txt or https://s3.amazonaws.com/koding-kites/klient/production/latest-version.txt is also updated that reflects the latest version
- A background updater in `klient` kite in the remote machine is checking those endpoints every 5 minutes. Those parameters can be changed via the `-update-interval` and `-update-url` flags via klient if wished. Default values are `5 Minutes` and `https://s3.amazonaws.com/koding-kites/klient/"+protocol.Environment+"/latest-version.txt` (note that the environment is dynamic and depends on the environment. There is an additional checking which prevents to set the interval very low. The minimum value is `1 minute` (mean no one can abuse the update process with a very low interval)
- Klient compares the latest version with his own version. If it's less it's downloading the latest binary in the form of `klient-version.gz` and gunzipping it automatically. The old binary is automatically backuped and the new binary is replaced on top of it.
- If everything is ok, Klient restarts itself via the `syscall.Exec` command that replaces the current process immediately.
- During the whole update process (checking url, downloading bin, etc..) all other `klient` methods are blocked and each call is responding with an error `Updating klient. Can't accept any method.`
- There is an additional klient method called `klient.update` that explicitly triggers the update process. This can be used later in addition with the Koding.com webpage to provide a more seamless update experience such as asking "Do you want to update your machine to the latest version" and calling the `klient.update`. This method is only callable via the `koding` user and is permitted for any other user.

I've tested it with the `kodingme` branch, created an amazon machine, and waited for 6 minutes. Everything was working without any problem.

Here is a screenshot that shows the process in action:

![53e513b60077911bfe6c7b8e](https://cloud.githubusercontent.com/assets/438920/3861076/d88f24e4-1f2a-11e4-8e1d-0bfc14cf3449.png)
