### PR TITLE
Social: remove z-index of message header in private conversation [fixes #76624410]

### DIFF
--- a/client/Social/Activity/styl/activity.styl
+++ b/client/Social/Activity/styl/activity.styl
@@ -1385,7 +1385,6 @@ span.collapsedtext
         top             2px
         left            -62px
         text-align      right
-        z-index         10
         abs()
 
         time


### PR DESCRIPTION
before: https://www.dropbox.com/s/vgvd1isc92yt26c/Screenshot%202014-08-11%2018.23.11.png
after: https://www.dropbox.com/s/aq64nfo7fv4p8ve/Screenshot%202014-08-11%2018.21.37.png
