### PR TITLE
kite: enable kontrol discovery via a central etcd cluster  [completes #76433472]

### DIFF
--- a/go/src/github.com/koding/kite/cmd/register.go
+++ b/go/src/github.com/koding/kite/cmd/register.go
@@ -52,8 +52,6 @@ func (r *Register) Exec(args []string) error {
 		return err
 	}
 
-	fmt.Println("result", result)
-
 	if err := kitekey.Write(result.MustString()); err != nil {
 		return err
 	}

--- a/go/src/github.com/koding/kite/examples/exp2-query/exp2-query.go
+++ b/go/src/github.com/koding/kite/examples/exp2-query/exp2-query.go
@@ -20,23 +20,14 @@ func main() {
 	k := kite.New("exp2", "1.0.0")
 	k.Config = config.MustGet()
 
-	fmt.Printf("k.Config.Id %+v\n", k.Config.Id)
 	kites, err := k.GetKites(protocol.KontrolQuery{
 		Username:    k.Config.Username,
 		Environment: k.Config.Environment,
 		Name:        "math",
-		// Version:     "1.0.0",
-		// Region:      k.Config.Region,
-		// Hostname:    k.Kite().Hostname,
-		// ID: k.Config.Id,
 	})
 	if err != nil {
 		log.Fatalln(err)
 	}
-
-	fmt.Printf("found kites %+v\n", kites)
-
-	// os.Exit(1)
 
 	// Connect to remote kite
 	mathWorker := kites[0]

--- a/go/src/github.com/koding/kite/kontrol/etcd.go
+++ b/go/src/github.com/koding/kite/kontrol/etcd.go
@@ -20,8 +20,8 @@ var keyOrder = []string{
 	"id",
 }
 
-// registerValue is the type of the value that is saved to etcd.
-type registerValue struct {
+// RegisterValue is the type of the value that is saved to etcd.
+type RegisterValue struct {
 	URL string `json:"url"`
 }
 
@@ -47,7 +47,7 @@ func validateKiteKey(k *protocol.Kite) error {
 func (k *Kontrol) etcdKeyFromId(id string) (string, error) {
 	k.Kite.Log.Info("Searching etcd key from id %s", KitesPrefix+"/"+id)
 
-	node, err := k.storage.Get(KitesPrefix + "/" + id)
+	n, err := k.storage.Get(KitesPrefix + "/" + id)
 	if err != nil {
 		if err2, ok := err.(*etcdErr.Error); ok && err2.ErrorCode == etcdErr.EcodeKeyNotFound {
 			return "", nil
@@ -57,7 +57,15 @@ func (k *Kontrol) etcdKeyFromId(id string) (string, error) {
 		return "", fmt.Errorf("internal error - getKites")
 	}
 
-	return node.node.Value, nil
+	return n.Node.Value, nil
+}
+
+func (k *Kontrol) getEtcdKey(q *protocol.KontrolQuery) (string, error) {
+	if onlyIDQuery(q) {
+		return k.etcdKeyFromId(q.ID)
+	}
+
+	return GetQueryKey(q)
 }
 
 // onlyIDQuery returns true if the query contains only a non-empty ID and all
@@ -83,12 +91,7 @@ func onlyIDQuery(q *protocol.KontrolQuery) bool {
 }
 
 // getQueryKey returns the etcd key for the query.
-func (k *Kontrol) getQueryKey(q *protocol.KontrolQuery) (string, error) {
-	// check first if it's an ID search
-	if onlyIDQuery(q) {
-		return k.etcdKeyFromId(q.ID)
-	}
-
+func GetQueryKey(q *protocol.KontrolQuery) (string, error) {
 	fields := q.Fields()
 
 	if q.Username == "" {

--- a/go/src/github.com/koding/kite/kontrol/kontrol.go
+++ b/go/src/github.com/koding/kite/kontrol/kontrol.go
@@ -63,6 +63,10 @@ type Kontrol struct {
 	// storage defines the storage of the kites.
 	storage Storage
 
+	// RegisterURL defines the URL that is used to self register when adding
+	// itself to the storage backend
+	RegisterURL string
+
 	// a list of etcd machintes to connect
 	Machines []string
 }
@@ -286,6 +290,12 @@ func (k *Kontrol) registerSelf() {
 	value := &kontrolprotocol.RegisterValue{
 		URL: k.Kite.Config.KontrolURL,
 	}
+
+	// change if the user wants something different
+	if k.RegisterURL != "" {
+		value.URL = k.RegisterURL
+	}
+
 	setter, _, _ := k.makeSetter(k.Kite.Kite(), value)
 	for {
 		if err := setter(); err != nil {

--- a/go/src/github.com/koding/kite/kontrol/kontrol.go
+++ b/go/src/github.com/koding/kite/kontrol/kontrol.go
@@ -18,6 +18,7 @@ import (
 	"github.com/koding/kite/config"
 	"github.com/koding/kite/dnode"
 	"github.com/koding/kite/kitekey"
+	kontrolprotocol "github.com/koding/kite/kontrol/protocol"
 	"github.com/koding/kite/protocol"
 	"github.com/nu7hatch/gouuid"
 )
@@ -239,7 +240,7 @@ func (k *Kontrol) register(r *kite.Client, kiteURL string) error {
 		return err
 	}
 
-	value := &registerValue{
+	value := &kontrolprotocol.RegisterValue{
 		URL: kiteURL,
 	}
 
@@ -282,7 +283,7 @@ func requestHeartbeat(r *kite.Client, setterFunc func() error) error {
 
 // registerSelf adds Kontrol itself to etcd as a kite.
 func (k *Kontrol) registerSelf() {
-	value := &registerValue{
+	value := &kontrolprotocol.RegisterValue{
 		URL: k.Kite.Config.KontrolURL,
 	}
 	setter, _, _ := k.makeSetter(k.Kite.Kite(), value)
@@ -298,7 +299,7 @@ func (k *Kontrol) registerSelf() {
 }
 
 //  makeSetter returns a func for setting the kite key with value in etcd.
-func (k *Kontrol) makeSetter(kite *protocol.Kite, value *registerValue) (setter func() error, etcdKey, etcdIDKey string) {
+func (k *Kontrol) makeSetter(kite *protocol.Kite, value *kontrolprotocol.RegisterValue) (setter func() error, etcdKey, etcdIDKey string) {
 	etcdKey = KitesPrefix + kite.String()
 	etcdIDKey = KitesPrefix + "/" + kite.ID
 
@@ -389,8 +390,8 @@ func (k *Kontrol) getKites(r *kite.Request, query protocol.KontrolQuery, watchCa
 	var hasVersionConstraint bool // does query contains a constraint on version?
 	var keyRest string            // query key after the version field (not including version)
 
-	// We will make a get request to etcd store with this key.
-	etcdKey, err := k.getQueryKey(&query)
+	// We will make a get request to etcd store with this key. Check first if
+	etcdKey, err := k.getEtcdKey(&query)
 	if err != nil {
 		return nil, err
 	}
@@ -421,7 +422,7 @@ func (k *Kontrol) getKites(r *kite.Request, query protocol.KontrolQuery, watchCa
 		}
 		// We will make a get request to all nodes under this name
 		// and filter the result later.
-		etcdKey, _ = k.getQueryKey(nameQuery)
+		etcdKey, _ = GetQueryKey(nameQuery)
 
 		// Rest of the key after version field
 		keyRest = "/" + strings.TrimRight(query.Region+"/"+query.Hostname+"/"+query.ID, "/")
@@ -604,7 +605,7 @@ func (k *Kontrol) handleGetToken(r *kite.Request) (interface{}, error) {
 		return nil, errors.New("Invalid query")
 	}
 
-	kiteKey, err := k.getQueryKey(&query)
+	kiteKey, err := k.getEtcdKey(&query)
 	if err != nil {
 		return nil, err
 	}

--- a/go/src/github.com/koding/kite/kontrol/kontrol/main.go
+++ b/go/src/github.com/koding/kite/kontrol/kontrol/main.go
@@ -20,6 +20,7 @@ var (
 	port        = flag.Int("port", 4000, "")
 	tlsCertFile = flag.String("tls-cert", "", "TLS certificate file")
 	tlsKeyFile  = flag.String("tls-key", "", "TLS key file")
+	registerURL = flag.String("register-url", "", "Change self register URL")
 
 	// For self register and initial first key on a machine
 	initial    = flag.Bool("init", false, "create a new kite.key")
@@ -79,6 +80,10 @@ func main() {
 
 	if *machines != "" {
 		k.Machines = strings.Split(*machines, ",")
+	}
+
+	if *registerURL != "" {
+		k.RegisterURL = *registerURL
 	}
 
 	k.Run()

--- a/go/src/github.com/koding/kite/kontrol/kontrol_test.go
+++ b/go/src/github.com/koding/kite/kontrol/kontrol_test.go
@@ -439,7 +439,7 @@ func TestGetQueryKey(t *testing.T) {
 		Username:    "cenk",
 		Environment: "production",
 	}
-	key, err := kon.getQueryKey(q)
+	key, err := GetQueryKey(q)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -453,7 +453,7 @@ func TestGetQueryKey(t *testing.T) {
 		Username: "cenk",
 		Name:     "fs",
 	}
-	key, err = kon.getQueryKey(q)
+	key, err = GetQueryKey(q)
 	if err == nil {
 		t.Errorf("Error is expected")
 	}
@@ -466,7 +466,7 @@ func TestGetQueryKey(t *testing.T) {
 		Environment: "production",
 		Name:        "fs",
 	}
-	key, err = kon.getQueryKey(q)
+	key, err = GetQueryKey(q)
 	if err == nil {
 		t.Errorf("Error is expected")
 	}

--- a/go/src/github.com/koding/kite/kontrol/node/kites.go
+++ b/go/src/github.com/koding/kite/kontrol/node/kites.go
@@ -1,7 +1,8 @@
-package kontrol
+package node
 
 import (
 	"math/rand"
+	"strings"
 
 	"github.com/hashicorp/go-version"
 	"github.com/koding/kite/protocol"
@@ -39,4 +40,20 @@ func (k Kites) Filter(constraint version.Constraints, keyRest string) {
 	}
 
 	k = filtered
+}
+
+func isValid(k *protocol.Kite, c version.Constraints, keyRest string) bool {
+	// Check the version constraint.
+	v, _ := version.NewVersion(k.Version)
+	if !c.Check(v) {
+		return false
+	}
+
+	// Check the fields after version field.
+	kiteKeyAfterVersion := "/" + strings.TrimRight(k.Region+"/"+k.Hostname+"/"+k.ID, "/")
+	if !strings.HasPrefix(kiteKeyAfterVersion, keyRest) {
+		return false
+	}
+
+	return true
 }

--- a/go/src/github.com/koding/kite/kontrol/protocol/protocol.go
+++ b/go/src/github.com/koding/kite/kontrol/protocol/protocol.go
@@ -1,0 +1,6 @@
+package protocol
+
+// RegisterValue is the type of the value that is saved to etcd.
+type RegisterValue struct {
+	URL string `json:"url"`
+}

--- a/go/src/github.com/koding/kite/kontrol/storage.go
+++ b/go/src/github.com/koding/kite/kontrol/storage.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/coreos/go-etcd/etcd"
 	"github.com/koding/kite"
+	"github.com/koding/kite/kontrol/node"
 )
 
 // Storage is an interface to a kite storage.
 type Storage interface {
-	Get(key string) (*Node, error)
+	Get(key string) (*node.Node, error)
 	Set(key, value string) error
 	Delete(key string) error
 	Watch(key string, index uint64) (*Watcher, error)
@@ -81,11 +82,11 @@ func (e *Etcd) Watch(key string, index uint64) (*Watcher, error) {
 	}, nil
 }
 
-func (e *Etcd) Get(key string) (*Node, error) {
+func (e *Etcd) Get(key string) (*node.Node, error) {
 	resp, err := e.client.Get(key, false, true)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewNode(resp.Node), nil
+	return node.New(resp.Node), nil
 }

--- a/go/src/github.com/koding/kite/kontrol/watcher.go
+++ b/go/src/github.com/koding/kite/kontrol/watcher.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/koding/kite"
 	"github.com/koding/kite/dnode"
+	"github.com/koding/kite/kontrol/node"
 	"github.com/koding/kite/protocol"
 )
 
@@ -108,7 +109,7 @@ func (k *Kontrol) watchAndSendKiteEvents(
 					continue
 				}
 
-				otherKite, err := NewNode(etcdEvent.Node).Kite()
+				otherKite, err := node.New(etcdEvent.Node).Kite()
 				if err != nil {
 					continue
 				}
@@ -129,7 +130,7 @@ func (k *Kontrol) watchAndSendKiteEvents(
 			// Delete happens when we detect that otherKite is disconnected.
 			// Expire happens when we don't get heartbeat from otherKite.
 			case "delete", "expire":
-				otherKite, err := NewNode(etcdEvent.Node).KiteFromKey()
+				otherKite, err := node.New(etcdEvent.Node).KiteFromKey()
 				if err != nil {
 					continue
 				}

--- a/go/src/github.com/koding/kite/kontrolclient.go
+++ b/go/src/github.com/koding/kite/kontrolclient.go
@@ -26,6 +26,7 @@ var ErrNoKitesAvailable = errors.New("no kites availabile")
 // kontrolClient is a kite for registering and querying Kites from Kontrol.
 type kontrolClient struct {
 	*Client
+	sync.Mutex // protects Client
 
 	// used for synchronizing methods that needs to be called after
 	// successful connection or/and registiration to kontrol.
@@ -77,7 +78,10 @@ func (k *Kite) SetupKontrolClient() error {
 		Key:  k.Config.KiteKey,
 	}
 
+	k.kontrol.Lock()
 	k.kontrol.Client = client
+	k.kontrol.Unlock()
+
 	k.kontrol.watchers = list.New()
 
 	k.kontrol.OnConnect(func() {

--- a/go/src/github.com/koding/kite/server.go
+++ b/go/src/github.com/koding/kite/server.go
@@ -40,9 +40,11 @@ func (k *Kite) Run() {
 func (k *Kite) Close() {
 	k.Log.Info("Closing kite...")
 
+	k.kontrol.Lock()
 	if k.kontrol != nil && k.kontrol.Client != nil {
 		k.kontrol.Close()
 	}
+	k.kontrol.Unlock()
 
 	if k.listener != nil {
 		k.listener.Close()

--- a/go/src/koding/kites/kloud/deploy.go
+++ b/go/src/koding/kites/kloud/deploy.go
@@ -27,6 +27,7 @@ type KodingDeploy struct {
 	KontrolPublicKey  string
 	KontrolPrivateKey string
 	KontrolURL        string
+	DiscoveryURL      string
 
 	Bucket *Bucket
 }

--- a/go/src/koding/kites/kloud/main.go
+++ b/go/src/koding/kites/kloud/main.go
@@ -149,6 +149,10 @@ func newKite() *kite.Kite {
 		Bucket:            newBucket("koding-kites", klientFolder),
 	}
 
+	if *flagDiscovery {
+		deployer.DiscoveryURL = etcd.DefaultDiscoveryURL
+	}
+
 	kld := kloud.NewKloud()
 	kld.Storage = kodingProvider
 	kld.Log = newLogger("kloud")

--- a/go/src/koding/kites/kloud/main.go
+++ b/go/src/koding/kites/kloud/main.go
@@ -266,5 +266,8 @@ func kontrolURL(k *kite.Kite) string {
 		kontrolURL = u.String()
 	}
 
+	// we are going to use our final url for kontrol queries and registering
+	k.Config.KontrolURL = kontrolURL
+
 	return kontrolURL
 }

--- a/go/src/koding/kites/kloud/signer.go
+++ b/go/src/koding/kites/kloud/signer.go
@@ -29,12 +29,13 @@ func (k *KodingDeploy) createKey(username, kiteId string) (string, error) {
 	token := jwt.New(jwt.GetSigningMethod("RS256"))
 
 	token.Claims = map[string]interface{}{
-		"iss":        "koding",                              // Issuer, should be the same username as kontrol
-		"sub":        username,                              // Subject
-		"iat":        time.Now().UTC().Unix(),               // Issued At
-		"jti":        kiteId,                                // JWT ID
-		"kontrolURL": k.KontrolURL,                          // Kontrol URL
-		"kontrolKey": strings.TrimSpace(k.KontrolPublicKey), // Public key of kontrol
+		"iss":         "koding",                              // Issuer, should be the same username as kontrol
+		"sub":         username,                              // Subject
+		"iat":         time.Now().UTC().Unix(),               // Issued At
+		"jti":         kiteId,                                // JWT ID
+		"discoverURL": k.DiscoveryURL,                        // Use discovery to search fo a Kontrol URL
+		"kontrolURL":  k.KontrolURL,                          // Kontrol URL
+		"kontrolKey":  strings.TrimSpace(k.KontrolPublicKey), // Public key of kontrol
 	}
 
 	return token.SignedString([]byte(k.KontrolPrivateKey))

--- a/go/src/koding/kites/kontrol/kontrol.go
+++ b/go/src/koding/kites/kontrol/kontrol.go
@@ -17,10 +17,11 @@ import (
 const version = "0.0.6"
 
 var (
-	flagProfile  = flag.String("c", "", "Configuration profile")
-	flagRegion   = flag.String("r", "", "Region")
-	flagMachines = flag.String("m", "", "Machines (comma seperated)")
-	flagPort     = flag.Int("port", 4000, "Port number of kontrol server")
+	flagProfile     = flag.String("c", "", "Configuration profile")
+	flagRegion      = flag.String("r", "", "Region")
+	flagMachines    = flag.String("m", "", "Machines (comma seperated)")
+	flagPort        = flag.Int("port", 4000, "Port number of kontrol server")
+	flagRegisterURL = flag.String("register-url", "", "Change self register URL")
 )
 
 func main() {
@@ -59,6 +60,10 @@ func main() {
 
 	kon := kontrol.New(kiteConf, version, string(publicKey), string(privateKey))
 	kon.Machines = machines
+
+	if *flagRegisterURL != "" {
+		kon.RegisterURL = *flagRegisterURL
+	}
 
 	kon.AddAuthenticator("sessionID", authenticateFromSessionID)
 	kon.MachineAuthenticate = authenticateFromKodingPassword

--- a/go/src/koding/tools/etcd/etcd.go
+++ b/go/src/koding/tools/etcd/etcd.go
@@ -1,0 +1,68 @@
+package etcd
+
+import (
+	"errors"
+	"log"
+	"os"
+
+	"github.com/coreos/go-etcd/etcd"
+	"github.com/koding/kite/kontrol"
+	"github.com/koding/kite/kontrol/node"
+	"github.com/koding/kite/protocol"
+)
+
+var (
+	DefaultDiscoveryURL = "http://discovery.koding.io"
+
+	ErrNotFound = errors.New("no kontrol kites found")
+)
+
+// Kontrol defines a single Kontrol entity with URL stored in etcd cluster.
+type Kontrol struct {
+	Kite protocol.Kite
+	URL  string
+}
+
+// GetKontrols returns a list of kontrol URLs from a set of etcd instances
+// behind a load balancer.
+func Kontrols(query *protocol.KontrolQuery) ([]*Kontrol, error) {
+	client := etcd.NewClient([]string{DefaultDiscoveryURL})
+
+	// Set the logger to see what's going on.
+	etcd.SetLogger(log.New(os.Stderr, "etcd-discovery ", log.LstdFlags))
+
+	// STRONG_CONSISTENCY doesn't play good with AMAZON ELB
+	client.SetConsistency(etcd.WEAK_CONSISTENCY)
+
+	etcdKey, err := kontrol.GetQueryKey(query)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Get("/kites"+etcdKey, false, true)
+	if err != nil {
+		return nil, err
+	}
+
+	node := node.New(resp.Node)
+
+	kites, err := node.Kites()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(kites) == 0 {
+		return nil, ErrNotFound
+	}
+
+	var kontrols []*Kontrol = make([]*Kontrol, len(kites))
+
+	for i, kite := range kites {
+		kontrols[i] = &Kontrol{
+			Kite: kite.Kite,
+			URL:  kite.URL,
+		}
+	}
+
+	return kontrols, nil
+}

--- a/go/src/koding/tools/etcd/etcd.go
+++ b/go/src/koding/tools/etcd/etcd.go
@@ -2,8 +2,6 @@ package etcd
 
 import (
 	"errors"
-	"log"
-	"os"
 
 	"github.com/coreos/go-etcd/etcd"
 	"github.com/koding/kite/kontrol"
@@ -29,7 +27,7 @@ func Kontrols(query *protocol.KontrolQuery) ([]*Kontrol, error) {
 	client := etcd.NewClient([]string{DefaultDiscoveryURL})
 
 	// Set the logger to see what's going on.
-	etcd.SetLogger(log.New(os.Stderr, "etcd-discovery ", log.LstdFlags))
+	// etcd.SetLogger(log.New(os.Stderr, "etcd-discovery ", log.LstdFlags))
 
 	// STRONG_CONSISTENCY doesn't play good with AMAZON ELB
 	client.SetConsistency(etcd.WEAK_CONSISTENCY)


### PR DESCRIPTION
This PR gives us a new Go package primitive that allows us to search for kontrol instances connected to a central etcd (https://github.com/coreos/etcd) cluster behind a single domain (http://discovery.koding.io). One can use this function to connect to a different kontrol than what's written in the `kite.key`. Example usage of this new package is:

``` go
query := &protocol.KontrolQuery{
    Username:    "koding",
    Environment: "production",
}

kontrols, err := etcd.Kontrols(query)
if err != nil {
    log.Fatalln(err)
}

// kontrols contains the URL and full path fields
```

After picking up a URL, the client just need to do:

``` go
k := kite.New("example-kite", "1.0.0")
k.Config.KontrolURL = kontrols[0].URL
```

Now this `example-kite` is going to connect to given kontrol instead of the one from `kite.key`. Note that it's the duty of the client to connect to an authorized kontrol. Otherwise the public key from the key might not match the kontrol's private key which would cause an authentication problem.

This new package is helpful if there is a cluster of distributed kontrols with the same public/private key pairs but different URL's  (say http://foo.koding.com/kontrol, http://bar.koding.com/kontrol, etc..) Here it's not helpful if we have one single `kontrolURL` field in the `kite.key`. 

This package is going to be merged eventually into koding/kite once we know how it works quite well in production. An idea would be having a new field called `kontrolDiscovery` inside kite.key with a discovery endpoint url. Than kites would search from the discovery before connecting to kontrol (the procedure above).

Update:
Kloud now searches via discovery endpoint if started with the `-discovery` flag. After finding a production kontrol it connects to it and registers himself. During a machine creation it also embeds the discovery url (if given) to the `Klient` kite's machine. Now when a `Klient` starts on a remote machine it goes and searches for a kontrol via this discovery endpoint (just like kloud). 
