### PR TITLE
EmailNotifier: Clicking unsubscribe from daily email gives wrong message [fixes #76581992]

### DIFF
--- a/go/src/socialapi/Makefile
+++ b/go/src/socialapi/Makefile
@@ -158,6 +158,8 @@ testapi:
 	@./models.test $(DBG) $(METRICS) -c $(CONFIG)
 	@rm ./models.test
 
+	@go test config/*.go $(DBG)
+
 	@echo "$(OK_COLOR)--> api tests... $(NO_COLOR)"
 	@go test -c workers/algoliaconnector/algoliaconnector/*.go
 	@./algoliaconnector.test -c $(CONFIG)

--- a/go/src/socialapi/config/config.go
+++ b/go/src/socialapi/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -22,7 +21,7 @@ func MustGet() *Config {
 	return conf
 }
 
-func createLoader(path string, flagSet *flag.FlagSet) *multiconfig.DefaultLoader {
+func createLoader(path string) (*multiconfig.DefaultLoader, error) {
 	loaders := []multiconfig.Loader{}
 
 	// Choose what while is passed
@@ -47,7 +46,7 @@ func createLoader(path string, flagSet *flag.FlagSet) *multiconfig.DefaultLoader
 // and tries to open and read it into Config struct
 // If file is not there or file is not given, it panics
 // If the given file is not formatted well, panics
-func MustRead(path string, flagSet *flag.FlagSet) *Config {
+func MustRead(path string) *Config {
 	conf = &Config{}
 
 	m := createLoader(path, flagSet)

--- a/go/src/socialapi/config/config_test.go
+++ b/go/src/socialapi/config/config_test.go
@@ -54,7 +54,7 @@ func TestConfigMustRead(t *testing.T) {
 			err := os.Setenv("SOCIAL_API_HOSTNAME", hostname)
 			So(err, ShouldBeNil)
 			aPath := MustRead(testConfigPath)
-			So(aPath.Uri, ShouldEqual, hostname)
+			So(aPath.Hostname, ShouldEqual, hostname)
 		})
 	})
 }

--- a/go/src/socialapi/tests/private_message_test.go
+++ b/go/src/socialapi/tests/private_message_test.go
@@ -33,7 +33,7 @@ func CreatePrivateMessageUser(nickname string) {
 }
 
 func TestPrivateMesssage(t *testing.T) {
-	mm := config.MustRead(*flagConfFile, nil).Mongo
+	mm := config.MustRead(*flagConfFile).Mongo
 	modelhelper.Initialize(mm)
 	defer modelhelper.Close()
 	CreatePrivateMessageUser("devrim")

--- a/go/src/socialapi/workers/common/runner/runner.go
+++ b/go/src/socialapi/workers/common/runner/runner.go
@@ -102,7 +102,7 @@ func (r *Runner) InitWithConfigFile(configFile string) error {
 	// r.FlagSet.Parse(os.Args[1:])
 	configFile = *flagConfFile
 
-	r.Conf = config.MustRead(configFile, r.FlagSet)
+	r.Conf = config.MustRead(configFile)
 
 	r.Conf.Debug = *flagDebug
 

--- a/go/src/socialapi/workers/emailnotifier/models/templateparser.go
+++ b/go/src/socialapi/workers/emailnotifier/models/templateparser.go
@@ -144,6 +144,7 @@ func (tp *TemplateParser) buildMailContent(contentType string, currentDate strin
 		CurrentDate: currentDate,
 		Unsubscribe: &UnsubscribeContent{
 			Token:       tp.UserContact.Token,
+			ShowLink:    contentType != "daily", // do not show link for daily emails
 			ContentType: contentType,
 			Recipient:   url.QueryEscape(tp.UserContact.Email),
 		},

--- a/go/src/socialapi/workers/emailnotifier/models/unsubscribecontent.go
+++ b/go/src/socialapi/workers/emailnotifier/models/unsubscribecontent.go
@@ -3,5 +3,6 @@ package models
 type UnsubscribeContent struct {
 	Token       string
 	ContentType string
+	ShowLink    bool
 	Recipient   string
 }

--- a/go/src/socialapi/workers/emailnotifier/templates/unsubscribe.tmpl
+++ b/go/src/socialapi/workers/emailnotifier/templates/unsubscribe.tmpl
@@ -1,3 +1,6 @@
 {{define "unsubscribe"}}
-Unsubscribe from <a href="{{.Uri}}/Unsubscribe/{{.Unsubscribe.Token}}/{{.Unsubscribe.Recipient}}">{{.Unsubscribe.ContentType}}</a> notifications / Unsubscribe from <a href="{{.Uri}}/Unsubscribe/{{.Unsubscribe.Token}}/{{.Unsubscribe.Recipient}}/all">all</a> emails from Koding.
+{{if .Unsubscribe.ShowLink }}
+Unsubscribe from <a href="{{.Uri}}/Unsubscribe/{{.Unsubscribe.Token}}/{{.Unsubscribe.Recipient}}">{{.Unsubscribe.ContentType}}</a> notifications /
+{{end}}
+Unsubscribe from <a href="{{.Uri}}/Unsubscribe/{{.Unsubscribe.Token}}/{{.Unsubscribe.Recipient}}/all">all</a> emails from Koding.
 {{end}}


### PR DESCRIPTION
In this PR I have changed more than the <a href="https://www.pivotaltracker.com/story/show/76581992">bug</a> asks.

Email notification settings was always confusing. This is the old one: http://note.io/1ouyARk
The problem here is when we disable daily digest e-mails, its behavior was to send emails instantly. Also for fully disabling email notifications, you had to disable global notifications. 

Now i have changed it with one select box. So confusions are (hopefully) gone now:
http://note.io/1pNPZ5H
http://note.io/1pNQmNr
http://note.io/1ouzltu

Open for suggestions about behavior, styling and content. 

About the bug, i have fully removed daily notification unsubscribe option from emails. If we receive a daily email its footer is like this: http://note.io/1pNOGnf

The reason is I do not know what it means to unsubscribe from daily emails. Is that means send me instant emails, or I no longer want to receive emails. So instead of another confusing implementation I just removed it. :)
