### PR TITLE
ui: set initial line-height of loader element [fixes #76425910]

### DIFF
--- a/client/Main/styl/resurrection.commons.styl
+++ b/client/Main/styl/resurrection.commons.styl
@@ -542,6 +542,7 @@ button.app-settings-menu
 
   .kdloader
     size               auto, auto
+    line-height        initial
     vendor             transform, translateX(-50%) translateY(-50%)
 
 


### PR DESCRIPTION
On a block container element whose content is composed of inline-level elements, 'line-height' specifies the minimal height of line boxes within the element.

http://www.w3.org/wiki/CSS/Properties/line-height
