### PR TITLE
login: fix handling of password reset routing [fixes #76940432]

### DIFF
--- a/client/Login/routes.coffee
+++ b/client/Login/routes.coffee
@@ -6,8 +6,9 @@ do ->
     else
       KD.getSingleton('router').handleRoute "/Activity"
 
-  handleResetRoute = ({params:{token}})->
-    KD.singleton('appManager').open 'Login', (app) ->
+  handleResetRoute = ({params:{token}}) ->
+    {appManager} = KD.singletons
+    appManager.require 'Login', (app) ->
       if KD.isLoggedIn()
         KD.remote.api.JUser.fetchUser (err, user)->
           if user and user.passwordStatus is "valid"
@@ -15,8 +16,9 @@ do ->
           else
             KD.getSingleton('router').handleRoute "/Account/Profile?focus=password&token=#{token}"
       else
-        app.getView().setCustomDataToForm('reset', {recoveryToken:token})
-        app.getView().animateToForm('reset')
+        appManager.open 'Login', ->
+          app.getView().setCustomDataToForm('reset', {recoveryToken:token})
+          app.getView().animateToForm('reset')
 
   handleVerifyRoute = ({params:{token}})->
     router = KD.getSingleton 'router'


### PR DESCRIPTION
If user is logged in redirect to account settings. Otherwise, show password reset form in `Login` app.
