### PR TITLE
Client: fix confusing follow/unfollow button states [fixes #75486014]

### DIFF
--- a/client/Main/styl/resurrection.sidebar.styl
+++ b/client/Main/styl/resurrection.sidebar.styl
@@ -237,13 +237,11 @@ resurrection.styl
       padding       0
       borderBox()
       &:hover
-        border-color    transparent
-        bg              color #777
+        border          none
         .icon
           r-sprite      activity 'check-gray'
 
       .icon
-        r-sprite        activity 'check-gray'
         margin          0 6px 0 0
         padding         0
         fr()
@@ -257,6 +255,11 @@ resurrection.styl
 
         .icon
           r-sprite      activity 'check-gray'
+
+        &:hover
+          border        1px solid #b1b1b1
+          .icon
+            display     none
 
   .kdlistitemview-sidebar-item.selected
     background          #15171A
@@ -279,15 +282,14 @@ resurrection.styl
       &.follow:before
         color           #d1efdf
 
-      .icon
-        r-sprite      activity 'check-gray'
-
       &.following
         bg              color transparent
         border-color    transparent
 
-        .icon
-          r-sprite      activity 'check-gray'
+        &:hover
+          border          1px solid #b1b1b1
+          .icon
+            display       none
 
   .conversations
   .messages


### PR DESCRIPTION
This was merged to activity.styl a week ago, but when moving it to resurrection.sidebar.styl the latest changes were discarded.

See: https://github.com/koding/koding/pull/378
