### PR TITLE
profile: remove avatar upload buttons temporarily

### DIFF
--- a/client/Account/views/username.coffee
+++ b/client/Account/views/username.coffee
@@ -13,6 +13,9 @@ class AccountEditUsername extends JView
 
     @avatar = new AvatarStaticView @getAvatarOptions(), @account
 
+    # TODO Since avatar upload is dependent on oskite
+    # these buttons are not appended to view, until a new
+    # avatar upload implementation
     @uploadAvatarBtn  = new KDButtonView
       icon            : yes
       style           : 'solid medium green'
@@ -276,14 +279,13 @@ class AccountEditUsername extends JView
     """
     <div class='account-avatar-area clearfix'>
       {{> @avatar}}
-      <div class='avatar-buttons'>
-        {{> @uploadAvatarBtn}}
-        {{> @uploadAvatarInput}}
-        {{> @useGravatarBtn}}
-      </div>
-    </div>
+    #   <div class='avatar-buttons'>
+    #     {{> @uploadAvatarBtn}}
+    #     {{> @uploadAvatarInput}}
+    #     {{> @useGravatarBtn}}
+    #   </div>
+    # </div>
     <section>
       {{> @emailForm}}
     </section>
     """
-


### PR DESCRIPTION
Avatar upload buttons are removed till we implement new s3 upload feature

<img src="https://www.evernote.com/shard/s160/sh/956fe086-5e6f-4f3c-bcd6-66c20c43747f/d473b5fadc8258bbf4afbe962a8c0703/res/d7de86e3-b0ad-4714-bb08-ce19607d4a21/skitch.png?resizeSmall&width=832">
