### PR TITLE
InputWidget improvements

### DIFF
--- a/client/Social/Activity/includes.coffee
+++ b/client/Social/Activity/includes.coffee
@@ -72,6 +72,7 @@ module.exports = [
 
   "views/inputview.coffee"
   "views/inputwidget.coffee"
+  "views/inputhelperview.coffee"
   "views/inputeditwidget.coffee"
   "views/settingsview.coffee"
 

--- a/client/Social/Activity/views/inputhelperview.coffee
+++ b/client/Social/Activity/views/inputhelperview.coffee
@@ -1,0 +1,101 @@
+class ActivityInputHelperView extends KDCustomHTMLView
+
+  helpMap      =
+    mysql      :
+      niceName : 'MySQL'
+      tooltip  :
+        title  : 'Open your terminal and type <code>help mysql</code>'
+    phpmyadmin :
+      niceName : 'phpMyAdmin'
+      tooltip  :
+        title  : 'Open your terminal and type <code>help phpmyadmin</code>'
+    "vm size"  :
+      pattern  : 'vm\\ssize|vm\\sconfig'
+      niceName : 'VM config'
+      tooltip  :
+        title  : 'Open your terminal and type <code>help specs</code>'
+    "vm down"  :
+      pattern  : 'vm\\sdown|vm\\snot\\sworking|vm\\sis\\snot\\sworking'
+      niceName : 'non-working VM'
+      tooltip  :
+        title  : 'You can go to your environments and try to restart your VM'
+    help       :
+      niceName : 'Help!!!'
+      tooltip  :
+        title  : "You don't need to type help in your post, just ask your question."
+    wordpress  :
+      niceName : 'WordPress'
+      link     : 'http://learn.koding.com/?s=wordpress'
+
+
+  constructor: (options = {}, data) ->
+
+    options.cssClass  ?= 'help-container hidden'
+    options.partial   ?= 'Need help with:'
+
+    super options, data
+
+    @currentHelperNames = []
+
+
+  getPattern: ->
+    helpKeys = Object.keys helpMap
+    ///#{(helpMap[key].pattern or key for key in helpKeys).join('|')}///gi
+
+
+  checkForCommonQuestions: KD.utils.throttle 200, (val)->
+
+    @hideAllHelpers()
+
+    pattern = @getPattern()
+    match   = pattern.exec val
+    matches = []
+    while match isnt null
+      matches.push match[0] if match
+      match = pattern.exec val
+
+    @addHelper keyword for keyword in matches
+
+
+  addHelper: (val) ->
+
+    @show()
+
+    unless helpMap[val.toLowerCase()]
+      for own key, item of helpMap when item.pattern
+        if ///#{item.pattern}///i.test val
+          val = key
+          break
+
+    return if val in @currentHelperNames
+
+    {niceName, link, tooltip} = helpMap[val.toLowerCase()]
+
+    Klass     = KDCustomHTMLView
+    options   =
+      tagName : 'span'
+      partial : niceName
+
+    if tooltip
+      options.tooltip           = _.extend {}, tooltip
+      options.tooltip.cssClass  = 'activity-helper'
+      options.tooltip.placement = 'bottom'
+
+    if link
+      Klass           = CustomLinkView
+      options.tagName = 'a'
+      options.title   = niceName
+      options.href    = link or '#'
+      options.target  = if link?[0] isnt '/' then '_blank' else ''
+
+    @addSubView new Klass options
+    @currentHelperNames.push val
+
+
+  hideAllHelpers:->
+
+    @hide()
+    @destroySubViews()
+    @currentHelperNames = []
+
+

--- a/client/Social/Activity/views/inputwidget.coffee
+++ b/client/Social/Activity/views/inputwidget.coffee
@@ -2,34 +2,6 @@ class ActivityInputWidget extends KDView
 
   {daisy, dash} = Bongo
 
-  helpMap      =
-    mysql      :
-      niceName : 'MySQL'
-      tooltip  :
-        title  : 'Open your terminal and type <code>help mysql</code>'
-    phpmyadmin :
-      niceName : 'phpMyAdmin'
-      tooltip  :
-        title  : 'Open your terminal and type <code>help phpmyadmin</code>'
-    "vm size"  :
-      pattern  : 'vm\\ssize|vm\\sconfig'
-      niceName : 'VM config'
-      tooltip  :
-        title  : 'Open your terminal and type <code>help specs</code>'
-    "vm down"  :
-      pattern  : 'vm\\sdown|vm\\snot\\sworking|vm\\sis\\snot\\sworking'
-      niceName : 'non-working VM'
-      tooltip  :
-        title  : 'You can go to your environments and try to restart your VM'
-    help       :
-      niceName : 'Help!!!'
-      tooltip  :
-        title  : "You don't need to type help in your post, just ask your question."
-    wordpress  :
-      niceName : 'WordPress'
-      link     : 'http://learn.koding.com/?s=wordpress'
-
-
   constructor: (options = {}, data) ->
     options.cssClass = KD.utils.curry "activity-input-widget", options.cssClass
     super options, data
@@ -64,6 +36,7 @@ class ActivityInputWidget extends KDView
         @bugNotification.hide()
 
     @embedBox = new EmbedBoxWidget delegate: @input, data
+    @helperView   = new ActivityInputHelperView
 
     @submitButton = new KDButtonView
       type        : "submit"
@@ -98,67 +71,12 @@ class ActivityInputWidget extends KDView
       click    : =>
         if not @preview then @showPreview() else @hidePreview()
 
-    @helpContainer = new KDCustomHTMLView
-      cssClass : 'help-container hidden'
-      partial  : 'Need help with:'
-
-    @currentHelperNames = []
 
 
-  checkForCommonQuestions: KD.utils.throttle 200, (val)->
-
-    @hideAllHelpers()
-
-    pattern = ///#{(helpMap[item].pattern or item for item in Object.keys(helpMap)).join('|')}///gi
-    match   = pattern.exec val
-    matches = []
-    while match isnt null
-      matches.push match[0] if match
-      match = pattern.exec val
-
-    @addHelper keyword for keyword in matches
 
 
-  addHelper:(val)->
-
-    @helpContainer.show()
-
-    unless helpMap[val.toLowerCase()]
-      for own key, item of helpMap when item.pattern
-        if ///#{item.pattern}///i.test val
-          val = key
-          break
-
-    return if val in @currentHelperNames
-
-    {niceName, link, tooltip} = helpMap[val.toLowerCase()]
-
-    Klass     = KDCustomHTMLView
-    options   =
-      tagName : 'span'
-      partial : niceName
-
-    if tooltip
-      options.tooltip           = _.extend {}, tooltip
-      options.tooltip.cssClass  = 'activity-helper'
-      options.tooltip.placement = 'bottom'
-
-    if link
-      Klass           = CustomLinkView
-      options.tagName = 'a'
-      options.title   = niceName
-      options.href    = link or '#'
-      options.target  = if link?[0] isnt '/' then '_blank' else ''
-
-    @helpContainer.addSubView new Klass options
-    @currentHelperNames.push val
 
 
-  hideAllHelpers:->
-
-    @helpContainer.hide()
-    @helpContainer.destroySubViews()
-    @currentHelperNames = []
 
 
   submit: (value, timestamp) ->
@@ -344,7 +262,7 @@ class ActivityInputWidget extends KDView
     @addSubView @embedBox
     @addSubView @buttonBar
     @addSubView @bugNotification
-    @addSubView @helpContainer
+    @addSubView @helperView
     @buttonBar.addSubView @submitButton
     @buttonBar.addSubView @previewIcon
     @hide()  unless KD.isLoggedIn()

--- a/client/Social/Activity/views/privatemessage/replyinputwidget.coffee
+++ b/client/Social/Activity/views/privatemessage/replyinputwidget.coffee
@@ -2,13 +2,30 @@ class ReplyInputWidget extends ActivityInputWidget
 
   constructor: (options = {}, data) ->
 
-    options.placeholder    or= ''
-    options.inputViewClass or= ReplyInputView
+    options.placeholder    = ''
+    options.inputViewClass = ReplyInputView
 
     super options, data
+
     @setClass 'reply-input-widget'
 
+
+  initEvents: ->
+    @input.on "Escape", @bound "reset"
+    @input.on "Enter",  @bound "submit"
+    @input.on "keyup", =>
+      @showPreview() if @preview #Updates preview if it exists
+
     @forwardEvent @input, 'Enter'
+
+
+  createSubViews: ->
+    { inputViewClass, defaultValue, placeholder } = @getOptions()
+    data = @getData()
+
+    @input    = new inputViewClass {defaultValue, placeholder}
+    @embedBox = new EmbedBoxWidget delegate: @input, data
+    @icon     = new KDCustomHTMLView tagName : 'figure'
 
 
   lockSubmit: -> @locked = yes


### PR DESCRIPTION
This PR introduces the following:
- Move helper view for activity input to its own class. Reduce distractions in `ActivityInputWidget`
- Move subview initations and event bindings to their own methods, so that subclasses `e.g. ReplyInputWidget` can override to not to use unnecessary views.
- Refactor `ReplyInputWidget` respectively.

ping @sinan 
