### PR TITLE
Activity item improvements [fixes #77356774 #77272532]

### DIFF
--- a/client/Social/Activity/styl/activity.styl
+++ b/client/Social/Activity/styl/activity.styl
@@ -434,17 +434,17 @@ div.kdtooltip.activity-helper
 
 
   &.edit-widget
-    margin            0
-    padding           12px
+    margin            12px 0
 
-    .input-view >div
-      padding         11px
-      border          1px solid #e9e9e9
-      rounded         0
+    .input-view > div
+      padding         5px
+      border          2px solid #e9e9e9
+      rounded         3px
       font-size       14px
       line-height     19px
       color           #4c4c4c
       opacity         .99
+      min-height      inherit
 
 
 span.collapsedtext
@@ -843,12 +843,13 @@ span.collapsedtext
           padding-left    0
 
         div[contenteditable=true]
-          rounded         6px
+          rounded         3px
           background      #fff
           color           #4c4c4c
           line-height     18px
-          padding         10px
+          padding         5px
           shadow          none
+          borderBox()
 
         .cancel-description
           font-size       12px

--- a/client/Social/Activity/styl/activity.styl
+++ b/client/Social/Activity/styl/activity.styl
@@ -497,6 +497,12 @@ span.collapsedtext
   padding-left              56px
   borderBox()
 
+  &.edited article > p:after
+    content       ' (edited)'
+    display       inline
+    font-size     11px
+    color         #ccc
+
   .activity-content-wrapper
     // background              #fff
     // rounded                 6px 6px 0 0
@@ -787,8 +793,8 @@ span.collapsedtext
         &.edited p:after
           content       ' (edited)'
           display       inline
-          font-size     12px
-          color         #999
+          font-size     11px
+          color         #ccc
 
         p
           a

--- a/client/Social/Activity/views/activitylistitem.coffee
+++ b/client/Social/Activity/views/activitylistitem.coffee
@@ -14,6 +14,7 @@ class ActivityListItemView extends KDListItemView
 
     data   = @getData()
     list   = @getDelegate()
+
     origin =
       constructorName : data.account.constructorName
       id              : data.account._id
@@ -73,9 +74,14 @@ class ActivityListItemView extends KDListItemView
     @editWidget = new ActivityEditWidget null, @getData()
     @editWidget.on 'SubmitSucceeded', @bound 'resetEditing'
     @editWidget.input.on 'Escape', @bound 'resetEditing'
+
+    KD.utils.defer @editWidget.bound 'focus'
+
     @editWidgetWrapper.addSubView @editWidget, null, yes
     @editWidgetWrapper.show()
+
     @setClass 'editing'
+    @unsetClass 'edited'
 
 
   resetEditing : ->
@@ -83,6 +89,10 @@ class ActivityListItemView extends KDListItemView
     @editWidget.destroy()
     @editWidgetWrapper.hide()
     @unsetClass 'editing'
+
+    { createdAt, updatedAt } = @getData().meta
+
+    @setClass 'edited'  if updatedAt > createdAt
 
 
   delete: ->
@@ -210,6 +220,10 @@ class ActivityListItemView extends KDListItemView
     JView::viewAppended.call this
 
     @setAnchors()
+
+    { updatedAt, createdAt } = @getData().meta
+
+    @setClass 'edited'  if updatedAt > createdAt
 
     @utils.defer =>
       if @getData().link?.link_url? isnt ''

--- a/client/Social/Activity/views/inputwidget.coffee
+++ b/client/Social/Activity/views/inputwidget.coffee
@@ -158,7 +158,11 @@ class ActivityInputWidget extends KDView
           userMessage: "You are not allowed to edit this post."
         return @showError err, options
 
-      callback()
+      activity.body = body
+      activity.meta.updatedAt = new Date
+      activity.emit 'update'
+
+      callback err, activity
 
       KD.mixpanel "Status update edit, success"
 

--- a/client/Social/Activity/views/settingsview.coffee
+++ b/client/Social/Activity/views/settingsview.coffee
@@ -18,11 +18,11 @@ class ActivitySettingsView extends KDCustomHTMLView
       style          : 'resurrection'
       callback       : (event) => @settings.contextMenu event
 
-    if @getOptions().disableFollow    \
-      and not KD.isMyPost(@getData()) \
-      and not KD.checkFlag('super-admin')
-        @hide()
-        return
+    followDisabled = @getOptions().disableFollow
+    myPost         = KD.isMyPost @getData()
+    iAmAdmin       = KD.checkFlag 'super-admin'
+
+    return @hide()  if followDisabled or (not myPost and not iAmAdmin)
 
     activityController = KD.getSingleton('activityController')
 


### PR DESCRIPTION
This PR improves overall style and functionality of activity items with the main focus on the consistency between comments.
- [x] Add `(edited)` label to posts as well. (it was already implemented in comments)
- [x] Improve the `(edited)` label style for both comments and posts.
- [x] Improve post's editing state input style.
- [x] Fix the posts' setting button showing logic.
### Screenshots

---
#### Before

![before_activity](https://cloud.githubusercontent.com/assets/1783869/4001886/85ec501c-2967-11e4-8b9d-7455ad44365a.jpg)
#### After

![after_activity](https://cloud.githubusercontent.com/assets/1783869/4001897/968b9f90-2967-11e4-83c9-722bcddf6d19.jpg)

ping @sinan @szkl 
