### PR TITLE
Fix wrong isInteracted property for Social Messages [fixes #77298258]

### DIFF
--- a/go/src/socialapi/workers/api/modules/account/account.go
+++ b/go/src/socialapi/workers/api/modules/account/account.go
@@ -37,7 +37,7 @@ func ListChannels(u *url.URL, h http.Header, _ interface{}, c *models.Context) (
 
 func ListPosts(u *url.URL, h http.Header, _ interface{}) (int, http.Header, interface{}, error) {
 	query := request.GetQuery(u)
-	buildMessageQuery := query
+	buildMessageQuery := query.Clone()
 
 	accountId, err := request.GetURIInt64(u, "id")
 	if err != nil {


### PR DESCRIPTION
There was a pointer issue that caused the `isInteracted` objects in `account.go`. This PR fixes that. Thanks @cihangir for help.

ping @canthefason 
