### PR TITLE
Fix realtime edited state updates [fixes #77272532 #77272386]

### DIFF
--- a/client/Main/CommonViews/activitywidgetitem.coffee
+++ b/client/Main/CommonViews/activitywidgetitem.coffee
@@ -11,7 +11,7 @@ class ActivityWidgetItem extends JView
       delegate : @commentBox.commentList
     , data
 
-    @timeAgo = new KDTimeAgoView null, data.meta.createdAt
+    @timeAgo = new KDTimeAgoView null, data.createdAt
 
   createAuthor: ->
     {avatarWidth, avatarHeight} = @getOptions()

--- a/client/Main/socialapicontroller.coffee
+++ b/client/Main/socialapicontroller.coffee
@@ -66,11 +66,6 @@ class SocialApiController extends KDController
         actorsPreview : []
         isInteracted  : no
 
-    m.meta      =
-      createdAt : new Date createdAt
-      deletedAt : new Date deletedAt
-      updatedAt : new Date updatedAt
-
     if payload
       m.link       =
         link_url   : payload.link_url

--- a/client/Main/utils.coffee
+++ b/client/Main/utils.coffee
@@ -753,9 +753,6 @@ utils.extend utils,
       updatedAt        : isoNow
       replies          : []
       repliesCount     : 0
-      meta             :
-        createdAt      : now
-        updatedAt      : now
       interactions     :
         like           :
           isInteracted : no

--- a/client/Social/Activity/AppController.coffee
+++ b/client/Social/Activity/AppController.coffee
@@ -162,6 +162,6 @@ class ActivityAppController extends AppController
       return @emit "activitiesCouldntBeFetched", err  if err
 
       if activities?.length > 0
-        lastOne = activities.last.meta.createdAt
+        lastOne = activities.last.createdAt
         @profileLastTo = (new Date(lastOne)).getTime()
       callback err, activities

--- a/client/Social/Activity/ContentDisplays/ContentDisplayMeta.coffee
+++ b/client/Social/Activity/ContentDisplays/ContentDisplayMeta.coffee
@@ -14,7 +14,7 @@ class ContentDisplayMeta extends KDView
     name = KD.utils.getFullnameFromAccount account, yes
 
     dom = $ """
-      <div>In #{activity.group} by <a href="#">#{name}</a> <time class='timeago' datetime="#{new Date(activity.meta.createdAt).format 'isoUtcDateTime'}"></time></div>
+      <div>In #{activity.group} by <a href="#">#{name}</a> <time class='timeago' datetime="#{activity.createdAt}"></time></div>
     """
     dom.find("time.timeago").timeago()
     dom

--- a/client/Social/Activity/styl/activity.styl
+++ b/client/Social/Activity/styl/activity.styl
@@ -498,8 +498,10 @@ span.collapsedtext
   borderBox()
 
   &.edited article > p:after
+  &.edited article > pre:after
     content       ' (edited)'
     display       inline
+    font-family   openSansFamily
     font-size     11px
     color         #ccc
 

--- a/client/Social/Activity/views/activitylistitem.coffee
+++ b/client/Social/Activity/views/activitylistitem.coffee
@@ -62,7 +62,7 @@ class ActivityListItemView extends KDListItemView
     else
       new KDCustomHTMLView
 
-    @timeAgoView = new KDTimeAgoView {}, @getData().meta.createdAt
+    @timeAgoView = new KDTimeAgoView {}, @getData().createdAt
 
     @editWidgetWrapper = new KDCustomHTMLView
       cssClass         : 'edit-widget-wrapper'
@@ -82,6 +82,7 @@ class ActivityListItemView extends KDListItemView
 
     @setClass 'editing'
     @unsetClass 'edited'
+
 
 
   resetEditing : ->
@@ -221,7 +222,7 @@ class ActivityListItemView extends KDListItemView
 
     @setAnchors()
 
-    { updatedAt, createdAt } = @getData().meta
+    { updatedAt, createdAt } = @getData()
 
     @setClass 'edited'  if updatedAt > createdAt
 
@@ -247,3 +248,4 @@ class ActivityListItemView extends KDListItemView
     </div>
     {{> @commentBox}}
     """
+

--- a/client/Social/Activity/views/comments/inputeditwidget.coffee
+++ b/client/Social/Activity/views/comments/inputeditwidget.coffee
@@ -42,7 +42,6 @@ class CommentInputEditWidget extends CommentInputWidget
       return KD.showError err  if err
 
       data.body = body
-      data.meta.updatedAt = new Date
       data.emit 'update'
 
 

--- a/client/Social/Activity/views/comments/listitemview.coffee
+++ b/client/Social/Activity/views/comments/listitemview.coffee
@@ -10,6 +10,24 @@ class CommentListItemView extends KDListItemView
 
     (KD.singleton 'mainController').on 'AccountChanged', @bound 'addMenu'
 
+    @initDataEvents()
+
+
+  initDataEvents: ->
+
+    data = @getData()
+
+    data.on 'update', @bound 'handleUpdate'
+
+
+  handleUpdate: ->
+
+    { updatedAt, createdAt } = @getData()
+
+    if updatedAt > createdAt
+    then @body.setClass 'edited'
+    else @body.unsetClass 'edited'
+
 
   click: (event) -> KD.utils.showMoreClickHandler event
 
@@ -42,7 +60,6 @@ class CommentListItemView extends KDListItemView
     @replyView?.show()
     @editInput.destroy()
     @body.show()
-    @body.setClass 'edited'  if updatedAt > createdAt
     @editInput.hide()
 
 

--- a/client/Social/Activity/views/comments/listitemview.coffee
+++ b/client/Social/Activity/views/comments/listitemview.coffee
@@ -35,7 +35,7 @@ class CommentListItemView extends KDListItemView
 
   hideEditForm: ->
 
-    {meta: {createdAt, updatedAt}} = @getData()
+    { createdAt, updatedAt } = @getData()
 
     @menuWrapper.show()
     @likeView.show()
@@ -157,7 +157,7 @@ class CommentListItemView extends KDListItemView
 
   # updateTemplate: (force = no) ->
 
-  #   {meta: {createdAt, deletedAt}} = @getData()
+  #   { createdAt, deletedAt } = @getData()
 
   #   if deletedAt > createdAt
   #     {type} = @getOptions()

--- a/client/Social/Activity/views/comments/listviewcontroller.coffee
+++ b/client/Social/Activity/views/comments/listviewcontroller.coffee
@@ -22,7 +22,7 @@ class CommentListViewController extends KDListViewController
 
   instantiateListItems: (items) ->
 
-    super items.sort (a, b) -> a.meta.createdAt - b.meta.createdAt
+    super items.sort (a, b) -> a.createdAt - b.createdAt
 
 
   addItem: (item, index) ->

--- a/client/Social/Activity/views/comments/view.coffee
+++ b/client/Social/Activity/views/comments/view.coffee
@@ -116,7 +116,7 @@ class CommentView extends KDView
 
     {appManager} = KD.singletons
     activity     = @getData()
-    from         = activity.replies[0].meta.createdAt.toISOString()
+    from         = activity.replies.first.createdAt
     limit        = 10
 
     appManager.tell 'Activity', 'listReplies', {activity, from, limit}, (err, replies) =>

--- a/client/Social/Activity/views/inputwidget.coffee
+++ b/client/Social/Activity/views/inputwidget.coffee
@@ -159,7 +159,6 @@ class ActivityInputWidget extends KDView
         return @showError err, options
 
       activity.body = body
-      activity.meta.updatedAt = new Date
       activity.emit 'update'
 
       callback err, activity
@@ -211,19 +210,7 @@ class ActivityInputWidget extends KDView
 
     return unless value = @input.getValue().trim()
 
-    data            =
-      on            : -> return this
-      watch         : -> return this
-      account       : { _id : KD.whoami().getId(), constructorName : "JAccount"}
-      body          : value
-      typeConstant  : 'post'
-      replies       : []
-      interactions  :
-        like        :
-          actorsCount : 0
-          actorsPreview : []
-      meta          :
-        createdAt   : new Date
+    data = KD.utils.generateDummyMessage value
 
     @preview?.destroy()
     @addSubView @preview = new ActivityListItemView cssClass: 'preview', data

--- a/client/Social/Activity/views/messagepane.coffee
+++ b/client/Social/Activity/views/messagepane.coffee
@@ -277,7 +277,7 @@ class MessagePane extends KDTabPaneView
 
     return  unless last
 
-    from         = last.getData().meta.createdAt.toISOString()
+    from         = last.getData().createdAt
 
     @fetch {from}, (err, items = []) =>
       @listController.hideLazyLoader()

--- a/client/Social/Activity/views/privatemessage/pane.coffee
+++ b/client/Social/Activity/views/privatemessage/pane.coffee
@@ -134,7 +134,7 @@ class PrivateMessagePane extends MessagePane
     first         = @listController.getItemsOrdered().first
     return  unless first
 
-    from         = first.getData().meta.createdAt.toISOString()
+    from         = first.getData().createdAt
 
     @fetch {from, limit: 10}, (err, items = []) =>
       @listController.hideLazyLoader()

--- a/client/Social/Apps/Views/appdetailsview.coffee
+++ b/client/Social/Apps/Views/appdetailsview.coffee
@@ -97,7 +97,7 @@ class AppDetailsView extends KDScrollView
 
     {icns, identifier, version, authorNick} = app.manifest
 
-    @updatedTimeAgo = new KDTimeAgoView {}, @getData().meta.createdAt
+    @updatedTimeAgo = new KDTimeAgoView {}, @getData().createdAt
 
     @slideShow = new KDCustomHTMLView
       tagName   : "ul"

--- a/client/Social/Bugs/AppController.coffee
+++ b/client/Social/Bugs/AppController.coffee
@@ -71,6 +71,6 @@ class BugReportController extends AppController
   # # Store first & last cache activity timestamp.
   # extractMessageTimeStamps: (messages)->
   #   return  if messages.length is 0
-  #   from = new Date(messages.last.meta.createdAt).getTime()
-  #   to   = new Date(messages.first.meta.createdAt).getTime()
+  #   from = new Date(messages.last.createdAt).getTime()
+  #   to   = new Date(messages.first.createdAt).getTime()
   #   @setLastTimestamps to, from #from, to

--- a/go/src/github.com/jinzhu/gorm/callback_update.go
+++ b/go/src/github.com/jinzhu/gorm/callback_update.go
@@ -36,7 +36,7 @@ func BeforeUpdate(scope *Scope) {
 func UpdateTimeStampWhenUpdate(scope *Scope) {
 	_, ok := scope.Get("gorm:update_column")
 	if !ok {
-		scope.SetColumn("UpdatedAt", time.Now())
+		scope.SetColumn("UpdatedAt", time.Now().UTC())
 	}
 }
 

--- a/go/src/socialapi/models/channelmessage_bongo.go
+++ b/go/src/socialapi/models/channelmessage_bongo.go
@@ -18,6 +18,7 @@ func (c *ChannelMessage) BeforeCreate() error {
 
 func (c *ChannelMessage) BeforeUpdate() error {
 	c.DeletedAt = ZeroDate()
+	c.UpdatedAt = time.Now().UTC()
 
 	return c.MarkIfExempt()
 }


### PR DESCRIPTION
Fixes several problem.
- [x] Update `channel message` `UpdatedAt` field to return `UTC` time. /cc @cihangir 
- [x] Remove `meta` property to simplify social message. It was confusing to have 2 different properties. And this way since it is in the top level of data object, fields depending on them can be autorendered.
- [x] Add hooks to data object's `update` event at both `ActivityListItemView` and `CommentListItemView` so that only one place can be responsible edited state changes. [Fixes [#77272532](https://www.pivotaltracker.com/story/show/77272532)]
- [x] Show edited state of markdown posts as well. [Fixes [#77272386](https://www.pivotaltracker.com/story/show/77272386)]

ping @sinan 
