### PR TITLE
Changed default avatar url [fixes #76892690]

### DIFF
--- a/client/Main/CommonViews/avatarviews/avatarview.coffee
+++ b/client/Main/CommonViews/avatarviews/avatarview.coffee
@@ -75,7 +75,7 @@ class AvatarView extends LinkView
     # and you need to upload them to koding-cdn/images bucket.
     # Thanks to gravatar to not support svg's, damn.
 
-    defaultAvatarUri = "https://koding-cdn.s3.amazonaws.com/images/default.avatar.#{size}.png"
+    defaultAvatarUri = "https://koding-cdn.s3.amazonaws.com/square-avatars/default.avatar.#{size}.png"
     return "//gravatar.com/avatar/#{profile.hash}?size=#{size}&d=#{defaultAvatarUri}&r=g"
 
   render: ->


### PR DESCRIPTION
@szkl is creating a new folder named 'square-avatars' and upload new avatars there on s3. So avatars on current prod wont be changed.
