### PR TITLE
mongo: remove broken auto_reconnect search param

### DIFF
--- a/workers/auth/lib/auth/bongo.coffee
+++ b/workers/auth/lib/auth/bongo.coffee
@@ -8,7 +8,7 @@ KONFIG = require('koding-config-manager').load("main.#{argv.c}")
 
 {mq, projectRoot, authWorker} = KONFIG
 
-mongo = "mongodb://#{KONFIG.mongo}?auto_reconnect"
+mongo = "mongodb://#{KONFIG.mongo}"
 
 mqOptions = extend {}, mq
 mqOptions.login = authWorker.login if authWorker?.login?

--- a/workers/emailsender/main.coffee
+++ b/workers/emailsender/main.coffee
@@ -12,7 +12,7 @@ template      = require './templates'
   require('koding-config-manager').load("main.#{argv.c}")
 
 if 'string' is typeof mongo
-  mongo = "mongodb://#{mongo}?auto_reconnect"
+  mongo = "mongodb://#{mongo}"
 
 broker = new Broker mq
 


### PR DESCRIPTION
If you pass `?auto_reconnect`, it is the same as passing `auto_reconnect=false`. Don't pass that here and just propagate the value from the config as-is.
