### PR TITLE
optout: a feature to allow users to temporarily opt out of newkoding

### DIFF
--- a/client/Core/KD.extend.coffee
+++ b/client/Core/KD.extend.coffee
@@ -7,6 +7,18 @@
 #   window.WebSocket = null
 
 KD.extend
+  newKodingLaunchDate: do ->
+    d = new Date()
+    d.setUTCFullYear 2014
+    d.setUTCMonth 7
+    d.setUTCDate 30
+    d.setUTCHours 17
+    d.setUTCMinutes 0
+    d
+
+  setVersionCookie: ({ meta:{ createdAt }}) ->
+    if (new Date createdAt) > KD.newKodingLaunchDate
+      Cookies.set 'useNewKoding', 'true'
 
   apiUri       : KD.config.apiUri
   appsUri      : KD.config.appsUri

--- a/client/Core/maincontroller.coffee
+++ b/client/Core/maincontroller.coffee
@@ -145,6 +145,9 @@ class MainController extends KDController
       mainView._logoutAnimation()
       KD.singletons.localSync.removeLocalContents()
 
+      Cookies.expire "useNewKoding"
+      Cookies.expire "useOldKoding"
+
       wc = KD.singleton 'windowController'
       wc.clearUnloadListeners()
 
@@ -219,6 +222,7 @@ class MainController extends KDController
 
     JUser.login credentials, (err, result) =>
       return callback err  if err
+      KD.setVersionCookie result.account
       @swapAccount result, callback
 
   handleFinishRegistration: (formData, callback) ->

--- a/client/Login/AppView.coffee
+++ b/client/Login/AppView.coffee
@@ -431,7 +431,6 @@ class LoginView extends JView
     groupsController.groupChannel?.close()
 
     KD.remote.api.JUser.convert formData, (err, user) =>
-
       form.button.hideLoader()
 
       if err
@@ -440,6 +439,7 @@ class LoginView extends JView
         form.notificationsDisabled = no
         form.emit "SubmitFailed", message
       else
+        KD.setVersionCookie user.account
         {account, newToken} = user
         account ?= KD.whoami()
 

--- a/client/Main/avatararea/avatarareagroupswitcherpopup.coffee
+++ b/client/Main/avatararea/avatarareagroupswitcherpopup.coffee
@@ -132,6 +132,16 @@ class AvatarPopupGroupSwitcher extends AvatarPopup
         router.handleRoute '/Account'
         @hide()
 
+
+    @avatarPopupContent.addSubView new KDCustomHTMLView
+      tagName    : 'a'
+      attributes : href : '/Optout'
+      cssClass   : 'bottom-separator'
+      partial    : 'Use "old" Koding'
+      click      : (event)=>
+        Cookies.set 'useOldKoding', 'true'
+        location.reload()
+
     # @avatarPopupContent.addSubView new KDCustomHTMLView
     #   tagName    : 'a'
     #   partial    : 'Environments'

--- a/client/Main/avatararea/avatarareagroupswitcherpopup.coffee
+++ b/client/Main/avatararea/avatarareagroupswitcherpopup.coffee
@@ -133,14 +133,14 @@ class AvatarPopupGroupSwitcher extends AvatarPopup
         @hide()
 
 
-    @avatarPopupContent.addSubView new KDCustomHTMLView
-      tagName    : 'a'
-      attributes : href : '/Optout'
-      cssClass   : 'bottom-separator'
-      partial    : 'Use "old" Koding'
-      click      : (event)=>
-        Cookies.set 'useOldKoding', 'true'
-        location.reload()
+    # @avatarPopupContent.addSubView new KDCustomHTMLView
+    #   tagName    : 'a'
+    #   attributes : href : '/Optout'
+    #   cssClass   : 'bottom-separator'
+    #   partial    : 'Use "old" Koding'
+    #   click      : (event)=>
+    #     Cookies.set 'useOldKoding', 'true'
+    #     location.reload()
 
     # @avatarPopupContent.addSubView new KDCustomHTMLView
     #   tagName    : 'a'

--- a/servers/lib/server/index.coffee
+++ b/servers/lib/server/index.coffee
@@ -238,6 +238,10 @@ app.post "/:name?/Login", (req, res) ->
       res.cookie 'clientId', response.replacementToken
       res.send 200, 'ok'
 
+app.post '/:name?/Optout', (req, res) ->
+  res.cookie 'useOldKoding', 'true'
+  res.redirect 301, '/'
+
 app.all "/:name?/Logout", (req, res)->
   if req.method is 'POST'
     res.clearCookie 'clientId'

--- a/servers/lib/server/index.coffee
+++ b/servers/lib/server/index.coffee
@@ -224,17 +224,24 @@ app.post "/:name?/Login", (req, res) ->
   { JUser } = koding.models
   { username, password, redirect } = req.body
   { clientId } = req.cookies
-  redirect ?= "/"
-  JUser.login clientId, { username, password }, (err, response) ->
+
+  JUser.login clientId, { username, password }, (err, info) ->
     return res.send 403, err  if err
-    res.cookie 'clientId', response.replacementToken
-    # handle the request as an XHR response:
-    return res.send 200, null if req.xhr
-    # handle the request with an HTTP redirect:
-    res.redirect 301, redirect
+    # implementing a temporary opt-out for new koding:
+    storageOptions =
+      appId   : 'NewKoding'
+      version : '2.0'
+    info.account.fetchOrCreateAppStorage storageOptions, (err, appStorage) ->
+      return res.send 500, "Internal error"  if err
+      if appStorage.bucket.useOldKoding is on
+        res.cookie 'useOldKoding', 'true'
+      res.cookie 'clientId', response.replacementToken
+      res.send 200, 'ok'
 
 app.all "/:name?/Logout", (req, res)->
-  res.clearCookie 'clientId'  if req.method is 'POST'
+  if req.method is 'POST'
+    res.clearCookie 'clientId'
+    res.clearCookie 'useOldKoding'
   res.redirect 301, '/'
 
 app.get "/humans.txt", (req, res)->

--- a/servers/lib/server/index.coffee
+++ b/servers/lib/server/index.coffee
@@ -233,8 +233,6 @@ app.post "/:name?/Login", (req, res) ->
       version : '2.0'
     info.account.fetchOrCreateAppStorage storageOptions, (err, appStorage) ->
       return res.send 500, "Internal error"  if err
-      if appStorage.bucket.useOldKoding is on
-        res.cookie 'useOldKoding', 'true'
       res.cookie 'clientId', response.replacementToken
       res.send 200, 'ok'
 
@@ -246,6 +244,7 @@ app.all "/:name?/Logout", (req, res)->
   if req.method is 'POST'
     res.clearCookie 'clientId'
     res.clearCookie 'useOldKoding'
+    res.clearCookie 'useNewKoding'
   res.redirect 301, '/'
 
 app.get "/humans.txt", (req, res)->

--- a/workers/social/lib/social/models/account.coffee
+++ b/workers/social/lib/social/models/account.coffee
@@ -1025,10 +1025,7 @@ module.exports = class JAccount extends jraphical.Module
             data        : {name}
           rel.save (err)-> callback err, storage
 
-  fetchAppStorage$: secure (client, options, callback)->
-    unless @equals client.connection.delegate
-      return callback "Attempt to access unauthorized application storage"
-
+  fetchOrCreateAppStorage: (options, callback) ->
     {appId, version} = options
     @fetchAppStorage {'data.appId':appId, 'data.version':version}, (err, storage)=>
       if err then callback err
@@ -1050,6 +1047,12 @@ module.exports = class JAccount extends jraphical.Module
             rel.save (err)-> callback err, newStorage
       else
         callback err, storage
+
+  fetchAppStorage$: secure (client, options, callback)->
+    unless @equals client.connection.delegate
+      return callback "Attempt to access unauthorized application storage"
+
+    @fetchOrCreateAppStorage options, callback
 
   fetchUser:(callback)->
     JUser = require './user'


### PR DESCRIPTION
This implements a feature whereby users can temporarily opt out of newkoding.
- [x] A menu item and corresponding endpoint which enables the user to opt out of newkoding

~~\- [ ] A menu item and corresponding endpoint which enables the user to opt back into newkoding (implemented on pull request #580 against master)~~
- [x] A persistent app storage which tracks the user's opt-out preference
- [x] A cookie that tracks the user's preference per-session that nginx can use for routing

~~\- [ ] An nginx rule that will route, based on the presence of a `useOldKoding` cookie, to the old or new backends.~~

A change has been requested, and the new semantics are different. For the time being:
- [x] Temporarily disable the above menu items. (Note: don't merge #580 for now)
- [ ] An nginx rule that will route users based on the presence of a `useNewKoding` cookie to the new koding backend, otherwise, routes users to the old koding backend.
- [x] All new users will get directed to the new koding (they'll get the `useNewKoding` cookie).
- [x] All existing users will be directed to the old koding (they won't get the `useNewKoding` cookie).
