### PR TITLE
Backwards compatible names

### DIFF
--- a/client/Dashboard/views/permissionsform.coffee
+++ b/client/Dashboard/views/permissionsform.coffee
@@ -75,7 +75,7 @@ class PermissionsForm extends KDFormViewWithFields
       "SocialMessage"  : "Social API"
       "JVM"            : "Compute"
       "JGroupBundle"   : "Group Bundles"
-      "JDomain"        : "Domains"
+      "JProposedDomain": "Domains"
       "JProxyFilter"   : "Proxy Filters"
       "JInvitation"    : "Invitations"
       "JStack"         : "Stacks"
@@ -147,7 +147,7 @@ class PermissionsForm extends KDFormViewWithFields
           cascadeHeaderElements roles, roles.length
 
     # set.permissionsByModule is giving all the possible permissions
-    # module is collection name (JComment, JDomain etc..)
+    # module is collection name (JComment, JProposedDomain etc..)
     # var permissions is permission under collection (module)
     # like "edit comments" for JComment
     for own module, permissions of set.permissionsByModule

--- a/client/Environments/views/clonestackmodal.coffee
+++ b/client/Environments/views/clonestackmodal.coffee
@@ -97,7 +97,7 @@ class CloneStackModal extends KDModalView
     @newDomains = []
     isValidated = yes
 
-    KD.remote.api.JDomain.fetchDomains (err, domains) =>
+    KD.remote.api.JProposedDomain.fetchDomains (err, domains) =>
       return @notify "Unable to fetch your domains"  if err
 
       userDomains.push domain.domain  for domain in domains
@@ -135,7 +135,7 @@ class CloneStackModal extends KDModalView
       newName = @newDomains[index]
       domainList.push newName
       @queue.push =>
-        KD.remote.api.JDomain.createDomain { domain: newName, stack: @stack.getId() }, (err, res) =>
+        KD.remote.api.JProposedDomain.createDomain { domain: newName, stack: @stack.getId() }, (err, res) =>
           if err
             @notify "Unable to create your domain"
             @queue.error()

--- a/client/Environments/views/clonestackmodal.coffee
+++ b/client/Environments/views/clonestackmodal.coffee
@@ -182,7 +182,7 @@ class CloneStackModal extends KDModalView
       @destroy()
 
   createStack: (callback = noop) ->
-    # KD.remote.api.JStack.createStack @getOptions().meta, (err, @stack) =>
+    # KD.remote.api.JComputeStack.createStack @getOptions().meta, (err, @stack) =>
     #   return @notify "Failed to create a new stack. Try again later!"  if err
 
     callback()

--- a/client/Environments/views/domains/domaincreateform.coffee
+++ b/client/Environments/views/domains/domaincreateform.coffee
@@ -69,7 +69,7 @@ class DomainCreateForm extends KDCustomHTMLView
 
     @hideError()
 
-    @createJDomain domain, (err, domain)=>
+    @createJProposedDomain domain, (err, domain)=>
       createButton.hideLoader()
       if err
         @showError err.message
@@ -92,7 +92,7 @@ class DomainCreateForm extends KDCustomHTMLView
     domain = Encoder.XSSEncode \
       "#{domain}.#{KD.nick()}.#{KD.config.userSitesDomain}"
 
-    @createJDomain domain, (err, domain)=>
+    @createJProposedDomain domain, (err, domain)=>
       createButton.hideLoader()
       return @handleDomainCreationError err  if err
 
@@ -108,13 +108,13 @@ class DomainCreateForm extends KDCustomHTMLView
       else
         @showError err.message or "An unknown error occured. Please try again later.", @subdomainForm
 
-  createJDomain:(domain, callback) ->
+  createJProposedDomain:(domain, callback) ->
 
     {stack} = @getData()
     stack   = stack?._id
 
-    { JDomain } = KD.remote.api
-    JDomain.createDomain { domain, stack }, callback
+    { JProposedDomain } = KD.remote.api
+    JProposedDomain.createDomain { domain, stack }, callback
 
   showSuccess:(domain, view = @subdomainForm) ->
 

--- a/client/Environments/views/environmentsmainscene.coffee
+++ b/client/Environments/views/environmentsmainscene.coffee
@@ -37,7 +37,7 @@ class EnvironmentsMainScene extends KDView
 
   createNewStack: (meta, modal)->
 
-    KD.remote.api.JStack.create meta, (err, stack)=>
+    KD.remote.api.JComputeStack.create meta, (err, stack)=>
 
       title = "Failed to create a new stack. Try again later!"
       return new KDNotificationView { title }  if err?

--- a/client/Environments/views/scene/environmentdomaincontainer.coffee
+++ b/client/Environments/views/scene/environmentdomaincontainer.coffee
@@ -4,7 +4,7 @@ class EnvironmentDomainContainer extends EnvironmentContainer
 
   #   new Promise (resolve, reject)->
 
-  #     KD.remote.api.JDomain.fetchDomains (err, domains)->
+  #     KD.remote.api.JProposedDomain.fetchDomains (err, domains)->
   #       if err or not domains or domains.length is 0
   #         warn "Failed to fetch domains", err  if err
   #         return resolve []

--- a/client/Environments/views/scene/environmentsceneview.coffee
+++ b/client/Environments/views/scene/environmentsceneview.coffee
@@ -40,7 +40,7 @@ class EnvironmentScene extends KDDiaScene
     {domain, machine, rule, extra} = items
 
     if domain and machine
-      jDomain   = domain.dia.getData().domain # JDomain
+      jDomain   = domain.dia.getData().domain # JProposedDomain
       machineId = machine.dia.getData()._id   # JMachine._id
       jDomain.unbindMachine machineId, (err)->
         return KD.showError err  if err
@@ -76,7 +76,7 @@ class EnvironmentScene extends KDDiaScene
     #       title : "A domain name can only be bound to one machine."
 
     if domain and machine
-      jDomain   = domain.dia.getData().domain # JDomain
+      jDomain   = domain.dia.getData().domain # JProposedDomain
       machineId = machine.dia.getData()._id   # JMachine._id
       jDomain.bindMachine machineId, (err)->
         return  if KD.showError err

--- a/client/Main/providers/computecontroller.coffee
+++ b/client/Main/providers/computecontroller.coffee
@@ -43,7 +43,7 @@ class ComputeController extends KDController
 
       return  if (queue.push callback) > 1
 
-      KD.remote.api.JStack.some {}, (err, stacks = [])=>
+      KD.remote.api.JComputeStack.some {}, (err, stacks = [])=>
 
         if err?
           cb err  for cb in queue

--- a/docs/Environments.md
+++ b/docs/Environments.md
@@ -78,7 +78,7 @@ explanation of each part below:
     In the Koding Backend (social worker) we have following models in DB:
 
 
-      - **JStack**
+      - **JComputeStack**
 
         Stack model, which is a packed storage for followings:
 
@@ -93,7 +93,7 @@ explanation of each part below:
 
       - **JStackTemplate**
 
-        It's the template version of `JStack`, basically its using as data
+        It's the template version of `JComputeStack`, basically its using as data
         source to create new stacks. It has one extra field (`connections`) to
         keep track relations between domains with machine, rules with domains
         etc.

--- a/docs/Environments.md
+++ b/docs/Environments.md
@@ -83,7 +83,7 @@ explanation of each part below:
         Stack model, which is a packed storage for followings:
 
         - Rules (WIP)
-        - Domains  -> `ObjectIDs` of `JDomain`s
+        - Domains  -> `ObjectIDs` of `JProposedDomain`s
         - Machines -> `ObjectIDs` of `JMachine`s
         - Extras (WIP)
         - and the `configuration` which is shared with every member of this

--- a/migrate/migrate-user-domains.js
+++ b/migrate/migrate-user-domains.js
@@ -29,7 +29,7 @@ db.jVMs.find().forEach(function(vm) {
       var domainRelCount, relSelector;
 
       relSelector = {
-        targetName: "JDomain",
+        targetName: "JProposedDomain",
         targetId: domain._id,
         sourceName: "JAccount",
         sourceId: rel.targetId,

--- a/workers/guestcleaner/lib/guestcleaner/guestcleanerwoker.coffee
+++ b/workers/guestcleaner/lib/guestcleaner/guestcleanerwoker.coffee
@@ -7,7 +7,7 @@ module.exports = class GuestCleanerWorker
   {Relationship} = jraphical
   constructor: (@bongo, @options = {}) ->
 
-  whitlistedModels = ["JSession", "JUser", "JVM", "JDomain", "JAppStorage", "JName"]
+  whitlistedModels = ["JSession", "JUser", "JVM", "JProposedDomain", "JAppStorage", "JName"]
 
   collectDataAndRelationships:(relationships, callback)->
     toBeDeletedData = {}

--- a/workers/social/lib/social/models/account.coffee
+++ b/workers/social/lib/social/models/account.coffee
@@ -326,7 +326,7 @@ module.exports = class JAccount extends jraphical.Module
 
       domain        :
         as          : 'owner'
-        targetType  : 'JDomain'
+        targetType  : 'JProposedDomain'
 
       proxyFilter   :
         as          : 'owner'

--- a/workers/social/lib/social/models/computeproviders/computeprovider.coffee
+++ b/workers/social/lib/social/models/computeproviders/computeprovider.coffee
@@ -17,7 +17,7 @@ module.exports = class ComputeProvider extends Base
   {permit} = require '../group/permissionset'
 
   JMachine = require './machine'
-  JDomain  = require '../domain'
+  JProposedDomain  = require '../domain'
 
   @share()
 
@@ -228,7 +228,7 @@ module.exports = class ComputeProvider extends Base
 
           queue.push ->
             domain = domainInfo.domain.replace "${username}", user.username
-            JDomain.createDomain {
+            JProposedDomain.createDomain {
               domain, account,
               stack : stack._id
               group : group.slug

--- a/workers/social/lib/social/models/computeproviders/computeprovider.coffee
+++ b/workers/social/lib/social/models/computeproviders/computeprovider.coffee
@@ -119,8 +119,8 @@ module.exports = class ComputeProvider extends Base
     { r: { account } } = client
     { stack } = options
 
-    JStack = require '../stack'
-    JStack.getStack account, stack, (err, revivedStack)=>
+    JComputeStack = require '../stack'
+    JComputeStack.getStack account, stack, (err, revivedStack)=>
       return callback err  if err?
       return callback new KodingError "No such stack"  unless revivedStack
 
@@ -194,8 +194,8 @@ module.exports = class ComputeProvider extends Base
 
       { account, user, group, template } = res
 
-      JStack = require '../stack'
-      JStack.create {
+      JComputeStack = require '../stack'
+      JComputeStack.create {
         title       : template.title
         config      : template.config
         baseStackId : template._id

--- a/workers/social/lib/social/models/domain.coffee
+++ b/workers/social/lib/social/models/domain.coffee
@@ -204,8 +204,8 @@ module.exports = class JProposedDomain extends jraphical.Module
     domainData = { proposedDomain: domain, group }
     domainData.hostnameAlias = hostnameAlias  if hostnameAlias?
 
-    JStack = require './stack'
-    JStack.getStack account, stack, (err, stack)=>
+    JComputeStack = require './stack'
+    JComputeStack.getStack account, stack, (err, stack)=>
       return callback err  if err?
 
       domain = new JProposedDomain domainData

--- a/workers/social/lib/social/models/domain.coffee
+++ b/workers/social/lib/social/models/domain.coffee
@@ -6,7 +6,7 @@
 KONFIG   = require('koding-config-manager').load("main.#{argv.c}")
 
 jraphical = require 'jraphical'
-module.exports = class JDomain extends jraphical.Module
+module.exports = class JProposedDomain extends jraphical.Module
 
   DomainManager      = require 'domainer'
   Validators         = require './group/validators'
@@ -208,7 +208,7 @@ module.exports = class JDomain extends jraphical.Module
     JStack.getStack account, stack, (err, stack)=>
       return callback err  if err?
 
-      domain = new JDomain domainData
+      domain = new JProposedDomain domainData
       domain.save (err)->
         return callback err  if err
 
@@ -221,7 +221,7 @@ module.exports = class JDomain extends jraphical.Module
 
   checkExistence = (domain, callback)->
 
-    JDomain.count { domain }, (err, count)->
+    JProposedDomain.count { domain }, (err, count)->
 
       return callback err  if err
 
@@ -255,7 +255,7 @@ module.exports = class JDomain extends jraphical.Module
       resolveDomain domain, (err)->
         return callback err  if err
 
-        JDomain.createDomain {
+        JProposedDomain.createDomain {
           domain, group, stack
           account: delegate
         }, callback
@@ -269,7 +269,7 @@ module.exports = class JDomain extends jraphical.Module
 
     domains.forEach (domain) ->
 
-      JDomain.createDomain {
+      JProposedDomain.createDomain {
         domain, account, group, stack
         hostnameAlias : [ hostnameAlias ]
       }, (err, domain)->

--- a/workers/social/lib/social/models/proxy/restriction.coffee
+++ b/workers/social/lib/social/models/proxy/restriction.coffee
@@ -3,7 +3,7 @@ KodingError    = require '../../error'
 module.exports = class JProxyRestriction extends jraphical.Module
 
   {secure, signature, ObjectId} = require 'bongo'
-  JDomain      = require "../domain"
+  JProposedDomain = require "../domain"
   JProxyFilter = require "./index"
 
   @share()
@@ -44,7 +44,7 @@ module.exports = class JProxyRestriction extends jraphical.Module
     if not domainName and not filterId
       return callback new KodingError { message: "Missing arguments" }
 
-    JDomain.fetchDomains client, (err, domains) ->
+    JProposedDomain.fetchDomains client, (err, domains) ->
       userDomains = (domain.domain for domain in domains)
       if userDomains.indexOf(domainName) is -1
         return callback new KodingError { message: "Access Denied" }

--- a/workers/social/lib/social/models/stack.coffee
+++ b/workers/social/lib/social/models/stack.coffee
@@ -192,7 +192,7 @@ module.exports = class JStack extends jraphical.Module
 
   revive: (callback)->
 
-    JDomain  = require "./domain"
+    JProposedDomain = require "./domain"
     JMachine = require "./computeproviders/machine"
 
     queue    = []
@@ -206,7 +206,7 @@ module.exports = class JStack extends jraphical.Module
         queue.next()
 
     (@domains ? []).forEach (domainId)->
-      queue.push -> JDomain.one _id: domainId, (err, domain)->
+      queue.push -> JProposedDomain.one _id: domainId, (err, domain)->
         if not err? and domain
           domains.push domain
         queue.next()
@@ -233,13 +233,13 @@ module.exports = class JStack extends jraphical.Module
       # TODO Implement delete methods.
       @update $set: status: "Terminating"
 
-      JDomain  = require "./domain"
+      JProposedDomain  = require "./domain"
       JMachine = require "./computeproviders/machine"
 
       { delegate } = client.connection
 
       @domains?.forEach (_id)->
-        JDomain.one {_id}, (err, domain)->
+        JProposedDomain.one {_id}, (err, domain)->
           if not err? and domain?
             domain.remove (err)->
               if err then console.error \

--- a/workers/social/lib/social/models/stack.coffee
+++ b/workers/social/lib/social/models/stack.coffee
@@ -1,5 +1,5 @@
 jraphical = require 'jraphical'
-module.exports = class JStack extends jraphical.Module
+module.exports = class JComputeStack extends jraphical.Module
 
   KodingError        = require '../error'
 
@@ -93,7 +93,7 @@ module.exports = class JStack extends jraphical.Module
 
   @getStack = (account, _id, callback)->
 
-    JStack.one { _id, originId : account.getId() }, (err, stackObj)->
+    JComputeStack.one { _id, originId : account.getId() }, (err, stackObj)->
       if err? or not stackObj?
         return callback new KodingError "A valid stack id required"
       callback null, stackObj
@@ -110,7 +110,7 @@ module.exports = class JStack extends jraphical.Module
 
 
   ###*
-   * JStack::create wrapper for client requests
+   * JComputeStack::create wrapper for client requests
    * @param  {Mixed}    client
    * @param  {Object}   data
    * @param  {Function} callback
@@ -122,11 +122,11 @@ module.exports = class JStack extends jraphical.Module
     data.groupSlug = client.context.group
     delete data.baseStackId
 
-    JStack.create data, callback
+    JComputeStack.create data, callback
 
 
   ###*
-   * JStack::create
+   * JComputeStack::create
    * @param  {Object}   data
    * @param  {Function} callback
    * @return {void}
@@ -136,7 +136,7 @@ module.exports = class JStack extends jraphical.Module
     { account, groupSlug, config, title, baseStackId } = data
     originId = account.getId()
 
-    stack = new JStack {
+    stack = new JComputeStack {
       title, config, originId, baseStackId,
       group: groupSlug
     }
@@ -162,7 +162,7 @@ module.exports = class JStack extends jraphical.Module
 
       selector = @getSelector selector, delegate
 
-      JStack.some selector, options, (err, _stacks)->
+      JComputeStack.some selector, options, (err, _stacks)->
 
         if err
 

--- a/workers/social/lib/social/models/vm.coffee
+++ b/workers/social/lib/social/models/vm.coffee
@@ -18,7 +18,7 @@ module.exports = class JVM extends Module
   JPaymentSubscription = require './payment/subscription'
   JPaymentPack         = require './payment/pack'
   JPermissionSet       = require './group/permissionset'
-  JDomain              = require './domain'
+  JProposedDomain      = require './domain'
 
   @share()
 
@@ -385,7 +385,7 @@ module.exports = class JVM extends Module
                 return console.error "Failed to create VM for ", \
                                      {users, groups, hostnameAlias, err}
 
-              JDomain.createDomains {
+              JProposedDomain.createDomains {
                 account, stackId,
                 domains: hostnameAliases
                 hostnameAlias: hostnameAliases[0]
@@ -394,7 +394,7 @@ module.exports = class JVM extends Module
 
               group.addVm vm, (err)=>
                 return callback err  if err
-                JDomain.ensureDomainSettingsForVM {
+                JProposedDomain.ensureDomainSettingsForVM {
                   account, vm, type, nickname, group: groupSlug, stackId
                 }
                 account.sendNotification "VMCreated"
@@ -528,12 +528,12 @@ module.exports = class JVM extends Module
     { delegate } = client.connection
     @fetchAccountVmsBySelector delegate, { hostnameAlias: $in: names }, callback
 
-  # TODO: Move these methods to JDomain at some point ~ GG
+  # TODO: Move these methods to JProposedDomain at some point ~ GG
   # ------------------------------------------------------
   # Private static method to fetch domains
   @fetchDomains = (selector, callback)->
-    JDomain = require './domain'
-    JDomain.someData selector, {domain:1}, \
+    JProposedDomain = require './domain'
+    JProposedDomain.someData selector, {domain:1}, \
     (err, cursor)->
       return callback err, []  if err
       cursor.toArray (err, arr)->
@@ -574,8 +574,8 @@ module.exports = class JVM extends Module
       hostnameAlias : vm.hostnameAlias
       domain        : { $in : aliasesToDelete }
 
-    JDomain = require './domain'
-    JDomain.remove selector, (err)->
+    JProposedDomain = require './domain'
+    JProposedDomain.remove selector, (err)->
       callback err
       return console.error "Failed to delete domains:", err  if err
 
@@ -709,11 +709,11 @@ module.exports = class JVM extends Module
 
       group = groupSlug
 
-      JDomain.ensureDomainSettingsForVM {
+      JProposedDomain.ensureDomainSettingsForVM {
         account, vm, type, nickname, group, stack
       }
 
-      JDomain.createDomains {
+      JProposedDomain.createDomains {
         account, domains:hostnameAliases,
         group, hostnameAlias, stack
       }
@@ -832,7 +832,7 @@ module.exports = class JVM extends Module
                     type:'user', groupSlug:group
                   }
 
-                  JDomain.createDomains {
+                  JProposedDomain.createDomains {
                     account, stack, group,
                     domains:hostnameAliases,
                     hostnameAlias:hostnameAliases[0]

--- a/workers/social/lib/social/models/vm.coffee
+++ b/workers/social/lib/social/models/vm.coffee
@@ -333,7 +333,7 @@ module.exports = class JVM extends Module
   # discussion between Devrim, Chris T. and Badahir  C.T.
   @createVm = ({account, type, groupSlug, planCode, stackId, subscriptionCode}, callback)->
     JGroup = require './group'
-    JStack = require './stack'
+    JComputeStack = require './stack'
     JGroup.one {slug: groupSlug}, (err, group)=>
       return callback err  if err
       return callback new Error "Group not found"  unless group
@@ -802,8 +802,8 @@ module.exports = class JVM extends Module
             # New account found
             webHome       = username
 
-            JStack = require './stack'
-            JStack.getStackId {user:username, group}, (err, stack)=>
+            JComputeStack = require './stack'
+            JComputeStack.getStackId {user:username, group}, (err, stack)=>
 
               if err then warn "Failed to get stack:", err
 


### PR DESCRIPTION
`JStack` and `JDomain` exist under current koding, but with different schema and behavior than what we have in "new" koding. Since we want to run the two versions alongside each other for some period of time, it makes sense to rename these classes so that they do not cause conflict and corruption.

This PR changes the name of `JDomain` to `JProposedDomain`, since @gokmen said that name better-matches for its semantics. `JStack` is renamed `JComputeStack` as it was thought that name was not misleading, and was better than alternatives.

cc @gokmen @devrim @rsbrown @cihangir 
