### PR TITLE
activity: fetch subsequent pages from the server

### DIFF
--- a/client/Social/Activity/AppController.coffee
+++ b/client/Social/Activity/AppController.coffee
@@ -98,7 +98,7 @@ class ActivityAppController extends AppController
     else
       socialapi.channel.fetchActivities {id, from, limit}, callback
 
-    firstFetch = yes
+    firstFetch = no
 
 
   bindModalDestroy: (modal, lastRoute) ->


### PR DESCRIPTION
We were setting the `firstFetch` flag to true again, but it should be set to false.

This will address https://www.pivotaltracker.com/story/show/77728880
