### PR TITLE
kloud: wait until klient is ready for start/build methods [completes #77768150]

### DIFF
--- a/go/src/koding/kites/klient/klient.go
+++ b/go/src/koding/kites/klient/klient.go
@@ -155,7 +155,7 @@ func main() {
 		go k.RegisterToProxy(registerURL, proxyQuery)
 	} else {
 		if err := k.RegisterForever(registerURL); err != nil {
-			log.Fatal(err)
+			log.Panic(err)
 		}
 	}
 

--- a/go/src/koding/kites/kloud/deploy.go
+++ b/go/src/koding/kites/kloud/deploy.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"koding/db/mongodb"
+	"koding/kites/kloud/klient"
 	"path/filepath"
 	"strings"
 	"time"
@@ -222,6 +223,18 @@ func (k *KodingDeploy) ServeKite(r *kite.Request) (interface{}, error) {
 	}
 
 	query := kiteprotocol.Kite{ID: tknID.String()}
+
+	k.Log.Info("Connecting to remote Klient instance")
+	klient, err := klient.NewKlient(k.Kite, query.String())
+	if err != nil {
+		k.Log.Warning("Connecting to remote Klient instance err: %s", err)
+	} else {
+		defer klient.Close()
+		k.Log.Info("Sending a ping message")
+		if err := klient.Ping(); err != nil {
+			k.Log.Warning("Sending a ping message err:", err)
+		}
+	}
 
 	artifact.KiteQuery = query.String()
 	return artifact, nil

--- a/go/src/koding/kites/kloud/deploy.go
+++ b/go/src/koding/kites/kloud/deploy.go
@@ -225,7 +225,7 @@ func (k *KodingDeploy) ServeKite(r *kite.Request) (interface{}, error) {
 	query := kiteprotocol.Kite{ID: tknID.String()}
 
 	k.Log.Info("Connecting to remote Klient instance")
-	klientRef, err := klient.NewKlient(k.Kite, query.String())
+	klientRef, err := klient.NewWithTimeout(k.Kite, query.String(), time.Minute)
 	if err != nil {
 		k.Log.Warning("Connecting to remote Klient instance err: %s", err)
 	} else {

--- a/go/src/koding/kites/kloud/deploy.go
+++ b/go/src/koding/kites/kloud/deploy.go
@@ -225,13 +225,13 @@ func (k *KodingDeploy) ServeKite(r *kite.Request) (interface{}, error) {
 	query := kiteprotocol.Kite{ID: tknID.String()}
 
 	k.Log.Info("Connecting to remote Klient instance")
-	klient, err := klient.NewKlient(k.Kite, query.String())
+	klientRef, err := klient.NewKlient(k.Kite, query.String())
 	if err != nil {
 		k.Log.Warning("Connecting to remote Klient instance err: %s", err)
 	} else {
-		defer klient.Close()
+		defer klientRef.Close()
 		k.Log.Info("Sending a ping message")
-		if err := klient.Ping(); err != nil {
+		if err := klientRef.Ping(); err != nil {
 			k.Log.Warning("Sending a ping message err:", err)
 		}
 	}

--- a/go/src/koding/kites/kloud/klient/klient.go
+++ b/go/src/koding/kites/kloud/klient/klient.go
@@ -1,4 +1,6 @@
-package koding
+// Package klient provides an instance and abstraction to a remote klient kite.
+// It is used to easily call methods of a klient kite
+package klient
 
 import (
 	"fmt"
@@ -11,7 +13,8 @@ import (
 // Klient represents a remote klient instance
 type Klient struct {
 	client   *kite.Client
-	username string
+	kite     *kite.Kite
+	Username string
 }
 
 // Klient returns a new connected klient instance to the given queryString. The
@@ -37,8 +40,9 @@ func NewKlient(k *kite.Kite, queryString string) (*Klient, error) {
 
 	// klient connection is ready now
 	return &Klient{
+		kite:     k,
 		client:   remoteKite,
-		username: remoteKite.Username,
+		Username: remoteKite.Username,
 	}, nil
 
 }

--- a/go/src/koding/kites/kloud/koding/klient.go
+++ b/go/src/koding/kites/kloud/koding/klient.go
@@ -17,14 +17,15 @@ type Klient struct {
 // Klient returns a new connected klient instance to the given queryString. The
 // klient is ready to use. It's connected and will redial if there is any
 // disconnections.
-func (p *Provider) Connect(queryString string) (*Klient, error) {
+func NewKlient(k *kite.Kite, queryString string) (*Klient, error) {
 	query, err := protocol.KiteFromString(queryString)
 	if err != nil {
 		return nil, err
 	}
 
-	p.Log.Debug("Querying for Klient: %s", queryString)
-	kites, err := p.Kite.GetKites(query.Query())
+	k.Log.Debug("Querying for Klient: %s", queryString)
+
+	kites, err := k.GetKites(query.Query())
 	if err != nil {
 		return nil, err
 	}

--- a/go/src/koding/kites/kloud/koding/provider.go
+++ b/go/src/koding/kites/kloud/koding/provider.go
@@ -367,7 +367,7 @@ func (p *Provider) Start(opts *protocol.Machine) (*protocol.Artifact, error) {
 	artifact.DomainName = machineData.Domain
 
 	p.Log.Info("Connecting to remote Klient instance")
-	klientRef, err := klient.NewKlient(p.Kite, machineData.QueryString)
+	klientRef, err := klient.NewWithTimeout(p.Kite, machineData.QueryString, time.Minute*1)
 	if err != nil {
 		p.Log.Warning("Connecting to remote Klient instance err: %s", err)
 	} else {

--- a/go/src/koding/kites/kloud/koding/provider.go
+++ b/go/src/koding/kites/kloud/koding/provider.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"koding/db/mongodb"
+	"koding/kites/kloud/klient"
 
 	"github.com/koding/kite"
 	amazonClient "github.com/koding/kloud/api/amazon"
@@ -364,6 +365,18 @@ func (p *Provider) Start(opts *protocol.Machine) (*protocol.Artifact, error) {
 	}
 
 	artifact.DomainName = machineData.Domain
+
+	p.Log.Info("Connecting to remote Klient instance")
+	klientRef, err := klient.NewKlient(p.Kite, machineData.QueryString)
+	if err != nil {
+		p.Log.Warning("Connecting to remote Klient instance err: %s", err)
+	} else {
+		defer klientRef.Close()
+		p.Log.Info("Sending a ping message")
+		if err := klientRef.Ping(); err != nil {
+			p.Log.Warning("Sending a ping message err:", err)
+		}
+	}
 
 	///// ROUTE 53 /////////////////
 

--- a/go/src/koding/kites/kloud/koding/queue.go
+++ b/go/src/koding/kites/kloud/koding/queue.go
@@ -68,7 +68,7 @@ func (p *Provider) CheckUsage(machine *Machine) error {
 	// release the lock from mongodb after we are done
 	defer p.ResetAssignee(machine.Id.Hex())
 
-	klient, err := klient.NewKlient(p.Kite, machine.QueryString)
+	klient, err := klient.New(p.Kite, machine.QueryString)
 	if err != nil {
 		return err
 	}

--- a/go/src/koding/kites/kloud/koding/queue.go
+++ b/go/src/koding/kites/kloud/koding/queue.go
@@ -67,7 +67,7 @@ func (p *Provider) CheckUsage(machine *Machine) error {
 	// release the lock from mongodb after we are done
 	defer p.ResetAssignee(machine.Id.Hex())
 
-	klient, err := p.Connect(machine.QueryString)
+	klient, err := NewKlient(p.Kite, machine.QueryString)
 	if err != nil {
 		return err
 	}

--- a/go/src/koding/kites/kloud/koding/queue.go
+++ b/go/src/koding/kites/kloud/koding/queue.go
@@ -2,6 +2,7 @@ package koding
 
 import (
 	"errors"
+	"koding/kites/kloud/klient"
 	"time"
 
 	"github.com/koding/kite"
@@ -67,7 +68,7 @@ func (p *Provider) CheckUsage(machine *Machine) error {
 	// release the lock from mongodb after we are done
 	defer p.ResetAssignee(machine.Id.Hex())
 
-	klient, err := NewKlient(p.Kite, machine.QueryString)
+	klient, err := klient.NewKlient(p.Kite, machine.QueryString)
 	if err != nil {
 		return err
 	}
@@ -101,7 +102,7 @@ func (p *Provider) CheckUsage(machine *Machine) error {
 		CurrentData: machine,
 	}
 
-	m.Builder["username"] = klient.username
+	m.Builder["username"] = klient.Username
 
 	// add a fake eventer, means we are not reporting anyone and prevent also
 	// panicing when someone try to call the eventer


### PR DESCRIPTION
Previously we were immediately returning true after a start or build method. Now additionally we are waiting until the klient is ready by searching it from kontrol, connecting and sending a ping method. 
