### PR TITLE
terminal: call resetFunc only when we receive an input

### DIFF
--- a/go/src/koding/kite-handler/terminal/terminal.go
+++ b/go/src/koding/kite-handler/terminal/terminal.go
@@ -22,6 +22,8 @@ import (
 
 const randomStringLength = 24 // 144 bit base64 encoded
 
+var ResetFunc func()
+
 // Server is the type of object that is sent to the connected client.
 // Represents a running shell process on the server.
 type Server struct {
@@ -171,15 +173,6 @@ func Connect(r *kite.Request) (interface{}, error) {
 				n++
 			}
 
-			// this is only used for koding's own purpose to count wheter an
-			// input was called or not. There is probably better ways, like
-			// exposing messageCounter variable and check it. However this just
-			// works now.
-			if val, err := r.Context.Get("resetFunc"); err == nil {
-				resetFunc := val.(func())
-				resetFunc()
-			}
-
 			// Rate limiting...
 			if server.throttling {
 				s := time.Now().Unix()
@@ -210,6 +203,12 @@ func Connect(r *kite.Request) (interface{}, error) {
 // Input is called when some text is written to the terminal.
 func (s *Server) Input(d *dnode.Partial) {
 	data := d.MustSliceOfLength(1)[0].MustString()
+
+	// this is only used for koding's own purpose to count wheter an
+	// input was called or not. There is probably better ways, like
+	// exposing messageCounter variable and check it. However this just
+	// works now.
+	ResetFunc()
 
 	// There is no need to protect the Write() with a mutex because
 	// Kite Library guarantees that only one message is processed at a time.

--- a/go/src/koding/kites/klient/klient.go
+++ b/go/src/koding/kites/klient/klient.go
@@ -114,16 +114,10 @@ func main() {
 	k.HandleFunc("fs.move", fs.Move)
 	k.HandleFunc("fs.copy", fs.Copy)
 
-	k.HandleFunc("webterm.getSessions", terminal.GetSessions)
-	k.HandleFunc("webterm.connect", terminal.Connect).PreHandleFunc(func(r *kite.Request) (interface{}, error) {
-		// this function is used to reset inactivity whenever something is put into terminal :)
-		reset := func() {
-			usg.Reset()
-		}
+	terminal.ResetFunc = usg.Reset
 
-		r.Context.Set("resetFunc", reset)
-		return nil, nil
-	})
+	k.HandleFunc("webterm.getSessions", terminal.GetSessions)
+	k.HandleFunc("webterm.connect", terminal.Connect)
 
 	k.HandleFunc("webterm.killSession", terminal.KillSession)
 	k.HandleFunc("exec", command.Exec)


### PR DESCRIPTION
This is a simple trick but I don't know why I didn't thought about this before! :) Basically we now are resetting the 30 minute timer only when the user sends as a input. That means the user needs to press on a key on terminal to reset the timer. Previous we would reset whenever an input was received on `tty`. means on the terminal _display_.
