### PR TITLE
terminal: scroll down terminal container element [fixes #77684044]

### DIFF
--- a/client/Terminal/webtermview.coffee
+++ b/client/Terminal/webtermview.coffee
@@ -8,6 +8,8 @@ class WebTermView extends KDView
 
     @initBackoff()
 
+    KD.getSingleton('mainView').on 'MainTabPaneShown', @bound 'mainTabPaneShown'
+
   viewAppended: ->
 
     @container = new KDView
@@ -321,3 +323,11 @@ class WebTermView extends KDView
       event.preventDefault()
 
   initBackoff: KDBroker.Broker::initBackoff
+
+
+  mainTabPaneShown: (pane) ->
+
+    return  unless pane.getElement().contains @getElement()
+
+    el = @container.getElement()
+    el.scrollTop = el.scrollHeight


### PR DESCRIPTION
When a main tab pane is shown and `WebTermView` is in DOM.
