### PR TITLE
kloud: create a separate user for a permitted access control

### DIFF
--- a/go/src/koding/kites/kloud/koding/provider.go
+++ b/go/src/koding/kites/kloud/koding/provider.go
@@ -26,9 +26,10 @@ var (
 	DefaultInstanceType = "t2.micro"
 	DefaultRegion       = "us-east-1"
 
+	// Credential belongs to the `koding-kloud` user in AWS IAM's
 	kodingCredential = map[string]interface{}{
-		"access_key": "AKIAI6IUMWKF3F4426CA",
-		"secret_key": "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",
+		"access_key": "AKIAIDPT7E2UHZHT2CXQ",
+		"secret_key": "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",
 	}
 )
 


### PR DESCRIPTION
We now have a `koding-kloud` user in AWS that belongs to the `kloud` group with the following policy:

```
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Action": "ec2:*",
      "Effect": "Allow",
      "Resource": "*"
    },
    {
      "Effect": "Allow",
      "Action": "route53:*",
      "Resource": "*"
    }
  ]
}
```

The `koding` group doesn't have any access to user created instances with the tag `koding-user` anymore. 

@canthefason can you deploy a new sandbox after merging this please? Thanks.
