### PR TITLE
Utils: add actorsPreview property to fake message

### DIFF
--- a/client/Main/utils.coffee
+++ b/client/Main/utils.coffee
@@ -699,18 +699,19 @@ utils.extend utils,
       constructorName: 'JAccount'
 
     fakeObject         =
-      isFake           : yes
-      on               : -> this
-      watch            : -> this
-      body             : body
-      account          : account
-      createdAt        : isoNow
-      updatedAt        : isoNow
-      replies          : []
-      repliesCount     : 0
-      interactions     :
-        like           :
-          isInteracted : no
-          actorsCount  : 0
+      isFake            : yes
+      on                : -> this
+      watch             : -> this
+      body              : body
+      account           : account
+      createdAt         : isoNow
+      updatedAt         : isoNow
+      replies           : []
+      repliesCount      : 0
+      interactions      :
+        like            :
+          isInteracted  : no
+          actorsCount   : 0
+          actorsPreview : []
 
 


### PR DESCRIPTION
after new changes to activity items, those were causing fake messages not to be deleted.

ping @szkl @sinan 
