### PR TITLE
Embedly: Show videos in posts

### DIFF
--- a/client/Main/utils.coffee
+++ b/client/Main/utils.coffee
@@ -509,7 +509,7 @@ utils.extend utils,
   #       to bypass awful hacks by Arvid Kahl:
   getEmbedType: (type) ->
     switch type
-      when 'audio', 'xml', 'json', 'ppt', 'rss', 'atom'
+      when 'audio', 'xml', 'json', 'ppt', 'rss', 'atom', 'video', 'rich'
         return 'object'
 
       # this is usually just a single image

--- a/client/Social/Activity/styl/activity.styl
+++ b/client/Social/Activity/styl/activity.styl
@@ -1114,6 +1114,16 @@ span.collapsedtext
     overflow                visible
     borderBox()
 
+    .embed-object-view
+      size                  100%, 0px
+      position              relative
+      padding-bottom        58%
+      background            #f7f7f7
+
+      > iframe
+        size                100%, 100%
+        abs                 0px 0 0 0px
+
     .embed-link-view
 
       .preview-image

--- a/client/Social/Activity/views/embedbox.coffee
+++ b/client/Social/Activity/views/embedbox.coffee
@@ -8,6 +8,9 @@ class EmbedBox extends KDView
 
     embedType = (@utils.getEmbedType data?.link_embed?.type) or 'link'
 
+    if data?.link_embed?.media?.type is 'video'
+      embedType = @utils.getEmbedType data.link_embed.media.type
+
     containerClass = switch embedType
       when 'image'  then EmbedBoxImageView
       when 'object' then EmbedBoxObjectView

--- a/client/Social/Activity/views/embedbox/embedboxobjectview.coffee
+++ b/client/Social/Activity/views/embedbox/embedboxobjectview.coffee
@@ -1,7 +1,7 @@
 class EmbedBoxObjectView extends JView
 
   pistachio:->
-    objectHtml = @getData().link_embed?.object?.html
+    objectHtml = @getData().link_embed?.media?.html
     """
     <div class="embed embed-object-view custom-object">
       #{Encoder.htmlDecode objectHtml or ''}

--- a/client/Social/Activity/views/embedboxwidget.coffee
+++ b/client/Social/Activity/views/embedboxwidget.coffee
@@ -181,10 +181,7 @@ class EmbedBoxWidget extends KDView
 
     @imageIndex = 0
 
-    desiredFields = [
-      'url', 'safe', 'type', 'provider_name', 'error_type', 'content',
-      'error_message', 'safe_type', 'safe_message', 'images'
-    ]
+    desiredFields = ['original_url']
 
     for key in desiredFields
       wantedData[key] = data[key]

--- a/workers/social/lib/social/models/socialapi/message.coffee
+++ b/workers/social/lib/social/models/socialapi/message.coffee
@@ -73,10 +73,19 @@ module.exports = class SocialMessage extends Base
     doRequest, permittedRequest,
     ensureGroupChannel } = require "./helper"
 
+  cachedEmbedlyResult = {}
+
   @post = permit 'create posts',
     success: (client, data, callback)->
       ensureGroupChannel client, (err, socialApiChannelId)->
         data.channelId = socialApiChannelId
+
+        if data.payload?.link_embed
+          {original_url} = data.payload.link_embed
+          cachedEmbed    = cachedEmbedlyResult[original_url][0]
+
+          data.payload.link_embed = cachedEmbed
+
         doRequest 'postToChannel', client, data, callback
 
   @reply = permit 'create posts',
@@ -221,9 +230,6 @@ module.exports = class SocialMessage extends Base
         if accountId is socialApiId
           return callback null, yes
         fn client, callback
-
-
-  cachedEmbedlyResult = {}
 
   @fetchDataFromEmbedly = (urls, options, callback) ->
 


### PR DESCRIPTION
Plus: When saving a post with an embedly content; it's now uses the cached version of it. Not the one which is sent by the client. 
Because, we need to show some html content which are supplied by embedly to show videos or rich contents. But user can change it before sending, and this can be harmful for us. 
