### PR TITLE
nginx: save pid to /var/run/nginx.pid

### DIFF
--- a/deployment/nginx.coffee
+++ b/deployment/nginx.coffee
@@ -77,7 +77,7 @@ module.exports.create = (workers, environment)->
   #error_log  logs/error.log  notice;
   #error_log  logs/error.log  info;
 
-  #pid        logs/nginx.pid;
+  pid         /var/run/nginx.pid;
 
   events { worker_connections  1024; }
 


### PR DESCRIPTION
It's the backreference for commands {restart,stop}.
