### PR TITLE
Client: redirect /Terminal to /Login if not logged in

### DIFF
--- a/client/Terminal/routes.coffee
+++ b/client/Terminal/routes.coffee
@@ -1,9 +1,8 @@
 do ->
 
-
-
-
-
   KD.registerRoutes 'Terminal',
     '/:name?/Terminal' : (routeInfo, state, path) ->
-      KD.singletons.router.handleRoute path.replace(/\/Terminal/, '/IDE')
+      if !KD.isLoggedIn()
+        KD.singletons.router.handleRoute "/Login"
+      else
+        KD.singletons.router.handleRoute path.replace(/\/Terminal/, '/IDE')


### PR DESCRIPTION
If user isn't logged in, /Terminal redirects to /Activity/Public which throws a bunch of errors. I've tried to fix it, but it'll take me a bit longer, so I'm doing this temporarily so when we deploy Terminal chrome app won't break.
