### PR TITLE
compute controller: don't trigger state changes from .info method

### DIFF
--- a/client/Main/providers/computecontroller.coffee
+++ b/client/Main/providers/computecontroller.coffee
@@ -296,10 +296,6 @@ class ComputeController extends KDController
       @eventListener.addListener stateEvent, machine._id
       return Promise.resolve()
 
-    @eventListener.triggerState machine,
-      status      : machine.status.state
-      percentage  : 0
-
     call = @kloud.info { machineId: machine._id }
 
     .then (response)=>


### PR DESCRIPTION
Triggering a state change here can cause a stack overflow if the state change causes any calls to "info". cc @gokmen, @fatihacet, @sinan
