### PR TITLE
nginx: improve pid management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .dev.nginx.conf
+.dev.nginx.pid
 *.dump
 *.orig
 *.orig

--- a/config/main.dev.coffee
+++ b/config/main.dev.coffee
@@ -409,7 +409,7 @@ Configuration = (options={}) ->
 
       function kill_all () {
         #{killlist()}
-        nginx -s quit
+        nginx -c #{projectRoot}/.dev.nginx.conf -g 'pid #{projectRoot}/.dev.nginx.pid;' -s quit
         ps aux | grep koding | grep -E 'node|go/bin' | awk '{ print $2 }' | xargs kill -9
       }
 
@@ -417,8 +417,9 @@ Configuration = (options={}) ->
       function nginxrun () {
 
         echo "starting nginx"
-        nginx -s quit
-        nginx -c #{projectRoot}/.dev.nginx.conf
+        touch #{projectRoot}/.dev.nginx.pid
+        nginx -c #{projectRoot}/.dev.nginx.conf -g 'pid #{projectRoot}/.dev.nginx.pid;' -s quit
+        nginx -c #{projectRoot}/.dev.nginx.conf -g 'pid #{projectRoot}/.dev.nginx.pid;'
 
       }
 
@@ -619,10 +620,7 @@ Configuration = (options={}) ->
         echo "Starting services: $SERVICES"
         docker start $SERVICES
 
-        echo "starting nginx"
-        nginx -s quit
-        nginx -c `pwd`/.dev.nginx.conf
-
+        nginxrun
       }
 
 

--- a/deployment/nginx.coffee
+++ b/deployment/nginx.coffee
@@ -122,7 +122,7 @@ module.exports.create = (workers, environment)->
   #error_log  logs/error.log  notice;
   #error_log  logs/error.log  info;
 
-  pid #{if environment is 'dev' then '.nginx.pid' else '/var/run/nginx.pid'};
+  #{if environment is 'dev' then '' else 'pid /var/run/nginx.pid;'}
 
   events { worker_connections  1024; }
 


### PR DESCRIPTION
nginx needs to be given the same configuration file for starting/stopping.

nginx resets every environment variable it inherits (except TZ) and
changes working directory. `pid` directive needs to be passed as a
command line option to set a custom path.
