### PR TITLE
scrubber: don't blow the call stack

### DIFF
--- a/node_modules_koding/scrubber/index.js
+++ b/node_modules_koding/scrubber/index.js
@@ -5,11 +5,11 @@ Traverse = require('traverse');
 
 global = typeof window !== "undefined" && window !== null ? window : this;
 
+
 /**
 * @helper daisy
 * @description - serial async helper
-*/
-
+ */
 
 daisy = function(args) {
   return process.nextTick(args.next = function() {
@@ -21,12 +21,16 @@ daisy = function(args) {
 };
 
 slowDaisy = function(args) {
-  return console.log("it's a slow daisy", args);
+  return process.nextTick(args.next = function() {
+    var fn;
+    if (fn = args.shift()) {
+      return process.nextTick(fn.bind.apply(fn, [null].concat(__slice.call(args))));
+    }
+  });
 };
 
 module.exports = Scrubber = (function() {
-  var seemsTooComplex,
-    _this = this;
+  var seemsTooComplex;
 
   Scrubber.use = function() {
     var middleware;
@@ -38,11 +42,11 @@ module.exports = Scrubber = (function() {
     }
   };
 
+
   /**
   * @constructor Scrubber
   * @description - initializes the Scrubber instance.
-  */
-
+   */
 
   function Scrubber() {
     var middleware;
@@ -54,12 +58,12 @@ module.exports = Scrubber = (function() {
     }
   }
 
+
   /**
   * @method Scrubber#scrub
   * @description - traverses an arbitrary JS object and applies the middleware
   *  stack, serially, to each node encountered during the walk.
-  */
-
+   */
 
   Scrubber.prototype.scrub = function(obj, callback) {
     var nodes, queue, scrubber, steps;
@@ -94,11 +98,15 @@ module.exports = Scrubber = (function() {
     queue.push(function() {
       return callback.call(scrubber);
     });
-    return daisy(queue);
+    if (seemsTooComplex(queue.length, 4)) {
+      return slowDaisy(queue);
+    } else {
+      return daisy(queue);
+    }
   };
 
   seemsTooComplex = (function() {
-    var f, i, maxStackSize;
+    var e, f, i, maxStackSize;
     maxStackSize = (function() {
       try {
         i = 0;
@@ -106,7 +114,8 @@ module.exports = Scrubber = (function() {
           i++;
           return f();
         })();
-      } catch (e) {
+      } catch (_error) {
+        e = _error;
         return i;
       }
     })();
@@ -116,6 +125,7 @@ module.exports = Scrubber = (function() {
       return guess > maxStackSize;
     };
   })();
+
 
   /**
   * @method Scrubber#forEach
@@ -130,8 +140,7 @@ module.exports = Scrubber = (function() {
   * @method Scrubber#push
   * @description - proxies for the native Array methods; they apply themselves
   *   to the middleware stack
-  */
-
+   */
 
   ['forEach', 'indexOf', 'join', 'pop', 'reverse', 'shift', 'sort', 'splice', 'unshift', 'push'].forEach(function(method) {
     return Scrubber.prototype[method] = function() {
@@ -141,14 +150,14 @@ module.exports = Scrubber = (function() {
     };
   });
 
+
   /**
   * @method Scrubber#use
   * @description alias for push.
-  */
-
+   */
 
   Scrubber.prototype.use = Scrubber.prototype.push;
 
   return Scrubber;
 
-}).call(this);
+})();

--- a/node_modules_koding/scrubber/lib/scrubber/index.coffee
+++ b/node_modules_koding/scrubber/lib/scrubber/index.coffee
@@ -9,7 +9,8 @@ daisy =(args)->
     if fn = args.shift() then !!fn args
 
 slowDaisy =(args)->
-  console.log "it's a slow daisy", args
+  process.nextTick args.next = ->
+    if fn = args.shift() then process.nextTick fn.bind null, args...
 
 module.exports = class Scrubber
 
@@ -56,10 +57,10 @@ module.exports = class Scrubber
       return
     queue.push ->
       callback.call scrubber
-    # if seemsTooComplex queue.length, 4
-    #   slowDaisy queue
-    # else
-    daisy queue
+    if seemsTooComplex queue.length, 4
+      slowDaisy queue
+    else
+      daisy queue
 
   seemsTooComplex =do->
     maxStackSize = try


### PR DESCRIPTION
This fixes the long-extant bongo `RangeError` bug
