### PR TITLE
terminal: fix row and column count for small terminals

### DIFF
--- a/client/Terminal/src/Terminal.coffee
+++ b/client/Terminal/src/Terminal.coffee
@@ -180,12 +180,12 @@ class WebTerm.Terminal extends KDObject
     @scrollToBottom()
 
     [@currentWidth, @currentHeight] = [swidth, sheight]
-    {width, height} = @getCharSizes()
+    {width: charWidth, height: charHeight} = @getCharSizes()
 
-    newWidth  = Math.max width,  Math.floor swidth  / width
-    newHeight = Math.max height, Math.floor sheight / height
+    newCols = Math.max 1, Math.floor swidth  / charWidth
+    newRows = Math.max 1, Math.floor sheight / charHeight
 
-    @setSize newWidth, newHeight
+    @setSize newCols, newRows
 
   windowDidResize: _.throttle (-> @updateSize()), 500
 


### PR DESCRIPTION
On the one hand, we end up with a row and column count, but on the other hand we end up with a pixel measurement. This causes a glitch for small terminals, where the top lines will be positioned offscreen. cc @gniting, @gokmen 
