### PR TITLE
algolia-migrator: use extant expando to filter unmigrated accounts

### DIFF
--- a/go/src/socialapi/workers/migrator/controller/accountmigrator_algolia.go
+++ b/go/src/socialapi/workers/migrator/controller/accountmigrator_algolia.go
@@ -16,7 +16,8 @@ func (mwc *Controller) migrateAllAccountsToAlgolia() {
 	successCount := 0
 
 	s := modelhelper.Selector{
-		"type": "registered",
+		"migration": modelhelper.Selector{"$exists": false},
+		"type":      "registered",
 	}
 
 	c := config.MustGet()


### PR DESCRIPTION
Rather than adding an additional expando property, use the one that is already there.
