### PR TITLE
activity: add scroll offsets to share popup positioning [fixes #78408034]

### DIFF
--- a/client/Social/Activity/views/activityactions.coffee
+++ b/client/Social/Activity/views/activityactions.coffee
@@ -35,8 +35,8 @@ class ActivityActionsView extends JView
           cssClass    : "activity-share-popup"
           type        : "activity-share"
           delegate    : this
-          x           : @shareLink.getX() + 25
-          y           : @shareLink.getY() - 7
+          x           : @shareLink.getX() + window.scrollX + 25
+          y           : @shareLink.getY() + window.scrollY - 7
           menuMaxWidth: 400
           menuMinWidth: 192
           lazyLoad    : yes


### PR DESCRIPTION
The amount of scrolling that has been done of the viewport area (or any
other scrollable element) is taken into account when computing the
bounding rectangle. This means that the top and left property change
their values as soon as the scrolling position changes (so their values
are relative to the viewport and not absolute).

https://developer.mozilla.org/en-US/docs/Web/API/Element.getBoundingClientRect
