### PR TITLE
User profile again

### DIFF
--- a/client/Main/routes.coffee
+++ b/client/Main/routes.coffee
@@ -42,12 +42,8 @@ do ->
 
       {router} = KD.singletons
       route = name unless route
-      contentDisplay = router.openRoutes[route.split('?')[0]]
 
-      if contentDisplay?
-        KD.singleton('display').hideAllDisplays contentDisplay
-        contentDisplay.emit 'handleQuery', query
-      else if models?
+      if models?
         router.openContent name, section, models, route, query, passOptions
       else
         router.loadContent name, section, slug, route, query, passOptions

--- a/client/Social/Feeder/FeedController.coffee
+++ b/client/Social/Feeder/FeedController.coffee
@@ -175,7 +175,7 @@ class FeedController extends KDViewController
     then group = KD.config.entryPoint.slug
     else group = 'koding'
 
-    groupsController.changeGroup group, =>
+    groupsController.ready =>
 
       currentGroup = group
       feedId = "#{currentGroup}-#{feedId}"


### PR DESCRIPTION
If the content display was cached, we weren't showing the user profile content again. Apparently there was a regression where content displays were not being cleaned up from the open routes map of the router. I talked to @sinan and we agreed that this caching behavior was only there for our old "stack-style" content displays where each they would slide out of the way when closing them, revealing the displays that were "under" or "back in history". We don't have this behavior anymore, so this fix works by simply removing the special case path that deals with the openRoutes map
