### PR TITLE
config: fix `KONFIG.uri.address` [fixes #78429414]

### DIFF
--- a/config/main.dev.coffee
+++ b/config/main.dev.coffee
@@ -77,7 +77,7 @@ Configuration = (options={}) ->
     publicHostname                 : publicHostname
     version                        : version
     broker                         : broker
-    uri                            : {address: "#{customDomain.public}"}
+    uri                            : address: customDomain.public
     userSitesDomain                : userSitesDomain
     projectRoot                    : projectRoot
     socialapi                      : socialapi

--- a/config/main.feature.coffee
+++ b/config/main.feature.coffee
@@ -76,7 +76,7 @@ Configuration = (options={}) ->
     publicHostname                 : publicHostname
     version                        : version
     broker                         : broker
-    uri                            : {address: "#{customDomain.public}:#{customDomain.port}"}
+    uri                            : address: customDomain.public
     userSitesDomain                : userSitesDomain
     projectRoot                    : projectRoot
     socialapi                      : socialapi

--- a/config/main.prod.coffee
+++ b/config/main.prod.coffee
@@ -75,7 +75,7 @@ Configuration = (options={}) ->
     publicHostname                 : publicHostname
     version                        : version
     broker                         : broker
-    uri                            : {address: "#{customDomain.public}:#{customDomain.port}"}
+    uri                            : address: customDomain.public
     userSitesDomain                : userSitesDomain
     projectRoot                    : projectRoot
     socialapi                      : socialapi

--- a/config/main.sandbox.coffee
+++ b/config/main.sandbox.coffee
@@ -74,7 +74,7 @@ Configuration = (options={}) ->
     publicHostname                 : publicHostname
     version                        : version
     broker                         : broker
-    uri                            : {address: "#{customDomain.public}:#{customDomain.port}"}
+    uri                            : address: customDomain.public
     userSitesDomain                : userSitesDomain
     projectRoot                    : projectRoot
     socialapi                      : socialapi


### PR DESCRIPTION
[Profile links are wrong in logged-out views](https://www.pivotaltracker.com/story/show/78429414)

`customDomain.public` is constructed using hostname which handles port
number as well.
