### PR TITLE
activity: ignore "MessageAdded" events in most liked filter [fixes #78542854]

### DIFF
--- a/client/Social/Activity/views/messagepane.coffee
+++ b/client/Social/Activity/views/messagepane.coffee
@@ -214,6 +214,7 @@ class MessagePane extends KDTabPaneView
 
   addMessage: (message) ->
 
+    return  if @currentFilter is "MOST_LIKED"
     return  if message.account._id is KD.whoami()._id
 
     {lastToFirst} = @getOptions()
@@ -351,4 +352,3 @@ class MessagePane extends KDTabPaneView
     @listController.removeAllItems()
     @listController.showLazyLoader()
     @populate()
-


### PR DESCRIPTION
[New posts shouldn't be listed in most liked filter](https://www.pivotaltracker.com/story/show/78542854)
