### PR TITLE
chat: position at the bottom [fixes #78432058]

### DIFF
--- a/client/Social/Activity/styl/activity.styl
+++ b/client/Social/Activity/styl/activity.styl
@@ -30,6 +30,14 @@ body.activity
     .message-pane.privatemessage > .listview-wrapper
       margin-top        0
 
+      &.padded
+        height            auto
+        abs               0 0 0px 34px
+        kalc              width (100%\-34px)
+
+        .kdscrollview
+          height          auto
+
     .channel-title
       font-size         18px
       line-height       24px

--- a/client/Social/Activity/views/messagepane.coffee
+++ b/client/Social/Activity/views/messagepane.coffee
@@ -17,9 +17,17 @@ class MessagePane extends KDTabPaneView
 
     {itemClass, type, lastToFirst, wrapper, channelId} = @getOptions()
     {typeConstant} = @getData()
-    viewOptions = {itemOptions: {channelId}}
 
-    @listController = new ActivityListController { wrapper, itemClass, type: typeConstant, viewOptions, lastToFirst}
+    @listController = new ActivityListController {
+      type          : typeConstant
+      viewOptions   :
+        itemOptions : {channelId}
+      wrapper
+      itemClass
+      lastToFirst
+    }
+
+    @listController.getView().setClass 'padded'
 
     @createChannelTitle()
     @createInputWidget()

--- a/client/Social/Activity/views/messagepane.coffee
+++ b/client/Social/Activity/views/messagepane.coffee
@@ -288,7 +288,7 @@ class MessagePane extends KDTabPaneView
       @listController.getListItems().first?.commentBox.input.focus()
 
 
-  populate: ->
+  populate: (callback = noop) ->
 
     @fetch null, (err, items = []) =>
 
@@ -298,6 +298,8 @@ class MessagePane extends KDTabPaneView
       items.forEach @bound 'appendMessageDeferred'
 
       KD.utils.defer @bound 'focus'
+
+      callback()
 
 
   appendMessageDeferred: (item) -> KD.utils.defer @lazyBound 'appendMessage', item

--- a/client/Social/Activity/views/messagepane.coffee
+++ b/client/Social/Activity/views/messagepane.coffee
@@ -295,9 +295,12 @@ class MessagePane extends KDTabPaneView
       return KD.showError err  if err
 
       @listController.hideLazyLoader()
-      items.forEach (item) => KD.utils.defer => @appendMessage item
+      items.forEach @bound 'appendMessageDeferred'
 
       KD.utils.defer @bound 'focus'
+
+
+  appendMessageDeferred: (item) -> KD.utils.defer @lazyBound 'appendMessage', item
 
 
   fetch: (options = {}, callback)->
@@ -351,4 +354,3 @@ class MessagePane extends KDTabPaneView
     @listController.removeAllItems()
     @listController.showLazyLoader()
     @populate()
-

--- a/client/Social/Activity/views/privatemessage/pane.coffee
+++ b/client/Social/Activity/views/privatemessage/pane.coffee
@@ -216,6 +216,14 @@ class PrivateMessagePane extends MessagePane
     @appendMessage item
 
 
+  populate: ->
+
+    super =>
+
+      listView = @listController.getView()
+      @listPreviousReplies()  if listView.getHeight() <= window.innerHeight
+
+
   fetch: (options = {}, callback) ->
 
     super options, (err, data) =>

--- a/client/Social/Activity/views/privatemessage/pane.coffee
+++ b/client/Social/Activity/views/privatemessage/pane.coffee
@@ -185,7 +185,12 @@ class PrivateMessagePane extends MessagePane
   messageAdded: (item, index) ->
 
     @scrollDown item
-    {data} = item
+    data         = item.getData()
+    listView     = @listController.getView()
+    headerHeight = @heads?.getHeight() or 0
+
+    if window.innerHeight - headerHeight < listView.getHeight()
+      listView.unsetClass 'padded'
 
     # TODO: This is a temporary fix,
     # we need to revisit this part.

--- a/client/Social/Activity/views/privatemessage/pane.coffee
+++ b/client/Social/Activity/views/privatemessage/pane.coffee
@@ -142,22 +142,31 @@ class PrivateMessagePane extends MessagePane
   hasSameOwner = (a, b) -> a.getData().account._id is b.getData().account._id
 
 
-  listPreviousReplies: (event) ->
+  listPreviousReplies: do ->
 
-    @listController.showLazyLoader()
+    inProgress = false
 
-    {appManager} = KD.singletons
-    first         = @listController.getItemsOrdered().first
-    return  unless first
+    (event) ->
 
-    from         = first.getData().createdAt
+      return  if inProgress
 
-    @fetch {from, limit: 10}, (err, items = []) =>
-      @listController.hideLazyLoader()
+      inProgress = true
+      @listController.showLazyLoader()
 
-      return KD.showError err  if err
+      {appManager} = KD.singletons
+      first         = @listController.getItemsOrdered().first
+      return  unless first
 
-      items.forEach @lazyBound 'loadMessage'
+      from         = first.getData().createdAt
+
+      @fetch {from, limit: 10}, (err, items = []) =>
+        @listController.hideLazyLoader()
+
+        return KD.showError err  if err
+
+        items.forEach @lazyBound 'loadMessage'
+
+        inProgress = false
 
 
   messageAdded: (item, index) ->

--- a/client/Social/Activity/views/privatemessage/pane.coffee
+++ b/client/Social/Activity/views/privatemessage/pane.coffee
@@ -41,6 +41,19 @@ class PrivateMessagePane extends MessagePane
 
     @filterLinks = null
 
+    KD.singleton('windowController').on 'ScrollHappened', @bound 'handleScroll'
+
+
+  handleScroll: do ->
+
+    previous = 0
+
+    KD.utils.throttle ->
+      current = document.body.scrollTop
+      @listPreviousReplies()  if current < 20 and current < previous
+      previous = current
+    , 200
+
 
   createInputWidget: ->
 

--- a/client/Social/Activity/views/privatemessage/pane.coffee
+++ b/client/Social/Activity/views/privatemessage/pane.coffee
@@ -209,6 +209,13 @@ class PrivateMessagePane extends MessagePane
       nextSibling.unsetClass 'consequent'
 
 
+  appendMessageDeferred: (item) ->
+    # Super method defers adding list items to minimize page load
+    # congestion. This function is overrides super function to render
+    # all conversation messages to be displayed at the same time
+    @appendMessage item
+
+
   fetch: (options = {}, callback) ->
 
     super options, (err, data) =>


### PR DESCRIPTION
[Reverse the chat scroll](https://www.pivotaltracker.com/story/show/78432058)
- [x] having the first messages appear at the bottom
- [x] when there are many messages page should be scrollable (pos:abs avoids that)
- [x] avoid page flickering when loading many messages on reload
- [x] load messages until viewport is filled
- [x] show previous messages button should be displayed if there is old messages not displayed yet
- [x] scrolling to top lazily loads previous replies
