### PR TITLE
Sidebar chat improvements [fixes #78675562]

### DIFF
--- a/client/Main/styl/resurrection.sidebar.styl
+++ b/client/Main/styl/resurrection.sidebar.styl
@@ -445,22 +445,6 @@ sidebarSelectedBg = #15171A
       margin        0
       borderBox()
 
-      .sidebar-message-text
-        > .purpose
-        > .profile
-          display     block
-          float       none
-          padding     0 0 0 36px
-          line-height 18px
-          width       auto
-          color       sidebarActive
-          font-weight 600
-          borderBox()
-          ellipsis()
-
-        > .profile > .profile
-            color     sidebarActive
-
       > .user-numbers
         padding     0 0 0 36px
         margin      -1px 0 0
@@ -486,6 +470,34 @@ sidebarSelectedBg = #15171A
         left          0
         abs()
 
+      .stacked
+
+        margin-left   -1px
+        margin-top    2px
+        size          auto auto
+        display       block
+
+        .avatarview
+
+          img
+            border      1px solid rgb(50, 50, 50)
+            borderBox()
+
+          &:nth-of-type(1)
+            top       0
+            left      6px
+            z-index   1
+
+          &:nth-of-type(2)
+            top       3px
+            left      9px
+            z-index   2
+
+          &:nth-of-type(3)
+            top       6px
+            left      12px
+            z-index   3
+
       &.unread
         > .profile
           color       #F9F7F3
@@ -496,7 +508,25 @@ sidebarSelectedBg = #15171A
   .messages
 
     .kdlistitemview-sidebar-item
-      height            28px
+      height            34px
+
+
+      .sidebar-message-text
+        > .purpose
+        > .profile
+          display     block
+          float       none
+          padding     0 0 0 36px
+          line-height 18px
+          width       auto
+          color       sidebarActive
+          font-weight 600
+          borderBox()
+          ellipsis()
+          margin-top  3px
+
+        > .profile > .profile
+            color     sidebarActive
 
       > .purpose
       > .profile

--- a/client/Main/styl/resurrection.sidebar.styl
+++ b/client/Main/styl/resurrection.sidebar.styl
@@ -445,19 +445,21 @@ sidebarSelectedBg = #15171A
       margin        0
       borderBox()
 
-      > .purpose
-      > .profile
-        display     block
-        float       none
-        padding     0 0 0 36px
-        line-height 18px
-        width       auto
-        color       sidebarGray
-        font-weight 600
-        borderBox()
+      .sidebar-message-text
+        > .purpose
+        > .profile
+          display     block
+          float       none
+          padding     0 0 0 36px
+          line-height 18px
+          width       auto
+          color       sidebarActive
+          font-weight 600
+          borderBox()
+          ellipsis()
 
-      > .purpose
-        ellipsis()
+        > .profile > .profile
+            color     sidebarActive
 
       > .user-numbers
         padding     0 0 0 36px
@@ -478,9 +480,10 @@ sidebarSelectedBg = #15171A
           font-weight inherit
           color       inherit
 
+      .sidebar-message-icon
       .avatarview
-        top           6px
-        left          8px
+        top           0
+        left          0
         abs()
 
       &.unread

--- a/client/Social/Activity/includes.coffee
+++ b/client/Social/Activity/includes.coffee
@@ -8,6 +8,7 @@ module.exports = [
   "sidebar/activitysideview.coffee"
   "sidebar/sidebaritem.coffee"
   "sidebar/memberitem.coffee"
+  "sidebar/messageitemtext.coffee"
   "sidebar/messageitem.coffee"
   "sidebar/topicitem.coffee"
   "sidebar/pinneditem.coffee"

--- a/client/Social/Activity/includes.coffee
+++ b/client/Social/Activity/includes.coffee
@@ -9,6 +9,7 @@ module.exports = [
   "sidebar/sidebaritem.coffee"
   "sidebar/memberitem.coffee"
   "sidebar/messageitemtext.coffee"
+  "sidebar/messageitemicon.coffee"
   "sidebar/messageitem.coffee"
   "sidebar/topicitem.coffee"
   "sidebar/pinneditem.coffee"

--- a/client/Social/Activity/sidebar/messageitem.coffee
+++ b/client/Social/Activity/sidebar/messageitem.coffee
@@ -10,34 +10,11 @@ class SidebarMessageItem extends SidebarItem
 
     super options, data
 
-    data = @getData()
-
-    # users can send messages to themselves and to others; if they're others
-    # show their avatars, fallback to user's avatar if they're the only one
-    if data.participantsPreview.length is 1
-      origin = data.participantsPreview[0]
-    else
-      for account in data.participantsPreview when account._id isnt KD.userAccount._id
-        origin = account
-        break
-
-    origin = constructorName : 'JAccount', id : origin._id
-
-    @actor = new ProfileTextView {origin}
-
-    # we need a multiple avatarview here
-    @avatar = new AvatarStaticView
-      size       : width : 24, height : 24
-      cssClass   : "avatarview"
-      showStatus : yes
-      origin     : origin
-
-    if data.purpose
-      @purpose = new KDCustomHTMLView
-        tagName  : 'span'
-        cssClass : 'purpose'
-        partial  : data.purpose
+    @icon = new SidebarMessageItemIcon {}, data
+    @text = new SidebarMessageItemText {}, data
 
 
   pistachio: ->
-    "{{> @avatar}}{{> @purpose or @actor}}{{> @unreadCount}}"
+    "{{> @icon}}{{> @text}}{{> @unreadCount}}"
+
+

--- a/client/Social/Activity/sidebar/messageitemicon.coffee
+++ b/client/Social/Activity/sidebar/messageitemicon.coffee
@@ -44,17 +44,38 @@ class SidebarMessageItemIcon extends JView
 
   createGrouped: ->
 
+    @icon = new KDCustomHTMLView
+      tagName  : 'span'
+
+    @setClass 'stacked'
+
     { width, height, cssClass } = @getOptions().size
 
-    cssClass = KD.utils.curry cssClass, 'stacked'
+    @getParticipantOrigins (origins) =>
 
-    { lastMessage } = @getData()
+      for i in [origins.length - 1..0]
+        @icon.addSubView new AvatarStaticView
+          size       : { width, height }
+          cssClass   : cssClass
+          showStatus : yes
+          origin     : origins[i]
 
-    origin = { constructorName : 'JAccount', id : lastMessage.account._id }
 
-    @icon = new AvatarStaticView
-      size       : { width, height }
-      cssClass   : cssClass
+  getParticipantOrigins: (callback) ->
+
+    { lastMessage, participantsPreview, participantCount } = @getData()
+
+    lastMessageOwner = lastMessage.account
+
+    origins  = [lastMessageOwner]
+
+    filtered = participantsPreview.filter (p) ->
+      return not (p._id in [KD.whoami()._id, lastMessageOwner._id])
+
+    origins = origins.concat filtered.slice 0, 2
+    origins = origins.map (origin) -> { constructorName : 'JAccount', id : origin._id }
+
+    callback origins
 
 
   pistachio: -> "{{> @icon}}"

--- a/client/Social/Activity/sidebar/messageitemicon.coffee
+++ b/client/Social/Activity/sidebar/messageitemicon.coffee
@@ -1,0 +1,62 @@
+class SidebarMessageItemIcon extends JView
+
+  constructor: (options = {}, data) ->
+
+    options.tagName    = 'span'
+    options.cssClass or= 'sidebar-message-icon'
+    options.size     or= { width: 24, height: 24 }
+
+    super options, data
+
+    @init()
+
+
+  init: ->
+
+    { participantCount, participantsPreview } = @getData()
+
+    shouldBeGrouped = no
+
+    if participantCount is 1
+      sample = participantsPreview
+    else
+      sample = participantsPreview.filter (acc) -> return acc._id isnt KD.whoami()._id
+      shouldBeGrouped = yes  if participantCount > 2
+
+    origin = sample.first
+
+    if shouldBeGrouped
+    then @createGrouped()
+    else @createSingle origin
+
+  createSingle: (origin) ->
+
+    { width, height, cssClass } = @getOptions().size
+
+    origin = { constructorName : 'JAccount', id : origin._id }
+
+    @icon = new AvatarStaticView
+      size       : { width, height }
+      cssClass   : cssClass
+      showStatus : yes
+      origin     : origin
+
+
+  createGrouped: ->
+
+    { width, height, cssClass } = @getOptions().size
+
+    cssClass = KD.utils.curry cssClass, 'stacked'
+
+    { lastMessage } = @getData()
+
+    origin = { constructorName : 'JAccount', id : lastMessage.account._id }
+
+    @icon = new AvatarStaticView
+      size       : { width, height }
+      cssClass   : cssClass
+
+
+  pistachio: -> "{{> @icon}}"
+
+

--- a/client/Social/Activity/sidebar/messageitemtext.coffee
+++ b/client/Social/Activity/sidebar/messageitemtext.coffee
@@ -49,7 +49,7 @@ class SidebarMessageItemText extends JView
     @text  = new ProfileTextView {origin}
 
 
-  fetchParticipants: (callback) ->
+  getParticipantOrigins: (callback) ->
 
     { lastMessage, participantsPreview, participantCount } = @getData()
 
@@ -63,7 +63,7 @@ class SidebarMessageItemText extends JView
     origins = (origins.concat filtered).slice 0, 3
     origins = origins.map (origin) -> { constructorName : 'JAccount', id : origin._id }
 
-    KD.remote.cacheable origins, callback
+    callback origins
 
 
   createGrouped: ->
@@ -72,17 +72,15 @@ class SidebarMessageItemText extends JView
       tagName  : 'span'
       cssClass : 'profile'
 
-    @fetchParticipants (err, participants) =>
-
-      return KD.showError err  if err
+    @getParticipantOrigins (origins) =>
 
       { participantCount } = @getData()
 
-      nameCount = participants.length
+      nameCount = origins.length
 
-      participants.forEach (participant, index) =>
+      origins.forEach (origin, index) =>
 
-        @addProfileElement participant
+        @addProfileElement origin
         @addTextElement partial: @getSeparatorPartial participantCount, nameCount, index
 
       @addPlusMoreElement participantCount, nameCount  if participantCount > nameCount + 1
@@ -100,7 +98,7 @@ class SidebarMessageItemText extends JView
     @text.addSubView new KDCustomHTMLView options, data
 
 
-  addProfileElement: (data) ->
+  addProfileElement: (origin) ->
 
     @text.addSubView profileView = new ProfileTextView
       origin    : origin

--- a/client/Social/Activity/sidebar/messageitemtext.coffee
+++ b/client/Social/Activity/sidebar/messageitemtext.coffee
@@ -1,0 +1,122 @@
+class SidebarMessageItemText extends JView
+
+  constructor: (options = {}, data) ->
+
+    options.cssClass or= 'sidebar-message-text'
+
+    super options, data
+
+    @init()
+
+
+  pistachio: -> "{{> @text}}"
+
+
+  init: ->
+
+    { purpose } = @getData()
+
+    return @createPurpose purpose  if purpose
+
+    { participantCount, participantsPreview } = @getData()
+
+    shouldBeGrouped = no
+
+    if participantCount is 1
+      sample = participantsPreview
+    else
+      sample = participantsPreview.filter (acc) -> return acc._id isnt KD.whoami()._id
+      shouldBeGrouped = yes  if participantCount > 2
+
+    origin = sample.first
+
+    if shouldBeGrouped
+    then @createGrouped()
+    else @createSingle origin
+
+
+  createPurpose: (purpose) ->
+
+    @text = new KDCustomHTMLView
+      tagName  : 'span'
+      cssClass : 'purpose'
+      partial  : purpose
+
+
+  createSingle: (origin) ->
+
+    origin = { constructorName : 'JAccount', id : origin._id }
+    @text  = new ProfileTextView {origin}
+
+
+  fetchParticipants: (callback) ->
+
+    { lastMessage, participantsPreview, participantCount } = @getData()
+
+    lastMessageOwner = lastMessage.account
+
+    origins  = if lastMessageOwner._id is KD.whoami()._id then [] else [lastMessageOwner]
+
+    filtered = participantsPreview.filter (p) ->
+      return not (p._id in [KD.whoami()._id, lastMessageOwner._id])
+
+    origins = (origins.concat filtered).slice 0, 3
+    origins = origins.map (origin) -> { constructorName : 'JAccount', id : origin._id }
+
+    KD.remote.cacheable origins, callback
+
+
+  createGrouped: ->
+
+    @text = new KDCustomHTMLView
+      tagName  : 'span'
+      cssClass : 'profile'
+
+    @fetchParticipants (err, participants) =>
+
+      return KD.showError err  if err
+
+      { participantCount } = @getData()
+
+      nameCount = participants.length
+
+      participants.forEach (participant, index) =>
+
+        @addProfileElement participant
+        @addTextElement partial: @getSeparatorPartial participantCount, nameCount, index
+
+      @addPlusMoreElement participantCount, nameCount  if participantCount > nameCount + 1
+
+
+  addPlusMoreElement: (participantCount, nameCount) ->
+
+    return  unless participantCount > nameCount + 1
+
+    @addTextElement partial: " #{participantCount - nameCount - 1} more"
+
+
+  addTextElement: (options = {}, data) ->
+    options.tagName = 'span'
+    @text.addSubView new KDCustomHTMLView options, data
+
+
+  addProfileElement: (data) ->
+
+    @text.addSubView profileView = new ProfileTextView
+      origin    : origin
+      pistachio : "{{ #(profile.firstName)}}"
+
+    return profileView
+
+
+  getSeparatorPartial: (participantCount, nameCount, position) ->
+
+    thereIsDifference = !!(participantCount - nameCount - 1)
+
+    switch
+      when (nameCount - position) is (if thereIsDifference then 1 else 2)
+        return ' & '
+      when position < nameCount - 1
+        return ', '
+
+


### PR DESCRIPTION
![screenshot 2014-09-11 21 57 22](https://cloud.githubusercontent.com/assets/1783869/4245471/528867be-3a39-11e4-847e-c5866464ebcb.png)

---
- [x] Add clever logic for message text
- [x] Show a placeholder image for now for chats that have more than 2 participants
- [x] Show stacked avatars for group messages.
- [x] Show last message sender's avatar in front all the time.

ping @sinan 
