### PR TITLE
auto-complete: tags are stored as 'name', not 'title'

### DIFF
--- a/client/Main/CommonViews/tagcontextmenuitem.coffee
+++ b/client/Main/CommonViews/tagcontextmenuitem.coffee
@@ -15,4 +15,4 @@ class TagContextMenuItem extends JContextMenuItem
     else if $deleted
       """You can not tag your post with <span class="ttag">#{Encoder.XSSEncode $deleted}</span>"""
     else
-      "{{#(title)}}"
+      "{{#(name)}}"


### PR DESCRIPTION
fix for a bug where tag auto-complete suggestions are reading "undefined": http://d.pr/i/trQc
