### PR TITLE
kloud: Use `write_files` directive for writing kite.key.

### DIFF
--- a/go/src/koding/kites/kloud/koding/cloudinit.go
+++ b/go/src/koding/kites/kloud/koding/cloudinit.go
@@ -32,6 +32,11 @@ users:
     sudo: ALL=(ALL) NOPASSWD:ALL
 
 write_files:
+  # Create kite.key
+  - content: |
+      {{.KiteKey}}
+    path: /etc/kite/kite.key
+
   # Apache configuration (/etc/apache2/sites-available/000-default.conf)
   - content: |
       <VirtualHost *:{{.ApachePort}}>
@@ -125,10 +130,6 @@ write_files:
     owner: {{.Username}}:{{.Username}}
 
 runcmd:
-  # Create kite.key
-  - [mkdir, "/etc/kite"]
-  - [sh, -c, 'echo "{{.KiteKey}}" >> /etc/kite/kite.key']
-
   # Install & Configure klient
   - [wget, "{{.LatestKlientURL}}", -O, /tmp/latest-klient.deb]
   - [dpkg, -i, /tmp/latest-klient.deb]

--- a/go/src/koding/kites/kloud/koding/cloudinit.go
+++ b/go/src/koding/kites/kloud/koding/cloudinit.go
@@ -11,7 +11,6 @@ import (
 var (
 	cloudInitTemplate = template.Must(template.New("cloudinit").Parse(cloudInit))
 
-	// TODO: write_files directive doesn't work properly. So we are echoing.
 	cloudInit = `
 #cloud-config
 output : { all : '| tee -a /var/log/cloud-init-output.log' }


### PR DESCRIPTION
write_files directive creates the missing directories recursively for
us and it has much cleaner syntax than `sh -c 'echo foo' > file`
