### PR TITLE
kloud: add tags all once instead of single

### DIFF
--- a/go/src/github.com/koding/kloud/api/amazon/tag.go
+++ b/go/src/github.com/koding/kloud/api/amazon/tag.go
@@ -15,3 +15,12 @@ func (a *Amazon) AddTag(instanceId, key, value string) error {
 
 	return nil
 }
+
+func (a *Amazon) AddTags(instanceId string, tags []ec2.Tag) error {
+	_, err := a.Client.CreateTags([]string{instanceId}, tags)
+	if err != nil {
+		return fmt.Errorf("Failed to tag a Name on the builder instance: %s", err)
+	}
+
+	return nil
+}

--- a/go/src/github.com/koding/kloud/build.go
+++ b/go/src/github.com/koding/kloud/build.go
@@ -37,7 +37,7 @@ func (b *Build) prepare(r *kite.Request, c *Controller) (interface{}, error) {
 	b.Storage.UpdateState(c.MachineId, machinestate.Building)
 	c.Eventer = b.NewEventer(r.Method + "-" + c.MachineId)
 
-	instanceName := r.Username + "-" + strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
+	instanceName := "user-" + r.Username + "-" + strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
 	i, ok := c.Machine.Builder["instanceName"]
 	if !ok || i == "" {
 		// if it's empty we use the instance name that was generated above

--- a/go/src/github.com/koding/kloud/provider/amazon/client.go
+++ b/go/src/github.com/koding/kloud/provider/amazon/client.go
@@ -92,12 +92,6 @@ func (a *AmazonClient) Build(instanceName string) (*protocol.Artifact, error) {
 		return nil, err
 	}
 
-	// Rename the machine
-	infoLog("Adding the tag '%s' to the instance '%s'", instanceName, instance.InstanceId)
-	if err := a.AddTag(instance.InstanceId, "Name", instanceName); err != nil {
-		return nil, err
-	}
-
 	return &protocol.Artifact{
 		IpAddress:     instance.PublicIpAddress,
 		InstanceName:  instanceName,


### PR DESCRIPTION
- Instead of five independent api calls we are making one call that adds all the tags
- Increased the timeout of klient checking from one minute to two minutes
- Use `user-name-time` for instance name tagging instead of `name-time` so we can list them easily on EC2 dashboard.
