### PR TITLE
kloud: Change kloud.NewKloud() function to kloud.NewWithDefaults()

### DIFF
--- a/go/src/koding/kites/kloud/kloud/kloud.go
+++ b/go/src/koding/kites/kloud/kloud/kloud.go
@@ -43,8 +43,8 @@ type Kloud struct {
 	Debug bool
 }
 
-// NewKloud creates a new Kloud instance with default providers.
-func NewKloud() *Kloud {
+// New creates a new Kloud instance without initializing the default providers.
+func New() *Kloud {
 	kld := &Kloud{
 		idlock:    idlock.New(),
 		Log:       logging.NewLogger(NAME),
@@ -52,7 +52,14 @@ func NewKloud() *Kloud {
 		providers: make(map[string]interface{}),
 	}
 
+	return kld
+}
+
+// NewWithDefaults creates a new Kloud instance with default providers.
+func NewWithDefaults() *Kloud {
+	kld := New()
 	kld.initializeProviders()
+
 	return kld
 }
 

--- a/go/src/koding/kites/kloud/main.go
+++ b/go/src/koding/kites/kloud/main.go
@@ -192,7 +192,7 @@ func newKite(conf *Config) *kite.Kite {
 	go kodingProvider.RunChecker(checkInterval)
 	go kodingProvider.RunCleaner(time.Minute)
 
-	kld := kloud.NewKloud()
+	kld := kloud.NewWithDefaults()
 	kld.Storage = kodingProvider
 	kld.Locker = kodingProvider
 	kld.Log = newLogger("kloud", conf.DebugMode)


### PR DESCRIPTION
Also offer an option to create a new kloud without initializing the
default providers. This is needed for tests.
