### PR TITLE
kloud: Decouple Storage interface from the underlying implementation.

### DIFF
--- a/go/src/koding/kites/kloud/kloud/controller.go
+++ b/go/src/koding/kites/kloud/kloud/controller.go
@@ -141,6 +141,17 @@ func (k *Kloud) Reinit(r *kite.Request) (resp interface{}, reqErr error) {
 func (k *Kloud) Stop(r *kite.Request) (resp interface{}, reqErr error) {
 	stopFunc := func(m *protocol.Machine, p protocol.Provider) (interface{}, error) {
 		err := p.Stop(m)
+		if err != nil {
+			return nil, err
+		}
+
+		err = k.Storage.Update(m.Id, &StorageData{
+			Type: "stop",
+			Data: map[string]interface{}{
+				"ipAddress": "",
+			},
+		})
+
 		return nil, err
 	}
 

--- a/go/src/koding/kites/kloud/koding/build.go
+++ b/go/src/koding/kites/kloud/koding/build.go
@@ -173,6 +173,7 @@ func (p *Provider) build(a *amazon.AmazonClient, m *protocol.Machine, v *pushVal
 		LatestKlientURL: signedLatestKlientURL,
 		ApachePort:      DefaultApachePort,
 		KitePort:        DefaultKitePort,
+		Test:            p.Test,
 	}
 
 	cloudInitConfig.setupMigrateScript()

--- a/go/src/koding/kites/kloud/koding/cloudinit.go
+++ b/go/src/koding/kites/kloud/koding/cloudinit.go
@@ -187,9 +187,15 @@ type CloudInitConfig struct {
 	VmNames       string
 	VmIds         string
 	ShouldMigrate bool
+
+	Test bool
 }
 
 func (c *CloudInitConfig) setupMigrateScript() {
+	// FIXME: Hack. Revise here.
+	if c.Test {
+		return
+	}
 	vms, err := modelhelper.GetUserVMs(c.Username)
 	if err != nil {
 		return

--- a/go/src/koding/kites/kloud/koding/provider.go
+++ b/go/src/koding/kites/kloud/koding/provider.go
@@ -7,7 +7,6 @@ import (
 
 	amazonClient "koding/kites/kloud/api/amazon"
 	"koding/kites/kloud/eventer"
-	"koding/kites/kloud/kloud"
 	"koding/kites/kloud/machinestate"
 	"koding/kites/kloud/protocol"
 	"koding/kites/kloud/provider/amazon"
@@ -162,19 +161,9 @@ func (p *Provider) Stop(m *protocol.Machine) error {
 		return err
 	}
 
-	a.Push("Deleting domain", 75, machinestate.Stopping)
+	a.Push("Deleting domain", 85, machinestate.Stopping)
 	if err := p.DNS.DeleteDomain(m.Domain.Name, m.IpAddress); err != nil {
 		return err
-	}
-
-	a.Push("Updating ip address", 85, machinestate.Stopping)
-	if err := p.Update(m.Id, &kloud.StorageData{
-		Type: "stop",
-		Data: map[string]interface{}{
-			"ipAddress": "",
-		},
-	}); err != nil {
-		p.Log.Error("[stop] storage update of essential data was not possible: %s", err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
kloud.Stop function should call kloud.Storage.Update instead of the
underlying implementation directly.

Also add a test-check to cloud-init setupMigrateScript() function to
by-pass the mongodb-specific logic.
