### PR TITLE
kloud: new AWS account changes

### DIFF
--- a/config/main.sandbox.coffee
+++ b/config/main.sandbox.coffee
@@ -62,7 +62,7 @@ Configuration = (options={}) ->
     debug             : yes
     stripe            : { secretToken : "sk_test_2ix1eKPy8WtfWTLecG9mPOvN" }
 
-  userSitesDomain     = "svm.koding.io"
+  userSitesDomain     = "sandbox.koding.io"
   socialQueueName     = "koding-social-#{configName}"
   logQueueName        = socialQueueName+'log'
 

--- a/go/src/koding/kites/kloud/koding/provider.go
+++ b/go/src/koding/kites/kloud/koding/provider.go
@@ -20,8 +20,8 @@ var (
 
 	// Credential belongs to the `koding-kloud` user in AWS IAM's
 	kodingCredential = map[string]interface{}{
-		"access_key": "AKIAIDPT7E2UHZHT2CXQ",
-		"secret_key": "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",
+		"access_key": "AKIAIKAVWAYVSMCW4Z5A",
+		"secret_key": "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",
 	}
 )
 

--- a/go/src/koding/kites/kloud/provisioner/koding-image.json
+++ b/go/src/koding/kites/kloud/provisioner/koding-image.json
@@ -14,6 +14,8 @@
             "instance_type": "m3.medium",
             "region": "us-east-1",
             "source_ami": "ami-680fd500",
+            "subnet_id": "subnet-98d30fef",
+            "vpc_id": "vpc-bf65dada",
             "ssh_username": "ubuntu",
             "type": "amazon-ebs"
         }
@@ -51,7 +53,7 @@
         },
         {
             "type": "file",
-    	    "source": "{{user `bash_dir`}}",
+            "source": "{{user `bash_dir`}}",
             "destination": "/tmp/userdata/bash"
         },
         {


### PR DESCRIPTION
Most of work is done manually in AWS such as setting up VPC, Subnet, SecurityGroups, KeyPairs, Domains etc.. We have a `kloud` user with the credentials seen in this PR. Also Packer provisioning is updated so it uses the new shared image from the original account.
