### PR TITLE
client: redirect /Login to /Activity when logged in

### DIFF
--- a/client/Main/routes.coffee
+++ b/client/Main/routes.coffee
@@ -55,6 +55,8 @@ do ->
       KD.mixpanel "Visit referrer url, success", {username}
       # give a notification to tell that this is a referral link here - SY
       @handleRoute if KD.isLoggedIn() then "/Activity" else "/"
+    '/:name?/Login'         : ({params:{name}})->
+      @handleRoute "/IDE"  if KD.isLoggedIn()
     '/:name?/Logout'         : ({params:{name}})->
       requireLogin ->
         {mainController} = KD.singletons


### PR DESCRIPTION
@sinan currently since we don't have a /Login route, it's showing "Login not found" modal. We need to redirectly /Login to /IDE for the chrome apps.
