### PR TITLE
payment: expose http endpoint on webserver for kloud to check

### DIFF
--- a/go/src/socialapi/workers/payment/api/api.go
+++ b/go/src/socialapi/workers/payment/api/api.go
@@ -19,6 +19,13 @@ func SubscriptionRequest(u *url.URL, h http.Header, _ interface{}) (int, http.He
 		AccountId: u.Query().Get("accountId"),
 	}
 
+	def := u.Query().Get("default")
+	if def == "false" {
+		return response.HandleResultAndClientError(
+			subscriptionRequest.Do(),
+		)
+	}
+
 	return response.HandleResultAndClientError(
 		subscriptionRequest.DoWithDefault(),
 	)

--- a/go/src/socialapi/workers/payment/payment.go
+++ b/go/src/socialapi/workers/payment/payment.go
@@ -45,7 +45,7 @@ type SubscriptionRequest struct {
 }
 
 type SubscriptionsResponse struct {
-	AccountId          string    `json:"acccountId"`
+	AccountId          string    `json:"accountId"`
 	PlanTitle          string    `json:"planTitle"`
 	PlanInterval       string    `json:"planInterval"`
 	State              string    `json:"state"`

--- a/go/src/socialapi/workers/payment/payment.go
+++ b/go/src/socialapi/workers/payment/payment.go
@@ -45,12 +45,10 @@ type SubscriptionRequest struct {
 }
 
 type SubscriptionsResponse struct {
-	AcccountId         string    `json:"acccountId"`
+	AccountId          string    `json:"acccountId"`
 	PlanTitle          string    `json:"planTitle"`
 	PlanInterval       string    `json:"planInterval"`
 	State              string    `json:"state"`
-	CreatedAt          time.Time `json:"createdAt"`
-	CanceledAt         time.Time `json:"canceledAt"`
 	CurrentPeriodStart time.Time `json:"currentPeriodStart"`
 	CurrentPeriodEnd   time.Time `json:"currentPeriodEnd"`
 }
@@ -86,6 +84,7 @@ func (s *SubscriptionRequest) Do() (*SubscriptionsResponse, error) {
 	}
 
 	resp := &SubscriptionsResponse{
+		AccountId:          s.AccountId,
 		PlanTitle:          plan.Title,
 		PlanInterval:       plan.Interval,
 		CurrentPeriodStart: currentSubscription.CurrentPeriodStart,
@@ -106,7 +105,7 @@ func (s *SubscriptionRequest) DoWithDefault() (*SubscriptionsResponse, error) {
 	}
 
 	defaultResp := &SubscriptionsResponse{
-		AcccountId:   s.AccountId,
+		AccountId:    s.AccountId,
 		PlanTitle:    "free",
 		PlanInterval: "month",
 		State:        "active",

--- a/servers/lib/server/index.coffee
+++ b/servers/lib/server/index.coffee
@@ -367,6 +367,7 @@ app.get '/-/image/cache'             , require "./image_cache"
 
 # Handlers for Stripe
 app.post '/-/stripe/webhook'         , require "./stripe_webhook"
+app.get  '/-/subscriptions'          , require "./subscriptions"
 
 # TODO: we need to add basic auth!
 app.all '/-/email/webhook', (req, res) ->

--- a/servers/lib/server/stripe_webhook.coffee
+++ b/servers/lib/server/stripe_webhook.coffee
@@ -4,6 +4,8 @@
 
 module.exports = (req, res) ->
   url = "/payments/stripe/webhook"
-  post url, data, callback
+  post url, data, (err)->
+    if err
+      return res.send 500
 
-  res.send 200
+    res.send 200

--- a/servers/lib/server/subscriptions.coffee
+++ b/servers/lib/server/subscriptions.coffee
@@ -20,7 +20,7 @@ module.exports = (req, res) ->
   # Hardcoding is wrong, however this key won't change
   # depending on environments, so there's point of
   # putting it in config : SA
-  unless kloud_key is "AAABBBCCCDDDEEE"
+  unless kloud_key is "R1PVxSPvjvDSWdlPRVqRv8IdwXZB"
     res.send 401, errMsg "kloud_key is wrong"
 
   url  = "/payments/subscriptions/#{account_id}"

--- a/servers/lib/server/subscriptions.coffee
+++ b/servers/lib/server/subscriptions.coffee
@@ -1,0 +1,32 @@
+{ get } = require (
+  "../../../workers/social/lib/social/models/socialapi/requests.coffee"
+)
+
+module.exports = (req, res) ->
+  errMsg = (msg)->
+    {
+      "description" : msg
+      "error"       : "bad_request"
+    }
+
+  {account_id, kloud_key} = req.query
+
+  unless account_id
+    res.send 400, errMsg "account_id is required"
+
+  unless kloud_key
+    res.send 401, errMsg "kloud_key is required"
+
+  # Hardcoding is wrong, however this key won't change
+  # depending on environments, so there's point of
+  # putting it in config : SA
+  unless kloud_key is "AAABBBCCCDDDEEE"
+    res.send 401, errMsg "kloud_key is wrong"
+
+  url  = "/payments/subscriptions/#{account_id}"
+  url += "?default=false"
+
+  get url, {}, (err, response)->
+    return res.send 400, err  if err
+
+    res.send 200, response


### PR DESCRIPTION
@fatih Like we discussed I've exposed an endpoint on koding.com that returns user's current subscription. The secret token is is `AAABBBCCCDDDEEE`

Example:
(Successful):

```
curl http://lvh.me:8090/-/subscriptions?account_id=542469df9eecccb69185a516&kloud_key=AAABBBCCCDDDEEE

{
  accountId: "542469df9eecccb69185a516",
  planTitle: "hobbyist",
  planInterval: "year",
  state: "active",
  currentPeriodStart: "2014-09-25T19:35:53Z",
  currentPeriodEnd: "2015-09-25T19:35:53Z"
}
```

Failure:

```
curl http://lvh.me:8090/-/subscriptions?account_id=1`

{
  description: "kloud_key is required",
  error: "bad_request"
}
```

```
curl http://lvh.me:8090/-/subscriptions?account_id=1&kloud_key=AAABBBCCCDDDEEE`

{
  description: "user not found",
  error: "bad_request"
}
```
