### PR TITLE
activity: fix delete regression [fixes: #79455442]

### DIFF
--- a/client/Social/Activity/views/activitycontentpane.coffee
+++ b/client/Social/Activity/views/activitycontentpane.coffee
@@ -45,7 +45,7 @@ class ActivityContentPane extends KDView
     @listController.getListView().items.length
 
   removeMessage: (message) ->
-    items = @listController.items.getItems()
+    { items } = @listController.getListView()
 
     items
       .filter (item) -> item.getData().getId() is message.getId()


### PR DESCRIPTION
I guess I regressed this when I was trying to remove the usage of `itemsOrdered`, which is deprecated.
