### PR TITLE
KodingProvider: if fetchPlan fails use provided default plan

### DIFF
--- a/client/Main/providers/computecontroller.coffee
+++ b/client/Main/providers/computecontroller.coffee
@@ -152,7 +152,7 @@ class ComputeController extends KDController
 
   createDefaultStack: ->
     return  unless KD.isLoggedIn()
-    KD.remote.api.ComputeProvider.createGroupStack (err, stack)=>
+    KD.remote.api.ComputeProvider.createGroupStack (err, res)=>
       return  if KD.showError err
       @reset yes
 

--- a/workers/social/lib/social/models/computeproviders/computeprovider.coffee
+++ b/workers/social/lib/social/models/computeproviders/computeprovider.coffee
@@ -296,7 +296,7 @@ module.exports = class ComputeProvider extends Base
 
         queue.push ->
 
-          callback null, stack, results
+          callback null, {stack, results}
 
         daisy queue
 
@@ -314,7 +314,9 @@ module.exports = class ComputeProvider extends Base
           delegate : member
         context    : group : group.slug
 
-      ComputeProvider.createGroupStack client, (err, stack, results)->
+      ComputeProvider.createGroupStack client, (err, res = {})->
+
+        {stack, results} = res
 
         if err?
           {nickname} = member.profile

--- a/workers/social/lib/social/models/computeproviders/computeprovider.coffee
+++ b/workers/social/lib/social/models/computeproviders/computeprovider.coffee
@@ -296,9 +296,7 @@ module.exports = class ComputeProvider extends Base
 
         queue.push ->
 
-          callback null, stack
-          # `results` keeps track of the all operation
-          # if needed return with callback.
+          callback null, stack, results
 
         daisy queue
 
@@ -316,11 +314,11 @@ module.exports = class ComputeProvider extends Base
           delegate : member
         context    : group : group.slug
 
-      ComputeProvider.createGroupStack client, (err, res)->
+      ComputeProvider.createGroupStack client, (err, stack, results)->
 
         if err?
           {nickname} = member.profile
-          console.log "Create group stack failed for #{nickname}:", err
+          console.log "Create group stack failed for #{nickname}:", err, results
 
 
     JAccount = require '../account'

--- a/workers/social/lib/social/models/computeproviders/koding.coffee
+++ b/workers/social/lib/social/models/computeproviders/koding.coffee
@@ -105,7 +105,9 @@ module.exports = class Koding extends ProviderInterface
 
     @fetchUserPlan client, (err, userPlan)=>
 
-      return callback err  if err?
+      # Commented-out this since if it fails to fetch
+      # plan it uses 'free' as default. ~ GG
+      # return callback err  if err?
 
       @fetchUsage client, options, (err, usage)->
 
@@ -142,9 +144,7 @@ module.exports = class Koding extends ProviderInterface
 
     @fetchUserPlan client, (err, userPlan)=>
 
-      # Commented-out this since if its failing to fetch plan
-      # its falling back to 'free' as default. ~ GG
-      # return callback err  if err?
+      return callback err  if err?
 
       @fetchUsage client, options, (err, usage)->
 

--- a/workers/social/lib/social/models/computeproviders/koding.coffee
+++ b/workers/social/lib/social/models/computeproviders/koding.coffee
@@ -142,7 +142,9 @@ module.exports = class Koding extends ProviderInterface
 
     @fetchUserPlan client, (err, userPlan)=>
 
-      return callback err  if err?
+      # Commented-out this since if its failing to fetch plan
+      # its falling back to 'free' as default. ~ GG
+      # return callback err  if err?
 
       @fetchUsage client, options, (err, usage)->
 


### PR DESCRIPTION
This was breaking the buildservices task since its using standalone script
which is not starting Social API while working. So, it was breaking the
user-importer to create developer machines for local development.
