### PR TITLE
Build and deploy `klient` via wercker. [fixes #79465368]

### DIFF
--- a/go/src/koding/kites/klient/klient.go
+++ b/go/src/koding/kites/klient/klient.go
@@ -33,7 +33,7 @@ var (
 	flagUpdateInterval = flag.Duration("update-interval", time.Minute*5,
 		"Change interval for checking for new updates")
 	flagUpdateURL = flag.String("update-url",
-		"https://s3.amazonaws.com/koding-kites/klient/"+protocol.Environment+"/latest-version.txt",
+		"https://s3.amazonaws.com/koding-klient/"+protocol.Environment+"/latest-version.txt",
 		"Change update endpoint for latest version")
 
 	VERSION = protocol.Version

--- a/go/src/koding/kites/klient/update.go
+++ b/go/src/koding/kites/klient/update.go
@@ -83,7 +83,7 @@ func (u *Updater) checkAndUpdate() error {
 
 	klog.Info("Current version: %s is old. Going to update to: %s", currentVer, latestVer)
 
-	basePath := "https://s3.amazonaws.com/koding-kites/klient/" + protocol.Environment + "/latest"
+	basePath := "https://s3.amazonaws.com/koding-klient/" + protocol.Environment + "/latest"
 	latestKlientURL := basePath + "/klient-" + latestVer + ".gz"
 
 	return updateBinary(latestKlientURL)

--- a/go/src/koding/kites/kloud/main.go
+++ b/go/src/koding/kites/kloud/main.go
@@ -146,11 +146,11 @@ func newKite(conf *Config) *kite.Kite {
 		koding.DefaultCustomAMITag = conf.AMITag
 	}
 
-	klientFolder := "klient/development/latest"
+	klientFolder := "development/latest"
 	checkInterval := time.Second * 5
 	if conf.ProdMode {
 		k.Log.Info("Prod mode enabled")
-		klientFolder = "klient/production/latest"
+		klientFolder = "production/latest"
 		checkInterval = time.Millisecond * 500
 	}
 	k.Log.Info("Klient distribution channel is: %s", klientFolder)
@@ -170,7 +170,7 @@ func newKite(conf *Config) *kite.Kite {
 		KontrolURL:        getKontrolURL(conf.KontrolURL),
 		KontrolPrivateKey: kontrolPrivateKey,
 		KontrolPublicKey:  kontrolPublicKey,
-		Bucket:            koding.NewBucket("koding-kites", klientFolder),
+		Bucket:            koding.NewBucket("koding-klient", klientFolder),
 		KeyName:           keys.DeployKeyName,
 		PublicKey:         keys.DeployPublicKey,
 		PrivateKey:        keys.DeployPrivateKey,

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -503,7 +503,7 @@ func newKloud() *kloud.Kloud {
 		KontrolURL:        conf.KontrolURL,
 		KontrolPrivateKey: testkeys.Private,
 		KontrolPublicKey:  testkeys.Public,
-		Bucket:            koding.NewBucket("koding-kites", "klient/development/latest"),
+		Bucket:            koding.NewBucket("koding-klient", "development/latest"),
 		Test:              true,
 		HostedZone:        "dev.koding.io", // TODO: Use test.koding.io
 		AssigneeName:      "kloud-test",

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,82 +1,69 @@
-box: koding/base@0.0.11
-services:
-  - wercker/postgresql@0.0.4
-  - wercker/rabbitmq@1.0.1
-  - wercker/redis@0.0.8
-  - wercker/mongodb@1.0.1
+# This file describes how to package klient.deb and uploads to a persistent
+# storage Packaging is done if a push is made to `klientkite.development` or
+# `klientkite.production` branches on `koding` repository.
+#
+# 1. If a push is made to either branches, a build number is created from the
+# latest version number and incremented.
+#
+# 2. A Debian package (deb) is built with a version with a semantical versioning.
+# Also a gzip file is created in the same directory.
+#
+# 3. These files are then uploaded to AWS S3 to `koding-klient` bucket in a
+# directory called `development/$BUILDNO/{foo.0.1.0.gz,foo.0.1.0_amd64.deb}`
+#
+# For future readers who are humble like me to inspect these variables:
+# KLIENT_CHANNEL: development/production
+# S3_KLIENTKITE: koding-klient
+box: koding/base@0.0.12
 
 build:
   steps:
     - script:
-        name: initialize submodules
-        code: git submodule update --init --recursive
-    - script:
-        name: npm install
-        code: |
-          npm cache clean
-          npm set registry https://registry.npmjs.org/
-          npm install || :
-          cd client/Framework && npm install && cd ../../
-          cd client/landing && npm install && cd ../../
-    - script:
-        name: configure build
-        code: ./configure --config $CONFIG --projectRoot /opt/koding
-    - script:
-        name: build client
-        code: |
-          sudo chown -R $USER ~/.npm
-          ./run
-    - script:
         name: build go binaries
         code: go/build.sh
-    - script:
-        name: build social api
-        cwd: go/src/socialapi
-        code: |
-          make configure
-          make install
-          make build
-    - script:
-        name: create postgresql tables
-        cwd: go/src/socialapi/db/sql
-        code: definition/create-wercker.sh .
-    - script:
-        name: test social api
-        code: |
-          sudo -E scripts/wercker/init-socialapi.sh
-          tail -n 100 /var/log/koding/social-api.log
-          tail -n 100 /var/log/koding/social-populartopic.log
-          tail -n 100 /var/log/koding/social-pinnedpost.log
-          cd go/src/socialapi
-          make testapi
 
 deploy:
   steps:
-    - create-file:
-        name: write version file
-        filename: $WERCKER_ROOT/VERSION
-        content: ${WERCKER_GIT_COMMIT:0:8}
-        overwrite: true
     - script:
-        name: zip
+        name: configure s3cmd (temporary workaround)
         code: |
-          cd $WERCKER_ROOT
+          echo '[default]' > ~/.s3cfg
+          echo "access_key=$S3_KEY_ID" >> ~/.s3cfg
+          echo "secret_key=$S3_KEY_SECRET" >> ~/.s3cfg
 
-          ./configure --config $CONFIG --projectRoot /opt/koding
-          ./run
+          # Shortcut to s3://koding-klient/development directory
+          export S3DIR="s3://$S3_KLIENTKITE/$KLIENT_CHANNEL"
 
-          rm -rf .git .build node_modules
-          rm -rf go/bin go/pkg
-          zip -q --symlinks -r $ARCHIVE .
-    - koding/s3put@0.0.3:
-          key-id: $S3_KEY_ID
-          key-secret: $S3_KEY_SECRET
-          file: $ARCHIVE
-          url: s3://$S3_EB_DEPLOY
-    - koding/eb-deploy@0.0.5:
-          access-key: $S3_KEY_ID
-          secret-key: $S3_KEY_SECRET
-          app-name: koding
-          env-name: $EB_ENV_NAME
-          app-location: $S3_EB_DEPLOY/$ARCHIVE
-          version-label: $ARCHIVE
+          # Fetch the latest build number since wercker doesn't provide one
+          s3cmd get $S3DIR/latest-version.txt version
+          export OLDBUILDNO=$(cat version)
+          export NEWBUILDNO=$(($OLDBUILDNO+1))
+          echo "New version will be: $NEWBUILDNO"
+          rm -f version
+
+    - script:
+        name: package klient.deb
+        code: |
+          # Create klient.0.1.x.gz
+          export GOPATH=$PWD/go
+          go run go/package.go -a klient -e $KLIENT_CHANNEL -b $NEWBUILDNO
+          go build -v -ldflags "-X koding/kites/klient/protocol.Version 0.1.$NEWBUILDNO -X koding/kites/klient/protocol.Environment $KLIENT_CHANNEL" koding/kites/klient
+          gzip -N klient
+          mv klient.gz klient-0.1.$NEWBUILDNO.gz
+
+    - script:
+        name: sync with s3
+        code: |
+          #  Copy files to S3.
+          s3cmd put *.deb  $S3DIR/$NEWBUILDNO/
+          s3cmd -P put *.gz  $S3DIR/$NEWBUILDNO/
+
+          # Cleanup the latest/ folder and put the latest one in there
+          s3cmd del --recursive $S3DIR/latest/
+          s3cmd put *.deb  $S3DIR/latest/
+          s3cmd -P put *.gz  $S3DIR/latest/
+
+          # Update latest-version.txt with the latest version
+          s3cmd del $S3DIR/latest-version.txt
+          echo $NEWBUILDNO > latest-version.txt
+          s3cmd -P put latest-version.txt  $S3DIR/latest-version.txt


### PR DESCRIPTION
klient.deb and klient.gz builder is wercker now, it was jenkins before.

All build and deploy steps are removed and all wercker.yml is about
building and deploying klient.deb to S3. Why? Because:

```
Wercker does not allow to deploy a push made to a certain branch.
Wercker does not have a build/deploy filter.
```

So, this branch's wercker.yml differed from other branches. When a push
is made to this branch, wercker will be notified and only klient will be
deployed, nothing else.

Same actions will take effect for klientkite.production branch.
