### PR TITLE
client: use default route instead of explicit '/' string route for logos [fixes #79645886]

### DIFF
--- a/client/Core/mainview.coffee
+++ b/client/Core/mainview.coffee
@@ -42,23 +42,26 @@ class MainView extends KDView
     @header.addSubView new TopNavigation
 
     @header.addSubView @logo = new KDCustomHTMLView
-      tagName   : "a"
-      domId     : "koding-logo"
-      cssClass  : if entryPoint?.type is 'group' then 'group' else ''
-      partial   : '<cite></cite>'
+      tagName    : "a"
+      attributes : href : '/'
+      domId      : "koding-logo"
+      cssClass   : if entryPoint?.type is 'group' then 'group' else ''
+      partial    : '<cite></cite>'
       click     : (event)=>
         KD.utils.stopDOMEvent event
         {router} = KD.singletons
-        if KD.isLoggedIn()
-        then router.handleRoute '/Activity', {entryPoint}
-        else router.handleRoute '/', {entryPoint}
+        router.handleRoute router.getDefaultRoute()
 
     @logo.setClass KD.config.environment
 
     @header.addSubView @logotype = new CustomLinkView
       cssClass : 'logotype'
       title    : 'Koding'
-      href     : '/Home'
+      href     : '/'
+      click    : (event)=>
+        KD.utils.stopDOMEvent event
+        {router} = KD.singletons
+        router.handleRoute router.getDefaultRoute()
 
 
   createSidebar: ->
@@ -69,9 +72,19 @@ class MainView extends KDView
       tagName  : 'aside'
       domId    : 'main-sidebar'
 
-    @aside.addSubView new KDCustomHTMLView
+    logoWrapper = new KDCustomHTMLView
       cssClass  : if entryPoint?.type is 'group' then 'logo-wrapper group' else 'logo-wrapper'
-      partial   : "<a href='/'><figure></figure></a>"
+
+    logoWrapper.addSubView new KDCustomHTMLView
+      tagName    : 'a'
+      attributes : href : '/' # so that it shows 'koding.com' on status bar of browser
+      partial    : '<figure></figure>'
+      click      : (event)=>
+        KD.utils.stopDOMEvent event
+        {router} = KD.singletons
+        router.handleRoute router.getDefaultRoute()
+
+    @aside.addSubView logoWrapper
 
     @aside.addSubView @sidebar = new KDCustomScrollView
       offscreenIndicatorClassName: 'unread'


### PR DESCRIPTION
The behavior in [here](https://github.com/koding/koding/blob/newkoding/client/Main/routes.coffee#L26) is defaulting user to `router.userRoute` which is only set on the initial page load, so if I reload at `/Features` page and go back to the activity from there, `router.userRoute` will always be `/Features` and all the code which is handled like : `router.handleRoute '/'` will redirect you to `/Features` page. 

This PR is fixing it by using `router.getDefaultRoute()` instead of explicit `handleRoute '/'`, and uses `href` attribute of the `a` element to make it look like it's redirecting you to `koding.com` on the status bar of the browser.

ping @szkl @sinan
