### PR TITLE
activity: visiting internal links [fixes #79647542]

### DIFF
--- a/client/Social/Activity/views/activitylistitem.coffee
+++ b/client/Social/Activity/views/activitylistitem.coffee
@@ -145,35 +145,35 @@ class ActivityListItemView extends KDListItemView
     @destroy()
 
 
-  setAnchors: ->
+  # setAnchors: ->
 
-    @$("article a").each (index, element) ->
-      {location: {origin}} = window
-      href = element.getAttribute "href"
-      return  unless href
+  #   @$("article a").each (index, element) ->
+  #     {location: {origin}} = window
+  #     href = element.getAttribute "href"
+  #     return  unless href
 
-      beginning = href.substring 0, origin.length
-      rest      = href.substring origin.length + 1
+  #     beginning = href.substring 0, origin.length
+  #     rest      = href.substring origin.length + 1
 
-      if beginning is origin
-        element.setAttribute "href", "/#{rest}"
-        element.classList.add "internal"
-        element.classList.add "teamwork"  if rest.match /^Teamwork/
-      else
-        element.setAttribute "target", "_blank"
+  #     if beginning is origin
+  #       element.setAttribute "href", "/#{rest}"
+  #       element.classList.add "internal"
+  #       element.classList.add "teamwork"  if rest.match /^Teamwork/
+  #     else
+  #       element.setAttribute "target", "_blank"
 
 
-  click: (event) ->
+  # click: (event) ->
 
-    {target} = event
+  #   {target} = event
 
-    if $(target).is "article a.internal"
-      @utils.stopDOMEvent event
-      href = target.getAttribute "href"
+  #   if $(target).is "article a.internal"
+  #     @utils.stopDOMEvent event
+  #     href = target.getAttribute "href"
 
-      if target.classList.contains("teamwork") and KD.singleton("appManager").get "Teamwork"
-      then window.open "#{window.location.origin}#{href}", "_blank"
-      else KD.singleton("router").handleRoute href
+  #     if target.classList.contains("teamwork") and KD.singleton("appManager").get "Teamwork"
+  #     then window.open "#{window.location.origin}#{href}", "_blank"
+  #     else KD.singleton("router").handleRoute href
 
 
   showResend: ->
@@ -221,8 +221,6 @@ class ActivityListItemView extends KDListItemView
     JView::viewAppended.call this
 
     emojify.run @getElement()
-
-    @setAnchors()
 
     { updatedAt, createdAt } = @getData()
 

--- a/client/Social/Activity/views/comments/listitemview.coffee
+++ b/client/Social/Activity/views/comments/listitemview.coffee
@@ -29,20 +29,40 @@ class CommentListItemView extends KDListItemView
     else @unsetClass 'edited'
 
 
-  click: (event) ->
+  # setAnchors: ->
 
-    if event.target.classList.contains 'profile-link'
-      @handleProfileLink event
+  #   @$("p a").each (index, element) ->
+  #     href = element.getAttribute "href"
+  #     return  unless href
 
-    KD.utils.showMoreClickHandler event
+  #     {location: {origin}} = window
+
+  #     beginning = href.substring 0, origin.length
+  #     rest      = href.substring origin.length + 1
+
+  #     if beginning is origin
+  #       element.setAttribute "href", "/#{rest}"
+  #     else if href is "/#{rest}" continue
+  #     else
+  #       element.setAttribute "target", "_blank"
 
 
-  handleProfileLink: (event) ->
+  # click: (event) ->
+
+  #   KD.utils.stopDOMEvent event
+
+  #   KD.singletons.router.handleRoute event.target.getAttribute 'href'
+
+  #   KD.utils.showMoreClickHandler event
+
+  #   return false
+
+
+  handleInternalLink: (event) ->
 
     KD.utils.stopDOMEvent event
-
-    {target} = event
-    KD.getSingleton('router').handleRoute target.getAttribute 'href'
+    href = event.target.getAttribute 'href'
+    KD.singletons.router.handleRoute href
 
 
   showEditForm: ->
@@ -215,6 +235,7 @@ class CommentListItemView extends KDListItemView
     @timeAgoView = new KDTimeAgoView {}, createdAt
 
     JView::viewAppended.call this
+    # @setAnchors()
 
 
   # updateTemplate: (force = no) ->


### PR DESCRIPTION
This PR

~~\- [x] catches internal links on comments as well~~
~~\- [x] mentions can be caught as internal links~~
~~\- [x] both tags and mentions are being handled by koding router now.~~
- [x] Removes unnecessary click event handlers and dom manipulations for links for `ActivityListItem`
- [x] Removes unnecessary click event handlers and dom manipulations for links for `CommentListItem`

ping @sinan @szkl 
