### PR TITLE
kloud/cloudinit: Dont fail if a username is an integer. [fixes #79714788]

### DIFF
--- a/go/src/koding/kites/kloud/koding/cloudinit.go
+++ b/go/src/koding/kites/kloud/koding/cloudinit.go
@@ -32,14 +32,14 @@ var (
 output : { all : '| tee -a /var/log/cloud-init-output.log' }
 disable_root: false
 disable_ec2_metadata: true
-hostname: {{.Hostname}}
+hostname: '{{.Hostname}}'
 
 bootcmd:
   - [sh, -c, 'echo "127.0.0.1 {{.Hostname}}" >> /etc/hosts']
 
 users:
   - default
-  - name: {{.Username}}
+  - name: '{{.Username}}'
     groups: sudo
     shell: /bin/bash
     gecos: koding user


### PR DESCRIPTION
Guard username and hostname with quotes in order to help cloudinit that they
are string, not integer.
