### PR TITLE
payment: use internal endpoint to get payment info from kloud [fixes #79719584]

### DIFF
--- a/config/main.dev.coffee
+++ b/config/main.dev.coffee
@@ -198,7 +198,7 @@ Configuration = (options={}) ->
       ports             :
         incoming        : "#{KONFIG.kloud.port}"
       supervisord       :
-        command         : "#{GOBIN}/kloud -planendpoint #{publicHostname}/-/subscriptions  -hostedzone #{userSitesDomain} -region #{region} -environment #{environment} -port #{KONFIG.kloud.port} -publickey #{kontrol.publicKeyFile} -privatekey #{kontrol.privateKeyFile} -kontrolurl #{kontrol.url}  -registerurl #{KONFIG.kloud.registerUrl} -mongourl #{KONFIG.mongo} -prodmode=#{configName is "prod"}"
+        command         : "#{GOBIN}/kloud -planendpoint #{socialapi.proxyUrl}/payments/subscriptions  -hostedzone #{userSitesDomain} -region #{region} -environment #{environment} -port #{KONFIG.kloud.port} -publickey #{kontrol.publicKeyFile} -privatekey #{kontrol.privateKeyFile} -kontrolurl #{kontrol.url}  -registerurl #{KONFIG.kloud.registerUrl} -mongourl #{KONFIG.mongo} -prodmode=#{configName is "prod"}"
       nginx             :
         websocket       : yes
         locations       : ["~^/kloud/.*"]

--- a/config/main.load.coffee
+++ b/config/main.load.coffee
@@ -197,7 +197,7 @@ Configuration = (options={}) ->
       ports             :
         incoming        : "#{KONFIG.kloud.port}"
       supervisord       :
-        command         : "#{GOBIN}/kloud -planendpoint #{publicHostname}/-/subscriptions  -hostedzone #{userSitesDomain} -region #{region} -environment #{environment} -port #{KONFIG.kloud.port} -publickey #{kontrol.publicKeyFile} -privatekey #{kontrol.privateKeyFile} -kontrolurl #{kontrol.url}  -registerurl #{KONFIG.kloud.registerUrl} -mongourl #{KONFIG.mongo} -prodmode=#{configName is "prod"}"
+        command         : "#{GOBIN}/kloud -planendpoint #{socialapi.proxyUrl}/payments/subscriptions  -hostedzone #{userSitesDomain} -region #{region} -environment #{environment} -port #{KONFIG.kloud.port} -publickey #{kontrol.publicKeyFile} -privatekey #{kontrol.privateKeyFile} -kontrolurl #{kontrol.url}  -registerurl #{KONFIG.kloud.registerUrl} -mongourl #{KONFIG.mongo} -prodmode=#{configName is "prod"}"
       nginx             :
         websocket       : yes
         locations       : ["~^/kloud/.*"]

--- a/config/main.prod.coffee
+++ b/config/main.prod.coffee
@@ -197,7 +197,7 @@ Configuration = (options={}) ->
       ports             :
         incoming        : "#{KONFIG.kloud.port}"
       supervisord       :
-        command         : "#{GOBIN}/kloud -planendpoint #{publicHostname}/-/subscriptions  -hostedzone #{userSitesDomain} -region #{region} -environment #{environment} -port #{KONFIG.kloud.port} -publickey #{kontrol.publicKeyFile} -privatekey #{kontrol.privateKeyFile} -kontrolurl #{kontrol.url}  -registerurl #{KONFIG.kloud.registerUrl} -mongourl #{KONFIG.mongo} -prodmode=#{configName is "prod"}"
+        command         : "#{GOBIN}/kloud -planendpoint #{socialapi.proxyUrl}/payments/subscriptions  -hostedzone #{userSitesDomain} -region #{region} -environment #{environment} -port #{KONFIG.kloud.port} -publickey #{kontrol.publicKeyFile} -privatekey #{kontrol.privateKeyFile} -kontrolurl #{kontrol.url}  -registerurl #{KONFIG.kloud.registerUrl} -mongourl #{KONFIG.mongo} -prodmode=#{configName is "prod"}"
       nginx             :
         websocket       : yes
         locations       : ["~^/kloud/.*"]

--- a/config/main.sandbox.coffee
+++ b/config/main.sandbox.coffee
@@ -195,7 +195,7 @@ Configuration = (options={}) ->
       ports             :
         incoming        : "#{KONFIG.kloud.port}"
       supervisord       :
-        command         : "#{GOBIN}/kloud -planendpoint #{publicHostname}/-/subscriptions -hostedzone #{userSitesDomain} -region #{region} -environment #{environment} -port #{KONFIG.kloud.port} -publickey #{kontrol.publicKeyFile} -privatekey #{kontrol.privateKeyFile} -kontrolurl #{kontrol.url}  -registerurl #{KONFIG.kloud.registerUrl} -mongourl #{KONFIG.mongo} -prodmode=#{configName is "prod"}"
+        command         : "#{GOBIN}/kloud -planendpoint #{socialapi.proxyUrl}/payments/subscriptions -hostedzone #{userSitesDomain} -region #{region} -environment #{environment} -port #{KONFIG.kloud.port} -publickey #{kontrol.publicKeyFile} -privatekey #{kontrol.privateKeyFile} -kontrolurl #{kontrol.url}  -registerurl #{KONFIG.kloud.registerUrl} -mongourl #{KONFIG.mongo} -prodmode=#{configName is "prod"}"
       nginx             :
         websocket       : yes
         locations       : ["~^/kloud/.*"]

--- a/go/src/koding/kites/kloud/koding/fetcher.go
+++ b/go/src/koding/kites/kloud/koding/fetcher.go
@@ -13,8 +13,6 @@ import (
 	"labix.org/v2/mgo/bson"
 )
 
-const SecretKey = "R1PVxSPvjvDSWdlPRVqRv8IdwXZB"
-
 type SubscriptionsResponse struct {
 	AccountId          string    `json:"accountId"`
 	PlanTitle          string    `json:"planTitle"`
@@ -48,7 +46,6 @@ func (p *Provider) Fetcher(endpoint string, m *protocol.Machine) (planResp Plan,
 
 	q := userEndpoint.Query()
 	q.Set("account_id", account.Id.Hex())
-	q.Set("kloud_key", SecretKey)
 	userEndpoint.RawQuery = q.Encode()
 
 	p.Log.Debug("[%s] fetching plan via URL: '%s'", m.Id, userEndpoint.String())

--- a/go/src/socialapi/workers/payment/api/api.go
+++ b/go/src/socialapi/workers/payment/api/api.go
@@ -16,7 +16,7 @@ func Subscribe(u *url.URL, h http.Header, req *payment.SubscribeRequest) (int, h
 
 func SubscriptionRequest(u *url.URL, h http.Header, _ interface{}) (int, http.Header, interface{}, error) {
 	subscriptionRequest := &payment.SubscriptionRequest{
-		AccountId: u.Query().Get("accountId"),
+		AccountId: u.Query().Get("account_id"),
 	}
 
 	return response.HandleResultAndClientError(

--- a/go/src/socialapi/workers/payment/api/handlers.go
+++ b/go/src/socialapi/workers/payment/api/handlers.go
@@ -21,7 +21,7 @@ func InitHandlers(mux *tigertonic.TrieServeMux, metrics *metrics.Metrics) *tiger
 		},
 	))
 
-	mux.Handle("GET", "/payments/subscriptions/{accountId}", handler.Wrapper(
+	mux.Handle("GET", "/payments/subscriptions", handler.Wrapper(
 		handler.Request{
 			Handler: SubscriptionRequest,
 			Name:    "payment-subscriptions",

--- a/go/src/socialapi/workers/payment/payment.go
+++ b/go/src/socialapi/workers/payment/payment.go
@@ -61,6 +61,10 @@ type SubscriptionsResponse struct {
 //		paymenterrors.ErrCustomerNotSubscribedToAnyPlans if user no subscriptions
 //		paymenterrors.ErrPlanNotFound if user subscription's plan isn't found
 func (s *SubscriptionRequest) Do() (*SubscriptionsResponse, error) {
+	if s.AccountId == "" {
+		return nil, paymenterrors.ErrAccountIdIsNotSet
+	}
+
 	customer, err := stripe.FindCustomerByOldId(s.AccountId)
 	if err != nil {
 		return nil, err

--- a/go/src/socialapi/workers/payment/paymenterrors/paymenterrors.go
+++ b/go/src/socialapi/workers/payment/paymenterrors/paymenterrors.go
@@ -15,6 +15,7 @@ var (
 	ErrCustomerNotSubscribedToAnyPlans = errors.New("user is not subscribed to any plans")
 	ErrTokenIsEmpty                    = errors.New("token is required")
 	ErrNoCreditCard                    = errors.New("no credit card")
+	ErrAccountIdIsNotSet               = errors.New("account_id is not set")
 
 	ErrStripePlanAlreadyExists = errors.New(`{"type":"invalid_request_error","message":"Plan already exists."}`)
 

--- a/workers/social/lib/social/models/payment.coffee
+++ b/workers/social/lib/social/models/payment.coffee
@@ -44,7 +44,7 @@ module.exports = class Payment extends Base
 
   @subscriptions = (client, data, callback)->
     data.accountId = getAccountId client
-    url = "/payments/subscriptions/#{data.accountId}"
+    url = "/payments/subscriptions?account_id=#{data.accountId}"
 
     get url, data, callback
 


### PR DESCRIPTION
When system is under load, I saw bunch of requests from kloud to the webserver fail and because of that the user didn't get a vm. Since kloud is running on the same machine as socialapi, we can talk to it directly, ie no need to go via the webserver. cc @cihangir @fatih 
