### PR TITLE
remove logo link, IDE sidebar collapses [fixes #79759088]

### DIFF
--- a/client/Core/mainview.coffee
+++ b/client/Core/mainview.coffee
@@ -79,10 +79,9 @@ class MainView extends KDView
       tagName    : 'a'
       attributes : href : '/' # so that it shows 'koding.com' on status bar of browser
       partial    : '<figure></figure>'
-      click      : (event)=>
+      click      : (event) =>
         KD.utils.stopDOMEvent event
-        {router} = KD.singletons
-        router.handleRoute router.getDefaultRoute()
+        KD.mixpanel 'Koding Logo, click'
 
     @aside.addSubView logoWrapper
 

--- a/client/Main/styl/resurrection.sidebar.styl
+++ b/client/Main/styl/resurrection.sidebar.styl
@@ -42,6 +42,7 @@ sidebarSelectedBg = #262626
       margin          0
       display         block
       r-sprite        app logo-full
+      cursor          default
 
   .more-items
     size              238px 20px


### PR DESCRIPTION
This PR removes the link from Koding Logo, this is the finishing part of koding/ide#34

ping @sinan 
