### PR TITLE
router: fix abstraction leak

### DIFF
--- a/client/Core/kodingrouter.coffee
+++ b/client/Core/kodingrouter.coffee
@@ -53,7 +53,7 @@ class KodingRouter extends KDRouter
       if not ///^#{entrySlug}///.test(route) and entrySlug isnt '/koding'
         route =  entrySlug + route
 
-    return @handleRoute '/Activity'  if /<|>/.test route
+    return @handleRoute @getDefaultRoute()  if /<|>/.test route
     super route, options
 
 

--- a/client/Core/kodingrouter.coffee
+++ b/client/Core/kodingrouter.coffee
@@ -53,6 +53,7 @@ class KodingRouter extends KDRouter
       if not ///^#{entrySlug}///.test(route) and entrySlug isnt '/koding'
         route =  entrySlug + route
 
+    return @handleRoute '/Activity'  if /<|>/.test route
     super route, options
 
 


### PR DESCRIPTION
This PR moves a bit of application-specific code from the router class in the kd framework to the subclass in the application. 
