### PR TITLE
sidebar: fix debounce usage of count source function [fixes #79899376]

### DIFF
--- a/client/Social/Activity/sidebar/activitysideview.coffee
+++ b/client/Social/Activity/sidebar/activitysideview.coffee
@@ -63,6 +63,7 @@ class ActivitySideView extends JView
       sidebar.selectedItem = item
 
     {countSource, limit} = @getOptions()
+    countSource = KD.utils.debounce 300, countSource
     @moreLink = new SidebarMoreLink {href: searchLink, countSource, limit}
     @moreLink.hide()
 

--- a/client/Social/Activity/sidebar/morelink.coffee
+++ b/client/Social/Activity/sidebar/morelink.coffee
@@ -11,7 +11,7 @@ class SidebarMoreLink extends CustomLinkView
     @updateCount()
 
 
-  updateCount: KD.utils.debounce 300, (visibleCount)->
+  updateCount: (visibleCount) ->
 
     @setOption 'visibleCount', visibleCount  if visibleCount
     {countSource} = @getOptions()


### PR DESCRIPTION
Function returned by KD.utils.debounce function overwrites context of
the actual method on sequential calls.

https://github.com/koding/koding/pull/1183/files#r18306668
https://github.com/koding/koding/pull/1183/files#r18308258
