### PR TITLE
kloud/cloudinit: Put the migrate.sh in its place. [fixes #79952222]

### DIFF
--- a/go/src/koding/kites/kloud/koding/cloudinit.go
+++ b/go/src/koding/kites/kloud/koding/cloudinit.go
@@ -104,7 +104,7 @@ write_files:
 
   # README.md
   - content: |
-      ## Welcome to Koding...You've said goodbye to localhost!
+      ##Welcome to Koding...You've said goodbye to localhost!
 
       Koding is a cloud-based development platform that allows you to:
       - Develop applications in the cloud
@@ -160,7 +160,6 @@ write_files:
       For more questions and FAQ, head over to http://learn.koding.com
       or send us an email at support@koding.com
     path: /home/{{.Username}}/README.md
-    owner: {{.Username}}:{{.Username}}
 
 
 {{if .ShouldMigrate }}
@@ -246,7 +245,6 @@ write_files:
       echo
     path: /home/{{.Username}}/migrate.sh
     permissions: '0755'
-    owner: {{.Username}}:{{.Username}}
 {{end}}
 
 runcmd:
@@ -305,6 +303,7 @@ type CloudInitConfig struct {
 func (c *CloudInitConfig) setupMigrateScript() {
 	// FIXME: Hack. Revise here.
 	if c.Test {
+		c.ShouldMigrate = true
 		return
 	}
 	vms, err := modelhelper.GetUserVMs(c.Username)


### PR DESCRIPTION
This was a regression that took my 3 hours to bisect and debug. I'm having a
hate relationship with YAML now thanks to this bug.

The main bug is in the first line of README.md. It contains a # and a 
whitespace character and YAML interprets it as a comment since it is the first
line of a block quote. Yaml implementation should interpret as it is a block
quote, not a comment line. Stupid implementation.

The second one is the `owner` parameter of the `write_files` directive. It is
broken somehow, I know the exception but I'm really tired of this shit.
