### PR TITLE
activity: channels don't need autoscroll [fixes #79936182]

### DIFF
--- a/client/Social/Activity/views/messagepane.coffee
+++ b/client/Social/Activity/views/messagepane.coffee
@@ -57,9 +57,6 @@ class MessagePane extends KDTabPaneView
           listView.on 'ItemWasAdded', @bound 'scrollDown'
       when 'privatemessage'
         @listController.getListView().on 'ItemWasAdded', @bound 'scrollDown'
-      when 'group', 'announcement'
-      else
-        @listController.getListView().on 'ItemWasAdded', @bound 'scrollUp'
 
 
   bindInputEvents: ->


### PR DESCRIPTION
- group
- topic
- announcement

[Scrolling down on activity feed to load more takes user back to the top](https://www.pivotaltracker.com/story/show/79936182)
