### PR TITLE
kloud: add pool of connected klients

### DIFF
--- a/go/src/koding/kites/kloud/klient/klient.go
+++ b/go/src/koding/kites/kloud/klient/klient.go
@@ -55,16 +55,16 @@ func (k *KlientPool) Get(queryString string) (*Klient, error) {
 		}
 
 		k.klients[queryString] = klient
+
+		// remove from the pool if we loose the connection
+		klient.client.OnDisconnect(func() {
+			k.log.Info("klient %s disconnected. removing from the pool", queryString)
+			k.Delete(queryString)
+			klient.Close()
+		})
 	} else {
 		k.log.Debug("fetching already connected klient (%s) from pool", queryString)
 	}
-
-	// remove from the pool if we loose the connection
-	klient.client.OnDisconnect(func() {
-		k.log.Info("klient %s disconnected. removing from the pool", queryString)
-		k.Delete(queryString)
-		klient.Close()
-	})
 
 	return klient, nil
 }

--- a/go/src/koding/kites/kloud/klient/klient.go
+++ b/go/src/koding/kites/kloud/klient/klient.go
@@ -6,17 +6,74 @@ import (
 	"fmt"
 	"koding/kite-handler/command"
 	"koding/kites/klient/usage"
+	"sync"
 	"time"
 
 	"github.com/koding/kite"
 	"github.com/koding/kite/protocol"
+	"github.com/koding/logging"
 )
+
+// KlientPool represents a pool of connected klients
+type KlientPool struct {
+	kite    *kite.Kite
+	klients map[string]*Klient
+	log     logging.Logger
+	sync.Mutex
+}
 
 // Klient represents a remote klient instance
 type Klient struct {
 	client   *kite.Client
 	kite     *kite.Kite
 	Username string
+}
+
+func NewPool(k *kite.Kite) *KlientPool {
+	return &KlientPool{
+		kite:    k,
+		klients: make(map[string]*Klient),
+		log:     logging.NewLogger("klientpool"),
+	}
+}
+
+// Get returns a ready to use and connected klient from the pool.
+func (k *KlientPool) Get(queryString string) (*Klient, error) {
+	var klient *Klient
+	var ok bool
+	var err error
+
+	k.Lock()
+	defer k.Unlock()
+
+	klient, ok = k.klients[queryString]
+	if !ok {
+		k.log.Info("creating new klient connection to %s", queryString)
+		klient, err = New(k.kite, queryString)
+		if err != nil {
+			return nil, err
+		}
+
+		k.klients[queryString] = klient
+	} else {
+		k.log.Info("fetching already connected klient (%s) from pool", queryString)
+	}
+
+	// remove from the pool if we loose the connection
+	klient.client.OnDisconnect(func() {
+		k.log.Info("klient %s disconnected. removing from the pool", queryString)
+		k.Delete(queryString)
+		klient.Close()
+	})
+
+	return klient, nil
+}
+
+func (k *KlientPool) Delete(queryString string) {
+	k.Lock()
+	defer k.Unlock()
+
+	delete(k.klients, queryString)
 }
 
 // New returns a new connected klient instance to the given queryString. The

--- a/go/src/koding/kites/kloud/klient/klient.go
+++ b/go/src/koding/kites/kloud/klient/klient.go
@@ -48,7 +48,7 @@ func (k *KlientPool) Get(queryString string) (*Klient, error) {
 
 	klient, ok = k.klients[queryString]
 	if !ok {
-		k.log.Info("creating new klient connection to %s", queryString)
+		k.log.Debug("creating new klient connection to %s", queryString)
 		klient, err = New(k.kite, queryString)
 		if err != nil {
 			return nil, err
@@ -56,7 +56,7 @@ func (k *KlientPool) Get(queryString string) (*Klient, error) {
 
 		k.klients[queryString] = klient
 	} else {
-		k.log.Info("fetching already connected klient (%s) from pool", queryString)
+		k.log.Debug("fetching already connected klient (%s) from pool", queryString)
 	}
 
 	// remove from the pool if we loose the connection
@@ -69,6 +69,7 @@ func (k *KlientPool) Get(queryString string) (*Klient, error) {
 	return klient, nil
 }
 
+// Delete removes the klient with the given queryString from the pool
 func (k *KlientPool) Delete(queryString string) {
 	k.Lock()
 	defer k.Unlock()

--- a/go/src/koding/kites/kloud/koding/checker.go
+++ b/go/src/koding/kites/kloud/koding/checker.go
@@ -3,7 +3,6 @@ package koding
 import (
 	"fmt"
 	"koding/db/mongodb"
-	"koding/kites/kloud/klient"
 	"strconv"
 
 	"labix.org/v2/mgo"
@@ -46,14 +45,13 @@ type Checker interface {
 }
 
 type PlanChecker struct {
-	Api        *amazon.AmazonClient
-	DB         *mongodb.MongoDB
-	Machine    *protocol.Machine
-	Provider   *Provider
-	Kite       *kite.Kite
-	Username   string
-	Log        logging.Logger
-	KlientPool *klient.KlientPool
+	Api      *amazon.AmazonClient
+	DB       *mongodb.MongoDB
+	Machine  *protocol.Machine
+	Provider *Provider
+	Kite     *kite.Kite
+	Username string
+	Log      logging.Logger
 }
 
 func (p *PlanChecker) AllowedInstances(wantInstance InstanceType) error {
@@ -113,7 +111,7 @@ func (p *PlanChecker) AlwaysOn() error {
 
 func (p *PlanChecker) Timeout() error {
 	// connect and get real time data directly from the machines klient
-	klient, err := p.KlientPool.Get(p.Machine.QueryString)
+	klient, err := p.Provider.KlientPool.Get(p.Machine.QueryString)
 	if err != nil {
 		return err
 	}

--- a/go/src/koding/kites/kloud/koding/checker.go
+++ b/go/src/koding/kites/kloud/koding/checker.go
@@ -46,13 +46,14 @@ type Checker interface {
 }
 
 type PlanChecker struct {
-	Api      *amazon.AmazonClient
-	DB       *mongodb.MongoDB
-	Machine  *protocol.Machine
-	Provider *Provider
-	Kite     *kite.Kite
-	Username string
-	Log      logging.Logger
+	Api        *amazon.AmazonClient
+	DB         *mongodb.MongoDB
+	Machine    *protocol.Machine
+	Provider   *Provider
+	Kite       *kite.Kite
+	Username   string
+	Log        logging.Logger
+	KlientPool *klient.KlientPool
 }
 
 func (p *PlanChecker) AllowedInstances(wantInstance InstanceType) error {
@@ -112,11 +113,10 @@ func (p *PlanChecker) AlwaysOn() error {
 
 func (p *PlanChecker) Timeout() error {
 	// connect and get real time data directly from the machines klient
-	klient, err := klient.New(p.Kite, p.Machine.QueryString)
+	klient, err := p.KlientPool.Get(p.Machine.QueryString)
 	if err != nil {
 		return err
 	}
-	defer klient.Close()
 
 	// get the usage directly from the klient, which is the most predictable source
 	usg, err := klient.Usage()

--- a/go/src/koding/kites/kloud/koding/info.go
+++ b/go/src/koding/kites/kloud/koding/info.go
@@ -1,7 +1,6 @@
 package koding
 
 import (
-	"koding/kites/kloud/klient"
 	"sync"
 	"time"
 
@@ -60,14 +59,13 @@ func (p *Provider) Info(m *protocol.Machine) (result *protocol.InfoArtifact, err
 	klientChecked := false
 	if dbState.In(machinestate.Running, machinestate.Stopped) && awsState == machinestate.Running {
 		klientChecked = true
-		klientRef, err := klient.NewWithTimeout(p.Kite, m.QueryString, time.Second*5)
+
+		klientRef, err := p.KlientPool.Get(m.QueryString)
 		if err != nil {
 			p.Log.Warning("[%s] state is '%s' but I can't connect to klient.",
 				m.Id, resultState)
 			resultState = machinestate.Stopped
 		} else {
-			defer klientRef.Close()
-
 			// now assume it's running
 			resultState = machinestate.Running
 

--- a/go/src/koding/kites/kloud/koding/provider.go
+++ b/go/src/koding/kites/kloud/koding/provider.go
@@ -7,6 +7,7 @@ import (
 
 	amazonClient "koding/kites/kloud/api/amazon"
 	"koding/kites/kloud/eventer"
+	"koding/kites/kloud/klient"
 	"koding/kites/kloud/machinestate"
 	"koding/kites/kloud/protocol"
 	"koding/kites/kloud/provider/amazon"
@@ -63,6 +64,9 @@ type Provider struct {
 	PublicKey  string `structure:"publicKey"`
 	PrivateKey string `structure:"privateKey"`
 	KeyName    string `structure:"keyName"`
+
+	// A set of connected, ready to use klients
+	KlientPool *klient.KlientPool
 
 	PlanChecker func(*protocol.Machine) (Checker, error)
 	PlanFetcher func(*protocol.Machine) (Plan, error)

--- a/go/src/koding/kites/kloud/main.go
+++ b/go/src/koding/kites/kloud/main.go
@@ -180,6 +180,8 @@ func newKite(conf *Config) *kite.Kite {
 	// be sure they they satisfy the provider interface
 	var _ kloudprotocol.Provider = kodingProvider
 
+	klientPool := klient.NewPool(kodingProvider.Kite)
+
 	kodingProvider.PlanChecker = func(m *kloudprotocol.Machine) (koding.Checker, error) {
 		a, err := kodingProvider.NewClient(m)
 		if err != nil {
@@ -194,7 +196,7 @@ func newKite(conf *Config) *kite.Kite {
 			Log:        kodingProvider.Log,
 			Username:   m.Username,
 			Machine:    m,
-			KlientPool: klient.NewPool(kodingProvider.Kite),
+			KlientPool: klientPool,
 		}, nil
 	}
 

--- a/go/src/koding/kites/kloud/main.go
+++ b/go/src/koding/kites/kloud/main.go
@@ -12,6 +12,7 @@ import (
 	"koding/kites/kloud/keys"
 	"koding/kites/kloud/koding"
 
+	"koding/kites/kloud/klient"
 	"koding/kites/kloud/kloud"
 	kloudprotocol "koding/kites/kloud/protocol"
 
@@ -186,13 +187,14 @@ func newKite(conf *Config) *kite.Kite {
 		}
 
 		return &koding.PlanChecker{
-			Api:      a,
-			Provider: kodingProvider,
-			DB:       kodingProvider.Session,
-			Kite:     kodingProvider.Kite,
-			Log:      kodingProvider.Log,
-			Username: m.Username,
-			Machine:  m,
+			Api:        a,
+			Provider:   kodingProvider,
+			DB:         kodingProvider.Session,
+			Kite:       kodingProvider.Kite,
+			Log:        kodingProvider.Log,
+			Username:   m.Username,
+			Machine:    m,
+			KlientPool: klient.NewPool(kodingProvider.Kite),
 		}, nil
 	}
 

--- a/go/src/koding/kites/kloud/main.go
+++ b/go/src/koding/kites/kloud/main.go
@@ -175,12 +175,11 @@ func newKite(conf *Config) *kite.Kite {
 		KeyName:           keys.DeployKeyName,
 		PublicKey:         keys.DeployPublicKey,
 		PrivateKey:        keys.DeployPrivateKey,
+		KlientPool:        klient.NewPool(k),
 	}
 
 	// be sure they they satisfy the provider interface
 	var _ kloudprotocol.Provider = kodingProvider
-
-	klientPool := klient.NewPool(kodingProvider.Kite)
 
 	kodingProvider.PlanChecker = func(m *kloudprotocol.Machine) (koding.Checker, error) {
 		a, err := kodingProvider.NewClient(m)
@@ -189,14 +188,13 @@ func newKite(conf *Config) *kite.Kite {
 		}
 
 		return &koding.PlanChecker{
-			Api:        a,
-			Provider:   kodingProvider,
-			DB:         kodingProvider.Session,
-			Kite:       kodingProvider.Kite,
-			Log:        kodingProvider.Log,
-			Username:   m.Username,
-			Machine:    m,
-			KlientPool: klientPool,
+			Api:      a,
+			Provider: kodingProvider,
+			DB:       kodingProvider.Session,
+			Kite:     kodingProvider.Kite,
+			Log:      kodingProvider.Log,
+			Username: m.Username,
+			Machine:  m,
 		}, nil
 	}
 


### PR DESCRIPTION
This improves the a lot of things. First no more connect/disconnect/connect.. for every single klient. Once kloud is connected to a klient it will be always connected and ready to use (until it get disconnected). So that means every `info` method now returns an immediate response instead of initiating a connection to klient, sending a method and sending back the response. Previously it was 5 second, now it's decreased to 0-1 second. You feel the speed on the client side. It's like driving a Ferrari (never drove one ...)
