### PR TITLE
activity: message pane improvements [fixes #79936182 #79935604]

### DIFF
--- a/client/Social/Activity/views/messagepane.coffee
+++ b/client/Social/Activity/views/messagepane.coffee
@@ -251,11 +251,12 @@ class MessagePane extends KDTabPaneView
   appendMessage: (message, index) -> @listController.addItem message, index
 
 
-  prependMessage: (message, index) ->
+  prependMessage: (message, index, callback = noop) ->
     KD.getMessageOwner message, (err, owner) =>
-      return error err  if err
-      return if KD.filterTrollActivity owner
-      @listController.addItem message, index
+      return callback err  if err
+      return callback() if KD.filterTrollActivity owner
+      item = @listController.addItem message, index
+      callback null, item
 
   removeMessage: (message) -> @listController.removeItem null, message
 

--- a/client/Social/Activity/views/messagepane.coffee
+++ b/client/Social/Activity/views/messagepane.coffee
@@ -50,17 +50,6 @@ class MessagePane extends KDTabPaneView
 
     KD.singletons.windowController.addFocusListener @bound 'handleFocus'
 
-    switch typeConstant
-      when 'post'
-        @listController.getListView().once 'ItemWasAdded', (item) =>
-          listView = @listController.getListItems().first.commentBox.controller.getListView()
-          listView.on 'ItemWasAdded', @bound 'scrollDown'
-      when 'privatemessage'
-        @listController.getListView().on 'ItemWasAdded', @bound 'scrollDown'
-      when 'group', 'announcement'
-      else
-        @listController.getListView().on 'ItemWasAdded', @bound 'scrollUp'
-
 
   bindInputEvents: ->
 
@@ -239,6 +228,12 @@ class MessagePane extends KDTabPaneView
     {lastToFirst} = @getOptions()
     index = if lastToFirst then @listController.getItemCount() else 0
     @prependMessage message, index
+
+    switch typeConstant
+      when 'post'
+        @listController.getListView().once 'ItemWasAdded', (item) =>
+          listView = @listController.getListItems().first.commentBox.controller.getListView()
+          listView.on 'ItemWasAdded', @bound 'scrollDown'
 
 
   loadMessage: (message) ->

--- a/client/Social/Activity/views/messagepane.coffee
+++ b/client/Social/Activity/views/messagepane.coffee
@@ -70,7 +70,10 @@ class MessagePane extends KDTabPaneView
         @input.once 'SubmitSucceeded', -> resolve()
 
   replaceFakeItemView: (message) ->
-    @putMessage message, @removeFakeMessage message.clientRequestId
+    index = @listController.getListView().getItemIndex @fakeMessageMap[message.clientRequestId]
+    item = @putMessage message, index
+    @removeFakeMessage message.clientRequestId
+    @scrollDown item
 
 
   removeFakeMessage: (identifier) ->
@@ -107,6 +110,8 @@ class MessagePane extends KDTabPaneView
     # save it to a map so that we have a reference
     # to it to be deleted.
     @fakeMessageMap[clientRequestId] = item
+
+    @scrollDown item
 
 
   messageSubmitFailed: (err, clientRequestId) ->

--- a/client/Social/Activity/views/privatemessage/pane.coffee
+++ b/client/Social/Activity/views/privatemessage/pane.coffee
@@ -127,14 +127,14 @@ class PrivateMessagePane extends MessagePane
 
     return  if message.account._id is KD.whoami()._id
 
-    @prependMessage message, @listController.getItemCount(), (err, item) =>
+    item = @prependMessage message, @listController.getItemCount()
+    isFromBot message, @bound 'setResponseMode'
+    @scrollDown item
 
-      return KD.showError err  if err
-      return unless item
 
-      isFromBot message, @bound 'setResponseMode'
+  prependMessage: (message, index) ->
 
-      KD.utils.defer => @scrollDown item
+    return @listController.addItem message, index
 
 
   putMessage: (message, index) ->
@@ -186,7 +186,6 @@ class PrivateMessagePane extends MessagePane
 
   messageAdded: (item, index) ->
 
-    @scrollDown item
     data         = item.getData()
     listView     = @listController.getView()
     headerHeight = @heads?.getHeight() or 0

--- a/client/Social/Activity/views/privatemessage/pane.coffee
+++ b/client/Social/Activity/views/privatemessage/pane.coffee
@@ -127,11 +127,14 @@ class PrivateMessagePane extends MessagePane
 
     return  if message.account._id is KD.whoami()._id
 
-    item = @prependMessage message, @listController.getItemCount()
+    @prependMessage message, @listController.getItemCount(), (err, item) =>
 
-    isFromBot message, @bound 'setResponseMode'
+      return KD.showError err  if err
+      return unless item
 
-    return item
+      isFromBot message, @bound 'setResponseMode'
+
+      KD.utils.defer => @scrollDown item
 
 
   putMessage: (message, index) ->


### PR DESCRIPTION
- [x] Group, topic and announcement feeds do not automatically scroll to any end.
- [x] Single post message pane scrolls down automatically
- [x] Chat message scrolls down in async callback
- [ ] Announcement channels automatically scrolls up (feature request)
- [x] [When user sends a chat message screen is flickering](https://www.pivotaltracker.com/story/show/79935604)
