### PR TITLE
search: don't filter out dashes [fixes #80006958]

### DIFF
--- a/client/Main/searchcontroller.coffee
+++ b/client/Main/searchcontroller.coffee
@@ -36,7 +36,7 @@ class SearchController extends KDObject
 
   searchAccounts: (seed) ->
 
-    seed = seed.replace /\W/g, ''
+    seed = seed.replace /[^-\w]/g, ''
 
     @search 'accounts', seed, hitsPerPage : 10
       .then (data) ->


### PR DESCRIPTION
We're currently filtering all non-word chars from the account search input. We should also also dashes.
