### PR TITLE
terminal: user C-b as screen escape

### DIFF
--- a/go/src/koding/kite-handler/terminal/command.go
+++ b/go/src/koding/kite-handler/terminal/command.go
@@ -69,7 +69,7 @@ func newCommand(mode, session, username string) (*Command, error) {
 	// let's assume by default its Screen
 	name := defaultScreenPath
 	defaultShell := getDefaultShell(username)
-	args := []string{"-e''", "-s", defaultShell, "-S"}
+	args := []string{"-e^Bb", "-s", defaultShell, "-S"}
 
 	switch mode {
 	case "shared", "resume":


### PR DESCRIPTION
We had trouble with `-e''` interpreting the `'` char as a literal apostrophe. This commit moved the escape back to C-b
