### PR TITLE
activity: show lazy loader indicator [fixes #79899620]

### DIFF
--- a/client/Social/Activity/styl/activity.styl
+++ b/client/Social/Activity/styl/activity.styl
@@ -138,7 +138,7 @@ body.activity
 .content-page.activity
 .member.content-display
   .lazy-loader
-    bottom              20px
+    bottom              25px
     left                50%
     abs()
 

--- a/client/Social/Activity/views/activitypane.coffee
+++ b/client/Social/Activity/views/activitypane.coffee
@@ -42,26 +42,32 @@ class ActivityPane extends MessagePane
     typeConstant  : @getData().typeConstant
 
   createMostLikedView: (options, data) ->
-    new ActivityContentPane options, data
+    pane = new ActivityContentPane options, data
       .on "NeedsMoreContent", =>
         from = null
         skip = @mostLiked.getLoadedCount()
 
+        pane.listController.showLazyLoader()
+
         @fetch { from, skip, mostLiked:yes }, @createContentAppender 'mostLiked'
 
   createMostRecentView: (options, data) ->
-    new ActivityContentPane options, data
+    pane = new ActivityContentPane options, data
       .on "NeedsMoreContent", =>
         from = @mostRecent.getContentFrom()
         skip = null
 
+        pane.listController.showLazyLoader()
+
         @fetch { from, skip }, @createContentAppender 'mostRecent'
 
   createSearchResultsView: (options, data) ->
-    new ActivitySearchResultsPane options, data
+    pane = new ActivitySearchResultsPane options, data
       .on "NeedsMoreContent", =>
         if @searchResults.currentPage?
           page = @searchResults.currentPage += 1
+
+          pane.listController.showLazyLoader()
 
           @search @currentSearch, { page, dontClear: yes }
 


### PR DESCRIPTION
[Spinner when scrolled down the bottom of page, indicating more posts are being fetched, is no longer shown](https://www.pivotaltracker.com/story/show/79899620)

Repetition bothers me in this patch. Ideally, most recent/liked panes should have their class definitions and implement `NeedsMoreContent` event handler to keep `ActivityPane` implementation clean. Though, this is just over work at current state for the task being addressed.

![feed-lazy-loader](https://cloud.githubusercontent.com/assets/1136739/4555153/c81d78d6-4eb9-11e4-9f84-920462b78c63.gif)
