### PR TITLE
kloud: more domain improvements

### DIFF
--- a/go/src/koding/kites/kloud/kloud/domain.go
+++ b/go/src/koding/kites/kloud/kloud/domain.go
@@ -66,6 +66,7 @@ func (k *Kloud) DomainAdd(r *kite.Request) (resp interface{}, reqErr error) {
 		}
 
 		domain := &protocol.Domain{
+			Username:  m.Username,
 			MachineId: m.Id,
 			Name:      args.DomainName,
 		}

--- a/go/src/koding/kites/kloud/kloud/domain.go
+++ b/go/src/koding/kites/kloud/kloud/domain.go
@@ -102,6 +102,12 @@ func (k *Kloud) DomainUnset(r *kite.Request) (resp interface{}, reqErr error) {
 			return nil, err
 		}
 
+		// remove the machineID for the given domain. The document is still
+		// there, but it'sn associated anymore with this domain.
+		if err := k.DomainStorage.UpdateMachine(args.DomainName, ""); err != nil {
+			return nil, err
+		}
+
 		return true, nil
 	}
 
@@ -111,6 +117,11 @@ func (k *Kloud) DomainUnset(r *kite.Request) (resp interface{}, reqErr error) {
 func (k *Kloud) DomainSet(r *kite.Request) (resp interface{}, reqErr error) {
 	setFunc := func(m *protocol.Machine, args *domainArgs) (interface{}, error) {
 		if err := k.Domainer.Create(args.DomainName, m.IpAddress); err != nil {
+			return nil, err
+		}
+
+		// addign the machineID for the given domain.
+		if err := k.DomainStorage.UpdateMachine(args.DomainName, m.Id); err != nil {
 			return nil, err
 		}
 

--- a/go/src/koding/kites/kloud/kloud/storage.go
+++ b/go/src/koding/kites/kloud/kloud/storage.go
@@ -26,12 +26,16 @@ type StorageData struct {
 }
 
 type DomainStorage interface {
-	// Add adds a new DomainDocument
+	// Add adds a new domain
 	Add(*protocol.Domain) error
 
 	// Delete deletes the DomainDocument with the given domain name
 	Delete(name string) error
 
-	// Get returns the DomainDocument with the given domain name
+	// UpdateMachine updates the machine relationship for the given domain name
+	// with the given new machine id. Machine ID can be empty
+	UpdateMachine(name, machine string) error
+
+	// Get returns the domain information with the given domain name
 	Get(name string) (*protocol.Domain, error)
 }

--- a/go/src/koding/kites/kloud/koding/domain.go
+++ b/go/src/koding/kites/kloud/koding/domain.go
@@ -62,6 +62,13 @@ func (d *Domains) Get(name string) (*protocol.Domain, error) {
 	}, nil
 }
 
+func (d *Domains) UpdateMachine(name, machineId string) error {
+	return d.DB.Run("jDomainAlias", func(c *mgo.Collection) error {
+		return c.Update(bson.M{"domain": name},
+			bson.M{"$set": bson.M{"machineId": machineId}})
+	})
+}
+
 // UpdateDomain sets the ip to the given domain. If there is no record a new
 // record will be created otherwise existing record is updated. This is just a
 // helper method that uses our DNS struct.

--- a/go/src/koding/kites/kloud/koding/domain.go
+++ b/go/src/koding/kites/kloud/koding/domain.go
@@ -1,6 +1,7 @@
 package koding
 
 import (
+	"koding/db/models"
 	"koding/db/mongodb"
 	"koding/kites/kloud/protocol"
 	"time"
@@ -12,6 +13,7 @@ import (
 // DomainDocument defines a single MongoDB document in the jDomains collection
 type DomainDocument struct {
 	Id         bson.ObjectId `bson:"_id" json:"-"`
+	OriginId   bson.ObjectId `bson:"originId"`
 	MachineId  bson.ObjectId `bson:"machineId"`
 	DomainName string        `bson:"domain"`
 	CreatedAt  time.Time     `bson:"createdAt"`
@@ -28,8 +30,16 @@ func NewDomainStorage(db *mongodb.MongoDB) *Domains {
 }
 
 func (d *Domains) Add(domain *protocol.Domain) error {
+	var account *models.Account
+	if err := d.DB.Run("jAccounts", func(c *mgo.Collection) error {
+		return c.Find(bson.M{"profile.nickname": domain.Username}).One(&account)
+	}); err != nil {
+		return err
+	}
+
 	doc := &DomainDocument{
 		Id:         bson.NewObjectId(),
+		OriginId:   account.Id,
 		MachineId:  bson.ObjectIdHex(domain.MachineId),
 		DomainName: domain.Name,
 		CreatedAt:  time.Now(),

--- a/go/src/koding/kites/kloud/koding/domain.go
+++ b/go/src/koding/kites/kloud/koding/domain.go
@@ -17,6 +17,7 @@ type DomainDocument struct {
 	MachineId  bson.ObjectId `bson:"machineId"`
 	DomainName string        `bson:"domain"`
 	CreatedAt  time.Time     `bson:"createdAt"`
+	ModifiedAt time.Time     `bson:"modifiedAt"`
 }
 
 type Domains struct {
@@ -42,7 +43,8 @@ func (d *Domains) Add(domain *protocol.Domain) error {
 		OriginId:   account.Id,
 		MachineId:  bson.ObjectIdHex(domain.MachineId),
 		DomainName: domain.Name,
-		CreatedAt:  time.Now(),
+		CreatedAt:  time.Now().UTC(),
+		ModifiedAt: time.Now().UTC(),
 	}
 
 	return d.DB.Run("jDomainAlias", func(c *mgo.Collection) error {
@@ -75,7 +77,10 @@ func (d *Domains) Get(name string) (*protocol.Domain, error) {
 func (d *Domains) UpdateMachine(name, machineId string) error {
 	return d.DB.Run("jDomainAlias", func(c *mgo.Collection) error {
 		return c.Update(bson.M{"domain": name},
-			bson.M{"$set": bson.M{"machineId": machineId}})
+			bson.M{"$set": bson.M{
+				"machineId":  machineId,
+				"modifiedAt": time.Now().UTC(),
+			}})
 	})
 }
 

--- a/go/src/koding/kites/kloud/protocol/protocol.go
+++ b/go/src/koding/kites/kloud/protocol/protocol.go
@@ -71,10 +71,8 @@ type Record struct {
 
 // Domain represents a machines domain necessary information
 type Domain struct {
-	// OriginId defines a unique ID that represents an ownership. There might
-	// be several domains each with the same OriginId, which means they all
-	// belong to a user.
-	OriginId string
+	// Username defines a the owner of the machine
+	Username string
 
 	// MachineId defines the ID of the respective machine. Each domain is bound
 	// to a single machine.

--- a/go/src/koding/kites/kloud/protocol/protocol.go
+++ b/go/src/koding/kites/kloud/protocol/protocol.go
@@ -71,10 +71,18 @@ type Record struct {
 
 // Domain represents a machines domain necessary information
 type Domain struct {
+	// OriginId defines a unique ID that represents an ownership. There might
+	// be several domains each with the same OriginId, which means they all
+	// belong to a user.
+	OriginId string
+
 	// MachineId defines the ID of the respective machine. Each domain is bound
 	// to a single machine.
 	MachineId string
-	Name      string
+
+	// Name is the domain name, such as "arslan.koding.io" or
+	// "fatih.arslan.koding.io"
+	Name string
 }
 
 // Machine is used as a data source for the appropriate interfaces


### PR DESCRIPTION
- Remove machineId when `domain.unset` is called
- Override machineId when `domain.set` is called
- Add new field called `OriginId` to the document that belongs to `jDomainAlias` collection. This field is set once when `domain.add` is called and is the same as the users `jAccount` id.
- Add new field called `ModifiedAt` which is updated when `domain.set` or `domain.unset` is called and created when `domain.add` is called.
