### PR TITLE
kloud/cloudinit: Retry on connrefused errors.

### DIFF
--- a/go/src/koding/kites/kloud/koding/cloudinit.go
+++ b/go/src/koding/kites/kloud/koding/cloudinit.go
@@ -251,7 +251,7 @@ runcmd:
   - [sh, -c, 'cp /etc/skel/.bashrc /home/{{.Username}}/.bashrc']
 
   # Install & Configure klient
-  - [wget, "{{.LatestKlientURL}}", -O, /tmp/latest-klient.deb]
+  - [wget, "{{.LatestKlientURL}}", --retry-connrefused, --tries, 5, -O, /tmp/latest-klient.deb]
   - [dpkg, -i, /tmp/latest-klient.deb]
   - [chown, -R, '{{.Username}}:{{.Username}}', /opt/kite/klient]
   - service klient stop


### PR DESCRIPTION
Some users' VMs are automatically shutdown although the VM is actively used.
The problem was that klient was not installed on their system.

S3 is refusing to accept any incoming connections sometimes and we don't know when, thus
there is no way to debug the problem. So while installing the klient package
from S3, treat the `connection refused` errors as transient and retry 5 times
on transient errors.
