### PR TITLE
chat item order

### DIFF
--- a/client/Social/Activity/views/messagepane.coffee
+++ b/client/Social/Activity/views/messagepane.coffee
@@ -308,14 +308,14 @@ class MessagePane extends KDTabPaneView
 
       @listController.hideLazyLoader()
       items.forEach (item, i) =>
-        @appendMessageDeferred item, i, items.length
+        @addMessageDeferred item, i, items.length
 
       KD.utils.defer @bound 'focus'
 
       callback()
 
 
-  appendMessageDeferred: (item, i, total) ->
+  addMessageDeferred: (item, i, total) ->
 
     KD.utils.defer =>
       @appendMessage item

--- a/client/Social/Activity/views/privatemessage/pane.coffee
+++ b/client/Social/Activity/views/privatemessage/pane.coffee
@@ -75,7 +75,7 @@ class PrivateMessagePane extends MessagePane
     # Super method defers adding list items to minimize page load
     # congestion. This function is overrides super function to render
     # all conversation messages to be displayed at the same time
-    @appendMessage item
+    @prependMessage item
     @emit 'ListPopulated'  if i is total - 1
 
 
@@ -207,8 +207,6 @@ class PrivateMessagePane extends MessagePane
   fetch: (options = {}, callback) ->
 
     super options, (err, data) =>
-
-      data.reverse()
 
       channel = @getData()
       channel.replies = data

--- a/client/Social/Activity/views/privatemessage/pane.coffee
+++ b/client/Social/Activity/views/privatemessage/pane.coffee
@@ -71,7 +71,7 @@ class PrivateMessagePane extends MessagePane
   prependMessage: (message) -> @listController.addItem message, 0
 
 
-  appendMessageDeferred: (item, i, total) ->
+  addMessageDeferred: (item, i, total) ->
     # Super method defers adding list items to minimize page load
     # congestion. This function is overrides super function to render
     # all conversation messages to be displayed at the same time


### PR DESCRIPTION
It was appending at first for the initial load, and then prepending them for the lazy fetches. This PR unifies that behavior, without reversing the data array, it always prepends to the list.

`MessagePane::appendMessageDeferred` changed to `MessagePane::addMessageDeferred`
