### PR TITLE
notification improvements

### DIFF
--- a/client/Main/CommonViews/linkviews/linkgroup.coffee
+++ b/client/Main/CommonViews/linkviews/linkgroup.coffee
@@ -92,3 +92,4 @@ class LinkGroup extends KDCustomHTMLView
   render:->
 
     @createParticipantSubviews()
+

--- a/client/Main/CommonViews/linkviews/profilelinkview.coffee
+++ b/client/Main/CommonViews/linkviews/profilelinkview.coffee
@@ -31,12 +31,17 @@ class ProfileLinkView extends LinkView
       tagName   : 'span'
 
     @setClass "profile"
+    @updateHref()
+
+
+
+  updateHref: ->
+    nickname = @getData().profile?.nickname
+    @setAttribute "href", "/#{nickname}"  if nickname
+
 
   render: (fields) ->
-    nickname = @getData().profile?.nickname
-    slug = KD.getGroup()?.slug or 'koding'
-    href = if slug is "koding" then "/#{nickname}" else "/#{slug}/#{nickname}"
-    @setAttribute "href", href  if nickname
+    @updateHref()
 
     # only admin can see troll users
     if KD.checkFlag "super-admin"

--- a/client/Main/CommonViews/linkviews/profilelinkview.coffee
+++ b/client/Main/CommonViews/linkviews/profilelinkview.coffee
@@ -34,7 +34,6 @@ class ProfileLinkView extends LinkView
     @updateHref()
 
 
-
   updateHref: ->
     nickname = @getData().profile?.nickname
     @setAttribute "href", "/#{nickname}"  if nickname

--- a/client/Main/notifications/notificationlistitem.coffee
+++ b/client/Main/notifications/notificationlistitem.coffee
@@ -31,6 +31,7 @@ class NotificationListItemView extends KDListItemView
 
     super options, data
 
+    @updateHref()
 
     @participants = new KDCustomHTMLView
     @avatar       = new KDCustomHTMLView
@@ -50,6 +51,25 @@ class NotificationListItemView extends KDListItemView
       @template.update()
     .catch (err) ->
       warn err.description
+
+
+  updateHref: ->
+
+    { socialapi } = KD.singletons
+
+    href = '#'
+
+    { groupifyLink } = KD.utils
+
+    switch @getData().type
+      when 'comment', 'like', 'mention'
+        socialapi.message.byId { id: @getData().targetId }, (err, post) =>
+          return warn err  if err
+          @setAttribute 'href', groupifyLink "/Activity/Post/#{post.slug}"
+      when 'follow'
+        @setAttribute 'href', groupifyLink "/#{@actors.first.profile.nickname}"
+      when 'join', 'leave'
+        @setAttribute 'href', '#'
 
 
   click: (event) ->

--- a/client/Main/styl/resurrection.account.dropdown.styl
+++ b/client/Main/styl/resurrection.account.dropdown.styl
@@ -72,7 +72,7 @@ resurrection.account.dropdown.styl
     margin-right  10px
 
   .link-group
-    display       inline-block
+    display       inline
 
   a.profile
     color         #1aaf5d

--- a/client/Main/styl/resurrection.account.dropdown.styl
+++ b/client/Main/styl/resurrection.account.dropdown.styl
@@ -60,6 +60,7 @@ resurrection.account.dropdown.styl
   font-size       12px
   cursor          pointer
   line-height     12px
+  color           #a0a0a0
 
   &:hover
     bg            color, #1A1A1A


### PR DESCRIPTION
This PR
- [x] Fixes the notification item `inline-block` styling, makes the action name an `inline` block. This was causing new line problems for notifications with 3+ participants.
- [x] Updates the href attributes of NotificationItems
- [x] Updates the href attributes of Participant games on notifications.
- [x] Cleans up the code style for notifications a little bit

This was more of a functionality improvement so I don't have any screen{shot, cast}.
