### PR TITLE
client: substitute `document.body.scrollTop` with `window.scrollY` [fixes #80403198]

### DIFF
--- a/client/About/AppView.coffee
+++ b/client/About/AppView.coffee
@@ -4,7 +4,7 @@ class AboutAppView extends JView
 
     super
 
-    @once 'viewAppended', -> document.body.scrollTop = 0
+    @once 'viewAppended', -> window.scrollTo 0, 0
 
     @footer = new FooterView
 

--- a/client/Core/maintabpaneview.coffee
+++ b/client/Core/maintabpaneview.coffee
@@ -11,18 +11,13 @@ class MainTabPane extends KDTabPaneView
 
     super
 
-    KD.utils.defer =>
-      {body, documentElement}   = document
-      documentElement.scrollTop = @lastScrollTops.window
-      body.scrollTop            = @lastScrollTops.body
+    KD.utils.defer => window.scrollTo 0, @lastScrollTops.window
 
 
   hide: ->
 
     return  unless @active
 
-    {body, documentElement} = document
-    @lastScrollTops.window  = documentElement.scrollTop
-    @lastScrollTops.body    = body.scrollTop
+    @lastScrollTops.window = window.scrollY
 
     super

--- a/client/Core/mainviewcontroller.coffee
+++ b/client/Core/mainviewcontroller.coffee
@@ -58,16 +58,16 @@ class MainViewController extends KDViewController
 
     (event) ->
 
-      {scrollHeight, scrollTop} = document.body
-      {innerHeight}             = window
+      {scrollHeight} = document.body
+      {scrollY, innerHeight} = window
 
       # return when it pulls the page on top
-      return lastPos = innerHeight  if scrollTop < 0
+      return lastPos = innerHeight  if scrollY < 0
 
       # return when it pulls the page at the bottom
-      return  if scrollHeight - scrollTop < innerHeight
+      return  if scrollHeight - scrollY < innerHeight
 
-      currentPos = scrollTop + innerHeight
+      currentPos = scrollY + innerHeight
       direction  = if currentPos > lastPos then 'down' else 'up'
 
       appManager = KD.singleton 'appManager'
@@ -75,7 +75,7 @@ class MainViewController extends KDViewController
 
       switch direction
         when 'up'
-          if scrollTop < threshold
+          if scrollY < threshold
             frontApp?.emit 'TopLazyLoadThresholdReached'
         when 'down'
           if currentPos > scrollHeight - threshold

--- a/client/Social/Activity/views/messagepane.coffee
+++ b/client/Social/Activity/views/messagepane.coffee
@@ -135,10 +135,10 @@ class MessagePane extends KDTabPaneView
 
   isPageAtBottom: ->
 
-    {innerHeight}             = window
-    {scrollHeight, scrollTop} = document.body
+    {innerHeight, scrollY} = window
+    {scrollHeight} = document.body
 
-    scrollTop + innerHeight >= scrollHeight
+    scrollY + innerHeight >= scrollHeight
 
 
   scrollDown: ->
@@ -148,15 +148,14 @@ class MessagePane extends KDTabPaneView
 
     return  unless @active
 
-    document.body.scrollTop = 0
+    window.scrollTo 0, 0
 
 
   setScrollTops: ->
 
     super
 
-    @lastScrollTops.window = window.scrollTop or 0
-    @lastScrollTops.body   = document.body.scrollTop
+    @lastScrollTops.window = window.scrollY
 
 
   applyScrollTops: ->
@@ -165,7 +164,6 @@ class MessagePane extends KDTabPaneView
 
     KD.utils.defer =>
       window.scrollTo 0, @lastScrollTops.window
-      document.body.scrollTop = @lastScrollTops.body
 
 
   createChannelTitle: ->
@@ -377,8 +375,7 @@ class MessagePane extends KDTabPaneView
 
   refresh: ->
 
-    document.body.scrollTop            = 0
-    document.documentElement.scrollTop = 0
+    window.scrollTo 0, 0
 
     @listController.removeAllItems()
     @listController.showLazyLoader()

--- a/client/Social/Activity/views/privatemessage/pane.coffee
+++ b/client/Social/Activity/views/privatemessage/pane.coffee
@@ -238,7 +238,7 @@ class PrivateMessagePane extends MessagePane
         items.forEach (item, i) =>
           {scrollHeight} = body
           @prependMessage item
-          body.scrollTop += body.scrollHeight - scrollHeight
+          window.scrollTo 0, body.scrollHeight - scrollHeight
 
         if items.length is 0
         then @listPreviousLink.hide()
@@ -395,19 +395,18 @@ class PrivateMessagePane extends MessagePane
   scrollDown: (item) ->
 
     return  unless @active
-    document.body.scrollTop = document.body.scrollHeight * 2
+    window.scrollTo 0, document.body.scrollHeight * 2
 
 
   setScrollTops: ->
 
-    {body} = document
-    @lastScrollTops.body = body.scrollTop or body.scrollHeight
+    {body: {scrollHeight}} = document
+    @lastScrollTops.window = window.scrollY or scrollHeight
 
 
   applyScrollTops: ->
 
-    {body} = document
-    body.scrollTop = @lastScrollTops.body
+    window.scrollTo 0, @lastScrollTops.window
 
 
   show: ->

--- a/client/Social/Activity/views/privatemessage/pane.coffee
+++ b/client/Social/Activity/views/privatemessage/pane.coffee
@@ -238,7 +238,7 @@ class PrivateMessagePane extends MessagePane
         items.forEach (item, i) =>
           {scrollHeight} = body
           @prependMessage item
-          window.scrollTo 0, body.scrollHeight - scrollHeight
+          window.scrollTo 0, window.scrollY + (body.scrollHeight - scrollHeight)
 
         if items.length is 0
         then @listPreviousLink.hide()


### PR DESCRIPTION
[Scrolling is broken on Firefox](https://www.pivotaltracker.com/story/show/80403198)

Please see https://github.com/koding/koding/commit/ee35c3b2e859904db2e7ac59d9bdfbf16100d1dd for detailed explanation.
- [x] Lazy loader scroll event handler
- [x] Private message pane
- [x] Rest of the references to `document.body.scrollTop`
