### PR TITLE
remove logged in user prerequisite from channel history endpoint [Fixes #80502760]

### DIFF
--- a/servers/lib/crawler/index.coffee
+++ b/servers/lib/crawler/index.coffee
@@ -96,7 +96,7 @@ fetchGroupContent = (models, options, callback) ->
 
 fetchGuestUserSession = (models, callback) ->
   {JSession} = models
-  JSession.createGuestUserSession (err, session) ->
+  JSession.fetchGuestUserSession (err, session) ->
     return callback err if err?
     return callback notFoundError "session" unless session?.clientId?
     callback null, session.clientId

--- a/servers/lib/crawler/staticpages/feed.coffee
+++ b/servers/lib/crawler/staticpages/feed.coffee
@@ -9,7 +9,7 @@ ITEMSPERPAGE = 20
 createFeed = (models, options, callback)->
   {JAccount, SocialChannel} = models
   { page, channelId, client
-    route, contentType, channelName } = options
+    route, contentType, channelName, sessionToken } = options
 
   return callback "channelId not set"  unless channelId
 
@@ -22,9 +22,10 @@ createFeed = (models, options, callback)->
     limit       : ITEMSPERPAGE
     skip        : skip
     channelName : channelName
+    sessionToken
   }
 
-  SocialChannel.fetchActivityCount {channelId}, (err, response)->
+  SocialChannel.fetchActivityCount {channelId, sessionToken}, (err, response)->
     return callback err  if err
     itemCount = response?.totalCount
     return callback null, getEmptyPage channelName  unless itemCount

--- a/workers/social/lib/social/models/session.coffee
+++ b/workers/social/lib/social/models/session.coffee
@@ -85,6 +85,16 @@ module.exports = class JSession extends Model
       else
         @createSession callback
 
+  @fetchGuestUserSession = (callback) ->
+    @one username : 'guestuser', (err, session) ->
+      return callback err if err?
+      return callback null, session if session?
+      clientId = createId()
+      session = new JSession { clientId, username }
+      session.save (err)->
+        return callback err if err?
+        callback null, session
+
   @updateClientIP = (clientId, ipAddress, callback)->
     JSession.update {clientId: clientId}, {$set: clientIP: ipAddress}, (err)->
       callback err

--- a/workers/social/lib/social/models/socialapi/helper.coffee
+++ b/workers/social/lib/social/models/socialapi/helper.coffee
@@ -59,7 +59,7 @@ doRequest = (funcName, client, options, callback)->
       options.accountId       = socialApiId
       options.accountNickname = nickname
       options.showExempt    or= delegate.isExempt
-      options.sessionToken   = client.sessionToken
+      options.sessionToken  or= client.sessionToken
 
       bareRequest funcName, options, callback
 


### PR DESCRIPTION
Currently for static pages we are using guestuser for fetching the activities. For this reason channel history list endpoint must be exposed to all users. 

I have changed some lines, but I am open for a better solution. 
