### PR TITLE
koding: clean build from watcher

### DIFF
--- a/go/build.sh
+++ b/go/build.sh
@@ -20,7 +20,6 @@ services=(
   koding/kites/os
   koding/kites/terminal
   github.com/koding/kite/kitectl
-  github.com/koding/kite/reverseproxy/reverseproxy
   koding/kites/kontrol
   github.com/coreos/etcd
   koding/kites/klient

--- a/go/src/github.com/canthefason/fresh/runner/build.go
+++ b/go/src/github.com/canthefason/fresh/runner/build.go
@@ -8,8 +8,6 @@ import (
 )
 
 func build() (string, bool) {
-	buildLog("Building...")
-
 	cmd := exec.Command("go", "build", "-o", buildPath(), root())
 
 	stderr, err := cmd.StderrPipe()

--- a/go/src/github.com/canthefason/fresh/runner/runner.go
+++ b/go/src/github.com/canthefason/fresh/runner/runner.go
@@ -14,17 +14,7 @@ func run() bool {
 		cmd = exec.Command(buildPath())
 	}
 
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		fatal(err)
-	}
-
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		fatal(err)
-	}
-
-	err = cmd.Start()
+	err := cmd.Start()
 	if err != nil {
 		fatal(err)
 	}

--- a/go/src/github.com/canthefason/fresh/runner/runner.go
+++ b/go/src/github.com/canthefason/fresh/runner/runner.go
@@ -1,14 +1,11 @@
 package runner
 
 import (
-	"io"
 	"os/exec"
 	"strings"
 )
 
 func run() bool {
-	runnerLog("Running...")
-
 	var cmd *exec.Cmd
 	if extArgs() != "" {
 		args := strings.Split(extArgs(), " ")
@@ -42,9 +39,6 @@ func run() bool {
 		}
 
 	}()
-
-	go io.Copy(appLogWriter{}, stderr)
-	go io.Copy(appLogWriter{}, stdout)
 
 	go func() {
 		<-stopChannel

--- a/go/src/github.com/canthefason/fresh/runner/start.go
+++ b/go/src/github.com/canthefason/fresh/runner/start.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"fmt"
 	"os"
-	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -41,7 +40,6 @@ func start() {
 	go func() {
 		for {
 			loopIndex++
-			mainLog("Waiting (loop %d)...", loopIndex)
 			// eventName := <-startChannel
 			<-startChannel
 
@@ -51,12 +49,6 @@ func start() {
 			// mainLog("flushing events")
 
 			flushEvents()
-
-			mainLog("Started! (%d Goroutines)", runtime.NumGoroutine())
-			err := removeBuildErrorsLog()
-			if err != nil {
-				mainLog(err.Error())
-			}
 
 			errorMessage, ok := build()
 			if !ok {
@@ -73,7 +65,6 @@ func start() {
 			}
 
 			started = true
-			mainLog(strings.Repeat("-", 20))
 		}
 	}()
 }
@@ -87,7 +78,7 @@ func init() {
 
 func initLogFuncs() {
 	mainLog = newLogFunc("main")
-	watcherLog = newLogFunc("watcher")
+	watcherLog = func(string, ...interface{}) {}
 	runnerLog = newLogFunc("runner")
 	buildLog = newLogFunc("build")
 	appLog = newLogFunc("app")

--- a/go/src/github.com/canthefason/fresh/runner/utils.go
+++ b/go/src/github.com/canthefason/fresh/runner/utils.go
@@ -7,13 +7,8 @@ import (
 )
 
 func initFolders() {
-	runnerLog("InitFolders")
 	path := tmpPath()
-	// runnerLog("mkdir %s", path)
-	err := os.Mkdir(path, 0755)
-	if err != nil {
-		runnerLog(err.Error())
-	}
+	os.Mkdir(path, 0755)
 }
 
 func isTmpDir(path string) bool {
@@ -54,10 +49,4 @@ func createBuildErrorsLog(message string) bool {
 	}
 
 	return true
-}
-
-func removeBuildErrorsLog() error {
-	err := os.Remove(buildErrorsFilePath())
-
-	return err
 }


### PR DESCRIPTION
It was annoying to see those `Building ...` and many other non informative logs so  we removed them with @igungor . It's now much more cleaner and it's not spamming the terminal anymore.
