### PR TITLE
Datadog: upgrade datadog agents

### DIFF
--- a/.ebextensions/099_datadog.config
+++ b/.ebextensions/099_datadog.config
@@ -23,4 +23,4 @@ container_commands:
         command: "cp .ebextensions/datadog/datadog.repo /etc/yum.repos.d/datadog.repo; yum -y makecache; yum -y install datadog-agent; /etc/init.d/datadog-agent stop"
     91setup_datadog:
         test: '[ ! -e /etc/dd-agent/datadog.conf ]'
-        command: "sh -c \"sed 's/api_key:.*/api_key: da163c47df4e1bdec0645604a129846c/' /etc/dd-agent/datadog.conf.example > /etc/dd-agent/datadog.conf\""
+        command: "sh -c \"sed 's/api_key:.*/api_key: 6d3e00fb829d97cb6ee015f80063627c/' /etc/dd-agent/datadog.conf.example > /etc/dd-agent/datadog.conf\""

--- a/.ebextensions/datadog/datadog.repo
+++ b/.ebextensions/datadog/datadog.repo
@@ -1,5 +1,5 @@
 [datadog]
 name = Datadog, Inc.
-baseurl = http://yum.datadoghq.com/rpm/
+baseurl = http://yum.datadoghq.com/rpm/x86_64/
 enabled=1
 gpgcheck=0


### PR DESCRIPTION
Updated according to this tut. https://app.datadoghq.com/account/settings#agent/aws

i upgraded in servers manually.
