### PR TITLE
kloud: multi region support

### DIFF
--- a/go/src/koding/kites/kloud/kloud/build.go
+++ b/go/src/koding/kites/kloud/kloud/build.go
@@ -57,6 +57,7 @@ kite query : %s
 				"domainName":   artifact.DomainName,
 				"instanceId":   artifact.InstanceId,
 				"instanceName": artifact.InstanceName,
+				"instanceType": artifact.InstanceType,
 				"queryString":  artifact.KiteQuery,
 			},
 		}), nil

--- a/go/src/koding/kites/kloud/kloud/controller.go
+++ b/go/src/koding/kites/kloud/kloud/controller.go
@@ -53,6 +53,7 @@ func (k *Kloud) Start(r *kite.Request) (resp interface{}, reqErr error) {
 				"domainName":   resp.DomainName,
 				"instanceId":   resp.InstanceId,
 				"instanceName": resp.InstanceName,
+				"instanceType": resp.InstanceType,
 			},
 		})
 
@@ -89,6 +90,7 @@ func (k *Kloud) Resize(r *kite.Request) (reqResp interface{}, reqErr error) {
 				"domainName":   resp.DomainName,
 				"instanceId":   resp.InstanceId,
 				"instanceName": resp.InstanceName,
+				"instanceType": resp.InstanceType,
 			},
 		})
 
@@ -128,6 +130,7 @@ func (k *Kloud) Reinit(r *kite.Request) (resp interface{}, reqErr error) {
 				"domainName":   resp.DomainName,
 				"instanceId":   resp.InstanceId,
 				"instanceName": resp.InstanceName,
+				"instanceType": resp.InstanceType,
 				"queryString":  resp.KiteQuery,
 			},
 		})

--- a/go/src/koding/kites/kloud/koding/build.go
+++ b/go/src/koding/kites/kloud/koding/build.go
@@ -29,7 +29,7 @@ var (
 	// http://www.ec2instances.info/. t2.micro is not included because it's
 	// already the default type which we start to build. Only supported types
 	// are here.
-	FallbackList = []string{
+	InstancesList = []string{
 		"t2.small",
 		"t2.medium",
 		"m3.medium",
@@ -317,7 +317,7 @@ func (p *Provider) build(a *amazon.AmazonClient, m *protocol.Machine, v *pushVal
 
 		// 3. Try to use another instance
 		instanceFunc := func() error {
-			for _, instanceType := range FallbackList {
+			for _, instanceType := range InstancesList {
 				a.Builder.InstanceType = instanceType
 
 				p.Log.Warning("[%s] Fallback: building again with using instance: %s instead of %s.",

--- a/go/src/koding/kites/kloud/koding/build.go
+++ b/go/src/koding/kites/kloud/koding/build.go
@@ -80,6 +80,8 @@ func (p *Provider) build(a *amazon.AmazonClient, m *protocol.Machine, v *pushVal
 		return nil, err
 	}
 
+	a.Log.Info("[%s] build is using region: '%s'", m.Id, a.Builder.Region)
+
 	a.Push("Initializing data", normalize(10), machinestate.Building)
 
 	infoLog := p.GetCustomLogger(m.Id, "info")

--- a/go/src/koding/kites/kloud/koding/helper.go
+++ b/go/src/koding/kites/kloud/koding/helper.go
@@ -3,6 +3,8 @@ package koding
 import (
 	"koding/kites/kloud/klient"
 	"time"
+
+	"github.com/mitchellh/goamz/ec2"
 )
 
 type infoFunc func(format string, formatArgs ...interface{})
@@ -42,4 +44,28 @@ func (p *Provider) IsKlientReady(querystring string) bool {
 	}
 
 	return true
+}
+
+func isCapacityError(err error) bool {
+	ec2Error, ok := err.(*ec2.Error)
+	if !ok {
+		return false // return back if it's not an ec2.Error type
+	}
+
+	fallbackErrors := []string{
+		"InsufficientInstanceCapacity",
+		"InstanceLimitExceeded",
+	}
+
+	// check wether the incoming error code is one of the fallback
+	// errors
+	for _, fbErr := range fallbackErrors {
+		if ec2Error.Code == fbErr {
+			return true
+		}
+	}
+
+	// return for non fallback errors, because we can't do much
+	// here and probably it's need a more tailored solution
+	return false
 }

--- a/go/src/koding/kites/kloud/koding/mongodb.go
+++ b/go/src/koding/kites/kloud/koding/mongodb.go
@@ -109,12 +109,14 @@ func (p *Provider) Update(id string, s *kloud.StorageData) error {
 		data["domain"] = s.Data["domainName"]
 		data["meta.instanceId"] = s.Data["instanceId"]
 		data["meta.instanceName"] = s.Data["instanceName"]
+		data["meta.instance_type"] = s.Data["instanceType"]
 	case "info":
 		data["meta.instanceName"] = s.Data["instanceName"]
 	case "start":
 		data["ipAddress"] = s.Data["ipAddress"]
 		data["domain"] = s.Data["domainName"]
 		data["meta.instanceId"] = s.Data["instanceId"]
+		data["meta.instance_type"] = s.Data["instanceType"]
 	case "stop":
 		data["ipAddress"] = s.Data["ipAddress"]
 	case "domain":

--- a/go/src/koding/kites/kloud/koding/provider.go
+++ b/go/src/koding/kites/kloud/koding/provider.go
@@ -99,7 +99,8 @@ func (p *Provider) NewClient(m *protocol.Machine) (*amazon.AmazonClient, error) 
 	}
 
 	if a.Builder.Region == "" {
-		return nil, errors.New("region is not set in meta/builder data")
+		a.Builder.Region = "us-east-1"
+		a.Log.Critical("[%s] region is not set in. Fallback to us-east-1.", m.Id)
 	}
 
 	client, err := p.EC2Clients.Region(a.Builder.Region)

--- a/go/src/koding/kites/kloud/koding/provider.go
+++ b/go/src/koding/kites/kloud/koding/provider.go
@@ -103,8 +103,6 @@ func (p *Provider) NewClient(m *protocol.Machine) (*amazon.AmazonClient, error) 
 		a.Log.Critical("[%s] region is not set in. Fallback to us-east-1.", m.Id)
 	}
 
-	a.Log.Info("[%s] Using region: '%s'", m.Id, a.Builder.Region)
-
 	client, err := p.EC2Clients.Region(a.Builder.Region)
 	if err != nil {
 		return nil, err

--- a/go/src/koding/kites/kloud/koding/provider.go
+++ b/go/src/koding/kites/kloud/koding/provider.go
@@ -182,7 +182,7 @@ func (p *Provider) Start(m *protocol.Machine) (*protocol.Artifact, error) {
 
 			p.Log.Error("[%s] IMPORTANT: %s", m.Id, err)
 
-			for _, instanceType := range FallbackList {
+			for _, instanceType := range InstancesList {
 				p.Log.Warning("[%s] Fallback: starting again with using instance: %s instead of %s",
 					m.Id, instanceType, a.Builder.InstanceType)
 

--- a/go/src/koding/kites/kloud/koding/provider.go
+++ b/go/src/koding/kites/kloud/koding/provider.go
@@ -103,6 +103,8 @@ func (p *Provider) NewClient(m *protocol.Machine) (*amazon.AmazonClient, error) 
 		a.Log.Critical("[%s] region is not set in. Fallback to us-east-1.", m.Id)
 	}
 
+	a.Log.Info("[%s] Using region: '%s'", m.Id, a.Builder.Region)
+
 	client, err := p.EC2Clients.Region(a.Builder.Region)
 	if err != nil {
 		return nil, err

--- a/go/src/koding/kites/kloud/protocol/protocol.go
+++ b/go/src/koding/kites/kloud/protocol/protocol.go
@@ -94,6 +94,10 @@ type Artifact struct {
 	// droplet Id, AWS returns an instance id, etc..
 	InstanceId string
 
+	// InstanceType defines the type of the instance. Such as t2.micro,
+	// m3.medium and so on
+	InstanceType string
+
 	// IpAddress defines the public ip address of the running machine.
 	IpAddress string
 

--- a/go/src/koding/kites/kloud/provider/amazon/client.go
+++ b/go/src/koding/kites/kloud/provider/amazon/client.go
@@ -114,8 +114,9 @@ func (a *AmazonClient) Build(withPush bool, start, finish int) (artifactResp *pr
 	}
 
 	return &protocol.Artifact{
-		IpAddress:  instance.PublicIpAddress,
-		InstanceId: instance.InstanceId,
+		IpAddress:    instance.PublicIpAddress,
+		InstanceId:   instance.InstanceId,
+		InstanceType: a.Builder.Region,
 	}, nil
 }
 
@@ -190,8 +191,9 @@ func (a *AmazonClient) Start(withPush bool) (*protocol.Artifact, error) {
 	}
 
 	return &protocol.Artifact{
-		InstanceId: instance.InstanceId,
-		IpAddress:  instance.PublicIpAddress,
+		InstanceId:   instance.InstanceId,
+		IpAddress:    instance.PublicIpAddress,
+		InstanceType: a.Builder.Region,
 	}, nil
 }
 


### PR DESCRIPTION
Now Kloud can build and manage VMs inside Singapore if the user has `meta.region` in their document set to `ap-southeast-1`.
