### PR TITLE
Main: override KDView::setAttribute for production

### DIFF
--- a/client/Core/includes.coffee
+++ b/client/Core/includes.coffee
@@ -7,6 +7,7 @@ module.exports = [
   'KD.extend.coffee'
   'oauthcontroller.coffee'
   'kodingrouter.coffee'
+  'kdview.coffee'
   'jview.coffee'
   'ApplicationManager.coffee'
   'AppController.coffee'

--- a/client/Core/kdview.coffee
+++ b/client/Core/kdview.coffee
@@ -1,0 +1,14 @@
+# overrride ::setAttribute to not to put
+# testpath attributes in production - SY
+do ->
+
+  {environment} = KD.config
+
+  return  if environment isnt 'production'
+
+  setAttribute = KDView::setAttribute
+
+  KDView::setAttribute = (attr, val) ->
+    return  if attr is 'testpath'
+    setAttribute.call this, attr, val
+


### PR DESCRIPTION
to filter testpath attributes from dom on production.
