### PR TITLE
datadog: send alerts to #alerts channel

### DIFF
--- a/workers/social/lib/social/models/datadog.coffee
+++ b/workers/social/lib/social/models/datadog.coffee
@@ -24,7 +24,7 @@ module.exports = class DataDog extends Base
     MachineStateFailed :
       title            : "vms.failed"
       text             : "VM start failed for user: %nickname%"
-      notify           : "@slack-_devops"
+      notify           : "@slack-alerts"
       tags             : ["user:%nickname%", "context:vms"]
 
 


### PR DESCRIPTION
I have missed the actual messages in #_devops channel because channel was flooded with messages from Datadog. I prefer alerts to be sent to #alerts channel as where alerts are intended to be posted. /cc @cihangir 
