### PR TITLE
kloud: Add informative log while retrying.

### DIFF
--- a/go/src/koding/kites/kloud/koding/build.go
+++ b/go/src/koding/kites/kloud/koding/build.go
@@ -305,6 +305,8 @@ func (p *Provider) build(a *amazon.AmazonClient, m *protocol.Machine, v *pushVal
 
 				if isCapacityError(err) {
 					// if there is no capacity we are going to use the next one
+					p.Log.Warning("[%s] Build failed on availability zone '%s' due to AWS capacity problems. Trying another region.",
+						m.Id, zone)
 					continue
 				}
 


### PR DESCRIPTION
While trying to build a machine on an availability zone, inform us about what
you are doing.
