### PR TITLE
pass clientIP with client object for secure wrapper

### DIFF
--- a/workers/log/lib/log/main.coffee
+++ b/workers/log/lib/log/main.coffee
@@ -51,12 +51,21 @@ koding = new Bongo {
     [callback, context] = [context, callback] unless callback
     context             ?= group: 'koding'
     callback            ?= ->
-    JUser.authenticateClient sessionToken, context, (err, account)->
+    JUser.authenticateClient sessionToken, context, (err, res = {})->
+
+      { account, session } = res
+
       if err
         console.error "bongo.fetchClient", {err, sessionToken, context}
         koding.emit 'error', err
+
       else if account instanceof JAccount
-        callback {sessionToken, context, connection:delegate:account}
+        { clientIP } = session
+        callback {
+          sessionToken, context, clientIP,
+          connection:delegate:account
+        }
+
       else
         console.error "this is not a proper account", {sessionToken}
         console.error "constructor is JAccount", JAccount is account.constructor

--- a/workers/social/lib/social/main.coffee
+++ b/workers/social/lib/social/main.coffee
@@ -63,12 +63,21 @@ koding = new Bongo {
     [callback, context] = [context, callback] unless callback
     context             ?= group: 'koding'
     callback            ?= ->
-    JUser.authenticateClient sessionToken, context, (err, account)->
+    JUser.authenticateClient sessionToken, context, (err, res = {})->
+
+      { account, session } = res
+
       if err
         console.error "bongo.fetchClient", {err, sessionToken, context}
         koding.emit 'error', err
+
       else if account instanceof JAccount
-        callback {sessionToken, context, connection:delegate:account}
+        { clientIP } = session
+        callback {
+          sessionToken, context, clientIP,
+          connection:delegate:account
+        }
+
       else
         console.error "this is not a proper account", {sessionToken}
         console.error "constructor is JAccount", JAccount is account.constructor


### PR DESCRIPTION
We need to reach client's ip `remoteAddr` from `bongo` methods which is already keeping in `JSession` in this PR this will pass `clientIP` of current `JSession` with-in `client` object in `secure` and `permit`.
