### PR TITLE
Supervisor status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ website/a/out
 
 /tests/users.json
 /tests/output/
+supervisor.html

--- a/config/main.dev.coffee
+++ b/config/main.dev.coffee
@@ -881,6 +881,16 @@ Configuration = (options={}) ->
           eval "worker_$2"
         fi
 
+      elif [ "$1" == "supervisor_status" ]; then
+
+        SUPERVISOR_ENV=$2
+        if [ $SUPERVISOR_ENV == "" ]; then
+          SUPERVISOR_ENV="production"
+        fi
+
+        go run scripts/supervisor_status.go $SUPERVISOR_ENV
+        open supervisor.html
+
       elif [ "$#" == "0" ]; then
 
         checkrunfile

--- a/config/main.dev.coffee
+++ b/config/main.dev.coffee
@@ -602,6 +602,7 @@ Configuration = (options={}) ->
         echo "  run testendpoints         : to test every URL endpoint programmatically."
         echo "  run printconfig           : to print koding config environment variables (output in json via --json flag)"
         echo "  run worker [worker]       : to run a single worker"
+        echo "  run supervisor [env]      : to show status of workers in that environment"
         echo "  run help                  : to show this list"
         echo ""
 
@@ -881,7 +882,7 @@ Configuration = (options={}) ->
           eval "worker_$2"
         fi
 
-      elif [ "$1" == "supervisor_status" ]; then
+      elif [ "$1" == "supervisor" ]; then
 
         SUPERVISOR_ENV=$2
         if [ $SUPERVISOR_ENV == "" ]; then

--- a/go/src/koding/tools/config/config.go
+++ b/go/src/koding/tools/config/config.go
@@ -22,6 +22,10 @@ type Broker struct {
 }
 
 type Config struct {
+	Aws struct {
+		Key    string
+		Secret string
+	}
 	BuildNumber int
 	Environment string
 	Regions     struct {

--- a/scripts/supervisor_status.go
+++ b/scripts/supervisor_status.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/mitchellh/goamz/aws"
+	"github.com/mitchellh/goamz/ec2"
+	"github.com/mitchellh/goamz/elb"
+)
+
+var environments = map[string]string{
+	"production": "awseb-e-x-AWSEBLoa-2AG3XORA8JXC",
+	"latest":     "awseb-e-3-AWSEBLoa-1S2VPBAQXDRW9",
+	"sandbox":    "awseb-e-2-AWSEBLoa-Z9CEV6ZDEFMC",
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatal("Please pass an environment")
+	}
+
+	env := os.Args[1]
+
+	loadBalancerName, ok := environments[env]
+	if !ok {
+		log.Fatal("Unknown environment. Please pick: production, latest, sandbox")
+	}
+
+	auth, err := aws.EnvAuth()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	elbClient := elb.New(auth, aws.USEast)
+	options := &elb.DescribeLoadBalancer{
+		Names: []string{loadBalancerName},
+	}
+
+	ec2Client := ec2.New(auth, aws.USEast)
+
+	elbResp, err := elbClient.DescribeLoadBalancers(options)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	elbInstances := elbResp.LoadBalancers[0].Instances
+	instances := []string{}
+
+	for _, instance := range elbInstances {
+		instances = append(instances, instance.InstanceId)
+	}
+
+	resp, err := ec2Client.Instances(instances, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ips := []string{}
+
+	for _, reservation := range resp.Reservations {
+		for _, instance := range reservation.Instances {
+			ips = append(ips, instance.PublicIpAddress)
+		}
+	}
+
+	var output string
+
+	for _, ip := range ips {
+		output += fmt.Sprintf(template, ip)
+	}
+
+	bites := []byte(output)
+	err = ioutil.WriteFile("supervisor.html", bites, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+var template = `
+<div>
+	%[1]s<br>
+	<iframe src="http://koding:1q2w3e4r@%[1]s:9001" width=800px height=1100px;">
+	</iframe>
+</div>
+`

--- a/scripts/supervisor_status.go
+++ b/scripts/supervisor_status.go
@@ -23,6 +23,8 @@ var environments = map[string]string{
 	"sandbox":    "awseb-e-2-AWSEBLoa-Z9CEV6ZDEFMC",
 }
 
+var region = aws.USEast
+
 func main() {
 	if len(os.Args) < 2 {
 		log.Fatal("No environment. Please pass: production, latest, sandbox")
@@ -41,7 +43,7 @@ func main() {
 	}
 
 	// get list of instances in a load balancer
-	elbClient := elb.New(auth, aws.USEast)
+	elbClient := elb.New(auth, region)
 	options := &elb.DescribeLoadBalancer{
 		Names: []string{loadBalancerName},
 	}
@@ -59,7 +61,7 @@ func main() {
 	}
 
 	// get the ipaddress of the instances
-	ec2Client := ec2.New(auth, aws.USEast)
+	ec2Client := ec2.New(auth, region)
 	resp, err := ec2Client.Instances(instances, nil)
 	if err != nil {
 		log.Fatal(err)

--- a/scripts/supervisor_status.go
+++ b/scripts/supervisor_status.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"koding/tools/config"
 	"log"
 	"os"
 
@@ -23,13 +24,13 @@ func main() {
 	}
 
 	env := os.Args[1]
-
 	loadBalancerName, ok := environments[env]
 	if !ok {
 		log.Fatal("Unknown environment. Please pick: production, latest, sandbox")
 	}
 
-	auth, err := aws.EnvAuth()
+	conf := config.MustConfig("dev")
+	auth, err := aws.GetAuth(conf.Aws.Key, conf.Aws.Secret)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/scripts/supervisor_status.go
+++ b/scripts/supervisor_status.go
@@ -74,7 +74,7 @@ func main() {
 	}
 
 	// generate html
-	var output string
+	var output string = fmt.Sprintf("Environment: %s", env)
 
 	for _, ip := range ips {
 		output += fmt.Sprintf(template, ip)


### PR DESCRIPTION
It's a hassle to ssh into each of the instances to see if kontrol or other workers are running or not. This script generates a html with supervisor web ui in iframe for all the instances in an environment. Looks something like: https://www.dropbox.com/s/ee3v01jojzpsqro/Screenshot%202014-10-29%2013.51.13.png?dl=0
