### PR TITLE
kloud: Reduce AWS API calls. [fixes #81801064]

### DIFF
--- a/go/src/koding/kites/kloud/koding/build.go
+++ b/go/src/koding/kites/kloud/koding/build.go
@@ -296,7 +296,7 @@ func (p *Provider) build(a *amazon.AmazonClient, m *protocol.Machine, v *pushVal
 				a.Builder.Zone = zone
 				a.Builder.SubnetId = subnet.SubnetId
 
-				p.Log.Warning("[%s] Building again by using availability zone: %s and subnet %s Err: %s",
+				p.Log.Warning("[%s] Building again by using availability zone: %s and subnet %s.",
 					m.Id, zone, a.Builder.SubnetId)
 
 				buildArtifact, err = a.Build(true, normalize(60), normalize(70))

--- a/go/src/koding/kites/kloud/koding/info.go
+++ b/go/src/koding/kites/kloud/koding/info.go
@@ -17,84 +17,95 @@ func (p *Provider) Info(m *protocol.Machine) (result *protocol.InfoArtifact, err
 	// initial machine state is the state that the storage has
 	dbState := m.State
 
-	// Assume the klient state as running initially
-	klientState := machinestate.Running
+	// Assume the klient state as unknown initially
+	klientState := machinestate.Unknown
 
 	// the final state that will be sent to the caller
-	resultState := dbState
+	var resultState machinestate.State
 
 	// Get the klient state.
 	err = klient.Exists(p.Kite, m.QueryString)
 	switch err {
+	case nil:
+		klientState = machinestate.Running
 	case kite.ErrNoKitesAvailable:
 		p.Log.Warning("[%s] Klient is disconnected, I couldn't find it through Kontrol. Err: %s",
 			m.Id, err)
-		klientState = machinestate.Stopped
-	case nil:
 	default:
 		// Any other error will fallback to here. So assume that kontrol
 		// failed or some other catastrophic failure occured. Thus, do not
 		// stop or destroy the machine because of our failure.
-		p.Log.Critical("[%s] couldn't get klient information to check the status: %s ", m.Id, err)
+		p.Log.Critical("[%s] couldn't get klient information to check machine status: %s ", m.Id, err)
 	}
 
 	p.Log.Debug("[%s] Info initials: Current db state: '%s'. Klient state: '%s'",
 		m.Id, dbState, klientState)
 
-	// States are in sync. Don't do anything and return early.
-	if klientState == dbState {
-		return &protocol.InfoArtifact{
-			State: resultState,
-		}, nil
-	}
-
-	// Machine states are in inconsistent state. Find out the correct state and sync them.
 	reason := ""
 	switch klientState {
 	case machinestate.Running:
-
-		// If the klient is running, then it is safe to say that the  machine
-		// is healthy.
-		reason = "Klient is active and healthy."
-		resultState = machinestate.Running
-		dbState = machinestate.Running
+		p.Log.Debug("[%s] Info log: klient is running", m.Id)
 
 		// Stop the shutdown timer if there is any.
 		p.stopTimer(m)
 
-	case machinestate.Stopped:
-		reason = "Klient is not active."
+		// If the klient is running, then it is safe to say that the  machine
+		// is healthy.
+		reason = "Klient is active and healthy."
+
+		if dbState == machinestate.Running {
+			p.Log.Debug("[%s] Info log: klient is running and dbstate is running too. Doing nothing but returning", m.Id)
+			return &protocol.InfoArtifact{
+				State: machinestate.Running,
+			}, nil
+		}
+		resultState = machinestate.Running
+		dbState = machinestate.Running
+		p.Log.Debug("[%s] Info log: klient is running and dbstate is not running. Setting dbstate to running.", m.Id)
+
+	case machinestate.Unknown:
+		p.Log.Debug("[%s] Info log: klient is not reachable. Asking to AWS about the machine state. Also started the shutdown-timer.", m.Id)
 
 		// Start the shutdown timer since the klient is unreachable.
 		// startTimer does not turn-off always-on machines, which is good
 		p.startTimer(m)
 
-		resultState = machinestate.Stopped
-		dbState = machinestate.Stopped
+		reason = "Klient is not reachable."
 
-		// don't mark always-on machines as stopped. ever.
-		if a, ok := m.Builder["alwaysOn"]; ok {
-			if isAlwaysOn, ok := a.(bool); ok && isAlwaysOn {
-				resultState = machinestate.Running
-				dbState = machinestate.Running
-				p.Log.Critical("[%s] Couldn't get klient information from an always-on machine. Treating it as in Running state", m.Id)
-			}
+		// Since klient is not registered, we have to ask for AWS about the machine state.
+		a, err := p.NewClient(m)
+		if err != nil {
+			return nil, err
 		}
-	default:
-		reason = "Klient is in unknown state."
+		infoResp, err := a.Info()
+		if err != nil {
+			return nil, err
+		}
+
+		awsState := infoResp.State
+
+		if dbState == awsState {
+			p.Log.Debug("[%s] Info log: dbState(%s) and awsState(%s) are the same. Not gonna update the db", m.Id, dbState, awsState)
+			return &protocol.InfoArtifact{
+				State: awsState,
+			}, nil
+		}
+
+		dbState = awsState
+		resultState = awsState
 	}
 
 	// auto-fix db state if the klient state is different than db state. This will
 	// not break existing actions like building, starting, stopping etc...
 	// because CheckAndUpdateState only update the state if there is no lock
 	// available.
-	p.Log.Info("[%s] Info decision: Inconsistent state between klient and db. Updating state to '%s'. Reason: %s", m.Id, dbState, reason)
+	p.Log.Info("[%s] Info decision: Inconsistent state between the machine and db document. Updating state to '%s'. Reason: %s", m.Id, dbState, reason)
 	err = p.CheckAndUpdateState(m.Id, reason, dbState)
 	if err != nil {
 		p.Log.Debug("[%s] Info decision: Error while updating the machine state. Err: %v", m.Id, err)
 	}
 
-	p.Log.Debug("[%s] Info result: '%s' username: %s", m.Id, resultState, m.Username)
+	p.Log.Debug("[%s] Info result: '%s'. Username: %s", m.Id, resultState, m.Username)
 
 	return &protocol.InfoArtifact{
 		State: resultState,

--- a/go/src/koding/kites/kloud/koding/info.go
+++ b/go/src/koding/kites/kloud/koding/info.go
@@ -1,8 +1,6 @@
 package koding
 
 import (
-	"fmt"
-	"sync"
 	"time"
 
 	"github.com/koding/kite"
@@ -11,122 +9,68 @@ import (
 	"labix.org/v2/mgo/bson"
 
 	"koding/kites/kloud/klient"
-	"koding/kites/kloud/kloud"
 	"koding/kites/kloud/machinestate"
 	"koding/kites/kloud/protocol"
 )
 
-// invalidChanges is a list of exceptions that applies when we fix the DB state
-// with the state coming from Amazon. For example if the db state is "stopped"
-// there is no need to change it with the Amazon state "stopping"
-var invalidChanges = map[machinestate.State]machinestate.State{
-	machinestate.Stopped:    machinestate.Stopping,
-	machinestate.Running:    machinestate.Starting,
-	machinestate.Terminated: machinestate.Terminating,
-}
-
-// protects invalidChanges
-var rwLock sync.RWMutex
-
-// validChange returns true if the given db state is a valid to change with the
-// aws state
-func validChange(db, aws machinestate.State) bool {
-	rwLock.Lock()
-	defer rwLock.Unlock()
-
-	return invalidChanges[db] != aws
-}
-
 func (p *Provider) Info(m *protocol.Machine) (result *protocol.InfoArtifact, err error) {
-	a, err := p.NewClient(m)
-	if err != nil {
-		return nil, err
-	}
-
-	// otherwise ask AWS to get an machine state
-	infoResp, err := a.Info()
-	if err != nil {
-		return nil, err
-	}
-
+	// initial machine state is the state that the storage has
 	dbState := m.State
-	awsState := infoResp.State
+
+	// Assume the klient state as running initially
+	klientState := machinestate.Running
+
+	err = klient.Exists(p.Kite, m.QueryString)
+	switch err {
+	case kite.ErrNoKitesAvailable:
+		p.Log.Warning("[%s] klient is disconnected, I couldn't find it trough Kontrol. err: %s",
+			m.Id, err)
+
+		klientState = machinestate.Stopped
+
+		// start shutdown timer, because klient is not running, don't let
+		// it be running forever
+		p.startTimer(m)
+	case nil:
+		// klient is running and there is no error. We are stopping the timer
+		// because everything seems cool.
+		p.stopTimer(m)
+	default:
+		// Any other error will fallback to here. So assume that kontrol
+		// failed or some other catastrophic failure occured. Thus, do not
+		// stop or destroy the machine because of our failure.
+		p.stopTimer(m)
+		p.Log.Critical("[%s] couldn't get klient information to check the status: %s ", m.Id, err)
+	}
+
+	p.Log.Debug("[%s] info initials: current db state is '%s'. klient state is '%s'",
+		m.Id, dbState, klientState)
 
 	// result state is the final state that is send back to the request
 	resultState := dbState
 
-	p.Log.Debug("[%s] info initials: current db state is '%s'. amazon ec2 state is '%s'",
-		m.Id, dbState, awsState)
-
-	// we don't check if the state is something else. Klient is only available
-	// when the machine is running
-	klientChecked := false
-	if dbState.In(machinestate.Running, machinestate.Stopped) && awsState == machinestate.Running {
-		klientChecked = true
-
-		err := klient.Exists(p.Kite, m.QueryString)
-		switch err {
-		case kite.ErrNoKitesAvailable:
-			p.Log.Warning("[%s] klient is disconnected, I couldn't find it trough Kontrol. err: %s",
-				m.Id, err)
-
-			resultState = machinestate.Stopped
-
-			// start shutdown timer, because klient is not running, don't let
-			// it be running forever
-			p.startTimer(m)
-		case nil:
-			// now assume it's running
-			resultState = machinestate.Running
-
-			// stop any if any timer is available
-			p.stopTimer(m)
+	// auto-fix db state if the klient state is different than db state. This will
+	// not break existing actions like building, starting, stopping etc...
+	// because CheckAndUpdateState only update the state if there is no lock
+	// available.
+	if dbState != klientState {
+		reason := ""
+		switch klientState {
+		case machinestate.Running:
+			reason = "Klient is active and healthy."
+		case machinestate.Stopped:
+			reason = "Klient is not active."
 		default:
-			p.stopTimer(m)
-			// error is something else and critical, so don't do anything until it's resolved
-			p.Log.Critical("[%s] couldn't get klient information to check the status: %s ", m.Id, err)
+			reason = "Klient is in unknown state."
 		}
 
-		if resultState != dbState {
-
-			reason := ""
-			switch resultState {
-			case machinestate.Running:
-				reason = "Klient is active and healthy."
-			case machinestate.Stopped:
-				reason = "Klient is not active."
-			default:
-				reason = "Klient is in unknown state."
-			}
-
-			// return an error anything here if the DB is locked.
-			if err := p.CheckAndUpdateState(m.Id, reason, resultState); err == mgo.ErrNotFound {
-				return nil, kloud.ErrLockAcquired
-			}
-		}
-
-		p.Log.Debug("[%s] info decision: based on klient interaction: '%s'",
-			m.Id, resultState)
-	}
-
-	// fix db state if the aws state is different than dbState. This will not
-	// break existing actions like building,starting,stopping etc.. because
-	// CheckAndUpdateState only update the state if there is no lock available.
-	// however only fix when it's there was no klient checking and the state
-	// changing is a valid transformation (for example prevent if it's
-	// "Stopped" -> "Stopping"
-	if dbState != awsState && !klientChecked && validChange(dbState, awsState) {
-		// this is only set if the lock is unlocked. Thefore it will not
-		// change the db state if there is an ongoing process. If there is no
-		// error than it means there is no lock so we could update it with the
-		// state from amazon. Therefore send it back!
-		reason := fmt.Sprintf("State is inconsistent. Have '%s' in DB, updating to AWS state: '%s'",
-			dbState, awsState)
-		err := p.CheckAndUpdateState(m.Id, reason, awsState)
+		// return an error anything here if the DB is locked.
+		err := p.CheckAndUpdateState(m.Id, reason, klientState)
 		if err == nil {
-			p.Log.Info("[%s] info decision : inconsistent state. using amazon state '%s'",
-				m.Id, awsState)
-			resultState = awsState
+			p.Log.Info("[%s] info decision : inconsistent state. using klient state '%s'",
+				m.Id, klientState)
+			// return klientState since it is the most updated one.
+			resultState = klientState
 		} else {
 			p.Log.Debug("[%s] info decision : using current db state '%s'",
 				m.Id, resultState)
@@ -137,7 +81,6 @@ func (p *Provider) Info(m *protocol.Machine) (result *protocol.InfoArtifact, err
 
 	return &protocol.InfoArtifact{
 		State: resultState,
-		Name:  infoResp.Name,
 	}, nil
 
 }


### PR DESCRIPTION
Bypass the AWS machine state check on kloud.info method. Use the klient status
instead.

If the klient is up and running, assume that the VM is running and don't look
for EC2.
