### PR TITLE
Editor: Initiate autocompletion when a word character is inserted [completes #80775420]

### DIFF
--- a/client/Ace/ace.coffee
+++ b/client/Ace/ace.coffee
@@ -87,6 +87,11 @@ class Ace extends KDView
     @editor.getSession().selection.on 'changeCursor', (cursor)=>
       @emit 'ace.change.cursor', @editor.getSession().getSelection().getCursor()
 
+    @editor.commands.on 'afterExec', (e) =>
+      if e.command.name is 'insertstring' and /^[\w.]$/.test e.args
+        @editor.completer and @editor.completer.autoInsert = off
+        @editor.execCommand 'startAutocomplete'
+
     {enableShortcuts, createFindAndReplaceView} = @getOptions()
 
     if enableShortcuts


### PR DESCRIPTION
[Autocomplete should trigger after every keypress on IDE](https://www.pivotaltracker.com/story/show/80775420)

![autocomplete](https://cloud.githubusercontent.com/assets/1136739/4918557/a8f9d5a4-64f2-11e4-94d8-373acc26487f.gif)
