### PR TITLE
sidebar modals search fix [fixes #82447694]

### DIFF
--- a/client/Social/Activity/sidebar/searchmodal.coffee
+++ b/client/Social/Activity/sidebar/searchmodal.coffee
@@ -79,6 +79,8 @@ class SidebarSearchModal extends KDModalView
 
     @listController.addItem itemData for itemData in items
 
+    @listController.lazyLoader.setClass 'do-not-show'
+
 
   handleLazyLoad: ->
 

--- a/client/Social/Activity/sidebar/searchmodal.coffee
+++ b/client/Social/Activity/sidebar/searchmodal.coffee
@@ -66,14 +66,16 @@ class SidebarSearchModal extends KDModalView
 
     @addSubView @listController.getView()
 
-    @listController.on 'LazyLoadThresholdReached', @bound 'handleLazyLoad'
+    debouncedLazyLoad = KD.utils.debounce 300, @bound 'handleLazyLoad'
+
+    @listController.on 'LazyLoadThresholdReached', debouncedLazyLoad
 
     @fetch {}, @bound 'populate'
 
 
   populate: (items) ->
 
-    return unless items?.length?
+    return  unless items?.length?
 
     @listController.addItem itemData for itemData in items
 

--- a/client/Social/Activity/styl/activity.styl
+++ b/client/Social/Activity/styl/activity.styl
@@ -285,6 +285,8 @@ body.activity
   .lazy-loader
     text-align        center
     margin            22px 0
+    &.do-not-show
+      hidden()
 
   .kdmodal-inner
     margin            22px 15px 22px 30px
@@ -302,6 +304,7 @@ body.activity
 
   .kdmodal-content
     margin            0 !important
+    overflow          visible
 
   .search-input
     height            35px

--- a/go/src/socialapi/models/channel.go
+++ b/go/src/socialapi/models/channel.go
@@ -460,7 +460,9 @@ func (c *Channel) Search(q *request.Query) ([]Channel, error) {
 	bongoQuery.AddScope(RemoveTrollContent(c, q.ShowExempt))
 
 	query := bongo.B.BuildQuery(c, bongoQuery)
-	query = query.Where("name like ?", "%"+q.Name+"%")
+
+	// use 'ilike' for case-insensitive search
+	query = query.Where("name ilike ?", "%"+q.Name+"%")
 
 	if err := bongo.CheckErr(
 		query.Find(&channels),

--- a/go/src/socialapi/workers/api/modules/privatemessage/privatemessage.go
+++ b/go/src/socialapi/workers/api/modules/privatemessage/privatemessage.go
@@ -113,7 +113,8 @@ func getPrivateMessageChannels(q *request.Query) ([]models.Channel, error) {
 	query := getUserChannelsQuery(q)
 
 	if q.Name != "" {
-		query = query.Where("api.channel.purpose like ?", "%"+q.Name+"%")
+		// use 'ilike' for case-insensitive search
+		query = query.Where("api.channel.purpose ilike ?", "%"+q.Name+"%")
 	}
 
 	// add exempt clause if needed


### PR DESCRIPTION
@canthefason saw the changes I made for queries.

@sinan Also I throttled the lazy load mechanism because, once you delete the value inside search box, the list controller emits the `'LazyLoadThresholdReached'` event, and it was causing duplicate list, because of the fact that when it is emitted we are starting to fetch for search as well. Throttling solved the issue, but I am not sure if it's the best way to solve this.
