### PR TITLE
terminal: ignore IDE fullscreen keybinding [fixes #80924820]

### DIFF
--- a/client/Terminal/src/Terminal.coffee
+++ b/client/Terminal/src/Terminal.coffee
@@ -144,7 +144,11 @@ class WebTerm.Terminal extends KDObject
     @keyInput?.destroy()
     super()
 
+  ignoreKeyDownEvent = (event) ->
+    (event.ctrlKey or event.metaKey) and event.shiftKey and event.keyCode is 13
+
   keyDown: (event) ->
+    return  if ignoreKeyDownEvent event
     @inputHandler.keyDown event
 
   keyPress: (event) ->


### PR DESCRIPTION
[Cmd-Shift-Enter emits newline to terminal](https://www.pivotaltracker.com/story/show/80924820)
