### PR TITLE
Workspace: pass same path as only option [fixes #82340712]

### DIFF
--- a/client/Social/Activity/sidebar/activitysidebar.coffee
+++ b/client/Social/Activity/sidebar/activitysidebar.coffee
@@ -697,10 +697,11 @@ class ActivitySidebar extends KDCustomHTMLView
         @emit 'WorkspaceCreateFailed'
         return KD.showError "Couldn't create your new workspace"
 
-      folderOptions =
-        type        : 'folder'
-        path        : workspace.rootPath
-        recursive   : yes
+      folderOptions  =
+        type         : 'folder'
+        path         : workspace.rootPath
+        recursive    : yes
+        samePathOnly : yes
 
       machine.fs.create folderOptions, (err, folder) =>
         if err


### PR DESCRIPTION
["Workspace from here" creates an additional unnecessary folder](https://www.pivotaltracker.com/story/show/82340712)
