### PR TITLE
activity: reload when you hit the same route twice [completes #82594112] [closed]

### DIFF
--- a/client/Core/ApplicationManager.coffee
+++ b/client/Core/ApplicationManager.coffee
@@ -181,25 +181,31 @@ class ApplicationManager extends KDObject
 
     appOptions  = KD.getAppOptions name
     appInstance = @get name
-
     appView     = appInstance.getView?()
+
     return unless appView
 
-    @emit 'AppIsBeingShown', appInstance, appView, appOptions
+    prevInstance = @getFrontApp()
+
+    @emit 'AppIsBeingShown', appInstance, appView, appOptions, prevInstance
     appInstance.appIsShown? appParams
 
     @setLastActiveIndex appInstance
     @utils.defer -> callback? appInstance
 
-  showInstance:(appInstance, callback)->
+
+  showInstance: (appInstance, callback) ->
 
     appView    = appInstance.getView?() or null
     appOptions = KD.getAppOptions appInstance.getOption "name"
 
     return if appOptions.background
 
-    @emit 'AppIsBeingShown', appInstance, appView, appOptions
+    prevInstance = @getFrontApp()
+
+    @emit 'AppIsBeingShown', appInstance, appView, appOptions, prevInstance
     appInstance.appIsShown?()
+
     @setLastActiveIndex appInstance
     @utils.defer -> callback? appInstance
 

--- a/client/Social/Activity/AppView.coffee
+++ b/client/Social/Activity/AppView.coffee
@@ -71,12 +71,17 @@ class ActivityAppView extends KDView
     name = if slug then "#{type}-#{slug}" else type
     pane = @tabs.getPaneByName name
 
+    activePane = @tabs.getActivePane()
+    activePane?.emit 'PaneWillDetach'  unless pane is activePane
+
     return @createTab name, data  unless pane
 
     unless @sidebar.selectedItem
       @sidebar.selectItemByRouteOptions type, slug
 
     @tabs.showPane pane
+
+    pane.emit 'RefreshRequested', data, type, slug  if pane is activePane
 
 
   # type: [topic|post|message|chat|null]

--- a/client/Social/Activity/AppView.coffee
+++ b/client/Social/Activity/AppView.coffee
@@ -56,41 +56,41 @@ class ActivityAppView extends KDView
       pane.setScrollTops()
 
 
+  openTab: (data, type, slug) ->
+
+    name = if slug then "#{type}-#{slug}" else type
+    pane = @tabs.getPaneByName name
+
+    return @createTab name, data  unless pane
+
+    unless @sidebar.selectedItem
+      @sidebar.selectItemByRouteOptions type, slug
+
+    @tabs.showPane pane
+
+
   # type: [topic|post|message|chat|null]
   # slug: [slug|id|name]
   open: (type, slug) ->
 
-    {socialapi, router, notificationController} = KD.singletons
-
-    # if type is 'topic' then @widgetsBar.show() else @widgetsBar.hide()
-
-    kallback = (data) =>
-      name = if slug then "#{type}-#{slug}" else type
-      pane = @tabs.getPaneByName name
-
-      unless @sidebar.selectedItem
-        @sidebar.selectItemByRouteOptions type, slug
-
-      if pane
-      then @tabs.showPane pane
-      else @createTab name, data
+    {socialapi, router} = KD.singletons
 
     @sidebar.selectItemByRouteOptions type, slug
     item = @sidebar.selectedItem
 
-    if not item
-      type_ = switch type
-        when 'message' then 'privatemessage'
-        when 'post'    then 'activity'
-        else type
-      socialapi.cacheable type_, slug, (err, data) =>
-        if err then router.handleNotFound router.getCurrentPath()
-        else
-          # put after #koding #changelog
-          @sidebar.addItem data, 2
-          kallback data
-    else
-      kallback item.getData()
+    return @openTab item.getData(), type, slug  if item
+
+    type_ = switch type
+      when 'message' then 'privatemessage'
+      when 'post'    then 'activity'
+      else type
+
+    socialapi.cacheable type_, slug, (err, data) =>
+
+      return router.handleNotFound router.getCurrentPath()  if err
+
+      @sidebar.addItem data, 2
+      @openTab data, type, slug
 
 
   openNext: ->

--- a/client/Social/Activity/AppView.coffee
+++ b/client/Social/Activity/AppView.coffee
@@ -41,6 +41,16 @@ class ActivityAppView extends KDView
 
       router.handleRoute path, { replaceState: yes }
 
+    appManager.on 'AppIsBeingShown', (controller, view, options, prevController) =>
+
+      nextIsActivity = controller instanceof ActivityAppController
+      prevIsActivity = prevController instanceof ActivityAppController
+
+      return  unless prevIsActivity
+
+      activePane = @tabs.getActivePane()
+      activePane.emit 'PaneWillDetach'  unless nextIsActivity
+
 
   viewAppended: ->
 

--- a/client/Social/Activity/AppView.coffee
+++ b/client/Social/Activity/AppView.coffee
@@ -31,6 +31,16 @@ class ActivityAppView extends KDView
       if type = pane.getData()?.typeConstant
         @tabs.setAttribute 'class', KD.utils.curry 'kdview kdtabview', type
 
+    { router, appManager } = KD.singletons
+
+    router.on 'AlreadyHere', (path, options) =>
+
+      [slug] = options.frags
+
+      return  if slug isnt 'Activity'
+
+      router.handleRoute path, { replaceState: yes }
+
 
   viewAppended: ->
 

--- a/client/Social/Activity/views/activitypane.coffee
+++ b/client/Social/Activity/views/activitypane.coffee
@@ -161,6 +161,13 @@ class ActivityPane extends MessagePane
 
   open: (name, query) ->
 
+    pane = @tabView.getPaneByName name
+    lastSelectedPane = this[@lastSelected]
+
+    return @refreshContentPane pane  if pane is lastSelectedPane
+
+    @setLastSelected name
+
     @tabView.showPane @tabView.getPaneByName name
 
     if name is 'Search' and not query

--- a/client/Social/Activity/views/activitypane.coffee
+++ b/client/Social/Activity/views/activitypane.coffee
@@ -132,6 +132,14 @@ class ActivityPane extends MessagePane
     @tabView.tabHandleContainer.setClass 'filters'
 
 
+  setLastSelected: (lastSelected) ->
+
+    @lastSelected = switch lastSelected
+      when 'Most Recent' then 'mostRecent'
+      when 'Most Liked'  then 'mostLiked'
+      when 'Search'      then 'search'
+
+
   open: (name, query) ->
 
     @tabView.showPane @tabView.getPaneByName name

--- a/client/Social/Activity/views/activitypane.coffee
+++ b/client/Social/Activity/views/activitypane.coffee
@@ -41,6 +41,13 @@ class ActivityPane extends MessagePane
 
     @fakeMessageMap = {}
 
+  getActiveContentPane: ->
+
+    switch KD.singletons.router.getCurrentPath()
+      when '/Activity/Public/Liked'  then @mostLiked
+      when '/Activity/Public/Recent' then @mostRecent
+
+
 
   bindLazyLoader: ->
 

--- a/client/Social/Activity/views/activitypane.coffee
+++ b/client/Social/Activity/views/activitypane.coffee
@@ -41,6 +41,12 @@ class ActivityPane extends MessagePane
 
     @fakeMessageMap = {}
 
+    @on 'PaneWillDetach', @bound 'paneWillDetach'
+
+
+  paneWillDetach: -> @lastSelected = null
+
+
   getActiveContentPane: ->
 
     switch KD.singletons.router.getCurrentPath()

--- a/client/Social/Activity/views/activitypane.coffee
+++ b/client/Social/Activity/views/activitypane.coffee
@@ -54,6 +54,19 @@ class ActivityPane extends MessagePane
       when '/Activity/Public/Recent' then @mostRecent
 
 
+  refreshContentPane: (contentPane) ->
+
+    { listController } = contentPane
+
+    listController.removeAllItems()
+    listController.showLazyLoader()
+
+    options = {}
+
+    options[@lastSelected] = yes
+
+    @fetch options, @createContentSetter(@lastSelected)
+
 
   bindLazyLoader: ->
 

--- a/client/Social/Activity/views/messagepane.coffee
+++ b/client/Social/Activity/views/messagepane.coffee
@@ -56,6 +56,15 @@ class MessagePane extends KDTabPaneView
 
     KD.singletons.windowController.addFocusListener @bound 'handleFocus'
 
+    @on 'RefreshRequested', @bound 'refreshContent'
+
+
+  refreshContent: ->
+
+    @listController.removeAllItems()
+    @listController.showLazyLoader()
+    @populate()
+
 
   createScrollView: ->
 


### PR DESCRIPTION
This PR introduces reload/refresh capabilities for the message/activity panes
- [x] Refresh when an activity route is being hit twice.
- [x] Handles `ActivityPane` -> `Most Liked` / `Most Recent` switches.
- [x] Handles the situation correctly when there is an app change required.

I couldn't find a good way to take a screen shot, but this pr is mostly about implementing in the activity, and trying to fix edge cases when you are switching apps, or staying in the same pane but changing views inside of that pane (e.g `ActivityPane`). I could do a screen-share and explain the details in a better way if needed.
