### PR TITLE
activity: reload when you hit the same route twice [completes #82594112]

### DIFF
--- a/client/Social/Activity/AppView.coffee
+++ b/client/Social/Activity/AppView.coffee
@@ -203,3 +203,13 @@ class ActivityAppView extends KDView
       top = window.innerHeight - 220
 
     return {top, left}
+
+
+  helper =
+
+    sanitizePath: (path) ->
+
+      if /\/Activity\/Public/.test path
+      then '/Activity/Public'
+      else path
+

--- a/client/Social/Activity/AppView.coffee
+++ b/client/Social/Activity/AppView.coffee
@@ -22,7 +22,7 @@ class ActivityAppView extends KDView
 
     @appStorage  = appStorageController.storage 'Activity', '2.0'
 
-    @pathPaneMap = {}
+    @panePathMap = {}
 
     @tabs = new KDTabView
       tagName             : 'main'
@@ -42,7 +42,7 @@ class ActivityAppView extends KDView
       return  if slug isnt 'Activity'
 
       path = helper.sanitizePath path
-      pane = @pathPaneMap[path]
+      pane = @panePathMap[path]
 
       pane?.refreshContent? path
 
@@ -157,7 +157,7 @@ class ActivityAppView extends KDView
 
     path = helper.sanitizePath path
 
-    @pathPaneMap[path] = pane
+    @panePathMap[path] = pane
 
     pane.on 'LeftChannel', => @tabs.removePane pane
 

--- a/client/Social/Activity/AppView.coffee
+++ b/client/Social/Activity/AppView.coffee
@@ -22,6 +22,8 @@ class ActivityAppView extends KDView
 
     @appStorage  = appStorageController.storage 'Activity', '2.0'
 
+    @pathPaneMap = {}
+
     @tabs = new KDTabView
       tagName             : 'main'
       hideHandleContainer : yes
@@ -137,6 +139,12 @@ class ActivityAppView extends KDView
         else ActivityPane
 
     @tabs.addPane pane = new paneClass {name, type, channelId}, data
+
+    path = KD.singletons.router.getCurrentPath()
+
+    path = helper.sanitizePath path
+
+    @pathPaneMap[path] = pane
 
     pane.on 'LeftChannel', => @tabs.removePane pane
 

--- a/client/Social/Activity/AppView.coffee
+++ b/client/Social/Activity/AppView.coffee
@@ -153,9 +153,7 @@ class ActivityAppView extends KDView
 
     @tabs.addPane pane = new paneClass {name, type, channelId}, data
 
-    path = KD.singletons.router.getCurrentPath()
-
-    path = helper.sanitizePath path
+    path = helper.sanitizePath KD.singletons.router.getCurrentPath()
 
     @panePathMap[path] = pane
 

--- a/client/Social/Activity/AppView.coffee
+++ b/client/Social/Activity/AppView.coffee
@@ -33,6 +33,19 @@ class ActivityAppView extends KDView
       if type = pane.getData()?.typeConstant
         @tabs.setAttribute 'class', KD.utils.curry 'kdview kdtabview', type
 
+    { router } = KD.singletons
+
+    router.on 'AlreadyHere', (path, options) =>
+
+      [slug] = options.frags
+
+      return  if slug isnt 'Activity'
+
+      path = helper.sanitizePath path
+      pane = @pathPaneMap[path]
+
+      pane?.refreshContent? path
+
 
   viewAppended: ->
 

--- a/client/Social/Activity/views/activitypane.coffee
+++ b/client/Social/Activity/views/activitypane.coffee
@@ -53,6 +53,27 @@ class ActivityPane extends MessagePane
     return panes[path]
 
 
+  refreshContent: ->
+
+    options = @getActiveContentOptions()
+
+    @refreshContentPane options
+
+
+  refreshContentPane: (options) ->
+
+    { pane, name } = options
+    { listController } = pane
+
+    listController.removeAllItems()
+    listController.showLazyLoader()
+
+    fetchOptions = {}
+    fetchOptions[name] = yes
+
+    @fetch fetchOptions, @createContentSetter name
+
+
   bindLazyLoader: ->
 
     @scrollView.wrapper.on 'LazyLoadThresholdReached', =>

--- a/client/Social/Activity/views/activitypane.coffee
+++ b/client/Social/Activity/views/activitypane.coffee
@@ -42,6 +42,17 @@ class ActivityPane extends MessagePane
     @fakeMessageMap = {}
 
 
+  getActiveContentOptions: ->
+
+    panes =
+      '/Activity/Public/Liked'  : { name: 'mostLiked',  pane: @mostLiked }
+      '/Activity/Public/Recent' : { name: 'mostRecent', pane: @mostRecent }
+
+    path = KD.singletons.router.getCurrentPath()
+
+    return panes[path]
+
+
   bindLazyLoader: ->
 
     @scrollView.wrapper.on 'LazyLoadThresholdReached', =>

--- a/client/Social/Activity/views/messagepane.coffee
+++ b/client/Social/Activity/views/messagepane.coffee
@@ -57,6 +57,13 @@ class MessagePane extends KDTabPaneView
     KD.singletons.windowController.addFocusListener @bound 'handleFocus'
 
 
+  refreshContent: ->
+
+    @listController.removeAllItems()
+    @listController.showLazyLoader()
+    @populate()
+
+
   createScrollView: ->
 
     @scrollView = new KDCustomScrollView


### PR DESCRIPTION
This PR introduces reload/refresh capabilities for the message/activity panes

Basically what it does:
- [x] Creates a map that maps route path to a specific `Pane` (e.g `ActivityPane`, `MessagePane`, `PrivateMessagePane`, etc.)
- [x] It attaches a listener to router's `AlreadyHere` event, and get the route path from there.
- [x] Whenever the `AlreadyHere` event is fired it finds the specific pane with that route and calls the `refreshContent` method of the pane, so that specific panes can do their job, rather than `ActivityAppView`
- [x] With `MessagePane::refreshContent` it solves all the panes except `ActivityPane` which has special cases inside.
- [x] `ActivityPane` handles the `ActivityContentPane` logic in itself.
