### PR TITLE
kloud: remove all logs and only return explicit errors

### DIFF
--- a/go/src/koding/kites/kloud/kloud/build.go
+++ b/go/src/koding/kites/kloud/kloud/build.go
@@ -43,11 +43,11 @@ username   : %s
 domain     : %s
 ip address : %s
 instance   : %s
-kite query : %s
-`
+kite query : %s`
+
 		resultInfo := fmt.Sprintf(resultStub, artifact.Username, artifact.DomainName,
 			artifact.IpAddress, artifact.InstanceName, artifact.KiteQuery)
-		k.Log.Info("[%s] building machine was successfull. Artifact data: %s",
+		k.Log.Info("[%s] ========== BUILD results ========== %s",
 			m.Id, resultInfo)
 
 		return k.Storage.Update(m.Id, &StorageData{

--- a/go/src/koding/kites/kloud/kloud/controller.go
+++ b/go/src/koding/kites/kloud/kloud/controller.go
@@ -184,7 +184,6 @@ func (k *Kloud) Destroy(r *kite.Request) (resp interface{}, reqErr error) {
 }
 
 func (k *Kloud) Info(r *kite.Request) (infoResp interface{}, infoErr error) {
-	start := time.Now()
 	machine, err := k.PrepareMachine(r)
 	if err != nil {
 		return nil, err
@@ -217,9 +216,6 @@ func (k *Kloud) Info(r *kite.Request) (infoResp interface{}, infoErr error) {
 	if err != nil {
 		return nil, err
 	}
-
-	infoDuration := time.Since(start)
-	k.Log.Info("[%s] infoDuration %+v, response %v\n", machine.Id, infoDuration, response)
 
 	if response.State == machinestate.Unknown {
 		response.State = machine.State

--- a/go/src/koding/kites/kloud/kloud/controller.go
+++ b/go/src/koding/kites/kloud/kloud/controller.go
@@ -307,15 +307,16 @@ func (k *Kloud) coreMethods(r *kite.Request, fn controlFunc) (result interface{}
 			eventErr = fmt.Sprintf("%s failed. Please contact support.", r.Method)
 			finishReason = fmt.Sprintf("User command: '%s' failed. Setting back to state: %s",
 				r.Method, machine.State)
+
+			k.Log.Info("[%s] ========== %s failed (user: %s) ==========",
+				machine.Id, strings.ToUpper(r.Method), r.Username)
+		} else {
+			totalDuration := time.Since(start)
+			k.Log.Info("[%s] ========== %s finished with success (user: %s, duration: %s) ==========",
+				machine.Id, strings.ToUpper(r.Method), r.Username, totalDuration)
 		}
 
-		totalDuration := time.Since(start)
-
-		k.Log.Info("[%s] ========== %s finished (user: %s, duration: %s) ==========",
-			machine.Id, strings.ToUpper(r.Method), r.Username, totalDuration)
-
 		// update final status in storage
-
 		k.Storage.UpdateState(machine.Id, finishReason, status)
 
 		// update final status in storage

--- a/go/src/koding/kites/kloud/koding/build.go
+++ b/go/src/koding/kites/kloud/koding/build.go
@@ -64,36 +64,32 @@ func (p *Provider) build(a *amazon.AmazonClient, m *protocol.Machine, v *pushVal
 		return int(normalized)
 	}
 
+	errLog := p.GetCustomLogger(m.Id, "error")
+
 	// Check for total amachine allowance
 	checker, err := p.PlanChecker(m)
 	if err != nil {
 		return nil, err
 	}
 
-	p.Log.Info("[%s] checking machine limit for user '%s'", m.Id, m.Username)
 	if err := checker.Total(); err != nil {
+		errLog("Checking total machine err: %s", err)
 		return nil, err
 	}
 
-	p.Log.Info("[%s] checking alwaysOn limit for user '%s'", m.Id, m.Username)
 	if err := checker.AlwaysOn(); err != nil {
+		errLog("Checking always on limit err: %s", err)
 		return nil, err
 	}
 
-	a.Log.Info("[%s] build is using region: '%s'", m.Id, a.Builder.Region)
+	a.Log.Debug("[%s] build is using region: '%s'", m.Id, a.Builder.Region)
 
 	a.Push("Initializing data", normalize(10), machinestate.Building)
-
-	infoLog := p.GetCustomLogger(m.Id, "info")
-	errLog := p.GetCustomLogger(m.Id, "error")
-
-	a.InfoLog = infoLog
 
 	a.Push("Checking network requirements", normalize(20), machinestate.Building)
 
 	// get all subnets belonging to Kloud
 	kloudKeyName := "Kloud"
-	infoLog("Searching for subnets with tag-key %s", kloudKeyName)
 	subnets, err := a.SubnetsWithTag(kloudKeyName)
 	if err != nil {
 		errLog("Searching subnet err: %v", err)
@@ -103,7 +99,6 @@ func (p *Provider) build(a *amazon.AmazonClient, m *protocol.Machine, v *pushVal
 	// sort and get the lowest
 	subnet := subnets.WithMostIps()
 
-	infoLog("Checking if security group for VPC id %s exists.", subnet.VpcId)
 	group, err := a.SecurityGroupFromVPC(subnet.VpcId, kloudKeyName)
 	if err != nil {
 		errLog("Checking security group err: %v", err)
@@ -113,11 +108,6 @@ func (p *Provider) build(a *amazon.AmazonClient, m *protocol.Machine, v *pushVal
 	a.Builder.SecurityGroupId = group.Id
 	a.Builder.SubnetId = subnet.SubnetId
 	a.Builder.Zone = subnet.AvailabilityZone
-
-	infoLog("Using subnet: '%s', zone: '%s', sg: '%s'. Subnet has %d available IPs",
-		subnet.SubnetId, subnet.AvailabilityZone, group.Id, subnet.AvailableIpAddressCount)
-
-	infoLog("Check if user is allowed to create instance type %s", a.Builder.InstanceType)
 
 	if a.Builder.InstanceType == "" {
 		a.Log.Critical("[%s] Instance type is empty. This shouldn't happen. Fallback to t2.micro", m.Id)
@@ -132,7 +122,6 @@ func (p *Provider) build(a *amazon.AmazonClient, m *protocol.Machine, v *pushVal
 
 	a.Push("Checking base build image", normalize(30), machinestate.Building)
 
-	infoLog("Checking if AMI with tag '%s' exists", DefaultCustomAMITag)
 	image, err := a.ImageByTag(DefaultCustomAMITag)
 	if err != nil {
 		errLog("Checking ami tag failed err: %v", err)
@@ -147,9 +136,9 @@ func (p *Provider) build(a *amazon.AmazonClient, m *protocol.Machine, v *pushVal
 		storageSize = a.Builder.StorageSize
 	}
 
-	infoLog("Check if user is allowed to create machine with '%dGB' storage", storageSize)
 	// check if the user is egligible to create a vm with this size
 	if err := checker.Storage(storageSize); err != nil {
+		errLog("Checking storage size failed err: %v", err)
 		return nil, err
 	}
 
@@ -270,7 +259,6 @@ func (p *Provider) build(a *amazon.AmazonClient, m *protocol.Machine, v *pushVal
 
 			currentZone := subnet.AvailabilityZone
 
-			infoLog("Fallback: Searching for a zone that has capacity amongst zones: %v", zones)
 			for _, zone := range zones {
 				if zone == currentZone {
 					// skip it because that's one is causing problems and doesn't have any capacity
@@ -382,7 +370,6 @@ func (p *Provider) build(a *amazon.AmazonClient, m *protocol.Machine, v *pushVal
 	instanceName := m.Builder["instanceName"].(string)
 	if instanceName == "terminated-instance" {
 		instanceName = "user-" + m.Username + "-" + strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
-		infoLog("Instance name is an artifact (terminated), changing to %s", instanceName)
 	}
 
 	buildArtifact.InstanceName = instanceName
@@ -422,7 +409,6 @@ func (p *Provider) build(a *amazon.AmazonClient, m *protocol.Machine, v *pushVal
 		{Key: "koding-domain", Value: m.Domain.Name},
 	}
 
-	infoLog("Adding user tags %v", tags)
 	if err := a.AddTags(buildArtifact.InstanceId, tags); err != nil {
 		errLog("Adding tags failed: %v", err)
 		return nil, errors.New("machine initialization requirements failed [3]")
@@ -434,9 +420,8 @@ func (p *Provider) build(a *amazon.AmazonClient, m *protocol.Machine, v *pushVal
 	buildArtifact.KiteQuery = query.String()
 
 	a.Push("Checking connectivity", normalize(75), machinestate.Building)
-	infoLog("Connecting to remote Klient instance")
 	if p.IsKlientReady(query.String()) {
-		p.Log.Info("[%s] klient is ready.", m.Id)
+		p.Log.Debug("[%s] klient is ready.", m.Id)
 	} else {
 		p.Log.Warning("[%s] klient is not ready. I couldn't connect to it.", m.Id)
 	}

--- a/go/src/koding/kites/kloud/koding/cleaners.go
+++ b/go/src/koding/kites/kloud/koding/cleaners.go
@@ -88,7 +88,7 @@ func (p *Provider) CleanDeletedVMs() error {
 			return p.Delete(id)
 		}
 
-		p.Log.Info("[%s] terminating user deleted machine. User %s",
+		p.Log.Info("[%s] cleaner: terminating user deleted machine. User %s",
 			id, m.Username)
 
 		p.Destroy(m)

--- a/go/src/koding/kites/kloud/koding/helper.go
+++ b/go/src/koding/kites/kloud/koding/helper.go
@@ -22,6 +22,8 @@ func (p *Provider) GetCustomLogger(prefix, mode string) infoFunc {
 			p.Log.Info(format, args...)
 		case "error":
 			p.Log.Error(format, args...)
+		case "debug":
+			p.Log.Debug(format, args...)
 		default:
 			p.Log.Info(format, args...)
 		}

--- a/go/src/koding/kites/kloud/koding/mongodb.go
+++ b/go/src/koding/kites/kloud/koding/mongodb.go
@@ -79,6 +79,7 @@ func (p *Provider) Get(id string) (*protocol.Machine, error) {
 }
 
 func (p *Provider) Delete(id string) error {
+	p.Log.Debug("[%s] Deleting machine document", id)
 	if !bson.IsObjectIdHex(id) {
 		return fmt.Errorf("Invalid machine id: %q", id)
 	}

--- a/go/src/koding/kites/kloud/koding/provider.go
+++ b/go/src/koding/kites/kloud/koding/provider.go
@@ -81,7 +81,7 @@ func (p *Provider) NewClient(m *protocol.Machine) (*amazon.AmazonClient, error) 
 	a := &amazon.AmazonClient{
 		Log: p.Log,
 		Push: func(msg string, percentage int, state machinestate.State) {
-			p.Log.Info("[%s] %s (username: %s)", m.Id, msg, m.Username)
+			p.Log.Debug("[%s] %s (username: %s)", m.Id, msg, m.Username)
 
 			m.Eventer.Push(&eventer.Event{
 				Message:    msg,
@@ -227,7 +227,7 @@ func (p *Provider) Start(m *protocol.Machine) (*protocol.Artifact, error) {
 			return nil, err
 		}
 
-		a.Log.Info("[%s] Updating user domain tag '%s' of instance '%s'",
+		a.Log.Debug("[%s] Updating user domain tag '%s' of instance '%s'",
 			m.Id, m.Domain.Name, artifact.InstanceId)
 		if err := a.AddTag(artifact.InstanceId, "koding-domain", m.Domain.Name); err != nil {
 			return nil, err
@@ -255,7 +255,7 @@ func (p *Provider) Start(m *protocol.Machine) (*protocol.Artifact, error) {
 
 	a.Push("Checking remote machine", 90, machinestate.Starting)
 	if p.IsKlientReady(m.QueryString) {
-		p.Log.Info("[%s] klient is ready.", m.Id)
+		p.Log.Debug("[%s] klient is ready.", m.Id)
 	} else {
 		p.Log.Warning("[%s] klient is not ready. I couldn't connect to it.", m.Id)
 	}
@@ -482,13 +482,9 @@ func (p *Provider) startTimer(curMachine *protocol.Machine) {
 		if infoResp.State == machinestate.Running {
 			err := klient.Exists(p.Kite, m.QueryString)
 			if err == nil {
-				p.Log.Info("[%s] stop timer aborting. Machine is already running (username: %s)",
+				p.Log.Info("[%s] stop timer aborting. Klient is already running (username: %s)",
 					m.Id, m.Username)
 				return errors.New("we have a klient connection")
-			}
-
-			if err != kite.ErrNoKitesAvailable {
-				return err
 			}
 		}
 

--- a/go/src/koding/kites/kloud/koding/resize.go
+++ b/go/src/koding/kites/kloud/koding/resize.go
@@ -202,7 +202,7 @@ func (p *Provider) Resize(m *protocol.Machine) (resArtifact *protocol.Artifact, 
 
 	infoLog("connecting to remote Klient instance")
 	if p.IsKlientReady(m.QueryString) {
-		p.Log.Info("[%s] klient is ready.", m.Id)
+		p.Log.Debug("[%s] klient is ready.", m.Id)
 	} else {
 		p.Log.Warning("[%s] klient is not ready. I couldn't connect to it.", m.Id)
 	}

--- a/go/src/koding/kites/kloud/koding/route53.go
+++ b/go/src/koding/kites/kloud/koding/route53.go
@@ -79,7 +79,7 @@ func (d *DNS) Rename(oldDomain, newDomain, currentIP string) error {
 		},
 	}
 
-	d.Log.Info("updating name of IP %s from %v to %v", currentIP, oldDomain, newDomain)
+	d.Log.Debug("updating name of IP %s from %v to %v", currentIP, oldDomain, newDomain)
 	_, err := d.Route53.ChangeResourceRecordSets(d.ZoneId, change)
 	if err != nil {
 		d.Log.Error(err.Error())
@@ -115,7 +115,7 @@ func (d *DNS) Update(domain, oldIP, newIP string) error {
 		},
 	}
 
-	d.Log.Info("updating domain %s IP from %v to %v", domain, oldIP, newIP)
+	d.Log.Debug("updating domain %s IP from %v to %v", domain, oldIP, newIP)
 	_, err := d.Route53.ChangeResourceRecordSets(d.ZoneId, change)
 	if err != nil {
 		d.Log.Error(err.Error())
@@ -143,7 +143,7 @@ func (d *DNS) Delete(domain string, oldIp string) error {
 		},
 	}
 
-	d.Log.Info("deleting domain name: %s which was associated to following ip: %v", domain, oldIp)
+	d.Log.Debug("deleting domain name: %s which was associated to following ip: %v", domain, oldIp)
 	_, err := d.Route53.ChangeResourceRecordSets(d.ZoneId, change)
 	if err != nil {
 		d.Log.Error(err.Error())
@@ -171,7 +171,7 @@ func (d *DNS) Create(domain string, newIp string) error {
 		},
 	}
 
-	d.Log.Info("creating domain name: %s to be associated with following ip: %v", domain, newIp)
+	d.Log.Debug("creating domain name: %s to be associated with following ip: %v", domain, newIp)
 	_, err := d.Route53.ChangeResourceRecordSets(d.ZoneId, change)
 	if err != nil {
 		d.Log.Error(err.Error())
@@ -187,7 +187,7 @@ func (d *DNS) Get(domain string) (*protocol.Record, error) {
 		Name: domain,
 	}
 
-	d.Log.Info("fetching domain record for name: %s", domain)
+	d.Log.Debug("fetching domain record for name: %s", domain)
 
 	resp, err := d.Route53.ListResourceRecordSets(d.ZoneId, lopts)
 	if err != nil {

--- a/go/src/koding/kites/kloud/provider/amazon/client.go
+++ b/go/src/koding/kites/kloud/provider/amazon/client.go
@@ -25,13 +25,8 @@ type AmazonClient struct {
 }
 
 func (a *AmazonClient) BuildWithCheck(start, finish int) (*protocol.Artifact, error) {
-	infoLog := func(format string, args ...interface{}) {
-		a.Log.Info(format, args...)
-	}
-
-	// Check wether a new infoLog was passed, and use it
-	if a.InfoLog != nil {
-		infoLog = a.InfoLog
+	debugLog := func(format string, args ...interface{}) {
+		a.Log.Debug(format, args...)
 	}
 
 	// Don't build anything without this, otherwise ec2 complains about it as a
@@ -41,7 +36,7 @@ func (a *AmazonClient) BuildWithCheck(start, finish int) (*protocol.Artifact, er
 	}
 
 	// Make sure AMI exists
-	infoLog("Checking if image '%s' exists", a.Builder.SourceAmi)
+	debugLog("Checking if image '%s' exists", a.Builder.SourceAmi)
 	if _, err := a.Image(a.Builder.SourceAmi); err != nil {
 		if err != nil {
 			return nil, err
@@ -51,7 +46,7 @@ func (a *AmazonClient) BuildWithCheck(start, finish int) (*protocol.Artifact, er
 	// Get the necessary keynames that we are going to provide with Amazon. If
 	// it doesn't exist a new one will be created.  check if the key exist, if
 	// yes return the keyname
-	infoLog("Checking if keypair '%s' does exist", a.Builder.KeyPair)
+	debugLog("Checking if keypair '%s' does exist", a.Builder.KeyPair)
 	keyName, err := a.DeployKey()
 	if err != nil {
 		return nil, err
@@ -60,7 +55,7 @@ func (a *AmazonClient) BuildWithCheck(start, finish int) (*protocol.Artifact, er
 	// Create instance with this keypair
 	a.Builder.KeyPair = keyName
 
-	infoLog("Creating instance with type: '%s' based on AMI: '%s'",
+	debugLog("Creating instance with type: '%s' based on AMI: '%s'",
 		a.Builder.InstanceType, a.Builder.SourceAmi)
 
 	return a.Build(true, start, finish)


### PR DESCRIPTION
This is so we can follow and debug kloud easily. We already got the
error so we know on which step kloud is behaving wrong/correct.
