### PR TITLE
pm: skip deserted private message channel test

### DIFF
--- a/go/src/socialapi/tests/channel_participant_test.go
+++ b/go/src/socialapi/tests/channel_participant_test.go
@@ -109,7 +109,9 @@ func TestChannelParticipantOperations(t *testing.T) {
 
 			})
 
-			Convey("All private messages must be deleted when all participant users leave the channel", func() {
+			// TODO Until we find a better way for handling async stuff, this test is skipped. Instead of sleep, we should use some
+			// timeouts for testing these kind of stuff.
+			SkipConvey("All private messages must be deleted when all participant users leave the channel", func() {
 				account := models.NewAccount()
 				err = account.ByNick("devrim")
 				So(err, ShouldBeNil)


### PR DESCRIPTION
Sleep is not a good way for async operation tests. Till finding a better way, I am skipping this test.
