### PR TITLE
show unread count on workspace items take #1

### DIFF
--- a/client/Main/includes.coffee
+++ b/client/Main/includes.coffee
@@ -180,6 +180,7 @@ module.exports = [
   "searchcontroller.coffee",
 
   "navigation/navigationlink.coffee",
+  "navigation/navigationworkspaceitem.coffee",
   "navigation/navigationitem.coffee",
   "navigation/navigationmachineitem.coffee",
 

--- a/client/Main/navigation/navigationitem.coffee
+++ b/client/Main/navigation/navigationitem.coffee
@@ -19,6 +19,7 @@ class NavigationItem extends JTreeItemView
 
 
   createMachineItem: (data) ->
+
     @type  = 'machine'
     @setClass 'machine'
     @child = new NavigationMachineItem {}, data
@@ -58,6 +59,7 @@ class NavigationItem extends JTreeItemView
 
 
   createNewWorkspaceView: ->
+
     @setClass 'workspace'
     { machineUId, machineLabel } = @getData()
 
@@ -65,6 +67,7 @@ class NavigationItem extends JTreeItemView
 
 
   createAppItem: ->
+
     @setClass 'app'
     @child    = new KDCustomHTMLView
       partial : """
@@ -77,3 +80,4 @@ class NavigationItem extends JTreeItemView
     """
       {{> @child}}
     """
+

--- a/client/Main/navigation/navigationitem.coffee
+++ b/client/Main/navigation/navigationitem.coffee
@@ -54,7 +54,7 @@ class NavigationItem extends JTreeItemView
             top    : Math.max bounds.y - 38, 0
             left   : bounds.x + bounds.w + 16
 
-          new WorkspaceSettingsPopup {position}, this
+          new WorkspaceSettingsPopup {position, delegate: this}
 
 
   createNewWorkspaceView: ->

--- a/client/Main/navigation/navigationitem.coffee
+++ b/client/Main/navigation/navigationitem.coffee
@@ -40,22 +40,10 @@ class NavigationItem extends JTreeItemView
         activitySidebar.emit 'MoreWorkspaceModalRequested', data
 
   createWorkspaceItem: (data) ->
+
     @setClass 'workspace'
-    @child    = new KDCustomHTMLView
-      partial : """
-        <figure></figure>
-        <a href='#{KD.utils.groupifyLink data.href}'>#{data.title}</a>
-      """
-      click   : (event) =>
-        if event.target.classList.contains 'ws-settings-icon'
-          KD.utils.stopDOMEvent event
 
-          bounds   = this.getBounds()
-          position =
-            top    : Math.max bounds.y - 38, 0
-            left   : bounds.x + bounds.w + 16
-
-          new WorkspaceSettingsPopup {position, delegate: this}
+    @child = new NavigationWorkspaceItem { delegate: this }, data
 
 
   createNewWorkspaceView: ->

--- a/client/Main/navigation/navigationworkspaceitem.coffee
+++ b/client/Main/navigation/navigationworkspaceitem.coffee
@@ -52,6 +52,19 @@ class NavigationWorkspaceItem extends JView
     new WorkspaceSettingsPopup { position, delegate: navItem }
 
 
+  setUnreadCount: (unreadCount = 0) ->
+
+    @count = unreadCount
+
+    if unreadCount is 0
+      @unreadCount.hide()
+      @unsetClass 'unread'
+    else
+      @unreadCount.updatePartial unreadCount
+      @unreadCount.show()
+      @setClass 'unread'
+
+
   pistachio: ->
     """
     <figure></figure>

--- a/client/Main/navigation/navigationworkspaceitem.coffee
+++ b/client/Main/navigation/navigationworkspaceitem.coffee
@@ -23,6 +23,8 @@ class NavigationWorkspaceItem extends JView
 
   click: (event) ->
 
+    # TODO: at least a KDView - DOM element check would
+    # be more appropriate, fix later. ~Umut
     isSettingsIconView = event.target.classList.contains 'ws-settings-icon'
     navItem            = @getDelegate()
 

--- a/client/Main/navigation/navigationworkspaceitem.coffee
+++ b/client/Main/navigation/navigationworkspaceitem.coffee
@@ -1,4 +1,4 @@
-class NavigationWorkspaceItem extends KDCustomHTMLView
+class NavigationWorkspaceItem extends JView
 
   constructor: (options = {}, data) ->
 
@@ -9,13 +9,16 @@ class NavigationWorkspaceItem extends KDCustomHTMLView
 
   init: ->
 
-    data = @getData()
+    @unsetClass 'kdview'
 
-    @setPartial """
-      <figure></figure>
-      <a href='#{KD.utils.groupifyLink data.href}'>#{data.title}</a>
-      <cite class='count hidden'>0</cite>
-    """
+    { href, title } = @getData()
+    href = KD.utils.groupifyLink href
+
+    @title = new CustomLinkView { href, title }
+
+    @unreadCount = new KDCustomHTMLView
+      tagName  : 'cite'
+      cssClass : 'count hidden'
 
 
   click: (event) ->
@@ -47,4 +50,12 @@ class NavigationWorkspaceItem extends KDCustomHTMLView
     position = { top, left }
 
     new WorkspaceSettingsPopup { position, delegate: navItem }
+
+
+  pistachio: ->
+    """
+    <figure></figure>
+    {{> @title}}
+    {{> @unreadCount}}
+    """
 

--- a/client/Main/navigation/navigationworkspaceitem.coffee
+++ b/client/Main/navigation/navigationworkspaceitem.coffee
@@ -11,9 +11,10 @@ class NavigationWorkspaceItem extends KDCustomHTMLView
 
     data = @getData()
 
-    @updatePartial """
+    @setPartial """
       <figure></figure>
       <a href='#{KD.utils.groupifyLink data.href}'>#{data.title}</a>
+      <cite class='count hidden'>0</cite>
     """
 
 

--- a/client/Main/navigation/navigationworkspaceitem.coffee
+++ b/client/Main/navigation/navigationworkspaceitem.coffee
@@ -1,0 +1,49 @@
+class NavigationWorkspaceItem extends KDCustomHTMLView
+
+  constructor: (options = {}, data) ->
+
+    super options, data
+
+    @init()
+
+
+  init: ->
+
+    data = @getData()
+
+    @updatePartial """
+      <figure></figure>
+      <a href='#{KD.utils.groupifyLink data.href}'>#{data.title}</a>
+    """
+
+
+  click: (event) ->
+
+    isSettingsIconView = event.target.classList.contains 'ws-settings-icon'
+    navItem            = @getDelegate()
+
+    # if the event's target settings icon
+    # do not pass the event to the delegate
+    # which is navigation item itself. if it's not
+    # don't do anything special and pass the event to
+    # delegate, so that it can do its job. ~Umut
+    if isSettingsIconView
+      KD.utils.stopDOMEvent event
+      @showSettingsPopup()
+      return
+
+    navItem.emit 'click', event
+
+
+  showSettingsPopup: ->
+
+    navItem     = @getDelegate()
+    { x, y, w } = navItem.getBounds()
+
+    top  = Math.max(y - 38, 0)
+    left = x + w + 16
+
+    position = { top, left }
+
+    new WorkspaceSettingsPopup { position, delegate: navItem }
+

--- a/client/Main/styl/resurrection.sidebar.styl
+++ b/client/Main/styl/resurrection.sidebar.styl
@@ -210,6 +210,7 @@ sidebarTextShadow()
       line-height     22px
       padding         0 0 0 35px
       rounded         0
+      overflow        visible
 
       figure
         display       block

--- a/client/Main/styl/resurrection.sidebar.styl
+++ b/client/Main/styl/resurrection.sidebar.styl
@@ -137,6 +137,19 @@ sidebarTextShadow()
   padding             1px 20px
   borderBox()
 
+  cite.count
+    size            20px 20px
+    line-height     20px
+    color           #fff
+    abs             3px 7px 0 0
+    font-size       10px
+    font-weight     700
+    background      sidebarCountBg
+    rounded         3px
+    text-align      center
+    vendor          transition, all .354s .177s ease
+    fr()
+
   .more-link
     font-size         12px
     color             sidebarSectionHeaderColor
@@ -241,7 +254,6 @@ sidebarTextShadow()
       border-radius   3px
       abs()
       hidden()
-
 
     &.selected a
       color             sidebarActive
@@ -441,20 +453,6 @@ sidebarTextShadow()
     &.out
       margin-top      -28px
       vendor          transform, translateX(-300px)
-
-    cite.count
-      size            20px 20px
-      line-height     20px
-      color           #fff
-      abs             3px 7px 0 0
-      font-size       10px
-      font-weight     700
-      background      sidebarCountBg
-      rounded         3px
-      text-align      center
-      vendor          transition, all .354s .177s ease
-
-      fr()
 
     .ttag
       display        block

--- a/client/Main/workspacesettingspopup.coffee
+++ b/client/Main/workspacesettingspopup.coffee
@@ -20,7 +20,7 @@ class WorkspaceSettingsPopup extends KDModalViewWithForms
 
   viewAppended:->
 
-    navItem   = @getData()
+    navItem   = @getDelegate()
     workspace = navItem.getData()
 
     @addSubView @deleteButton = new KDButtonView

--- a/client/Social/Activity/sidebar/activitysidebar.coffee
+++ b/client/Social/Activity/sidebar/activitysidebar.coffee
@@ -110,10 +110,10 @@ class ActivitySidebar extends KDCustomHTMLView
 
     item.setUnreadCount? unreadCount
 
-    @setUnreadCountForWorkspace data, unreadCount  if @workspaceItemChannelMap[data._id]
+    @setWorkspaceUnreadCount data, unreadCount  if @workspaceItemChannelMap[data._id]
 
 
-  setUnreadCountForWorkspace: (data, unreadCount) ->
+  setWorkspaceUnreadCount: (data, unreadCount) ->
 
     workspaceItem = @workspaceItemChannelMap[data._id]
 

--- a/client/Social/Activity/sidebar/activitysidebar.coffee
+++ b/client/Social/Activity/sidebar/activitysidebar.coffee
@@ -700,8 +700,17 @@ class ActivitySidebar extends KDCustomHTMLView
       countSource: (callback) ->
         KD.remote.api.SocialMessage.fetchPrivateMessageCount {}, callback
 
+    @sections.messages.on 'DataReady', @bound 'handleWorkspaceUnreadCounts'
+
     if KD.singletons.mainController.isFeatureDisabled 'private-messages'
       @sections.messages.hide()
+
+
+  handleWorkspaceUnreadCounts: (chatData) ->
+
+    chatData
+      .filter  (data) => @workspaceItemChannelMap[data._id]
+      .forEach (data) => @setWorkspaceUnreadCount data, data.unreadCount
 
 
   addNewWorkspace: (machineData) ->

--- a/client/Social/Activity/sidebar/activitysidebar.coffee
+++ b/client/Social/Activity/sidebar/activitysidebar.coffee
@@ -28,6 +28,7 @@ class ActivitySidebar extends KDCustomHTMLView
   constructor: (options = {}) ->
 
     options.cssClass  = 'activity-sidebar'
+    options.maxListeners = 20
 
     super options
 

--- a/client/Social/Activity/sidebar/activitysidebar.coffee
+++ b/client/Social/Activity/sidebar/activitysidebar.coffee
@@ -108,8 +108,16 @@ class ActivitySidebar extends KDCustomHTMLView
       else
         pane.putNewMessageIndicator()
 
-
     item.setUnreadCount? unreadCount
+
+    @setUnreadCountForWorkspace data, unreadCount  if @workspaceItemChannelMap[data._id]
+
+
+  setUnreadCountForWorkspace: (data, unreadCount) ->
+
+    workspaceItem = @workspaceItemChannelMap[data._id]
+
+    workspaceItem.child.setUnreadCount unreadCount
 
 
 

--- a/client/Social/Activity/sidebar/activitysidebar.coffee
+++ b/client/Social/Activity/sidebar/activitysidebar.coffee
@@ -575,19 +575,12 @@ class ActivitySidebar extends KDCustomHTMLView
     section.addSubView @machineTree.getView()
 
     @machineTree.on 'NodeWasAdded', (machineItem) =>
-
       machineItem.on 'click', @lazyBound 'handleMachineItemClick', machineItem
 
     if KD.userMachines.length
-      @listMachines KD.userMachines
-      @updateMachineTree()
-    else
-      @fetchMachines @bound 'listMachines'
+    then @listMachines KD.userMachines
+    else @fetchMachines @bound 'listMachines'
 
-    # section.addSubView more = new MoreVMsModal {}, null
-    # section.addSubView more = new SidebarMoreLink
-    #   tagName  : 'a'
-    #   click    : @bound 'handleMoreVMsClick'
 
   handleMachineItemClick: (machineItem, event) ->
 

--- a/client/Social/Activity/sidebar/activitysidebar.coffee
+++ b/client/Social/Activity/sidebar/activitysidebar.coffee
@@ -44,6 +44,8 @@ class ActivitySidebar extends KDCustomHTMLView
     @itemsByName  = {}
     @selectedItem = null
 
+    @workspaceItemChannelMap = {}
+
     # @appsList = new DockController
 
     router
@@ -426,6 +428,7 @@ class ActivitySidebar extends KDCustomHTMLView
           machineLabel : machine.slug or machine.label
 
       KD.userWorkspaces.forEach (workspace) ->
+
         if workspace.machineUId is machine.uid
           ideRoute = "/IDE/#{machine.slug or machine.label}/#{workspace.slug}"
           title    = "#{workspace.name}"
@@ -445,7 +448,20 @@ class ActivitySidebar extends KDCustomHTMLView
             id           : workspace._id
             parentId     : id
 
-    @machineTree.addNode data for data in treeData
+    for data in treeData
+
+      node = @machineTree.addNode data
+
+      @mapWorkspaceWithChannel data, node  if data.type is 'workspace'
+
+
+  mapWorkspaceWithChannel: (data, node) ->
+
+    return  unless data.data?.channelId?
+
+    { channelId } = data.data
+
+    @workspaceItemChannelMap[channelId] = node
 
 
   selectWorkspace: (data) ->

--- a/client/Social/Activity/sidebar/activitysideview.coffee
+++ b/client/Social/Activity/sidebar/activitysideview.coffee
@@ -82,6 +82,7 @@ class ActivitySideView extends JView
 
     {dataPath} = @getOptions()
     items = KD.singletons.socialapi.getPrefetchedData dataPath
+
     if items?.length
     then @renderItems null, items
     else @reload()
@@ -97,6 +98,7 @@ class ActivitySideView extends JView
 
 
   renderItems: (err, items = []) ->
+
     {limit} = @getOptions()
 
     @listController.hideLazyLoader()
@@ -104,6 +106,9 @@ class ActivitySideView extends JView
     return  if err
 
     @listController.addItem itemData for itemData, i in items when i < limit
+
+    KD.utils.defer => @emit 'DataReady', items
+
 
 
   pistachio: ->


### PR DESCRIPTION
It just adds the unread count to the associated workspace item, doesn't glance or something else. It just listens to `notificationController` and updates the unread counts of the workspace items.

This can be merged. It won't break anything, but this doesn't complete the feature.
