### PR TITLE
add kick channel participant support

### DIFF
--- a/client/Main/socialapicontroller.coffee
+++ b/client/Main/socialapicontroller.coffee
@@ -592,6 +592,10 @@ class SocialApiController extends KDController
       validateOptionsWith : ['channelId']
       successFn           : leaveChannel
 
+    kick                 : channelRequesterFn
+      fnName             : 'leave'
+      validateOptionsWith: ['channelId', 'accountIds']
+
     fetchFollowedChannels: channelRequesterFn
       fnName             : 'fetchFollowedChannels'
       mapperFn           : mapChannels

--- a/client/Main/socialapicontroller.coffee
+++ b/client/Main/socialapicontroller.coffee
@@ -592,7 +592,7 @@ class SocialApiController extends KDController
       validateOptionsWith : ['channelId']
       successFn           : leaveChannel
 
-    kick                 : channelRequesterFn
+    kickParticipants     : channelRequesterFn
       fnName             : 'leave'
       validateOptionsWith: ['channelId', 'accountIds']
 

--- a/go/src/socialapi/tests/channel_participant_test.go
+++ b/go/src/socialapi/tests/channel_participant_test.go
@@ -110,6 +110,11 @@ func TestChannelParticipantOperations(t *testing.T) {
 				Convey("Channel owner should be able to kick another conversation participant", func() {
 					_, err = rest.DeleteChannelParticipant(channelContainer.Channel.Id, ownerAccount.Id, secondAccount.Id)
 					So(err, ShouldBeNil)
+
+					participants, err := rest.ListChannelParticipants(channelContainer.Channel.Id, ownerAccount.Id)
+					So(err, ShouldBeNil)
+					So(participants, ShouldNotBeNil)
+					So(len(participants), ShouldEqual, 3)
 				})
 
 				Convey("Second user should not be able to kick another conversation participant", func() {

--- a/go/src/socialapi/tests/channel_participant_test.go
+++ b/go/src/socialapi/tests/channel_participant_test.go
@@ -88,7 +88,7 @@ func TestChannelParticipantOperations(t *testing.T) {
 				})
 
 				Convey("Second user should be able to leave conversation", func() {
-					_, err = rest.DeleteChannelParticipant(channelContainer.Channel.Id, ownerAccount.Id, secondAccount.Id)
+					_, err = rest.DeleteChannelParticipant(channelContainer.Channel.Id, secondAccount.Id, secondAccount.Id)
 					So(err, ShouldBeNil)
 
 					participants, err := rest.ListChannelParticipants(channelContainer.Channel.Id, ownerAccount.Id)
@@ -105,6 +105,17 @@ func TestChannelParticipantOperations(t *testing.T) {
 						So(participants, ShouldNotBeNil)
 						So(len(participants), ShouldEqual, 3)
 					})
+				})
+
+				Convey("Channel owner should be able to kick another conversation participant", func() {
+					_, err = rest.DeleteChannelParticipant(channelContainer.Channel.Id, ownerAccount.Id, secondAccount.Id)
+					So(err, ShouldBeNil)
+				})
+
+				Convey("Second user should not be able to kick another conversation participant", func() {
+					_, err = rest.DeleteChannelParticipant(channelContainer.Channel.Id, secondAccount.Id, thirdAccount.Id)
+					So(err, ShouldNotBeNil)
+					So(err.Error(), ShouldEqual, "koding.BadRequest-User is not allowed to kick other users")
 				})
 
 			})

--- a/go/src/socialapi/tests/channel_participant_test.go
+++ b/go/src/socialapi/tests/channel_participant_test.go
@@ -120,7 +120,6 @@ func TestChannelParticipantOperations(t *testing.T) {
 				Convey("Second user should not be able to kick another conversation participant", func() {
 					_, err = rest.DeleteChannelParticipant(channelContainer.Channel.Id, secondAccount.Id, thirdAccount.Id)
 					So(err, ShouldNotBeNil)
-					So(err.Error(), ShouldEqual, "koding.BadRequest-User is not allowed to kick other users")
 				})
 
 			})

--- a/workers/social/lib/social/models/socialapi/channel.coffee
+++ b/workers/social/lib/social/models/socialapi/channel.coffee
@@ -184,7 +184,7 @@ module.exports = class SocialChannel extends Base
     return callback message: "channel id is required for leaving a channel"  unless data.channelId
 
     { delegate } = client.connection
-    data.accountIds = [ delegate.socialApiId ]
+    data.accountIds = [ delegate.socialApiId ]  unless data.accountIds
 
     doRequest 'removeParticipants', client, data, callback
 


### PR DESCRIPTION
With this PR a channel owner is able to kick other participants. If some other user tries to kick a participant it returns 'User is not allowed to kick other users' error. 

I checked the cycleChannel event and after a user is kicked, they are not receiving further message events.
