### PR TITLE
JMachine: share helpers updates

### DIFF
--- a/workers/social/lib/social/models/computeproviders/machine.coffee
+++ b/workers/social/lib/social/models/computeproviders/machine.coffee
@@ -471,6 +471,10 @@ module.exports = class JMachine extends Module
       # Only another owner can unassign any other owner
       if user.username in target
         return callback \
+          new KodingError "You are not allowed to change your own state!"
+
+      if @provider is 'koding' and @credential in target
+        return callback \
           new KodingError "It is not allowed to change owner state!"
 
       JMachine::shareWith.call this, options, callback

--- a/workers/social/lib/social/models/computeproviders/machine.coffee
+++ b/workers/social/lib/social/models/computeproviders/machine.coffee
@@ -164,7 +164,7 @@ module.exports = class JMachine extends Module
     return owner
 
 
-  removeUser = (users, user)->
+  excludeUser = (users, user)->
 
     userId   = user.getId()
     newUsers = []
@@ -177,8 +177,8 @@ module.exports = class JMachine extends Module
 
   addUser = (users, user, owner)->
 
-    newUsers = removeUser users, user
     newUsers.push { id: user.getId(), owner }
+    newUsers = excludeUser users, user
 
     return newUsers
 
@@ -266,7 +266,7 @@ module.exports = class JMachine extends Module
     users = @users.splice 0
 
     for user in usersToRemove
-      users = removeUser users, user
+      users = excludeUser users, user
 
     @update $set: { users }, callback
 

--- a/workers/social/lib/social/models/computeproviders/machine.coffee
+++ b/workers/social/lib/social/models/computeproviders/machine.coffee
@@ -310,39 +310,6 @@ module.exports = class JMachine extends Module
       daisy queue
 
 
-  setDomain: permit 'set domain',
-
-    success: revive
-
-      shouldReviveClient   : yes
-      shouldReviveProvider : no
-
-    , (client, domain, callback)->
-
-      { r: { user } } = client
-
-      unless isOwner user, this
-        return callback new KodingError 'Access denied'
-
-      { nickname } = client.connection.delegate.profile
-      { userSitesDomain } = KONFIG
-
-      suffix  = "#{nickname}.#{userSitesDomain}"
-      _suffix = suffix.replace ".", "\\."
-
-      unless ///(^|\.)#{_suffix}$///.test domain
-        return callback new KodingError \
-          "Domain is invalid, it needs to be end with #{suffix}", "INVALIDDOMAIN"
-
-      JMachine.count {domain}, (err, count)=>
-
-        if err or count > 0
-          return callback new KodingError \
-            "The domain #{domain} already exists", "DUPLICATEDOMAIN"
-
-        @update $set: { domain }, (err)-> callback err
-
-
   setLabel: permit 'set domain',
 
     success: revive

--- a/workers/social/lib/social/models/computeproviders/machine.coffee
+++ b/workers/social/lib/social/models/computeproviders/machine.coffee
@@ -246,7 +246,11 @@ module.exports = class JMachine extends Module
     for user in usersToAdd
       users = addUser users, user, owner
 
-    @update $set: { users }, callback
+    if users.length > 10
+      callback new KodingError \
+        "Machine sharing is limited up to 10 users."
+    else
+      @update $set: { users }, callback
 
 
   removeUsers: (usersToRemove, callback)->

--- a/workers/social/lib/social/models/computeproviders/machine.coffee
+++ b/workers/social/lib/social/models/computeproviders/machine.coffee
@@ -8,7 +8,7 @@ KONFIG      = require('koding-config-manager').load("main.#{argv.c}")
 
 module.exports = class JMachine extends Module
 
-  { ObjectId, signature, daisy } = require 'bongo'
+  { ObjectId, signature, daisy, secure } = require 'bongo'
 
   @trait __dirname, '../../traits/protected'
 
@@ -45,6 +45,14 @@ module.exports = class JMachine extends Module
           (signature String, Function)
         setLabel        :
           (signature String, Function)
+        share           :
+          (signature Object, Function)
+        unshare         :
+          (signature Object, Function)
+        setAsOwner      :
+          (signature Object, Function)
+        unsetAsOwner    :
+          (signature Object, Function)
 
     permissions         :
       'list machines'   : ['member']
@@ -466,3 +474,20 @@ module.exports = class JMachine extends Module
           new KodingError "It is not allowed to change owner state!"
 
       JMachine::shareWith.call this, options, callback
+
+
+  share: secure (client, users, callback)->
+    options = target: users, user: yes
+    JMachine::shareWith$.call this, client, options, callback
+
+  unshare: secure (client, users, callback)->
+    options = target: users, user: no
+    JMachine::shareWith$.call this, client, options, callback
+
+  setAsOwner: secure (client, users, callback)->
+    options = target: users, user: yes, owner: yes
+    JMachine::shareWith$.call this, client, options, callback
+
+  unsetAsOwner: secure (client, users, callback)->
+    options = target: users, user: yes, owner: no
+    JMachine::shareWith$.call this, client, options, callback

--- a/workers/social/lib/social/models/computeproviders/machine.coffee
+++ b/workers/social/lib/social/models/computeproviders/machine.coffee
@@ -175,10 +175,10 @@ module.exports = class JMachine extends Module
     return newUsers
 
 
-  addUser = (users, user, owner)->
+  addUser = (users, user, asOwner)->
 
-    newUsers.push { id: user.getId(), owner }
     newUsers = excludeUser users, user
+    newUsers.push { id: user.getId(), owner: asOwner }
 
     return newUsers
 
@@ -247,12 +247,12 @@ module.exports = class JMachine extends Module
 
   # Instance Methods
 
-  addUsers: (usersToAdd, owner, callback)->
+  addUsers: (usersToAdd, asOwner, callback)->
 
     users = @users.splice 0
 
     for user in usersToAdd
-      users = addUser users, user, owner
+      users = addUser users, user, asOwner
 
     if users.length > 10
       callback new KodingError \
@@ -273,9 +273,9 @@ module.exports = class JMachine extends Module
 
   shareWith: (options, callback)->
 
-    { target, user, owner } = options
-    user  ?= yes
-    owner ?= no
+    { target, asUser, asOwner } = options
+    asUser  ?= yes
+    asOwner ?= no
 
     unless target?
       return callback new KodingError "Target required."
@@ -294,8 +294,8 @@ module.exports = class JMachine extends Module
 
       if target instanceof JUser
 
-        if user
-        then @addUsers targets, owner, callback
+        if asUser
+        then @addUsers targets, asOwner, callback
         else @removeUsers targets, callback
 
       else
@@ -443,9 +443,9 @@ module.exports = class JMachine extends Module
   # .shareWith can be used like this:
   #
   # JMachineInstance.shareWith {
-  #   user: yes, owner: no, target: ["gokmen", "dicle"]}, cb
+  #   asUser: yes, asOwner: no, target: ["gokmen", "dicle"]}, cb
   # }
-  #                    user slugs ->  ^^^^^^ ,  ^^^^^
+  #                        user slugs ->  ^^^^^^ ,  ^^^^^
 
   shareWith$: permit 'populate users',
 
@@ -481,17 +481,17 @@ module.exports = class JMachine extends Module
 
 
   share: secure (client, users, callback)->
-    options = target: users, user: yes
+    options = target: users, asUser: yes
     JMachine::shareWith$.call this, client, options, callback
 
   unshare: secure (client, users, callback)->
-    options = target: users, user: no
+    options = target: users, asUser: no
     JMachine::shareWith$.call this, client, options, callback
 
   setAsOwner: secure (client, users, callback)->
-    options = target: users, user: yes, owner: yes
+    options = target: users, asUser: yes, asOwner: yes
     JMachine::shareWith$.call this, client, options, callback
 
   unsetAsOwner: secure (client, users, callback)->
-    options = target: users, user: yes, owner: no
+    options = target: users, asUser: yes, asOwner: no
     JMachine::shareWith$.call this, client, options, callback

--- a/workers/social/lib/social/models/computeproviders/machine.coffee
+++ b/workers/social/lib/social/models/computeproviders/machine.coffee
@@ -432,14 +432,16 @@ module.exports = class JMachine extends Module
         @update $set: { label }, (err)-> kallback err, slug
 
 
-  # .share can be used like this:
+  # .shareWith can be used like this:
   #
-  # JMachineInstance.shareWith { user: yes, owner: no, target: "gokmen"}, cb
-  #                                                user slug -> ^^^^^^
+  # JMachineInstance.shareWith {
+  #   user: yes, owner: no, target: ["gokmen", "dicle"]}, cb
+  # }
+  #                    user slugs ->  ^^^^^^ ,  ^^^^^
 
   shareWith$: permit 'populate users',
 
-    success: revive
+    success : revive
 
       shouldReviveClient   : yes
       shouldReviveProvider : no
@@ -453,10 +455,14 @@ module.exports = class JMachine extends Module
 
       { target } = options
 
+      if target.length > 9
+        return callback new KodingError \
+          "It is not allowed to change more than 9 state at once."
+
       # Owners cannot unassign them from a machine
       # Only another owner can unassign any other owner
-      if user.username is target
+      if user.username in target
         return callback \
-          new KodingError "It's not allowed to change owner's state!"
+          new KodingError "It is not allowed to change owner state!"
 
       JMachine::shareWith.call this, options, callback


### PR DESCRIPTION
It's introducing following methods on a JMachine instance:

```
  # JMachine::share [username1, username2, …], callback
  # JMachine::unshare [username1, username2, …], callback

  # JMachine::setAsOwner [username1, username2, …], callback
  # JMachine::unsetAsOwner [username1, username2, …], callback
```

and also keeps current api, with array only support as target.

```
  # JMachineInstance.shareWith {
  #   user: yes, owner: no, target: ["gokmen", "dicle"]}, callback
  # }
```

As a side note, I put max 10 users limit to `JMachine::users` and max 9 users limit per operation. It can be changed but it's better to keep. Also there are some more guards against changing state of the real owner of machine.

Btw, I've also tidied up `machine.coffee` (removed outdated `::setDomain`, re-arranged some methods etc.), so it will be easy to review this by looking commits instead the final result.
