### PR TITLE
kloud: Cache DescribeSubnets AWS response for 10 minutes [fixes #83566170]

### DIFF
--- a/go/src/koding/kites/kloud/koding/build.go
+++ b/go/src/koding/kites/kloud/koding/build.go
@@ -159,9 +159,9 @@ func (b *Build) run() (*protocol.Artifact, error) {
 // buildData returns all necessary data that is needed to build a machine.
 func (b *Build) buildData() (*BuildData, error) {
 	// get all subnets belonging to Kloud
-	b.log.Debug("[%s] Searching for subnet that are tagged with '%s'",
-		b.machine.Id, DefaultKloudKeyName)
-	subnets, err := b.amazon.SubnetsWithTag(DefaultKloudKeyName)
+	b.log.Debug("[%s] Searching for subnet that are tagged with 'kloud-subnet-*'",
+		b.machine.Id)
+	subnets, err := b.amazon.Subnets()
 	if err != nil {
 		return nil, err
 	}
@@ -365,7 +365,7 @@ func (b *Build) create(buildData *BuildData) (string, error) {
 		return "", err
 	}
 
-	subnets, err := b.amazon.SubnetsWithTag(DefaultKloudKeyName)
+	subnets, err := b.amazon.Subnets()
 	if err != nil {
 		return "", err
 	}

--- a/go/src/koding/kites/kloud/provider/amazon/subnet.go
+++ b/go/src/koding/kites/kloud/provider/amazon/subnet.go
@@ -8,6 +8,8 @@ import (
 	"github.com/mitchellh/goamz/ec2"
 )
 
+const KloudSubnetValue = "kloud-subnet-*"
+
 type Subnets []ec2.Subnet
 
 func (s Subnets) Len() int      { return len(s) }
@@ -32,10 +34,18 @@ func (s Subnets) AvailabilityZone(zone string) (ec2.Subnet, error) {
 
 	return ec2.Subnet{}, errors.New("subnet not found")
 }
+func (a *AmazonClient) Subnets() (Subnets, error) {
+	resp, err := a.SubnetsWithTag(KloudSubnetValue)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("resp %+v\n", resp)
+	return resp, nil
+}
 
 func (a *AmazonClient) SubnetsWithTag(tag string) (Subnets, error) {
 	filter := ec2.NewFilter()
-	filter.Add("tag-key", tag)
+	filter.Add("tag-value", KloudSubnetValue)
 
 	resp, err := a.Client.DescribeSubnets([]string{}, filter)
 	if err != nil {


### PR DESCRIPTION
This should improve the build time and decrease more i/o timeouts.

Use `tag-value` filter for AWS calls.

There is no explicit documentation but our experience shows that Amazon has
an index on `tag-value` field on filters since the calls that are made with
this filter respond much faster than `tag-key` filters.
