### PR TITLE
Kloud progress improvements

### DIFF
--- a/go/src/koding/kites/kloud/koding/cleaners.go
+++ b/go/src/koding/kites/kloud/koding/cleaners.go
@@ -189,9 +189,18 @@ func (p *Provider) CleanStates(timeout time.Duration) error {
 		bad  string
 		good string
 	}{
+		// our "build" method can continue with the leftover data that was
+		// updated to MongoDB during the "build" process. So setting the state
+		// to NotInitialized will make it to continue from where it was left.
 		{machinestate.Building.String(), machinestate.NotInitialized.String()},
 		{machinestate.Terminating.String(), machinestate.Terminated.String()},
+		// once stopped, always stopped.
 		{machinestate.Stopping.String(), machinestate.Stopped.String()},
+		// the final state is  "stopped" because we don't know the if the
+		// domains are updated or if the machien was really started. If the
+		// machine is alrady started, the "start" method won't start it again,
+		// so setting it to "stopped" will at least make it updating the
+		// domains.
 		{machinestate.Starting.String(), machinestate.Stopped.String()},
 	}
 

--- a/go/src/koding/kites/kloud/koding/cleaners.go
+++ b/go/src/koding/kites/kloud/koding/cleaners.go
@@ -176,7 +176,8 @@ func (p *Provider) CleanStates(timeout time.Duration) error {
 			// only show if there is something, that will prevent spamming the
 			// output with the same content over and over
 			if info.Updated != 0 {
-				p.Log.Info("[checker] cleaned up %d documents", info.Updated)
+				p.Log.Info("[state cleaner] fixed %d documents from '%s' to '%s'",
+					info.Updated, badstate, goodstate)
 			}
 
 			return nil
@@ -193,7 +194,7 @@ func (p *Provider) CleanStates(timeout time.Duration) error {
 		{machinestate.Starting.String(), machinestate.Stopped.String()},
 	}
 
-	errs := multierrors.Errors{}
+	errs := multierrors.New()
 
 	var wg sync.WaitGroup
 	for _, state := range progressModes {
@@ -211,5 +212,6 @@ func (p *Provider) CleanStates(timeout time.Duration) error {
 	if errs.Len() == 0 {
 		return nil
 	}
+
 	return errs
 }

--- a/go/src/koding/kites/kloud/koding/cleaners.go
+++ b/go/src/koding/kites/kloud/koding/cleaners.go
@@ -158,8 +158,9 @@ func (p *Provider) CleanStates(timeout time.Duration) error {
 		return p.Session.Run("jMachines", func(c *mgo.Collection) error {
 			// machines that can't be updated because they seems to be in progress
 			badstateMachines := bson.M{
-				"status.state":      badstate,
-				"status.modifiedAt": bson.M{"$lt": time.Now().UTC().Add(-timeout)},
+				"assignee.inProgress": false, // never update during a onging process :)
+				"status.state":        badstate,
+				"status.modifiedAt":   bson.M{"$lt": time.Now().UTC().Add(-timeout)},
 			}
 
 			cleanMachines := bson.M{

--- a/go/src/koding/kites/kloud/koding/cleaners.go
+++ b/go/src/koding/kites/kloud/koding/cleaners.go
@@ -199,11 +199,11 @@ func (p *Provider) CleanStates(timeout time.Duration) error {
 	var wg sync.WaitGroup
 	for _, state := range progressModes {
 		wg.Add(1)
-		go func() {
+		go func(bad, good string) {
 			defer wg.Done()
-			err := cleanstateFunc(state.bad, state.good)
+			err := cleanstateFunc(bad, good)
 			errs.Add(err)
-		}()
+		}(state.bad, state.good)
 	}
 
 	wg.Wait()

--- a/go/src/koding/kites/kloud/koding/cleaners.go
+++ b/go/src/koding/kites/kloud/koding/cleaners.go
@@ -2,7 +2,10 @@ package koding
 
 import (
 	"koding/kites/kloud/eventer"
+	"koding/kites/kloud/machinestate"
+	"koding/kites/kloud/multierrors"
 	"koding/kites/kloud/protocol"
+	"sync"
 	"time"
 
 	"labix.org/v2/mgo"
@@ -19,13 +22,17 @@ var (
 // up/resets machine documents and VM leftovers.
 func (p *Provider) RunCleaners(interval time.Duration) {
 	cleaners := func() {
-		// run for the first
+		// run for the first time
 		if err := p.CleanLocks(CleanUpTimeout); err != nil {
 			p.Log.Warning("Cleaning locks: %s", err)
 		}
 
 		if err := p.CleanDeletedVMs(); err != nil {
 			p.Log.Warning("Cleaning deleted vms: %s", err)
+		}
+
+		if err := p.CleanStates(CleanUpTimeout); err != nil {
+			p.Log.Warning("Cleaning states vms: %s", err)
 		}
 	}
 
@@ -141,4 +148,68 @@ func (p *Provider) CleanLocks(timeout time.Duration) error {
 	}
 
 	return p.Session.Run("jMachines", query)
+}
+
+// CleanStates resets documents that has machine states in progress mode
+// (building, stopping, etc..) which weren't updated since 10 minutes. This
+// could be caused because of Kloud restarts or panics.
+func (p *Provider) CleanStates(timeout time.Duration) error {
+	cleanstateFunc := func(badstate, goodstate string) error {
+		return p.Session.Run("jMachines", func(c *mgo.Collection) error {
+			// machines that can't be updated because they seems to be in progress
+			badstateMachines := bson.M{
+				"status.state":      badstate,
+				"status.modifiedAt": bson.M{"$lt": time.Now().UTC().Add(-timeout)},
+			}
+
+			cleanMachines := bson.M{
+				"status.state":      goodstate,
+				"status.modifiedAt": time.Now().UTC(),
+			}
+
+			// reset all machines
+			info, err := c.UpdateAll(badstateMachines, bson.M{"$set": cleanMachines})
+			if err != nil {
+				return err
+			}
+
+			// only show if there is something, that will prevent spamming the
+			// output with the same content over and over
+			if info.Updated != 0 {
+				p.Log.Info("[checker] cleaned up %d documents", info.Updated)
+			}
+
+			return nil
+		})
+	}
+
+	progressModes := []struct {
+		bad  string
+		good string
+	}{
+		{machinestate.Building.String(), machinestate.NotInitialized.String()},
+		{machinestate.Terminating.String(), machinestate.Terminated.String()},
+		{machinestate.Stopping.String(), machinestate.Stopped.String()},
+		{machinestate.Starting.String(), machinestate.Stopped.String()},
+	}
+
+	errs := multierrors.Errors{}
+
+	var wg sync.WaitGroup
+	for _, state := range progressModes {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := cleanstateFunc(state.bad, state.good)
+			errs.Add(err)
+		}()
+	}
+
+	wg.Wait()
+
+	// if there is no errors just return a nil
+	if errs.Len() == 0 {
+		return nil
+	}
+	return errs
 }

--- a/go/src/koding/kites/kloud/koding/mongodb.go
+++ b/go/src/koding/kites/kloud/koding/mongodb.go
@@ -120,6 +120,8 @@ func (p *Provider) Update(id string, s *kloud.StorageData) error {
 	case "building":
 		data["meta.instanceId"] = s.Data["instanceId"]
 		data["queryString"] = s.Data["queryString"]
+	case "starting":
+		data["ipAddress"] = s.Data["ipAddress"]
 	case "info":
 		data["meta.instanceName"] = s.Data["instanceName"]
 	case "start":

--- a/go/src/koding/kites/kloud/multierrors/multierrors.go
+++ b/go/src/koding/kites/kloud/multierrors/multierrors.go
@@ -4,22 +4,30 @@ package multierrors
 
 import "fmt"
 
-type Errors []error
-
-func (e Errors) Add(err error) {
-	e = append(e, err)
+type Errors struct {
+	errs []error
 }
 
-func (e Errors) Len() int {
-	return len(e)
+func New() *Errors {
+	return &Errors{
+		errs: make([]error, 0),
+	}
 }
 
-func (e Errors) Error() string {
-	errorMsg := fmt.Sprintf("[%d errors] ", len(e))
-	for i, err := range e {
-		if err != nil {
-			errorMsg += fmt.Sprintf("[%d] %s", i, err.Error())
-		}
+func (e *Errors) Add(err error) {
+	if err != nil {
+		e.errs = append(e.errs, err)
+	}
+}
+
+func (e *Errors) Len() int {
+	return len(e.errs)
+}
+
+func (e *Errors) Error() string {
+	errorMsg := fmt.Sprintf("[%d errors] ", len(e.errs))
+	for _, err := range e.errs {
+		errorMsg += fmt.Sprintf("[%s]", err.Error())
 	}
 
 	return errorMsg

--- a/go/src/koding/kites/kloud/multierrors/multierrors.go
+++ b/go/src/koding/kites/kloud/multierrors/multierrors.go
@@ -1,0 +1,26 @@
+// package multierrors is a convenient helper package to return multipl errors
+// in type error
+package multierrors
+
+import "fmt"
+
+type Errors []error
+
+func (e Errors) Add(err error) {
+	e = append(e, err)
+}
+
+func (e Errors) Len() int {
+	return len(e)
+}
+
+func (e Errors) Error() string {
+	errorMsg := fmt.Sprintf("[%d errors] ", len(e))
+	for i, err := range e {
+		if err != nil {
+			errorMsg += fmt.Sprintf("[%d] %s", i, err.Error())
+		}
+	}
+
+	return errorMsg
+}


### PR DESCRIPTION
This PR aims to clean up bad states,states that are in progress, such as `Building` by cleaning them and setting them back to some sane defaults, in which the user can recover back from it.
