### PR TITLE
Server: /Register: don't wait for session to update client ip, force it.

### DIFF
--- a/servers/lib/server/index.coffee
+++ b/servers/lib/server/index.coffee
@@ -344,11 +344,15 @@ app.post '/:name?/Register', (req, res) ->
 
   return handleClientIdNotFound res, req unless clientId
 
+  clientIPAddress = req.headers['x-forwarded-for'] || req.connection.remoteAddress
+
   koding.fetchClient clientId, context, (client) ->
     # when there is an error in the fetchClient, it returns message in it
     if client.message
       console.error JSON.stringify {req, client}
       return res.status(500).send client.message
+
+    client.clientIP = (clientIPAddress.split ',')[0]
 
     JUser.convert client, req.body, (err, result) ->
       return res.status(400).send err.message  if err?

--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -789,8 +789,11 @@ Team Koding
     if password isnt passwordConfirm
       return callback createKodingError "Passwords must match!"
 
+    console.log "Client IP during registration:", clientIP
+
     if clientIP
       { ip, country, region } = Regions.findLocation clientIP
+      console.log "Found region:", {country, region}
 
     newToken       = null
     invite         = null


### PR DESCRIPTION
Since we have high load on production, it sometimes takes more time to update
the clientIP in session. And this causing to create vms from wrong region.
Instead waiting the ip from session update, we are forcing it in the handler.
