### PR TITLE
privatemessage: prevent activity fetch for /Activity/Message/New route

### DIFF
--- a/servers/lib/server/index.coffee
+++ b/servers/lib/server/index.coffee
@@ -642,6 +642,13 @@ app.all '/:name/:section?/:slug?', (req, res, next)->
   path = "#{path}/#{section}"  if section
   path = "#{path}/#{slug}"     if slug
 
+  # When we try to access /Activity/Message/New route, it is trying to
+  # fetch message history with channel id = 'New' and returning:
+  # Bad Request: strconv.ParseInt: parsing "New": invalid syntax error.
+  # Did not like the way I resolve this, but this handler function is already
+  # saying 'Refactor me' :)
+  return next()  if section is 'Message' and slug is 'New'
+
   return res.redirect 301, req.url.substring 7  if name in ['koding', 'guests']
   # Checks if its an internal request like /Activity, /Terminal ...
   #


### PR DESCRIPTION
When we directly access /Activity/Message/New route, it was returning `Bad Request: strconv.ParseInt: parsing "New": invalid syntax` error, and it was trying to fetch message history with channel id = 'New'

Not sure about the solution, but prevented further data fetch when section is 'Message' and slug is 'New'
