### PR TITLE
return correct view type to match fetch state

### DIFF
--- a/client/Social/Activity/views/activityautocompleteuseritemview.coffee
+++ b/client/Social/Activity/views/activityautocompleteuseritemview.coffee
@@ -1,24 +1,42 @@
-class ActivityAutoCompleteUserItemView extends KDAutoCompleteListItemView
+
+class FetchedActivityAutoCompleteUserItemView extends KDAutoCompleteListItemView
 
   constructor:(options, data)->
-
     options.type = 'dropdown-member'
-
     super options, data
 
-
   viewAppended: ->
-
     userInput = @getOptions().userInput or @getDelegate().userInput
+
+    obj = @getData()
 
     @addSubView new AvatarStaticView
       size      :
         width   : 25
         height  : 25
-    , @getData()
-
+    , obj
     @addSubView @profileLink = new AutoCompleteProfileTextView {
       shouldShowNick : yes
       userInput
-    }, @getData()
+    }, obj
 
+
+class FetchingActivityAutoCompleteUserItemView extends KDAutoCompleteFetchingItem
+
+  constructor:(options, data) ->
+    options.type = 'dropdown-member'
+    super options, data
+
+
+class ActivityAutoCompleteUserItemView
+
+  constructor:(options, data)->
+    isFetchingItem = data instanceof KDAutoCompleteFetchingItem
+    isNothingFoundItem = data instanceof KDAutoCompleteNothingFoundItem
+
+    if isFetchingItem
+      return (new FetchingActivityAutoCompleteUserItemView(options, data))
+    else if isNothingFoundItem
+      return (new KDAutoCompleteNothingFoundItem(options, data))
+    else
+      return (new FetchedActivityAutoCompleteUserItemView(options, data))


### PR DESCRIPTION
This fixes `a koding user(@undefined)` showing up on autocomplete suggestions. See: http://lvh.me:8090/Activity/Message/New

Problem is `ActivityAutoCompleteUserItemView` expects a `JAccount` instance, but getting `KDAutoCompleteFetchingItem` instead. As a result, it can't find any account information but renders the template anyway.

To fix this I converted this class into a some sort of `ListItemView` factory. It basically checks for instance type of given `data` and returns the correct view type to match the shape of things.
