### PR TITLE
Hide workspace pm

### DIFF
--- a/client/Social/Activity/sidebar/activitysidebar.coffee
+++ b/client/Social/Activity/sidebar/activitysidebar.coffee
@@ -70,6 +70,7 @@ class ActivitySidebar extends KDCustomHTMLView
       .on 'MachineBeingDestroyed',     @bound 'invalidateWorkspaces'
 
     @on 'MoreWorkspaceModalRequested', @bound 'handleMoreWorkspacesClick'
+    @on 'ReloadMessagesRequested',     @bound 'handleReloadMessages'
 
   # event handling
 
@@ -773,6 +774,9 @@ class ActivitySidebar extends KDCustomHTMLView
 
     if KD.singletons.mainController.isFeatureDisabled 'private-messages'
       @sections.messages.hide()
+
+
+  handleReloadMessages: -> @fetchWorkspaces => @sections.messages.reload()
 
 
   handleWorkspaceUnreadCounts: (chatData) ->

--- a/client/Social/Activity/sidebar/activitysidebar.coffee
+++ b/client/Social/Activity/sidebar/activitysidebar.coffee
@@ -393,9 +393,8 @@ class ActivitySidebar extends KDCustomHTMLView
     @addVMTree()
     @addFollowedTopics()
     @addConversations()
-    @addMessages()
 
-    @fetchWorkspaces()
+    @fetchWorkspaces => @addMessages()
 
 
   initiateFakeCounter: ->

--- a/client/Social/Activity/sidebar/activitysideview.coffee
+++ b/client/Social/Activity/sidebar/activitysideview.coffee
@@ -105,7 +105,13 @@ class ActivitySideView extends JView
 
     return  if err
 
-    @listController.addItem itemData for itemData, i in items when i < limit
+    workspaceChannels = KD.userWorkspaces
+      .filter (ws) -> ws.channelId
+      .map (ws) -> ws.channelId
+
+    for itemData, i in items when i < limit
+      item = @listController.addItem itemData
+      item.hide()  if itemData._id in workspaceChannels
 
     KD.utils.defer => @emit 'DataReady', items
 


### PR DESCRIPTION
Hide pms for the channels that are attached to a workspace when in session.

also add a functionality to reload activity sidebar chat messages.

This PR is a prerequisite for the IDE part of this implementation.
