### PR TITLE
klient: Add persistency to collaboration [fixes #83491840]

### DIFF
--- a/go/src/koding/kites/klient/collaboration/bolt.go
+++ b/go/src/koding/kites/klient/collaboration/bolt.go
@@ -28,7 +28,7 @@ func NewBoltStorage() (*boltdb, error) {
 	return d, nil
 }
 
-// DB satisfies Storage interface
+// boltdb satisfies Storage interface
 type boltdb struct {
 	*bolt.DB
 }

--- a/go/src/koding/kites/klient/collaboration/bolt.go
+++ b/go/src/koding/kites/klient/collaboration/bolt.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	DatabasePath = "/opt/kites/klient/klient.db"
+	DatabasePath = "/opt/kite/klient/klient.db"
 	UserBucket   = "users"
 )
 

--- a/go/src/koding/kites/klient/collaboration/bolt.go
+++ b/go/src/koding/kites/klient/collaboration/bolt.go
@@ -1,0 +1,143 @@
+package collaboration
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/boltdb/bolt"
+)
+
+const (
+	DatabasePath = "/opt/kites/klient/klient.db"
+	UserBucket   = "users"
+)
+
+type User struct {
+	Username string    `json:"username"`
+	SharedAt time.Time `json:"shared_at"`
+}
+
+func NewBolt() *DB {
+	d := &DB{}
+
+	// Ensure data directory exists.
+	dir := filepath.Dir(DatabasePath)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		panic(err.Error())
+	}
+
+	if err := d.Open(DatabasePath); err != nil {
+		panic(err.Error())
+	}
+
+	return d
+}
+
+// DB satisfies Storage interface
+type DB struct {
+	*bolt.DB
+}
+
+func (db *DB) Open(dbpath string) error {
+	var err error
+	db.DB, err = bolt.Open(dbpath, 0600, nil)
+	if err != nil {
+		return err
+	}
+
+	return db.Update(func(tx *Tx) error {
+		_, err := tx.CreateBucketIfNotExists([]byte(UserBucket))
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (db *DB) Get(username string) (string, error) {
+	var user string
+
+	err := db.View(func(tx *Tx) error {
+		value := tx.User(username)
+		if len(value) == 0 {
+			return ErrUserNotFound
+		}
+		user = value
+		return nil
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	return user, nil
+}
+
+// GetAll fetches all keys which are unique usernames in the bucket.
+func (db *DB) GetAll() ([]string, error) {
+	users := make([]string, 0)
+
+	err := db.View(func(tx *Tx) error {
+		tx.Bucket([]byte(UserBucket)).ForEach(func(k, _ []byte) error {
+			users = append(users, string(k))
+			return nil
+		})
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return users, nil
+}
+
+func (db *DB) Set(username, value string) error {
+	return db.Update(func(tx *Tx) error {
+		return tx.SetUser(username, value)
+	})
+}
+
+func (db *DB) Delete(username string) error {
+	return db.Update(func(tx *Tx) error {
+		return tx.DeleteUser(username)
+	})
+}
+
+func (db *DB) Close() error {
+	return db.DB.Close()
+}
+
+// Tx is our own transaction type which provides helper methods
+type Tx struct {
+	*bolt.Tx
+}
+
+// User retrieves a users field by name.
+func (tx *Tx) User(key string) string {
+	return string(tx.Bucket([]byte(UserBucket)).Get([]byte(key)))
+}
+
+// SetUser sets the value of a users field by name.
+func (tx *Tx) SetUser(key, value string) error {
+	return tx.Bucket([]byte(UserBucket)).Put([]byte(key), []byte(value))
+}
+
+// DeleteUser deletes the key of a users field by name.
+func (tx *Tx) DeleteUser(key string) error {
+	return tx.Bucket([]byte(UserBucket)).Delete([]byte(key))
+}
+
+// View executes a function in the context of a read-only transaction.
+func (db *DB) View(fn func(*Tx) error) error {
+	return db.DB.View(func(tx *bolt.Tx) error {
+		return fn(&Tx{tx})
+	})
+}
+
+// Update executes a function in the context of a writable transaction.
+func (db *DB) Update(fn func(*Tx) error) error {
+	return db.DB.Update(func(tx *bolt.Tx) error {
+		return fn(&Tx{tx})
+	})
+}

--- a/go/src/koding/kites/klient/collaboration/bolt.go
+++ b/go/src/koding/kites/klient/collaboration/bolt.go
@@ -43,7 +43,7 @@ type boltdb struct {
 
 func (b *boltdb) open(dbpath string) error {
 	var err error
-	b.DB, err = bolt.Open(dbpath, 0644, &bolt.Options{Timeout: 1 * time.Second})
+	b.DB, err = bolt.Open(dbpath, 0644, &bolt.Options{Timeout: 5 * time.Second})
 	if err != nil {
 		return err
 	}

--- a/go/src/koding/kites/klient/collaboration/collaboration.go
+++ b/go/src/koding/kites/klient/collaboration/collaboration.go
@@ -12,8 +12,18 @@ type Collaboration struct {
 }
 
 func New() *Collaboration {
+	// Try the persistent storage first. If it fails, try the in-memory one.
+
+	var db Storage
+	var err error
+
+	db, err = NewBoltStorage()
+	if err != nil {
+		db = NewMemoryStorage()
+	}
+
 	return &Collaboration{
-		Storage: NewBolt(),
+		Storage: db,
 	}
 }
 
@@ -26,7 +36,7 @@ func (c *Collaboration) Share(r *kite.Request) (interface{}, error) {
 		return nil, errors.New("Wrong usage.")
 	}
 
-	if err := c.Set(params.Username, ""); err  != nil {
+	if err := c.Set(params.Username, ""); err != nil {
 		return nil, errors.New("user is already in the shared list.")
 	}
 
@@ -42,7 +52,7 @@ func (c *Collaboration) Unshare(r *kite.Request) (interface{}, error) {
 		return nil, errors.New("Wrong usage.")
 	}
 
-	if  err := c.Delete(params.Username); err != nil {
+	if err := c.Delete(params.Username); err != nil {
 		return nil, errors.New("user is not in the shared list.")
 	}
 

--- a/go/src/koding/kites/klient/collaboration/collaboration.go
+++ b/go/src/koding/kites/klient/collaboration/collaboration.go
@@ -12,11 +12,10 @@ type Collaboration struct {
 }
 
 func New() *Collaboration {
-	// Try the persistent storage first. If it fails, try the in-memory one.
-
 	var db Storage
 	var err error
 
+	// Try the persistent storage first. If it fails, try the in-memory one.
 	db, err = NewBoltStorage()
 	if err != nil {
 		db = NewMemoryStorage()

--- a/go/src/koding/kites/klient/collaboration/collaboration.go
+++ b/go/src/koding/kites/klient/collaboration/collaboration.go
@@ -3,26 +3,21 @@ package collaboration
 import (
 	"errors"
 	"strings"
-	"sync"
 
 	"github.com/koding/kite"
 )
 
-type SharedUsers struct {
-	AllowedUsers map[string]bool
-	mu           sync.Mutex
+type Collaboration struct {
+	Storage
 }
 
-func New() *SharedUsers {
-	return &SharedUsers{
-		AllowedUsers: make(map[string]bool),
+func New() *Collaboration {
+	return &Collaboration{
+		Storage: NewBolt(),
 	}
 }
 
-func (s *SharedUsers) Share(r *kite.Request) (interface{}, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
+func (c *Collaboration) Share(r *kite.Request) (interface{}, error) {
 	var params struct {
 		Username string
 	}
@@ -31,19 +26,14 @@ func (s *SharedUsers) Share(r *kite.Request) (interface{}, error) {
 		return nil, errors.New("Wrong usage.")
 	}
 
-	if _, ok := s.AllowedUsers[params.Username]; ok {
+	if err := c.Set(params.Username, ""); err  != nil {
 		return nil, errors.New("user is already in the shared list.")
 	}
-
-	s.AllowedUsers[params.Username] = true
 
 	return "shared", nil
 }
 
-func (s *SharedUsers) Unshare(r *kite.Request) (interface{}, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
+func (c *Collaboration) Unshare(r *kite.Request) (interface{}, error) {
 	var params struct {
 		Username string
 	}
@@ -52,20 +42,17 @@ func (s *SharedUsers) Unshare(r *kite.Request) (interface{}, error) {
 		return nil, errors.New("Wrong usage.")
 	}
 
-	if _, ok := s.AllowedUsers[params.Username]; !ok {
+	if  err := c.Delete(params.Username); err != nil {
 		return nil, errors.New("user is not in the shared list.")
 	}
-
-	delete(s.AllowedUsers, params.Username)
 
 	return "unshared", nil
 }
 
-func (s *SharedUsers) Shared(r *kite.Request) (interface{}, error) {
-	shared := make([]string, 0)
-	for user := range s.AllowedUsers {
-		shared = append(shared, user)
+func (c *Collaboration) Shared(r *kite.Request) (interface{}, error) {
+	users, err := c.GetAll()
+	if err != nil {
+		return nil, err
 	}
-
-	return strings.Join(shared, ","), nil
+	return strings.Join(users, ","), nil
 }

--- a/go/src/koding/kites/klient/collaboration/memory.go
+++ b/go/src/koding/kites/klient/collaboration/memory.go
@@ -1,0 +1,59 @@
+package collaboration
+
+import "sync"
+
+func NewMemoryStorage() *memoryStorage {
+	return &memoryStorage{
+		users: make(map[string]string),
+	}
+}
+
+// memoryStorage satisfies Storage interface
+type memoryStorage struct {
+	users map[string]string
+	sync.Mutex
+}
+
+func (m *memoryStorage) Get(username string) (string, error) {
+	m.Lock()
+	defer m.Unlock()
+
+	if _, ok := m.users[username]; !ok {
+		return "", ErrUserNotFound
+	}
+
+	return m.users[username], nil
+}
+
+func (m *memoryStorage) GetAll() ([]string, error) {
+	m.Lock()
+	defer m.Unlock()
+
+	allUsers := make([]string, 0)
+	for user := range m.users {
+		allUsers = append(allUsers, user)
+	}
+	return allUsers, nil
+}
+
+func (m *memoryStorage) Set(username, value string) error {
+	m.Lock()
+	defer m.Unlock()
+
+	m.users[username] = value
+	return nil
+}
+
+func (m *memoryStorage) Delete(username string) error {
+	m.Lock()
+	defer m.Unlock()
+
+	if _, ok := m.users[username]; ok {
+		delete(m.users, username)
+	}
+	return nil
+}
+
+func (m *memoryStorage) Close() error {
+	return nil
+}

--- a/go/src/koding/kites/klient/collaboration/storage.go
+++ b/go/src/koding/kites/klient/collaboration/storage.go
@@ -1,0 +1,17 @@
+package collaboration
+
+import (
+	"errors"
+)
+
+var (
+	ErrUserNotFound = errors.New("User not found")
+)
+
+type Storage interface {
+	Get(string) (string, error)
+	GetAll() ([]string, error)
+	Set(string, string) error
+	Delete(string) error
+	Close() error
+}

--- a/go/src/koding/kites/klient/klient.go
+++ b/go/src/koding/kites/klient/klient.go
@@ -55,14 +55,14 @@ var (
 )
 
 func main() {
-	// Close the klient.db in any case. Corrupt db would be catastrophic
-	defer collab.Close()
-
 	flag.Parse()
 	if *flagVersion {
 		fmt.Println(VERSION)
 		os.Exit(0)
 	}
+
+	// Close the klient.db in any case. Corrupt db would be catastrophic
+	defer collab.Close()
 
 	k := kite.New(NAME, VERSION)
 	conf := config.MustGet()
@@ -132,15 +132,14 @@ func main() {
 			k.Log.Info("Kite '%s/%s/%s' called method: '%s'",
 				r.Username, r.Client.Environment, r.Client.Name, r.Method)
 
-			sharedUsers, err := collab.GetAll()
-			if err != nil {
-				return nil, fmt.Errorf("Can't read shared users from the storage.")
-			}
-
 			// Allow these users by default
-			allowedUsers := []string{k.Config.Username, "koding"}
+			allowedUsers := []string{k.Config.Username, "koding", "unknown"}
 
 			// Allow collaboration users as well
+			sharedUsers, err := collab.GetAll()
+			if err != nil {
+				return nil, fmt.Errorf("Can't read shared users from the storage. Err: %v", err)
+			}
 			allowedUsers = append(allowedUsers, sharedUsers...)
 
 			if !userIn(r.Username, allowedUsers...) {

--- a/go/src/koding/kites/klient/klient.go
+++ b/go/src/koding/kites/klient/klient.go
@@ -133,7 +133,7 @@ func main() {
 				r.Username, r.Client.Environment, r.Client.Name, r.Method)
 
 			// Allow these users by default
-			allowedUsers := []string{k.Config.Username, "koding", "unknown"}
+			allowedUsers := []string{k.Config.Username, "koding"}
 
 			// Allow collaboration users as well
 			sharedUsers, err := collab.GetAll()

--- a/go/src/koding/kites/klient/klient.go
+++ b/go/src/koding/kites/klient/klient.go
@@ -4,12 +4,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"koding/kite-handler/command"
-	"koding/kite-handler/fs"
-	"koding/kite-handler/terminal"
-	"koding/kites/klient/collaboration"
-	"koding/kites/klient/protocol"
-	"koding/kites/klient/usage"
 	"log"
 	"net"
 	"net/url"
@@ -17,6 +11,13 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"koding/kite-handler/command"
+	"koding/kite-handler/fs"
+	"koding/kite-handler/terminal"
+	"koding/kites/klient/collaboration"
+	"koding/kites/klient/protocol"
+	"koding/kites/klient/usage"
 
 	"github.com/koding/kite"
 	"github.com/koding/kite/config"
@@ -45,6 +46,7 @@ var (
 	usg  = usage.NewUsage()
 	klog kite.Logger
 
+	// this is used to allow other users to call any klient method.
 	collab = collaboration.New()
 
 	// we also could use an atomic boolean this is simple for now.
@@ -53,6 +55,9 @@ var (
 )
 
 func main() {
+	// Close the klient.db in any case. Corrupt db would be catastrophic
+	defer collab.Close()
+
 	flag.Parse()
 	if *flagVersion {
 		fmt.Println(VERSION)
@@ -127,13 +132,16 @@ func main() {
 			k.Log.Info("Kite '%s/%s/%s' called method: '%s'",
 				r.Username, r.Client.Environment, r.Client.Name, r.Method)
 
-			// Allow these users by default.
+			sharedUsers, err := collab.GetAll()
+			if err != nil {
+				return nil, fmt.Errorf("Can't read shared users from the storage.")
+			}
+
+			// Allow these users by default
 			allowedUsers := []string{k.Config.Username, "koding"}
 
-			// Add collaboration users to the list
-			for user := range collab.AllowedUsers {
-				allowedUsers = append(allowedUsers, user)
-			}
+			// Allow collaboration users as well
+			allowedUsers = append(allowedUsers, sharedUsers...)
 
 			if !userIn(r.Username, allowedUsers...) {
 				return nil, fmt.Errorf("User '%s' is not allowed to make a call to us.", r.Username)


### PR DESCRIPTION
We use `boltdb` for storage and persist the collaboration users at
$HOME/.config/koding/klient.bolt. If it fails, we're fallbacking to in-memory storage seemlessly.

Bolt is a fast key-value storage, it can be replaced with another database,
such as Sqlite, if necessary.

The only drawback of boltdb as far as I see is, you can't read the db if 
another process has a write lock on it. Such as, if klient owns the db, 
another process can't make any query on it, even if the query is read-only.
