### PR TITLE
Activity: styling of embeds without an image was broken

### DIFF
--- a/client/Social/Activity/styl/activity.listitem.styl
+++ b/client/Social/Activity/styl/activity.listitem.styl
@@ -604,13 +604,12 @@ activity.listitem.styl
   .preview-image
     size                    100px, 100px
     border                  none
-    margin-right            10px
     fl()
 
   .preview-text
     kalc                    width (100% \- 124px)
-    height                  96px
-    padding                 10px 10px 10px 0
+    height                  100px
+    padding                 10px
     overflow                hidden
     borderBox()
     fl()
@@ -640,9 +639,7 @@ activity.listitem.styl
       height                14px
       color                 #acacac
       font-size             12px
-      abs()
-      bottom                4px
-      left                  0
+      abs                   0 0 12px 10px
 
   // .activity-content-wrapper > .link-embed-box
   //   padding                 0 0 15px


### PR DESCRIPTION
![screen shot 2014-12-08 at 18 46 56](https://cloud.githubusercontent.com/assets/3121257/5342943/ca822ff0-7f0a-11e4-9eff-20ebc5182053.png)

cc/ @sinan 
