### PR TITLE
nginx: add kontrol manually to support additional paths

### DIFF
--- a/config/main.dev.coffee
+++ b/config/main.dev.coffee
@@ -227,8 +227,7 @@ Configuration = (options={}) ->
       supervisord       :
         command         : "#{GOBIN}/kontrol -region #{region} -machines #{etcd} -environment #{environment} -mongourl #{KONFIG.mongo} -port #{kontrol.port} -privatekey #{kontrol.privateKeyFile} -publickey #{kontrol.publicKeyFile} -storage postgres -postgres-dbname #{kontrolPostgres.dbname} -postgres-host #{kontrolPostgres.host} -postgres-port #{kontrolPostgres.port} -postgres-username #{kontrolPostgres.username} -postgres-password #{kontrolPostgres.password}"
       nginx             :
-        websocket       : yes
-        locations       : ["~^/kontrol/.*"]
+        disableLocation : yes
       healthCheckURL    : "http://localhost:#{KONFIG.kontrol.port}/healthCheck"
       versionURL        : "http://localhost:#{KONFIG.kontrol.port}/version"
 

--- a/config/main.prod.coffee
+++ b/config/main.prod.coffee
@@ -229,8 +229,7 @@ Configuration = (options={}) ->
       supervisord       :
         command         : "#{GOBIN}/kloud -planendpoint #{socialapi.proxyUrl}/payments/subscriptions -hostedzone #{userSitesDomain} -region #{region} -environment #{environment} -port #{KONFIG.kloud.port} -publickey #{kontrol.publicKeyFile} -privatekey #{kontrol.privateKeyFile} -kontrolurl #{kontrol.url}  -registerurl #{KONFIG.kloud.registerUrl} -mongourl #{KONFIG.mongo} -prodmode=#{configName is "prod"}"
       nginx             :
-        websocket       : yes
-        locations       : ["~^/kloud/.*"]
+        disableLocation : yes
       healthCheckURL    : "http://localhost:#{KONFIG.kloud.port}/healthCheck"
       versionURL        : "http://localhost:#{KONFIG.kloud.port}/version"
 

--- a/config/main.prod.coffee
+++ b/config/main.prod.coffee
@@ -217,8 +217,7 @@ Configuration = (options={}) ->
       supervisord       :
         command         : "#{GOBIN}/kontrol -region #{region} -machines #{etcd} -environment #{environment} -mongourl #{KONFIG.mongo} -port #{kontrol.port} -privatekey #{kontrol.privateKeyFile} -publickey #{kontrol.publicKeyFile} -storage postgres -postgres-dbname #{kontrolPostgres.dbname} -postgres-host #{kontrolPostgres.host} -postgres-port #{kontrolPostgres.port} -postgres-username #{kontrolPostgres.username} -postgres-password #{kontrolPostgres.password}"
       nginx             :
-        websocket       : yes
-        locations       : ["~^/kontrol/.*"]
+        disableLocation : yes
       healthCheckURL    : "http://localhost:#{KONFIG.kontrol.port}/healthCheck"
       versionURL        : "http://localhost:#{KONFIG.kontrol.port}/version"
 
@@ -229,7 +228,8 @@ Configuration = (options={}) ->
       supervisord       :
         command         : "#{GOBIN}/kloud -planendpoint #{socialapi.proxyUrl}/payments/subscriptions -hostedzone #{userSitesDomain} -region #{region} -environment #{environment} -port #{KONFIG.kloud.port} -publickey #{kontrol.publicKeyFile} -privatekey #{kontrol.privateKeyFile} -kontrolurl #{kontrol.url}  -registerurl #{KONFIG.kloud.registerUrl} -mongourl #{KONFIG.mongo} -prodmode=#{configName is "prod"}"
       nginx             :
-        disableLocation : yes
+        websocket       : yes
+        locations       : ["~^/kloud/.*"]
       healthCheckURL    : "http://localhost:#{KONFIG.kloud.port}/healthCheck"
       versionURL        : "http://localhost:#{KONFIG.kloud.port}/version"
 

--- a/config/main.sandbox.coffee
+++ b/config/main.sandbox.coffee
@@ -215,8 +215,7 @@ Configuration = (options={}) ->
       supervisord       :
         command         : "#{GOBIN}/kontrol -region #{region} -machines #{etcd} -environment #{environment} -mongourl #{KONFIG.mongo} -port #{kontrol.port} -privatekey #{kontrol.privateKeyFile} -publickey #{kontrol.publicKeyFile} -storage postgres -postgres-dbname #{kontrolPostgres.dbname} -postgres-host #{kontrolPostgres.host} -postgres-port #{kontrolPostgres.port} -postgres-username #{kontrolPostgres.username} -postgres-password #{kontrolPostgres.password}"
       nginx             :
-        websocket       : yes
-        locations       : ["~^/kontrol/.*"]
+        disableLocation : yes
       healthCheckURL    : "http://localhost:#{KONFIG.kontrol.port}/healthCheck"
       versionURL        : "http://localhost:#{KONFIG.kontrol.port}/version"
 

--- a/deployment/nginx.coffee
+++ b/deployment/nginx.coffee
@@ -96,7 +96,7 @@ createLocations = (KONFIG) ->
   locations = ""
   for name, options of workers when options.ports?
 
-    # don't add those who whis not to be generated, probably because those are
+    # don't add those who whish not to be generated, probably because those are
     # using manually written locations
     continue if options.nginx?.disableLocation?
 

--- a/deployment/nginx.coffee
+++ b/deployment/nginx.coffee
@@ -95,10 +95,16 @@ createLocations = (KONFIG) ->
 
   locations = ""
   for name, options of workers when options.ports?
+
+    # don't add those who whis not to be generated, probably because those are
+    # using manually written locations
+    continue if options.nginx?.disableLocation?
+
     options.nginx = {}  unless options.nginx
     location = ""
 
     options.nginx.locations or= ["/#{name}"]
+
 
     for location in options.nginx.locations
       # if this is a websocket proxy, add required configs
@@ -284,6 +290,27 @@ module.exports.create = (KONFIG, environment)->
         proxy_connect_timeout 1;
 
         #{if environment is "sandbox" then basicAuth else ""}
+      }
+
+      # special case for kontrol to support additional paths, like /kontrol/heartbeat
+      location ~^/kontrol/(.*) {
+        proxy_pass            http://kontrol/$1;
+
+        # needed for websocket handshake
+        proxy_http_version    1.1;
+        proxy_set_header      Upgrade         $http_upgrade;
+        proxy_set_header      Connection      $connection_upgrade;
+
+        proxy_set_header      Host $host;
+        proxy_set_header      X-Real-IP $remote_addr;
+        proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_redirect        off;
+
+        # Don't buffer WebSocket connections
+        proxy_buffering off;
+
+        # try again with another upstream if there is an error
+        proxy_next_upstream   error timeout   invalid_header http_500;
       }
 
       #{createLocations(KONFIG)}


### PR DESCRIPTION
This is needed so we can support our new `/kontrol/heartbeat/` endpoint
which enables HTTP based heartbeat mechanism
