### PR TITLE
Activity: add 'done' and 'cancel' buttons to edit widget [fixes #84259044]

### DIFF
--- a/client/Social/Activity/styl/activity.listitem.styl
+++ b/client/Social/Activity/styl/activity.listitem.styl
@@ -514,12 +514,22 @@ activity.listitem.styl
           margin          4px 10px 0 0
 
   &.editing
+    .edit-widget-wrapper
+      display             block
+
     .activity-content-wrapper
       > article
         display           none
 
       .activity-actions
         display           none
+
+      .cancel-editing
+        background        transparent
+        shadow            none
+
+        .button-title
+          color           #999
 
 
 .kdlistitemview-activity.preview
@@ -586,6 +596,9 @@ activity.listitem.styl
     padding                 24px 24px 16px
     rounded                 3px 3px 0 0
     borderBox()
+
+  .edit-widget-wrapper
+    display                 none
 
 .link-embed-box
   width                     auto

--- a/client/Social/Activity/views/activitylistitem.coffee
+++ b/client/Social/Activity/views/activitylistitem.coffee
@@ -77,7 +77,20 @@ class ActivityListItemView extends KDListItemView
       else new KDView
 
     @editWidgetWrapper = new KDCustomHTMLView
-      cssClass         : 'edit-widget-wrapper'
+      cssClass         : 'edit-widget-wrapper clearfix'
+
+    @editWidgetWrapper.addSubView new KDButtonView
+      style     : 'solid green mini fr'
+      title     : 'DONE'
+      callback  : =>
+        @editWidget.submit @editWidget.input.getValue()
+
+    @editWidgetWrapper.addSubView new KDButtonView
+      style     : 'solid mini fr'
+      cssClass  : 'cancel-editing'
+      title     : 'CANCEL'
+      callback  : =>
+        @editWidget.input.emit 'EscapePerformed'
 
     @resend = new KDCustomHTMLView cssClass: 'resend hidden'
 
@@ -119,7 +132,6 @@ class ActivityListItemView extends KDListItemView
       @editWidget = new editWidgetClass { delegate:this }, @getData()
       @editWidget.on 'SubmitSucceeded', @bound 'destroyEditWidget'
       @editWidget.input.on 'EscapePerformed', @bound 'destroyEditWidget'
-      @editWidget.input.on 'blur', @bound 'resetEditing'
       @editWidgetWrapper.addSubView @editWidget, null, yes
 
     KD.utils.defer =>


### PR DESCRIPTION
![screen shot 2014-12-16 at 13 25 57](https://cloud.githubusercontent.com/assets/3121257/5452744/53a59e3a-8527-11e4-960a-4280f39d380e.png)
