### PR TITLE
socialapi: Revert temporary BadRequest response change

### DIFF
--- a/go/src/socialapi/workers/common/response/response.go
+++ b/go/src/socialapi/workers/common/response/response.go
@@ -24,7 +24,7 @@ func NewBadRequest(err error) (int, http.Header, interface{}, error) {
 	// do not expose errors to the client
 	env := config.MustGet().Environment
 	// do not expose errors to the client.
-	if env == "production" {
+	if env != "dev" && env != "test" {
 		err = genericError
 	}
 


### PR DESCRIPTION
Found response of the failing test

```
Failures:

  * /pipeline/build/go/src/socialapi/tests/channel_message_test.go 
  Line 351:
  Expected: nil
  Actual:   'koding.BadRequest-pq: update or delete on table "channel_message" violates foreign key constraint "channel_message_list_message_id_fkey" on table "channel_message_list"'
```
