### PR TITLE
account: update payment method button visibility state

### DIFF
--- a/client/Account/views/billing.coffee
+++ b/client/Account/views/billing.coffee
@@ -88,7 +88,9 @@ class AccountBilling extends KDView
     paymentController.creditCard (err, cc) =>
 
       card = null  if err?
-
+      
+      # intentional if/else ifs
+      # to denote the edge cases - SY
       if subscription.provider is 'paypal'
         card = null
 

--- a/client/Account/views/billing.coffee
+++ b/client/Account/views/billing.coffee
@@ -29,7 +29,6 @@ class AccountBilling extends KDView
 
 
     @initSubscription()
-    @initPaymentMethod()
     @initPaymentHistory()
 
 
@@ -51,6 +50,8 @@ class AccountBilling extends KDView
         KD.singletons.router.handleRoute '/Pricing'
 
       @subscriptionWrapper.addSubView @subscription
+
+      @initPaymentMethod subscription
 
 
   noItemView = (partial) ->
@@ -75,16 +76,30 @@ class AccountBilling extends KDView
     @paymentMethodWrapper.addSubView @paymentMethod
 
 
-  initPaymentMethod: ->
+  initPaymentMethod: (subscription) ->
 
     { paymentController } = KD.singletons
 
     @paymentMethodWrapper.addSubView new KDHeaderView
       title : 'Payment Method'
 
-    paymentController.creditCard (err, card) =>
+
+
+    paymentController.creditCard (err, cc) =>
 
       card = null  if err?
+
+      if subscription.provider is 'paypal'
+        card = null
+
+      else if subscription.provider is 'stripe' and subscription.planTitle is 'free'
+        card = null
+
+      else if subscription.provider is 'koding'
+        card = null
+
+      else
+        card = cc
 
       @putPaymentMethodView card
 

--- a/client/Main/payment/paymentmethodview.coffee
+++ b/client/Main/payment/paymentmethodview.coffee
@@ -6,8 +6,6 @@ class PaymentMethodView extends JView
     options.editLink   ?= no
     options.removeLink ?= no
 
-    data = null  if @isNoCard data
-
     super options, data
 
     @createViews()
@@ -68,7 +66,7 @@ class PaymentMethodView extends JView
 
     noCardPartial = "<span class='no-item-found'>You have no payment methods</span>"
 
-    return noCardPartial  unless paymentMethod
+    return noCardPartial  if not paymentMethod or @isNoCard paymentMethod
 
     { last4 } = paymentMethod
 
@@ -87,6 +85,7 @@ class PaymentMethodView extends JView
     """
     <pre>#{numberPrefix}#{last4}</pre>
     """
+
 
   updatePaymentMethod: (paymentMethod) ->
 


### PR DESCRIPTION
There was an edge case when a user somehow deletes it's information on stripe but we still have him as a paid user, it show `update method` button on account settings.

/cc @sent-hil @gniting 
