### PR TITLE
Ace: remove ace default 'go to line' (cmd+L) key binding [fixes #79969942]

### DIFF
--- a/client/Ace/ace.coffee
+++ b/client/Ace/ace.coffee
@@ -32,6 +32,10 @@ class Ace extends KDView
             @emit 'FileContentRestored'  unless @isCurrentContentChanged()
 
           @editor.gotoLine 0
+          
+          # remove cmd+L binding. we have already defined cmd+g for this purpose
+          @editor.commands.removeCommand 'gotoline'
+
           @focus()
           @show()
 


### PR DESCRIPTION
We have already defined CMD+G for this purpose.
