### PR TITLE
comment: scroll into input widget after sending comment [fixes #83682732]

### DIFF
--- a/client/Social/Activity/views/comments/view.coffee
+++ b/client/Social/Activity/views/comments/view.coffee
@@ -162,6 +162,8 @@ class CommentView extends KDView
     @unsetClass 'no-comment commented'
     @setClass   'active-comment'
 
+    @getElement().scrollIntoView no
+
 
   setFixedHeight: (maxHeight) ->
 


### PR DESCRIPTION
This PR introduces a solution to solve the problem via scrolling into the comment view itself after something is posted.
