### PR TITLE
Tests: Improve wercker test instance launch procedure

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -46,12 +46,6 @@ build:
           INSTANCE_OPTIONS=$(scripts/wercker/get-instance-options)
           scripts/wercker/launch-test-instance $INSTANCE_OPTIONS | tail -n1 > $INSTANCE_DATA
           cat $INSTANCE_DATA
-          HOST=$(cat $INSTANCE_DATA | awk '{print $2}')
-          if [ -z "$HOST" ]; then exit 1; fi
-          echo $HOST > $INSTANCE_IP
-          scripts/wercker/check-connectivity $HOST 8090 1m 5
-          scripts/wercker/check-connectivity $HOST 4444 1m 7
-          scripts/notify-cebeci.sh "build" ${WERCKER_GIT_COMMIT:0:8} "test client in progress" "testing" 65
     - script:
         name: configure build
         code: ./configure --config $CONFIG --projectRoot /opt/koding
@@ -98,6 +92,14 @@ build:
         name: testing backend finished
         code: |
           scripts/notify-cebeci.sh "build" "<$WERCKER_BUILD_URL|build> of $WERCKER_GIT_BRANCH - test backend finished" "building" 45
+    - script:
+        name: check connectivity
+        code: |
+          HOST=$(cat $INSTANCE_DATA | awk '{print $2}')
+          if [ -z "$HOST" ]; then exit 1; fi
+          echo $HOST > $INSTANCE_IP
+          scripts/wercker/check-connectivity $HOST 8090 1m 5
+          scripts/wercker/check-connectivity $HOST 4444 1m 7
     - script:
         name: testing client started
         code: |

--- a/wercker.yml
+++ b/wercker.yml
@@ -99,7 +99,7 @@ build:
           HOST=$(cat $INSTANCE_DATA | awk '{print $2}')
           if [ -z "$HOST" ]; then exit 1; fi
           echo $HOST > $INSTANCE_IP
-          scripts/wercker/check-connectivity $HOST 8090 1m 3
+          scripts/wercker/check-connectivity $HOST 8090 1m 5
           scripts/wercker/check-connectivity $HOST 4444 1m 7
           scripts/notify-cebeci.sh "build" ${WERCKER_GIT_COMMIT:0:8} "test client in progress" "testing" 65
     - script:

--- a/wercker.yml
+++ b/wercker.yml
@@ -33,6 +33,26 @@ build:
           cd client/landing && npm install && cd ../../
           scripts/notify-cebeci.sh "build" "<$WERCKER_BUILD_URL|build> of $WERCKER_GIT_BRANCH - npm install (submodules) finished" "building" 30
     - script:
+        name: set up koding deployment key
+        code: |
+          chmod 600 $KODING_DEPLOYMENT_KEY
+    - mktemp:
+        envvar: INSTANCE_DATA
+    - mktemp:
+        envvar: INSTANCE_IP
+    - script:
+        name: launch test instance
+        code: |
+          INSTANCE_OPTIONS=$(scripts/wercker/get-instance-options)
+          scripts/wercker/launch-test-instance $INSTANCE_OPTIONS | tail -n1 > $INSTANCE_DATA
+          cat $INSTANCE_DATA
+          HOST=$(cat $INSTANCE_DATA | awk '{print $2}')
+          if [ -z "$HOST" ]; then exit 1; fi
+          echo $HOST > $INSTANCE_IP
+          scripts/wercker/check-connectivity $HOST 8090 1m 5
+          scripts/wercker/check-connectivity $HOST 4444 1m 7
+          scripts/notify-cebeci.sh "build" ${WERCKER_GIT_COMMIT:0:8} "test client in progress" "testing" 65
+    - script:
         name: configure build
         code: ./configure --config $CONFIG --projectRoot /opt/koding
     - script:
@@ -82,26 +102,6 @@ build:
         name: testing client started
         code: |
           scripts/notify-cebeci.sh "build" "<$WERCKER_BUILD_URL|build> of $WERCKER_GIT_BRANCH - test client started" "building" 46
-    - script:
-        name: set up koding deployment key
-        code: |
-          chmod 600 $KODING_DEPLOYMENT_KEY
-    - mktemp:
-        envvar: INSTANCE_DATA
-    - mktemp:
-        envvar: INSTANCE_IP
-    - script:
-        name: launch test instance
-        code: |
-          INSTANCE_OPTIONS=$(scripts/wercker/get-instance-options)
-          scripts/wercker/launch-test-instance $INSTANCE_OPTIONS | tail -n1 > $INSTANCE_DATA
-          cat $INSTANCE_DATA
-          HOST=$(cat $INSTANCE_DATA | awk '{print $2}')
-          if [ -z "$HOST" ]; then exit 1; fi
-          echo $HOST > $INSTANCE_IP
-          scripts/wercker/check-connectivity $HOST 8090 1m 5
-          scripts/wercker/check-connectivity $HOST 4444 1m 7
-          scripts/notify-cebeci.sh "build" ${WERCKER_GIT_COMMIT:0:8} "test client in progress" "testing" 65
     - script:
         name: run register test suite
         code: |

--- a/wercker.yml
+++ b/wercker.yml
@@ -101,7 +101,6 @@ build:
           echo $HOST > $INSTANCE_IP
           scripts/wercker/check-connectivity $HOST 8090 1m 3
           scripts/wercker/check-connectivity $HOST 4444 1m 7
-          sleep 120
           scripts/notify-cebeci.sh "build" ${WERCKER_GIT_COMMIT:0:8} "test client in progress" "testing" 65
     - script:
         name: run register test suite


### PR DESCRIPTION
Launching test instance is shaving off 8 to 12 minutes from current build time.
Topic follow/unfollow tests are disabled to prevent random build failures.
