### PR TITLE
kloud: Add NetworkUsage() checker.

### DIFF
--- a/go/src/koding/kites/kloud/main.go
+++ b/go/src/koding/kites/kloud/main.go
@@ -45,8 +45,11 @@ type Config struct {
 	// Connect to Koding mongodb
 	MongoURL string `required:"true"`
 
-	// Endpoint for fetchin plans
+	// Endpoint for fetching plans
 	PlanEndpoint string `required:"true"`
+
+	// Endpoint for fetching user machine network usage
+	NetworkUsageEndpoint string `required:"true"`
 
 	// --- DEVELOPMENT CONFIG ---
 	// Show version and exit if enabled
@@ -213,14 +216,15 @@ func newKite(conf *Config) *kite.Kite {
 		}
 
 		return &koding.PlanChecker{
-			Api:      a,
-			Provider: kodingProvider,
-			DB:       kodingProvider.Session,
-			Kite:     kodingProvider.Kite,
-			Log:      kodingProvider.Log,
-			Username: m.Username,
-			Machine:  m,
-			Plan:     plan,
+			Api:                  a,
+			Provider:             kodingProvider,
+			DB:                   kodingProvider.Session,
+			Kite:                 kodingProvider.Kite,
+			Log:                  kodingProvider.Log,
+			Username:             m.Username,
+			Machine:              m,
+			Plan:                 plan,
+			NetworkUsageEndpoint: conf.NetworkUsageEndpoint,
 		}, nil
 	}
 

--- a/go/src/koding/kites/kloud/provider/koding/checker.go
+++ b/go/src/koding/kites/kloud/provider/koding/checker.go
@@ -68,8 +68,8 @@ type PlanChecker struct {
 type networkUsageResponse struct {
 	CanStart     bool   `json:"can_start"`
 	Reason       string `json:"reason"`
-	AllowedUsage int    `json:"allowed"`
-	CurrentUsage int    `json:"current"`
+	AllowedUsage int    `json:"allowed_usage"`
+	CurrentUsage int    `json:"current_usage"`
 }
 
 func (p *PlanChecker) NetworkUsage() error {

--- a/go/src/koding/kites/kloud/provider/koding/checker.go
+++ b/go/src/koding/kites/kloud/provider/koding/checker.go
@@ -1,13 +1,14 @@
 package koding
 
 import (
+	"encoding/json"
 	"fmt"
-	"koding/db/mongodb"
+	"net/http"
+	"net/url"
 	"strconv"
 
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
-
+	"koding/db/models"
+	"koding/db/mongodb"
 	aws "koding/kites/kloud/api/amazon"
 	"koding/kites/kloud/klient"
 	"koding/kites/kloud/machinestate"
@@ -17,6 +18,8 @@ import (
 	"github.com/koding/kite"
 	"github.com/koding/logging"
 	"github.com/mitchellh/goamz/ec2"
+	"labix.org/v2/mgo"
+	"labix.org/v2/mgo/bson"
 )
 
 // Checker checks various aspects of a machine. It is used for limiting certain
@@ -44,17 +47,79 @@ type Checker interface {
 	// AllowedInstances checks whether the given machine has the permisison to
 	// create the given instance type
 	AllowedInstances(wantInstance InstanceType) error
+
+	// NetworkUsage checks whether the given machine has exceeded the network
+	// outbound limit
+	NetworkUsage() error
 }
 
 type PlanChecker struct {
-	Api      *amazon.AmazonClient
-	DB       *mongodb.MongoDB
-	Machine  *protocol.Machine
-	Provider *Provider
-	Kite     *kite.Kite
-	Username string
-	Log      logging.Logger
-	Plan     Plan
+	Api                  *amazon.AmazonClient
+	DB                   *mongodb.MongoDB
+	Machine              *protocol.Machine
+	Provider             *Provider
+	Kite                 *kite.Kite
+	Username             string
+	Log                  logging.Logger
+	Plan                 Plan
+	NetworkUsageEndpoint string
+}
+
+type networkUsageResponse struct {
+	CanStart     bool   `json:"can_start"`
+	Reason       string `json:"reason"`
+	AllowedUsage int    `json:"allowed"`
+	CurrentUsage int    `json:"current"`
+}
+
+func (p *PlanChecker) NetworkUsage() error {
+	networkEndpoint, err := url.Parse(p.NetworkUsageEndpoint)
+	if err != nil {
+		p.Log.Debug("[%s] Failed to parse network-usage endpoint: %v. err: %v",
+			p.Machine.Id, p.NetworkUsageEndpoint, err)
+		return nil
+	}
+
+	var account *models.Account
+	if err := p.DB.Run("jAccounts", func(c *mgo.Collection) error {
+		return c.Find(bson.M{"profile.nickname": p.Username}).One(&account)
+	}); err != nil {
+		p.Log.Warning("[%s] Failed to fetch user information while checking network-usage. err: %v",
+			p.Machine.Id, err)
+		return nil
+	}
+
+	q := networkEndpoint.Query()
+	q.Set("account_id", account.Id.Hex())
+	networkEndpoint.RawQuery = q.Encode()
+
+	resp, err := http.Get(networkEndpoint.String())
+	if err != nil {
+		p.Log.Warning("[%s] Failed to fetch network-usage because network-usage providing api host seems down. err: %v",
+			p.Machine.Id, err)
+		return nil
+	}
+	defer resp.Body.Close()
+
+	var usageResponse *networkUsageResponse
+	if err := json.NewDecoder(resp.Body).Decode(&usageResponse); err != nil {
+		p.Log.Warning("[%s] Failed to decode network-usage response. err: %v",
+			p.Machine.Id, err)
+		return nil
+	}
+
+	if resp.StatusCode != 200 {
+		p.Log.Debug("[%s] Network-usage response code is not 200. It's %v",
+			p.Machine.Id, resp.StatusCode)
+		return nil
+	}
+
+	if !usageResponse.CanStart {
+		p.Log.Debug("[%s] Network-usage limit is reached. Allowed usage: %v MiB, Current usage: %v MiB",
+			p.Machine.Id, usageResponse.AllowedUsage, usageResponse.CurrentUsage)
+		return nil
+	}
+	return nil
 }
 
 func (p *PlanChecker) AllowedInstances(wantInstance InstanceType) error {

--- a/go/src/koding/kites/kloud/provider/koding/checker.go
+++ b/go/src/koding/kites/kloud/provider/koding/checker.go
@@ -77,7 +77,7 @@ func (p *PlanChecker) NetworkUsage() error {
 	if err != nil {
 		p.Log.Debug("[%s] Failed to parse network-usage endpoint: %v. err: %v",
 			p.Machine.Id, p.NetworkUsageEndpoint, err)
-		return nil
+		return err
 	}
 
 	var account *models.Account
@@ -86,7 +86,7 @@ func (p *PlanChecker) NetworkUsage() error {
 	}); err != nil {
 		p.Log.Warning("[%s] Failed to fetch user information while checking network-usage. err: %v",
 			p.Machine.Id, err)
-		return nil
+		return err
 	}
 
 	q := networkEndpoint.Query()
@@ -97,7 +97,7 @@ func (p *PlanChecker) NetworkUsage() error {
 	if err != nil {
 		p.Log.Warning("[%s] Failed to fetch network-usage because network-usage providing api host seems down. err: %v",
 			p.Machine.Id, err)
-		return nil
+		return err
 	}
 	defer resp.Body.Close()
 
@@ -105,19 +105,19 @@ func (p *PlanChecker) NetworkUsage() error {
 	if err := json.NewDecoder(resp.Body).Decode(&usageResponse); err != nil {
 		p.Log.Warning("[%s] Failed to decode network-usage response. err: %v",
 			p.Machine.Id, err)
-		return nil
+		return err
 	}
 
 	if resp.StatusCode != 200 {
 		p.Log.Debug("[%s] Network-usage response code is not 200. It's %v",
 			p.Machine.Id, resp.StatusCode)
-		return nil
+		return err
 	}
 
 	if !usageResponse.CanStart {
 		p.Log.Debug("[%s] Network-usage limit is reached. Allowed usage: %v MiB, Current usage: %v MiB",
 			p.Machine.Id, usageResponse.AllowedUsage, usageResponse.CurrentUsage)
-		return nil
+		return err
 	}
 	return nil
 }

--- a/go/src/koding/kites/kloud/provider/koding/provider.go
+++ b/go/src/koding/kites/kloud/provider/koding/provider.go
@@ -133,6 +133,10 @@ func (p *Provider) Start(m *protocol.Machine) (*protocol.Artifact, error) {
 		return nil, err
 	}
 
+	if err := checker.NetworkUsage(); err != nil {
+		return nil, err
+	}
+
 	a, err := p.NewClient(m)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Do not start a VM if the plan of a user doesn't allow to excess a certain
outbound network limit.

There is a new parameter to kloud: -networkusageendpoint.

We have a new worker that serves an API and checks outbound network usage per
EC2 instance and collects them in Redis with a sorted-set.

Kloud uses this new API to check the outbound network and prevents to start a
machine if the limit is reached.
