### PR TITLE
Workspace: Skip dummy workspace for other machines [fixes #85652432]

### DIFF
--- a/client/Social/Activity/sidebar/activitysidebar.coffee
+++ b/client/Social/Activity/sidebar/activitysidebar.coffee
@@ -479,6 +479,8 @@ class ActivitySidebar extends KDCustomHTMLView
           userWorkspaces        = myWorkspaces.concat workspacesIHaveAccess
 
           KD.userMachines.forEach (machine) ->
+            return  if machine.data.credential isnt KD.nick()
+
             for workspace in KD.userWorkspaces \
               when workspace.slug is 'my-workspace' \
               and workspace.machineUId is machine.uid


### PR DESCRIPTION
[Non-shared dummy workspace is listed for participant](https://www.pivotaltracker.com/story/show/85652432)
