### PR TITLE
add versioning to sprites

### DIFF
--- a/build-client.coffee
+++ b/build-client.coffee
@@ -125,7 +125,7 @@ class Builder
           queue.next()
       ,
       ->
-        exec 'cd client/landing && gulp build-all-sites', (err, stdout, stderr)->
+        exec "cd client/landing && gulp build-all-sites --koding-version=#{args.version}", (err, stdout, stderr)->
           if err
           then console.error err
           else console.log """

--- a/build-client.coffee
+++ b/build-client.coffee
@@ -81,6 +81,7 @@ class Builder
     @canBuildSprites().then ->
       log.info "Building sprites... (it may take a while) (if it fails, try `ulimit -n 1024` first)"
       sprite
+        version   : args.version
         srcPath   : './sprites'
         destPath  : './website/a/sprites'
         httpPath  : '/a/sprites'

--- a/node_modules_koding/koding-sprites/lib/koding-sprites/stylus-helper.coffee
+++ b/node_modules_koding/koding-sprites/lib/koding-sprites/stylus-helper.coffee
@@ -1,5 +1,3 @@
-
-
 { join: joinPath } = require 'path'
 { nodes: { Property, Unit } } = require 'stylus'
 
@@ -21,7 +19,7 @@ module.exports = (layouts, options) ->
       @closestBlock.nodes.splice @closestBlock.index + 1, 0, widthNode, heightNode
 
     backgroundUrl = joinPath options.httpPath ? options.path, sprite.filename
-    background = "url(#{ backgroundUrl }) #{ left }px -#{ top }px"
+    background = "url(#{ backgroundUrl }?#{ options.version }) #{ left }px -#{ top }px"
 
     new Property ['background'], background
 


### PR DESCRIPTION
This method modifies `stylus-helper` package which is the `sprite` function we use in stylus. it adds cache busters to end of the url.
