### PR TITLE
build-client: use KONFIG_JSON instead of env variables [fixes #85805506]

### DIFF
--- a/build-client.coffee
+++ b/build-client.coffee
@@ -20,7 +20,11 @@ which             = Promise.promisify require 'which'
 buildAPI          = require 'bongo-api-builder'
 bongo             = require 'bongo'
 
-KONFIG = JSON.parse process.env.KONFIG_JSON or {}
+try
+  KONFIG = JSON.parse(process.env.KONFIG_JSON)
+catch error
+  console.log "buildclient: Error when trying to parse 'KONFIG_JSON'"
+  return
 
 args =
   watchDuration : argv.watchDuration  or 5000
@@ -43,6 +47,7 @@ formatByte = (bytes) ->
     minus  = '-'
     bytes *= -1
   thresh    = 1024
+
   units     = ["kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
   unitIndex = -1
   return "#{bytes} B"  if bytes < thresh
@@ -580,7 +585,7 @@ class Builder
   getProjects:->
 
     rp = (address)=>
-      "#{ address?.replace /^website\//, '/' }?#{ args.version }"
+      "#{ address?.replace(/^website\//, '/') }?#{ args.version }"
 
     apps = {}
     {projects, bundles} = require './projects'

--- a/build-client.coffee
+++ b/build-client.coffee
@@ -20,13 +20,15 @@ which             = Promise.promisify require 'which'
 buildAPI          = require 'bongo-api-builder'
 bongo             = require 'bongo'
 
+KONFIG = JSON.parse process.env.KONFIG_JSON or {}
 
 args =
   watchDuration : argv.watchDuration  or 5000
-  watch         : argv.watch          or process.env.KONFIG_CLIENT_WATCH or false
-  version       : argv.version        or process.env.KONFIG_VERSION      or "0.0.1"
-  sourceMapsUri : argv.sourceMapsUri  or process.env.KONFIG_CLIENT_RUNTIMEOPTIONS_SOURCEMAPSURI or "koding.com/sourcemaps"
+  watch         : argv.watch          or KONFIG.client.watch or false
+  version       : argv.version        or KONFIG.version      or "0.0.1"
+  sourceMapsUri : argv.sourceMapsUri  or KONFIG.client.runtimeOptions.sourceMapsUri or "koding.com/sourcemaps"
   verbose       : argv.verbose        or false
+
 console.log "building client with options:",args
 
 log =


### PR DESCRIPTION
/cc @gokmen 
