### PR TITLE
migrate: add existential check for channel.payload column

### DIFF
--- a/go/src/socialapi/db/sql/migrations/0002_collaboration_message_type.up.sql
+++ b/go/src/socialapi/db/sql/migrations/0002_collaboration_message_type.up.sql
@@ -2,4 +2,12 @@
 -- ALTER TYPE "api"."channel_type_constant_enum" ADD VALUE IF NOT EXISTS 'collaboration';
 
 -- add new coloumn into channel
-ALTER TABLE "api"."channel" ADD COLUMN "payload" hstore;
+DO $$
+  BEGIN
+    BEGIN
+      ALTER TABLE "api"."channel" ADD COLUMN "payload" hstore;
+    EXCEPTION
+      WHEN duplicate_column THEN RAISE NOTICE 'column already exists';
+    END;
+  END;
+$$;


### PR DESCRIPTION
since it is already added to create.sh, it was returning `ERROR 42701: column "payload" of relation "channel" already exists` error .
