### PR TITLE
Enable lazy loader when searching and scrolling data on channel modal [Fixes #83781738]

### DIFF
--- a/client/Social/Activity/sidebar/searchmodal.coffee
+++ b/client/Social/Activity/sidebar/searchmodal.coffee
@@ -81,8 +81,6 @@ class SidebarSearchModal extends KDModalView
       
     @listController.addItem itemData for itemData in items
 
-    @listController.lazyLoader.setClass 'do-not-show'
-
 
   handleLazyLoad: ->
 

--- a/client/Social/Activity/styl/activity.styl
+++ b/client/Social/Activity/styl/activity.styl
@@ -291,8 +291,6 @@ body.activity
   .lazy-loader
     text-align        center
     margin            22px 0
-    &.do-not-show
-      hidden()
 
   .kdmodal-inner
     margin            22px 15px 22px 30px


### PR DESCRIPTION
@usirin, @sinan - can you guys review this fix? I enabled lazy loader when searching and scrolling data on channels modal (it was disabled there before). 
I think it's logically to show loader icon every time new data is being requested by user - by searching and by scrolling pagination. I'm not sure it's a general approach of showing loader animation on the site but I think it looks good.
Here is a couple of screenshots how it works:
![scrolling-loader](https://cloud.githubusercontent.com/assets/492219/5777047/0bb5b4a2-9da0-11e4-96e1-b0d60fba6f2f.jpg)
![search-loader](https://cloud.githubusercontent.com/assets/492219/5777049/11749732-9da0-11e4-9a92-63f0a41982db.jpg)
