### PR TITLE
Cleaner fixes

### DIFF
--- a/go/src/koding/kites/kloud/cleaners/lookup/mongodb.go
+++ b/go/src/koding/kites/kloud/cleaners/lookup/mongodb.go
@@ -71,6 +71,7 @@ func (m *MongoDB) AlwaysOn() ([]MachineDocument, error) {
 	query := func(c *mgo.Collection) error {
 		alwaysOn := bson.M{
 			"meta.alwaysOn": true,
+			"provider":      "koding",
 		}
 
 		machine := MachineDocument{}

--- a/go/src/koding/kites/kloud/cleaners/lookup/mongodb.go
+++ b/go/src/koding/kites/kloud/cleaners/lookup/mongodb.go
@@ -1,6 +1,7 @@
 package lookup
 
 import (
+	"fmt"
 	"koding/db/models"
 	"koding/db/mongodb"
 	"time"
@@ -147,11 +148,23 @@ func (m *MongoDB) Accounts(ids ...string) ([]models.Account, error) {
 
 // RemoveAlwaysOn removes the alwaysOn flag for the given usernames
 func (m *MongoDB) RemoveAlwaysOn(usernames ...string) error {
+	users, err := m.Users(usernames...)
+	if err != nil {
+		return err
+	}
+
+	userIds := make([]bson.ObjectId, len(users))
+	for i, user := range users {
+		userIds[i] = user.ObjectId
+	}
+
 	query := func(c *mgo.Collection) error {
 		_, err := c.UpdateAll(
 			bson.M{
-				"credential": bson.M{"$in": usernames},
-				"provider":   "koding",
+				"provider":    "koding",
+				"users.id":    bson.M{"$in": userIds},
+				"users.sudo":  true,
+				"users.owner": true,
 			},
 			bson.M{"$set": bson.M{"meta.alwaysOn": false}},
 		)
@@ -160,4 +173,28 @@ func (m *MongoDB) RemoveAlwaysOn(usernames ...string) error {
 	}
 
 	return m.DB.Run("jMachines", query)
+}
+
+func (m *MongoDB) Users(usernames ...string) ([]models.User, error) {
+	users := make([]models.User, 0)
+
+	query := func(c *mgo.Collection) error {
+		all := bson.M{
+			"username": bson.M{"$in": usernames},
+		}
+
+		user := models.User{}
+		iter := c.Find(all).Batch(150).Iter()
+		for iter.Next(&user) {
+			users = append(users, user)
+		}
+
+		return iter.Close()
+	}
+
+	if err := m.DB.Run("jUsers", query); err != nil {
+		return nil, err
+	}
+
+	return users, nil
 }

--- a/go/src/koding/kites/kloud/cleaners/lookup/mongodb.go
+++ b/go/src/koding/kites/kloud/cleaners/lookup/mongodb.go
@@ -1,7 +1,6 @@
 package lookup
 
 import (
-	"fmt"
 	"koding/db/models"
 	"koding/db/mongodb"
 	"time"

--- a/go/src/koding/kites/kloud/cleaners/lookup/mongodb.go
+++ b/go/src/koding/kites/kloud/cleaners/lookup/mongodb.go
@@ -148,7 +148,10 @@ func (m *MongoDB) Accounts(ids ...string) ([]models.Account, error) {
 func (m *MongoDB) RemoveAlwaysOn(usernames ...string) error {
 	query := func(c *mgo.Collection) error {
 		_, err := c.UpdateAll(
-			bson.M{"credential": bson.M{"$in": usernames}},
+			bson.M{
+				"credential": bson.M{"$in": usernames},
+				"provider":   "koding",
+			},
 			bson.M{"$set": bson.M{"meta.alwaysOn": false}},
 		)
 


### PR DESCRIPTION
- Pick only `koding` providers
- Fetch via `users.id` instead of `credential`. To do this we need to fetch user ids from `jUsers` collection with the given usernames.
