### PR TITLE
Add Heap selectors for specific places [completes #86673452]

### DIFF
--- a/client/Pricing/views/singleplan.coffee
+++ b/client/Pricing/views/singleplan.coffee
@@ -68,11 +68,14 @@ class SinglePlanView extends KDView
         tagName  : 'dd'
         partial  : partial
 
+    heapClass = getHeapClass title.toLowerCase(), planInterval
     @addSubView @buyButton = new KDButtonView
-      style     : 'plan-buy-button'
+      style     : "plan-buy-button #{heapClass}"
       title     : 'SELECT'
       state     : { name, monthPrice, yearPrice }
       callback  : @bound 'select'
+
+    @buyButton.heapClass = heapClass
 
   select: ->
 
@@ -104,6 +107,13 @@ class SinglePlanView extends KDView
       <span class='interval-text'>MONTHLY</span>
     "
 
+    # this is for adding toggling heap css classes.
+    { title } = @getOptions()
+    title = title.toLowerCase()
+    @buyButton.unsetClass @buyButton.heapClass
+    @buyButton.setClass heapClass = getHeapClass title, planInterval
+    @buyButton.heapClass = heapClass
+
 
   getPrice: (planInterval) ->
 
@@ -122,5 +132,8 @@ class SinglePlanView extends KDView
   enable: ->
     @unsetClass 'current'
     @buyButton.enable()
+
+
+  getHeapClass = (title, interval) -> "heap-#{title}-#{interval}-button"
 
 


### PR DESCRIPTION
This PR adds css selectors as `cssClass` definitions to be used by our [Heap](https://heapanalytics.com) account:
- [x] Pricing plan buttons for logged in users
- [ ] Pricing plan buttons for logged out users
- [ ] 'Upgrade your plan' button on Credit Card Modal
- [ ] 'Turn it on' button on VM Start Modal
- [ ] 'Send' button on Activity
- [ ] 'Sign up' button on Homepage
- [ ] 'Create account' button on `/Register`

/cc @diclee @gniting 
