### PR TITLE
More Payment fixes

### DIFF
--- a/client/Main/includes.coffee
+++ b/client/Main/includes.coffee
@@ -200,6 +200,7 @@ module.exports = [
 
   # PAYMENT
   # controller
+  "payment/constants.coffee",
   "payment/paymentcontroller.coffee",
   # # views
   "payment/paymentmethodview.coffee",

--- a/client/Main/payment/constants.coffee
+++ b/client/Main/payment/constants.coffee
@@ -1,0 +1,27 @@
+PaymentConstants =
+
+  planInterval:
+    MONTH       : 'month'
+    YEAR        : 'year'
+
+  planTitle:
+    FREE         : 'free'
+    HOBBYIST     : 'hobbyist'
+    DEVELOPER    : 'developer'
+    PROFESSIONAL : 'professional'
+
+  provider:
+    STRIPE : 'stripe'
+    PAYPAL : 'paypal'
+    KODING : 'koding'
+
+  operation:
+    UPGRADE         : 1
+    INTERVAL_CHANGE : 0
+    DOWNGRADE       : -1
+
+  FAILED_ATTEMPT_LIMIT: 3
+  TOO_MANY_ATTEMPT_BLOCK_KEY: 'BlockForTooManyAttempts'
+  TOO_MANY_ATTEMPT_BLOCK_DURATION: KD.config.paymentBlockDuration
+
+

--- a/client/Main/payment/creditcardmodal.coffee
+++ b/client/Main/payment/creditcardmodal.coffee
@@ -5,14 +5,22 @@ class CreditCardModal extends PaymentBaseModal
     options.title    = 'Update Payment Method'
     options.subtitle = ''
 
+    @isInputValidMap = {}
+
     super options, data
 
+
+  observeForm: PaymentForm::observeForm
+  handleFormInputValidation: PaymentForm::handleFormInputValidation
+  handleValidationResult: PaymentForm::handleValidationResult
 
   initViews: ->
 
     @addSubView @form = new StripeFormView {
       callback : @lazyBound 'emit', 'CreditCardSubmitted'
     }
+
+    @observeForm()
 
     @addSubView @successMessage = new KDCustomHTMLView
       cssClass : 'success-msg hidden'
@@ -21,6 +29,7 @@ class CreditCardModal extends PaymentBaseModal
     @addSubView @submitButton = new KDButtonView
       style    : 'solid medium green'
       title    : 'UPDATE'
+      disabled : yes
       loader   : yes
       cssClass : 'submit-btn'
       callback : => @emit 'CreditCardSubmitted', @form.getData()
@@ -37,6 +46,7 @@ class CreditCardModal extends PaymentBaseModal
 
     @on 'CreditCardUpdateFailed', KD.showError
     @on 'CreditCardUpdateSucceeded', @bound 'handleSuccess'
+    @on 'GotValidationResult', @bound 'handleValidationResult'
 
     { cardNumber } = @form.inputs
 

--- a/client/Main/payment/form.coffee
+++ b/client/Main/payment/form.coffee
@@ -10,12 +10,12 @@
 # from the rest. ~Umut
 class PaymentForm extends JView
 
-  { UPGRADE, DOWNGRADE, INTERVAL_CHANGE } = PaymentWorkflow.operation
+  { UPGRADE, DOWNGRADE, INTERVAL_CHANGE } = PaymentConstants.operation
 
   getInitialState: ->
-    planInterval : PaymentWorkflow.planInterval.MONTH
-    planTitle    : PaymentWorkflow.planTitle.HOBBYIST
-    provider     : PaymentWorkflow.provider.KODING
+    planInterval : PaymentConstants.planInterval.MONTH
+    planTitle    : PaymentConstants.planTitle.HOBBYIST
+    provider     : PaymentConstants.provider.KODING
 
 
   constructor: (options = {}, data) ->
@@ -125,15 +125,15 @@ class PaymentForm extends JView
 
   filterViews: ->
 
-    { FREE }   = PaymentWorkflow.planTitle
-    { MONTH }  = PaymentWorkflow.planInterval
-    { KODING } = PaymentWorkflow.provider
+    { FREE }   = PaymentConstants.planTitle
+    { MONTH }  = PaymentConstants.planInterval
+    { KODING } = PaymentConstants.provider
     { currentPlan, planTitle, planInterval, provider, paymentMethod } = @state
 
     operation = PaymentWorkflow.getOperation currentPlan, planTitle
 
     @yearPriceMessage.hide()  if planInterval is MONTH
-    @yearPriceMessage.hide()  if operation is PaymentWorkflow.operation.INTERVAL_CHANGE
+    @yearPriceMessage.hide()  if operation is PaymentConstants.operation.INTERVAL_CHANGE
 
     # no need to show those views when they are
     # downgrading to free account.
@@ -248,7 +248,7 @@ class PaymentForm extends JView
 
     switch operation
 
-      when PaymentWorkflow.operation.UPGRADE
+      when PaymentConstants.operation.UPGRADE
 
         @successMessage.updatePartial "
           Depending on the plan upgraded to, you now have access to more computing
@@ -261,7 +261,7 @@ class PaymentForm extends JView
         "
         @successMessage.show()
 
-      when PaymentWorkflow.operation.INTERVAL_CHANGE
+      when PaymentConstants.operation.INTERVAL_CHANGE
 
         @successMessage.updatePartial "
           Your billing cycle has been successfully updated.
@@ -329,7 +329,7 @@ class PaymentForm extends JView
     {{> @yearPriceMessage}}
     {{> @submitButton}}
     #{
-      if @state.provider is PaymentWorkflow.provider.KODING
+      if @state.provider is PaymentConstants.provider.KODING
       then '<div class="divider">OR</div>'
       else ''
     }

--- a/client/Main/payment/modal.coffee
+++ b/client/Main/payment/modal.coffee
@@ -3,13 +3,13 @@
 # the process, (e.g validation errors etc)
 class PaymentModal extends PaymentBaseModal
 
-  { UPGRADE, DOWNGRADE, INTERVAL_CHANGE } = PaymentWorkflow.operation
+  { UPGRADE, DOWNGRADE, INTERVAL_CHANGE } = PaymentConstants.operation
 
   getInitialState: ->
-    planInterval : PaymentWorkflow.planInterval.MONTH
-    planTitle    : PaymentWorkflow.planTitle.HOBBYIST
-    provider     : PaymentWorkflow.provider.KODING
-    operation    : PaymentWorkflow.operation.UPGRADE
+    planInterval : PaymentConstants.planInterval.MONTH
+    planTitle    : PaymentConstants.planTitle.HOBBYIST
+    provider     : PaymentConstants.provider.KODING
+    operation    : PaymentConstants.operation.UPGRADE
 
 
   constructor: (options = {}, data) ->
@@ -36,8 +36,8 @@ class PaymentModal extends PaymentBaseModal
   initViews: ->
 
     { provider, planTitle } = @state
-    { PAYPAL } = PaymentWorkflow.provider
-    { FREE }   = PaymentWorkflow.planTitle
+    { PAYPAL } = PaymentConstants.provider
+    { FREE }   = PaymentConstants.planTitle
 
     @addSubView @errors = new KDCustomHTMLView {cssClass : 'errors hidden'}
     @addSubView @form   = new PaymentForm {@state}

--- a/client/Main/payment/workflow.coffee
+++ b/client/Main/payment/workflow.coffee
@@ -110,7 +110,7 @@ class PaymentWorkflow extends KDController
     # and 4 digit year, and different types of month
     # we are enforcing those, other than length problems
     # Stripe will take care of the rest. ~U
-    cardYear  = null  if cardYear.length isnt 4
+    cardYear  = null  unless cardYear.length in [2, 4]
     cardMonth = null  if cardMonth.length isnt 2
 
     binNumber = cardNumber.slice 0, 6

--- a/client/Main/payment/workflow.coffee
+++ b/client/Main/payment/workflow.coffee
@@ -7,52 +7,30 @@
 #
 # Necessary options when you instantiate it.
 #
-# planTitle  : string (see PaymentWorkflow.planTitle)
+# planTitle  : string (see PaymentConstants.planTitle)
 # monthPrice : int (e.g 1900 for $19)
 # yearPrice  : int (e.g 19000 for $190)
 class PaymentWorkflow extends KDController
 
-  @planInterval =
-    MONTH       : 'month'
-    YEAR        : 'year'
-
-  @planTitle =
-    FREE         : 'free'
-    HOBBYIST     : 'hobbyist'
-    DEVELOPER    : 'developer'
-    PROFESSIONAL : 'professional'
-
-  @provider =
-    STRIPE : 'stripe'
-    PAYPAL : 'paypal'
-    KODING : 'koding'
-
-  @operation =
-    UPGRADE         : 1
-    INTERVAL_CHANGE : 0
-    DOWNGRADE       : -1
-
-
-  FAILED_ATTEMPT_LIMIT = 3
-
-  TOO_MANY_ATTEMPT_BLOCK_KEY = 'BlockForTooManyAttempts'
+  { TOO_MANY_ATTEMPT_BLOCK_KEY,
+    TOO_MANY_ATTEMPT_BLOCK_DURATION } = PaymentConstants
 
   @getOperation = (current, selected) ->
 
     arr = [
-      PaymentWorkflow.planTitle.FREE
-      PaymentWorkflow.planTitle.HOBBYIST
-      PaymentWorkflow.planTitle.DEVELOPER
-      PaymentWorkflow.planTitle.PROFESSIONAL
+      PaymentConstants.planTitle.FREE
+      PaymentConstants.planTitle.HOBBYIST
+      PaymentConstants.planTitle.DEVELOPER
+      PaymentConstants.planTitle.PROFESSIONAL
     ]
 
     current  = arr.indexOf current
     selected = arr.indexOf selected
 
     return switch
-      when selected >  current then PaymentWorkflow.operation.UPGRADE
-      when selected is current then PaymentWorkflow.operation.INTERVAL_CHANGE
-      when selected <  current then PaymentWorkflow.operation.DOWNGRADE
+      when selected >  current then PaymentConstants.operation.UPGRADE
+      when selected is current then PaymentConstants.operation.INTERVAL_CHANGE
+      when selected <  current then PaymentConstants.operation.DOWNGRADE
 
 
   getInitialState: -> {
@@ -81,7 +59,7 @@ class PaymentWorkflow extends KDController
 
       @state.paymentMethod = card
 
-      { UPGRADE, DOWNGRADE, INTERVAL_CHANGE } = PaymentWorkflow.operation
+      { UPGRADE, DOWNGRADE, INTERVAL_CHANGE } = PaymentConstants.operation
 
       switch operation
         when DOWNGRADE                then @startDowngradeFlow()
@@ -98,7 +76,7 @@ class PaymentWorkflow extends KDController
     @modal.on 'PaymentWorkflowFinishedWithError', @bound 'finishWithError'
 
     @modal.on 'PaypalButtonClicked', =>
-      @state.provider = PaymentWorkflow.provider.PAYPAL
+      @state.provider = PaymentConstants.provider.PAYPAL
 
 
   startDowngradeFlow: ->
@@ -117,7 +95,10 @@ class PaymentWorkflow extends KDController
 
   handlePaymentSubmit: (formData) ->
 
-    return @failedAttemptLimitReached()  if @state.failedAttemptCount >= FAILED_ATTEMPT_LIMIT
+    { FAILED_ATTEMPT_LIMIT } = PaymentConstants
+
+    if @state.failedAttemptCount >= FAILED_ATTEMPT_LIMIT
+      return @failedAttemptLimitReached()
 
     {
       cardNumber, cardCVC, cardMonth,
@@ -140,7 +121,7 @@ class PaymentWorkflow extends KDController
         planTitle, planAmount, binNumber, lastFour, cardName
       }, noop
 
-    { KODING, STRIPE } = PaymentWorkflow.provider
+    { KODING, STRIPE } = PaymentConstants.provider
 
     @state.provider = STRIPE  if @state.provider is KODING
 


### PR DESCRIPTION
This PR fixes/adds the following:
- [x] moves all the constants from all over the place and packs them into `PaymentConstants` object that can be used from anywhere.
- [x] adds observable input validation functionality to `Update Credit Card` modal as well.
- [x] gives users the ability of using 2 digit years not only 4 digit years.

/cc @sent-hil 
