### PR TITLE
Payment sweet payment

### DIFF
--- a/client/Main/payment/form.coffee
+++ b/client/Main/payment/form.coffee
@@ -135,18 +135,20 @@ class PaymentForm extends JView
     @yearPriceMessage.hide()  if planInterval is MONTH
     @yearPriceMessage.hide()  if operation is PaymentConstants.operation.INTERVAL_CHANGE
 
-    # no need to show those views when they are
-    # downgrading to free account.
-    if planTitle is FREE
-      @securityNote.hide()
-      @existingCreditCardMessage.hide()
-      @yearPriceMessage.hide()
-
     if paymentMethod
       @submitButton.enable()
+      @form.hide()
     else
-      @form.show()
       @existingCreditCardMessage.hide()
+      @form.show()
+
+      # no need to show those views when they are
+      # downgrading to free account.
+      if planTitle is FREE
+        @securityNote.hide()
+        @yearPriceMessage.hide()
+        @form.hide()
+        @submitButton.enable()
 
     @paypalForm.destroy()  unless provider is KODING
 

--- a/client/Main/payment/form.coffee
+++ b/client/Main/payment/form.coffee
@@ -234,6 +234,7 @@ class PaymentForm extends JView
       We are sorry #{word} are disabled for Paypal.
       Please contact <a href='mailto:billing@koding.com'>billing@koding.com</a>
     "
+    @existingCreditCardMessage.show()
 
 
   showSuccess: (operation) ->
@@ -272,6 +273,7 @@ class PaymentForm extends JView
         "
         @successMessage.show()
 
+    @submitButton.enable()
     @submitButton.setTitle 'CONTINUE'
     @submitButton.setCallback =>
       @submitButton.hideLoader()

--- a/client/Main/payment/workflow.coffee
+++ b/client/Main/payment/workflow.coffee
@@ -126,7 +126,7 @@ class PaymentWorkflow extends KDController
     @state.provider = STRIPE  if @state.provider is KODING
 
     shouldRegisterNewPlan = \
-      currentPlan is PaymentWorkflow.planTitle.FREE or
+      currentPlan is PaymentConstants.planTitle.FREE or
       @state.subscriptionState is 'expired'
 
     if shouldRegisterNewPlan


### PR DESCRIPTION
This PR introduces several minor fixes for Payment workflow.
- [x] fixes a reference error, it was forgotten to be changed to `PaymentConstants` from `PaymentWorkflow`
- [x] doesn't show credit card form no matter what if user is downgrading to free.
- [x] fixes view problems at the success state of modal after a successful `PayPal` transaction.

/cc @sent-hil 
