### PR TITLE
Kloud: refactor validation and add kloudctl bypassing 

### DIFF
--- a/go/src/koding/kites/kloud/kloud/controller.go
+++ b/go/src/koding/kites/kloud/kloud/controller.go
@@ -244,6 +244,15 @@ func (k *Kloud) coreMethods(r *kite.Request, fn controlFunc) (result interface{}
 		return nil, NewError(ErrProviderAvailable)
 	}
 
+	// if the provider implements the validate method, validate it before we
+	// call any method
+	if validator, ok := provider.(protocol.Validator); ok {
+		err := validator.Validate(machine, r)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	controller, ok := provider.(protocol.Provider)
 	if !ok {
 		return nil, NewError(ErrProviderNotImplemented)

--- a/go/src/koding/kites/kloud/protocol/protocol.go
+++ b/go/src/koding/kites/kloud/protocol/protocol.go
@@ -3,6 +3,8 @@ package protocol
 import (
 	"koding/kites/kloud/eventer"
 	"koding/kites/kloud/machinestate"
+
+	"github.com/koding/kite"
 )
 
 // Provider manages a machine, it's start/stop/destroy/restart a machine.
@@ -33,6 +35,12 @@ type Provider interface {
 
 	// Info returns full information about a single machine
 	Info(*Machine) (*InfoArtifact, error)
+}
+
+// Validator validates a machine before passing it to the provider's
+// appropriate method call.
+type Validator interface {
+	Validate(machine *Machine, request *kite.Request) error
 }
 
 // Machine is used as a data source for the appropriate interfaces

--- a/go/src/koding/kites/kloud/protocol/protocol.go
+++ b/go/src/koding/kites/kloud/protocol/protocol.go
@@ -56,6 +56,10 @@ type Machine struct {
 	// Username defines the owner of the machine
 	Username string
 
+	// UserId is a unique id that defines a user. It can be used to verify
+	// identifiy a username
+	UserId string
+
 	// Provider defines the provider in which the data is used to be operated.
 	Provider string
 

--- a/go/src/koding/kites/kloud/protocol/protocol.go
+++ b/go/src/koding/kites/kloud/protocol/protocol.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"koding/db/models"
 	"koding/kites/kloud/eventer"
 	"koding/kites/kloud/machinestate"
 
@@ -56,9 +57,12 @@ type Machine struct {
 	// Username defines the owner of the machine
 	Username string
 
-	// UserId is a unique id that defines a user. It can be used to verify
-	// identifiy a username
-	UserId string
+	// User information.
+	User *models.User
+
+	// SharedUsers contain a list of users that have access to this machine.
+	// The list can contains the machine owner too.
+	SharedUsers []models.Permissions
 
 	// Provider defines the provider in which the data is used to be operated.
 	Provider string

--- a/go/src/koding/kites/kloud/provider/koding/mongodb.go
+++ b/go/src/koding/kites/kloud/provider/koding/mongodb.go
@@ -43,24 +43,13 @@ func (p *Provider) Get(id string) (*protocol.Machine, error) {
 		return nil, err
 	}
 
-	// do not check for admin users, or if test mode is enabled
-	if !IsAdmin(username) {
-		// check for user permissions
-		if err := p.checkUser(user.ObjectId, machine.Users); err != nil && !p.Test {
-			return nil, err
-		}
-
-		if user.Status != "confirmed" {
-			return nil, kloud.NewError(kloud.ErrUserNotConfirmed)
-		}
-	}
-
 	credential := p.GetCredential(machine.Credential)
 
 	m := &protocol.Machine{
 		Id:          id,
 		Username:    machine.Credential, // contains the username for koding provider
-		UserId:      user.ObjectId.Hex(),
+		User:        user,
+		SharedUsers: machine.Users,
 		Provider:    machine.Provider,
 		Builder:     machine.Meta,
 		Credential:  credential.Meta,

--- a/go/src/koding/kites/kloud/provider/koding/mongodb.go
+++ b/go/src/koding/kites/kloud/provider/koding/mongodb.go
@@ -60,6 +60,7 @@ func (p *Provider) Get(id string) (*protocol.Machine, error) {
 	m := &protocol.Machine{
 		Id:          id,
 		Username:    machine.Credential, // contains the username for koding provider
+		UserId:      user.ObjectId.Hex(),
 		Provider:    machine.Provider,
 		Builder:     machine.Meta,
 		Credential:  credential.Meta,

--- a/go/src/koding/kites/kloud/provider/koding/permission.go
+++ b/go/src/koding/kites/kloud/provider/koding/permission.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"koding/db/models"
 	"koding/kites/kloud/kloud"
+	"koding/kites/kloud/kloudctl/command"
 	"koding/kites/kloud/protocol"
 
 	"github.com/koding/kite"
@@ -21,6 +22,11 @@ func (p *Provider) Validate(m *protocol.Machine, r *kite.Request) error {
 
 	// do not check for admin users, or if test mode is enabled
 	if isAdmin(username) {
+		return nil
+	}
+
+	// give access to kloudctl
+	if r.Auth.Key == command.KloudSecretKey {
 		return nil
 	}
 

--- a/go/src/koding/kites/kloud/provider/koding/permission.go
+++ b/go/src/koding/kites/kloud/provider/koding/permission.go
@@ -16,6 +16,7 @@ import (
 var admins = []string{"kloud", "koding"}
 
 func (p *Provider) Validate(m *protocol.Machine, r *kite.Request) error {
+	p.Log.Debug("[%s] validating for method '%s'", m.Id, r.Method)
 	username := m.Username
 
 	// do not check for admin users, or if test mode is enabled

--- a/go/src/koding/kites/kloud/provider/koding/provider.go
+++ b/go/src/koding/kites/kloud/provider/koding/provider.go
@@ -366,7 +366,6 @@ func (p *Provider) Reinit(m *protocol.Machine) (*protocol.Artifact, error) {
 }
 
 func (p *Provider) Destroy(m *protocol.Machine) error {
-
 	if m.State == machinestate.NotInitialized {
 		return nil
 	}


### PR DESCRIPTION
This is needed so we can bypass validation of admin users, such as `kloudctl` or `vmwatcher`.
