### PR TITLE
activity feed: change link's color to green in comments area[fixes #86871726]

### DIFF
--- a/client/Social/Activity/styl/activity.listitem.styl
+++ b/client/Social/Activity/styl/activity.listitem.styl
@@ -467,7 +467,6 @@ activity.listitem.styl
 
         p
           a
-            color         inherit
             noTextDeco()
             font-weight   600
 


### PR DESCRIPTION
Now it looks like post's links
![greenlinks](https://cloud.githubusercontent.com/assets/295206/5937335/55ee0e30-a6ff-11e4-9209-74c595f372f5.png)
