### PR TITLE
embedly: remove 'content' from embedly data

### DIFF
--- a/client/Social/Activity/views/embedboxwidget.coffee
+++ b/client/Social/Activity/views/embedboxwidget.coffee
@@ -182,7 +182,7 @@ class EmbedBoxWidget extends KDView
     @imageIndex = 0
 
     desiredFields = [
-      'url', 'safe', 'type', 'provider_name', 'error_type', 'content',
+      'url', 'safe', 'type', 'provider_name', 'error_type',
       'error_message', 'safe_type', 'safe_message', 'images'
     ]
 


### PR DESCRIPTION
Content field in Embedly was fetching all the page content, which is totaly useless in our side. 
