### PR TITLE
Sidebar: Do not switch workspace on asynchronous event [fixes #85116430]

### DIFF
--- a/client/Social/Activity/sidebar/activitysidebar.coffee
+++ b/client/Social/Activity/sidebar/activitysidebar.coffee
@@ -652,7 +652,6 @@ class ActivitySidebar extends KDCustomHTMLView
       if state.status is Running
         machine.status.state = Running
         if appManager.getFrontApp().mountedMachineUId is machine.uid
-          @selectWorkspace { workspace, machine }
           delete @watchedMachines[machine._id]
 
     computeController.on "public-#{machine._id}", callback


### PR DESCRIPTION
[When user has more than two VMs on, the workspaces keep switching in the sidebar](https://www.pivotaltracker.com/story/show/85116430)
