### PR TITLE
Machine Model Helper: fetch only machines from koding provider

### DIFF
--- a/go/src/koding/db/mongodb/modelhelper/machine.go
+++ b/go/src/koding/db/mongodb/modelhelper/machine.go
@@ -86,7 +86,7 @@ func GetMachinesByUsername(username string) ([]*models.Machine, error) {
 
 	query := func(c *mgo.Collection) error {
 		return c.Find(
-			bson.M{"users.id": user.ObjectId, "users.sudo": true},
+			bson.M{"provider": "koding", "users.id": user.ObjectId, "users.sudo": true},
 		).All(&machines)
 	}
 


### PR DESCRIPTION
Since we have machine support for multiple providers, we need to limit vmwatcher to work only with `koding` provider. If we need to use `vmwatcher` for different providers too, we need to implement it in that way.
