### PR TITLE
social/activity: changed condition for preview update [fixes# 87103112]

### DIFF
--- a/client/Social/Activity/views/embedboxwidget.coffee
+++ b/client/Social/Activity/views/embedboxwidget.coffee
@@ -34,10 +34,11 @@ class EmbedBoxWidget extends KDView
 
     @embedLinks = new EmbedBoxLinksView { delegate: this }
 
-    @embedLinks.on 'LinkAdded', ({ url }) =>
+    @embedLinks.on 'LinkAdded', (url) =>
       @show()
       # if the embed index isn't set, set it to 0
       @setEmbedIndex 0  unless @getEmbedIndex()?
+      @addEmbed url
 
     @embedLinks.on 'LinkRemoved', ({ url, index }) =>
       @hide()  if @embedLinks.getLinkCount() is 0
@@ -61,14 +62,18 @@ class EmbedBoxWidget extends KDView
 
     fn = @bound 'checkInputForUrls'
 
+    delay = 1000
+    timerId = null
     input.on 'keydown', (event) ->
-      fn()  if event.which in [9, 13, 32]
+      window.clearTimeout timerId
+      timerId = window.setTimeout fn, delay
 
     input.on 'paste', fn
     input.on 'change', fn
 
   checkInputForUrls: ->
     KD.utils.defer =>
+
       input = @getDelegate()
       text = input.getValue()
 
@@ -76,7 +81,6 @@ class EmbedBoxWidget extends KDView
 
       staleUrls = _.difference @urls, urls
       newUrls   = _.difference urls, @urls
-
 
       @embedLinks.addLink     newUrl    for newUrl    in newUrls
       @embedLinks.removeLink  staleUrl  for staleUrl  in staleUrls

--- a/client/Social/Activity/views/embedboxwidget.coffee
+++ b/client/Social/Activity/views/embedboxwidget.coffee
@@ -63,11 +63,10 @@ class EmbedBoxWidget extends KDView
     fn = @bound 'checkInputForUrls'
 
     delay = 1000
-    timerId = null
+    timer = null
     input.on 'keydown', (event) ->
-      window.clearTimeout timerId
-      timerId = window.setTimeout fn, delay
-
+      KD.utils.killWait timer
+      timer = KD.utils.wait delay, fn
     input.on 'paste', fn
     input.on 'change', fn
 


### PR DESCRIPTION
|'ve added functionality for updating preview on editing. We use to press `space` or `escape` to trigger preview update. Now it updates on any changes.
It partially fixed problem that @canthefason descriped in https://github.com/koding/koding/pull/2584
But @canthefason there is a way to press 'Done' before preview was updated(it takes time to load url's data).
So i don't have any data to send it to server side.(just url) 
I'm not sure what is the best way to resolved this.

I suggest following solutions:

1) check it on server side and load if needed
2) disable 'Done' button while preview is updating
3) or on  press 'Done' handler, wait for preview updating before sent a request for update/create

@sinan @usirin @canthefason Could you advise what to do with above case?

cc: @ksavinkin FYI
