### PR TITLE
Position warning popup in the center of the screen [fixes #85779626]

### DIFF
--- a/client/Main/activitycontroller.coffee
+++ b/client/Main/activitycontroller.coffee
@@ -58,7 +58,7 @@ class ActivityController extends KDObject
                   KD.showErrorNotification err, options
                   modal.modalTabs.forms.BlockUser.buttons.blockUser.hideLoader()
                 else
-                  KD.showNotification "User is blocked!"
+                  KD.showNotification "User is blocked!", { type: "main" }
 
                 modal.destroy()
 
@@ -151,7 +151,7 @@ class ActivityController extends KDObject
           options = userMessage: "You are not allowed to mark this user as a troll"
           KD.showErrorNotification err, options
         else
-          KD.showNotification "@#{acc.profile.nickname} won't be treated as a troll anymore!"
+          KD.showNotification "@#{acc.profile.nickname} won't be treated as a troll anymore!", { type: "main" }
 
     if data.account._id
       KD.remote.cacheable "JAccount", data.account._id, (err, account)->
@@ -187,7 +187,7 @@ class ActivityController extends KDObject
                   options = userMessage: "You are not allowed to mark this user as a troll"
                   KD.showErrorNotification err, options
                 else
-                  KD.showNotification "@#{acc.profile.nickname} marked as a troll!"
+                  KD.showNotification "@#{acc.profile.nickname} marked as a troll!", { type: "main" }
 
                 modal.destroy()
 


### PR DESCRIPTION
@sinan, @canthefason - can you review this fix? It is related to https://www.pivotaltracker.com/story/show/85779626

Usage of `KD.showNotification(message, options)` to show a notification puts it near the right border of the screen by default (if options.type is not specified, it's set to "growl"). At the same time there are a lot places in the code where notifications are centered on the screen - for example, `new KDNotificationView { title: "Some text" }` (type is not specified and by default it is set to "main"). Maybe it makes sense to show a notification at the same position in both variants of code, i.e. at the center by default? What do you think?
