### PR TITLE
Several fixes for 'Add new participant' flow for both regular and collaborative chat [fixes #87683482 #87683192]

### DIFF
--- a/client/Social/Activity/includes.coffee
+++ b/client/Social/Activity/includes.coffee
@@ -117,6 +117,7 @@ module.exports = [
   "views/comments/timeview.coffee"
 
   "views/privatemessage/listitem.coffee"
+  "views/privatemessage/participantsearchcontroller.coffee"
   "views/privatemessage/form.coffee"
   "views/privatemessage/kodingbot.coffee"
   "views/privatemessage/pane.coffee"

--- a/client/Social/Activity/styl/activity.pm.styl
+++ b/client/Social/Activity/styl/activity.pm.styl
@@ -653,6 +653,9 @@ timeColor2 = #5F9E5E
     line-height         26px
     fl()
 
+    &.active .icon
+      vendor            transform, rotate(45deg)
+
     .icon
       display           inline-block
       r-sprite          'activity', 'new-participant-plus'

--- a/client/Social/Activity/styl/activity.styl
+++ b/client/Social/Activity/styl/activity.styl
@@ -187,7 +187,7 @@ body.activity
     font-size             16px
     font-weight           300
     letter-spacing        .02em
-    
+
 .status.content-display
   article
     max-height          100%
@@ -671,7 +671,7 @@ span.collapsedtext
 
   .kdcustomscrollview
     styleScrollBars       rgba(0,0,0,.15)
-  
+
     .kdview.kdscrolltrack:hover
       background          rgba(0,0,0,0.05)
 
@@ -948,6 +948,7 @@ dropdownBorder = 1px solid #E0E0E0
   rounded           0
   shadow            dropdownShadow
   margin-top        0
+  min-width         268px
   fix()
 
   .kdautocompletelistitem

--- a/client/Social/Activity/views/privatemessage/pane.coffee
+++ b/client/Social/Activity/views/privatemessage/pane.coffee
@@ -338,8 +338,24 @@ class PrivateMessagePane extends MessagePane
     return  unless participant
     return  unless @participantMap[participant._id]?
 
-    @participantMap[participant._id].destroy()
-    delete @participantMap[participant._id]
+    KD.remote.cacheable 'JAccount', participant._id, (err, account) =>
+
+      return warn err  if err
+
+      @participantMap[participant._id].destroy()
+      delete @participantMap[participant._id]
+
+      @removeFromAutoCompleteSelectedList account
+
+
+  removeFromAutoCompleteSelectedList: (account) ->
+
+    return  unless account in @autoComplete.getSelectedItemData()
+
+    # remove the account from autocomplete controller's
+    # selected list. So that it can show up in other searchs.
+    @autoComplete.removeSelectedItemData account
+    @autoComplete.selectedItemCounter--
 
 
   createPreviousLink: ->

--- a/client/Social/Activity/views/privatemessage/pane.coffee
+++ b/client/Social/Activity/views/privatemessage/pane.coffee
@@ -377,21 +377,16 @@ class PrivateMessagePane extends MessagePane
     @participantsView.addSubView @newParticipantButton = new KDButtonView
       cssClass    : 'new-participant'
       iconOnly    : yes
-      callback    : @bound 'showAutoCompleteInput'
+      callback    : @bound 'toggleAutoCompleteInput'
 
 
-  showAutoCompleteInput: ->
+  toggleAutoCompleteInput: ->
 
     @emit 'NewParticipantButtonClicked'
 
     @autoCompleteForm.toggleClass 'active'
     @newParticipantButton.toggleClass 'active'
     @autoComplete.getView().setFocus()  if @autoCompleteForm.hasClass 'active'
-
-    @autoComplete.getView().once 'blur',=>
-      @autoCompleteForm.toggleClass 'active'
-      @newParticipantButton.toggleClass 'active'
-      @input.input.setFocus()
 
 
   createAddParticipantForm: ->
@@ -416,6 +411,8 @@ class PrivateMessagePane extends MessagePane
       dataSource          : @bound 'fetchAccounts'
 
     @autoCompleteForm.inputs.recipient.addSubView @autoComplete.getView()
+
+    @autoComplete.on 'ItemSelected', @bound 'toggleAutoCompleteInput'
 
     @autoComplete.on 'ItemListChanged', (count) =>
       participant  = @autoComplete.getSelectedItemData()[count - 1]

--- a/client/Social/Activity/views/privatemessage/pane.coffee
+++ b/client/Social/Activity/views/privatemessage/pane.coffee
@@ -345,17 +345,7 @@ class PrivateMessagePane extends MessagePane
       @participantMap[participant._id].destroy()
       delete @participantMap[participant._id]
 
-      @removeFromAutoCompleteSelectedList account
-
-
-  removeFromAutoCompleteSelectedList: (account) ->
-
-    return  unless account in @autoComplete.getSelectedItemData()
-
-    # remove the account from autocomplete controller's
-    # selected list. So that it can show up in other searchs.
-    @autoComplete.removeSelectedItemData account
-    @autoComplete.selectedItemCounter--
+      @autoComplete.removeSelectedParticipant account
 
 
   createPreviousLink: ->
@@ -414,11 +404,12 @@ class PrivateMessagePane extends MessagePane
           itemClass      : KDView
       submit             : (e) -> e.preventDefault()
 
-    @autoComplete = new KDAutoCompleteController
+    @autoComplete = new ParticipantSearchController
       name                : 'userController'
       placeholder         : 'Type a username...'
       itemClass           : ActivityAutoCompleteUserItemView
       itemDataPath        : 'profile.nickname'
+      fetchInterval       : 0
       outputWrapper       : new KDView cssClass: 'hidden'
       listWrapperCssClass : 'private-message hidden'
       submitValuesAsText  : yes

--- a/client/Social/Activity/views/privatemessage/participantsearchcontroller.coffee
+++ b/client/Social/Activity/views/privatemessage/participantsearchcontroller.coffee
@@ -1,0 +1,79 @@
+class ParticipantSearchController extends KDAutoCompleteController
+
+  ### @constant {number} ###
+  SHOW_LOADER_TIMEOUT = 1000
+
+  constructor: (options = {}, data) ->
+
+    super options, data
+
+    @extendEvents()
+
+
+  ###*
+   * Extends the events of KDAutoCompleteController.
+   *
+   * @emits ItemSelected - when a new participant added.
+   * @emits ItemDeselected - when a new participant removed.
+  ###
+  extendEvents: ->
+
+    initialCount = 0
+
+    @on 'ItemListChanged', (count) =>
+
+      return  if count is initialCount
+
+      if count > initialCount
+      then @emit 'ItemSelected'
+      else @emit 'ItemDeselected'
+
+
+  ###*
+   * Removes a selected participant from the selected list.
+   *
+   * @param {JAccount} participant
+  ###
+  removeSelectedParticipant: (participant) ->
+
+    return  unless participant in @getSelectedItemData()
+
+    @removeSelectedItemData participant
+    @selectedItemCounter--
+
+
+  ###*
+   * Full override for delaying `showFetching` method.
+  ###
+  updateDropdownContents:->
+
+    inputView = @getView()
+    value     = inputView.getValue().trim()
+
+    return @hideDropdown() if value is ''
+
+    return if @active and value is @dropdownPrefix
+
+    @dropdownPrefix = value
+
+    {fetchInterval} = @getOptions()
+
+    # delay the execution of show loading method.
+    # if the fetching happens before timeout constant
+    # we will simply kill the waited version of the function.
+    # so that the loader will not be shown, and it will result in
+    # a better UX. ~Umut
+    delayed = KD.utils.wait SHOW_LOADER_TIMEOUT, => @showFetching()
+
+    @fetch KD.utils.debounce fetchInterval, (data) =>
+
+      KD.utils.killWait delayed
+
+      if data.length > 0
+        @refreshDropDown data
+        @showDropdown()
+      else
+        log 'no data found'
+        @showNoDataFound()
+
+


### PR DESCRIPTION
This PR fixes several problems with 'Add new participant' flow.
- [x] Removed participant should be deleted from auto complete controller's selected item list.

```
Commit log:

We were forgetting to sync up autocomplete controller's selected item data with chat's participant list data. This commit fixes that by manually removing the item and decreasing the count.
```
- [x] Introduce `ParticipantSearchController` as a subclass of `KDAutoCompleteController` to override some default behavior for this particular use. 

```
Commit log for ParticipantSearchController:

Autocomplete controller required some overrides for this particular use. especially `showFetching` method calls were causing glitches. This class delays the execution of the `showFetching` method in order to provide a better experience when typing a username.
```
- [x] Instead of showing or hiding the new participant input, toggle the state with new participant button.
- [x] Rotate the `plus` icon to look like `cross` icon when the new participant input is active.

```
Input-Autocomplete form relationship was really bad, the visibility state was broken. This PR fixes that behavior.
```
- [x] Add a minimum width for search result list.

```
Commit log:

This was mainly targeted for collaboration chat window. It also looks and works good in regular Private Chat window.
```
## Preview

![collab-chat-autocomplete](https://cloud.githubusercontent.com/assets/1783869/6075208/135adb0e-ad83-11e4-985b-21ba9acdebcc.gif)

![regular-chat-autocomplete](https://cloud.githubusercontent.com/assets/1783869/6075220/50e74d72-ad83-11e4-916d-4f5280ce0793.gif)
