### PR TITLE
Kloud domain fixes

### DIFF
--- a/client/Main/domains/managedomainsview.coffee
+++ b/client/Main/domains/managedomainsview.coffee
@@ -222,13 +222,8 @@ class ManageDomainsView extends KDView
           loader    :
             color   : 'darkred'
           callback  : ->
-            computeController.getKloud()
-              .unsetDomain {domainName: domain, machineId}
-              .then -> callback yes
-              .catch (err)->
-                warn err
-                callback no
-              .finally -> modal.destroy()
+            modal.destroy()
+            callback yes
         cancel      :
           title     : "Cancel"
           style     : 'modal-cancel'

--- a/go/src/koding/kites/kloud/provider/koding/route53.go
+++ b/go/src/koding/kites/kloud/provider/koding/route53.go
@@ -221,6 +221,10 @@ func (d *DNS) HostedZone() string {
 func (d *DNS) Validate(domain, username string) error {
 	hostedZone := d.hostedZone
 
+	if domain == "" {
+		return fmt.Errorf("Domain name argument is empty")
+	}
+
 	if domain == hostedZone {
 		return fmt.Errorf("Domain '%s' can't be the same as top-level domain '%s'", domain, hostedZone)
 	}


### PR DESCRIPTION
- Fix `domain.set` when previous machine ID was destroyed. 
