### PR TITLE
Sidebar: Update machine tree when a new workspace is created

### DIFF
--- a/client/Social/Activity/sidebar/activitysidebar.coffee
+++ b/client/Social/Activity/sidebar/activitysidebar.coffee
@@ -33,6 +33,7 @@ class ActivitySidebar extends KDCustomHTMLView
     super options
 
     {
+      mainController
       notificationController
       computeController
       socialapi
@@ -71,6 +72,10 @@ class ActivitySidebar extends KDCustomHTMLView
 
     @on 'MoreWorkspaceModalRequested', @bound 'handleMoreWorkspacesClick'
     @on 'ReloadMessagesRequested',     @bound 'handleReloadMessages'
+
+    mainController.ready =>
+      KD.whoami().on 'NewWorkspaceCreated', @bound 'newWorkspaceCreated'
+
 
   # event handling
 
@@ -980,3 +985,9 @@ class ActivitySidebar extends KDCustomHTMLView
 
     for nodeId, node of nodes when node.data?.jMachine is jMachine
       @machineTree.removeNode nodeId
+
+
+  newWorkspaceCreated: (workspace) ->
+
+    KD.userWorkspaces.push workspace
+    @updateMachineTree()

--- a/workers/social/lib/social/models/account.coffee
+++ b/workers/social/lib/social/models/account.coffee
@@ -53,6 +53,7 @@ module.exports = class JAccount extends jraphical.Module
         # { name: 'updateInstance' }
         { name: 'notification' }
         { name : "RemovedFromCollection" }
+        { name : 'NewWorkspaceCreated'}
       ]
     sharedMethods :
       static:

--- a/workers/social/lib/social/models/workspace.coffee
+++ b/workers/social/lib/social/models/workspace.coffee
@@ -70,6 +70,8 @@ module.exports = class JWorkspace extends Module
 
       workspace.save (err) ->
         return callback err  if err
+
+        delegate.emit 'NewWorkspaceCreated', workspace
         return callback null, workspace
 
 


### PR DESCRIPTION
[When host creates a new workspace it is not synced with the second tab](https://www.pivotaltracker.com/story/show/87776576)
