### PR TITLE
server: only return confirmed users in /payments/customers

### DIFF
--- a/go/src/koding/db/models/account.go
+++ b/go/src/koding/db/models/account.go
@@ -8,18 +8,13 @@ import (
 )
 
 type Account struct {
-	Id          bson.ObjectId `bson:"_id" json:"_id"`
-	GlobalFlags []string      `bson:"globalFlags" json:"globalFlags"`
-	SocialApiId string        `bson:"socialApiId" json:"socialApiId"`
-	Profile     struct {
-		Nickname  string `bson:"nickname" json:"nickname"`
-		FirstName string `bson:"firstName" json:"firstName"`
-		LastName  string `bson:"lastName" json:"lastName"`
-		Hash      string `bson:"hash" json:"hash"`
-	} `bson:"profile" json:"profile"`
-	Type       string `bson:"type" json:"type"`
-	Status     string `bson:"status" json:"status"`
-	SystemInfo struct {
+	Id          bson.ObjectId  `bson:"_id" json:"_id"`
+	GlobalFlags []string       `bson:"globalFlags" json:"globalFlags"`
+	SocialApiId string         `bson:"socialApiId" json:"socialApiId"`
+	Type        string         `bson:"type" json:"type"`
+	Status      string         `bson:"status" json:"status"`
+	Profile     AccountProfile `bson:"profile" json:"profile"`
+	SystemInfo  struct {
 		DefaultToLastUsedEnvironment bool `json:"defaultToLastUsedEnvironment" bson:"defaultToLastUsedEnvironment"`
 	} `json:"systemInfo"`
 	OnlineStatus bool `bson:"onlineStatus" json:"onlineStatus"`
@@ -30,6 +25,13 @@ type Account struct {
 	} `bson:"meta" json:"meta"`
 	IsExempt                bool `json:"isExempt" bson:"isExempt"`
 	LastLoginTimezoneOffset int  `json:"lastLoginTimezoneOffset" bson:"lastLoginTimezoneOffset"`
+}
+
+type AccountProfile struct {
+	Nickname  string `bson:"nickname" json:"nickname"`
+	FirstName string `bson:"firstName" json:"firstName"`
+	LastName  string `bson:"lastName" json:"lastName"`
+	Hash      string `bson:"hash" json:"hash"`
 }
 
 func (a *Account) GetSocialApiId() (int64, error) {

--- a/go/src/koding/vmwatcher/main.go
+++ b/go/src/koding/vmwatcher/main.go
@@ -107,6 +107,7 @@ func main() {
 			switch signal {
 			case syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGSTOP, syscall.SIGKILL:
 				listener.Close()
+				controller.Klient.Close()
 				os.Exit(0)
 			}
 		}

--- a/go/src/socialapi/workers/payment/api/api.go
+++ b/go/src/socialapi/workers/payment/api/api.go
@@ -37,6 +37,14 @@ func GetCustomersRequest(u *url.URL, h http.Header, _ interface{}) (int, http.He
 	)
 }
 
+func ExpireCustomerRequest(u *url.URL, h http.Header, req *payment.AccountRequest) (int, http.Header, interface{}, error) {
+	req.AccountId = u.Query().Get("accountId")
+
+	return response.HandleResultAndClientError(
+		req.Expire(),
+	)
+}
+
 func DeleteCustomerRequest(u *url.URL, h http.Header, _ interface{}) (int, http.Header, interface{}, error) {
 	req := &payment.AccountRequest{
 		AccountId: u.Query().Get("accountId"),

--- a/go/src/socialapi/workers/payment/api/handlers.go
+++ b/go/src/socialapi/workers/payment/api/handlers.go
@@ -47,6 +47,14 @@ func AddHandlers(m *mux.Mux) {
 			Endpoint: "/payments/customers/{accountId}",
 		})
 
+	m.AddHandler(
+		handler.Request{
+			Handler:  ExpireCustomerRequest,
+			Name:     "payment-expirecustomer",
+			Type:     handler.PostRequest,
+			Endpoint: "/payments/customers/{accountId}/expire",
+		})
+
 	//----------------------------------------------------------
 	// Invoices
 	//----------------------------------------------------------

--- a/go/src/socialapi/workers/payment/payment.go
+++ b/go/src/socialapi/workers/payment/payment.go
@@ -167,6 +167,21 @@ func (a *AccountRequest) ActiveUsernames() ([]string, error) {
 	return usernames, nil
 }
 
+func (a *AccountRequest) Expire() (interface{}, error) {
+	customer := paymentmodels.NewCustomer()
+	err := customer.ByOldId(a.AccountId)
+	if err != nil {
+		return nil, err
+	}
+
+	subscription, err := customer.FindActiveSubscription()
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, subscription.Expire()
+}
+
 //----------------------------------------------------------
 // UpdateCreditCard
 //----------------------------------------------------------

--- a/go/src/socialapi/workers/payment/payment_test.go
+++ b/go/src/socialapi/workers/payment/payment_test.go
@@ -1,10 +1,12 @@
 package payment
 
 import (
+	"koding/db/models"
 	"koding/db/mongodb/modelhelper"
 	"math/rand"
 	"socialapi/config"
 	"socialapi/workers/common/runner"
+	"socialapi/workers/payment/paymenterrors"
 	"socialapi/workers/payment/paymentmodels"
 	"socialapi/workers/payment/stripe"
 	"testing"
@@ -31,29 +33,62 @@ func init() {
 	rand.Seed(time.Now().UTC().UnixNano())
 }
 
-// func TestGetAllCustomers(t *testing.T) {
-//   Convey("Given two actively subscribed users", t, func() {
-//     token, accId, email := generateFakeUserInfo()
-//     err := stripe.Subscribe(
-//       token, accId, email, StartingPlan, StartingInterval,
-//     )
-//     So(err, ShouldBeNil)
+func TestGetAllCustomers(t *testing.T) {
+	Convey("Given two actively subscribed users", t, func() {
+		account := &models.Account{
+			Id:      bson.NewObjectId(),
+			Profile: models.AccountProfile{Nickname: "indianajones"},
+		}
+		err := modelhelper.CreateAccount(account)
+		So(err, ShouldBeNil)
 
-//     token, accId, email = generateFakeUserInfo()
-//     err = stripe.Subscribe(
-//       token, accId, email, StartingPlan, StartingInterval,
-//     )
-//     So(err, ShouldBeNil)
+		accId := account.Id.Hex()
 
-//     Convey("Then it should return their usernames", func() {
-//       req := AccountRequest{}
-//       usernames, err := req.ActiveUsernames()
-//       So(err, ShouldBeNil)
+		token, _, email := generateFakeUserInfo()
+		err = stripe.Subscribe(
+			token, accId, email, StartingPlan, StartingInterval,
+		)
+		So(err, ShouldBeNil)
 
-//       So(len(usernames), ShouldBeGreaterThan, 1)
-//     })
-//   })
-// }
+		Convey("Then it should return their usernames", func() {
+			req := AccountRequest{}
+			usernames, err := req.ActiveUsernames()
+			So(err, ShouldBeNil)
+
+			So(len(usernames), ShouldEqual, 1)
+			So(usernames[0], ShouldEqual, "indianajones")
+
+			Reset(func() {
+				modelhelper.RemoveAccount(account.Id)
+			})
+		})
+	})
+}
+
+func TestExpireSubscription(t *testing.T) {
+	Convey("Given user with active subscription", t, func() {
+		token, accId, email := generateFakeUserInfo()
+		err := stripe.Subscribe(
+			token, accId, email, StartingPlan, StartingInterval,
+		)
+		So(err, ShouldBeNil)
+
+		Convey("When request to expire subscription", func() {
+			req := AccountRequest{AccountId: accId}
+			_, err = req.Expire()
+			So(err, ShouldBeNil)
+
+			customer := paymentmodels.NewCustomer()
+			err = customer.ByOldId(req.AccountId)
+			So(err, ShouldBeNil)
+
+			Convey("Then it should expire subscription", func() {
+				_, err = customer.FindActiveSubscription()
+				So(err, ShouldEqual, paymenterrors.ErrCustomerNotSubscribedToAnyPlans)
+			})
+		})
+	})
+}
 
 func TestSubscriptionsRequest(t *testing.T) {
 	Convey("Given nonexistent user", t, func() {

--- a/go/src/socialapi/workers/payment/paymentwebhook/main.go
+++ b/go/src/socialapi/workers/payment/paymentwebhook/main.go
@@ -42,6 +42,7 @@ func main() {
 
 	// initialize client to talk to kloud
 	kiteClient := initializeKiteClient(r.Kite, kloud.SecretKey, kloud.Address)
+	defer kiteClient.Close()
 
 	// initialize client to send email
 	email := initializeEmail(conf.Email)

--- a/workers/social/lib/social/models/account.coffee
+++ b/workers/social/lib/social/models/account.coffee
@@ -2,6 +2,9 @@ jraphical   = require 'jraphical'
 KodingError = require '../error'
 ApiError    = require './socialapi/error'
 
+{argv}      = require 'optimist'
+KONFIG      = require('koding-config-manager').load("main.#{argv.c}")
+
 module.exports = class JAccount extends jraphical.Module
 
   @trait __dirname, '../traits/followable'
@@ -216,8 +219,8 @@ module.exports = class JAccount extends jraphical.Module
           (signature Function)
         setLastLoginTimezoneOffset:
           (signature Object, Function)
-        fetchCustomers:
-          (signature Object, Function)
+        expireSubscription:
+          (signature Function)
 
     schema                  :
       socialApiId           : String
@@ -1386,9 +1389,9 @@ module.exports = class JAccount extends jraphical.Module
       return callback new KodingError "Could not update last login timezone offset" if err
       callback null
 
-  fetchCustomers: secure ({connection}, options, callback) ->
-    if not isDummyAdmin connection.delegate.profile.nickname
+  expireSubscription: secure ({connection}, callback) ->
+    if KONFIG.environment is "production"
       return callback new KodingError "permission denied"
 
-    {getCustomers} = require './socialapi/requests'
-    getCustomers options, callback
+    {expireSubscription} = require "./socialapi/requests"
+    expireSubscription connection.delegate.getId(), callback

--- a/workers/social/lib/social/models/socialapi/requests.coffee
+++ b/workers/social/lib/social/models/socialapi/requests.coffee
@@ -384,9 +384,9 @@ checkOwnership = (data, callback) ->
   url = "/account/#{data.accountId}/owns"
   get url, data, callback
 
-getCustomers = (data, callback) ->
-  url = "/payments/customers"
-  get url, data, callback
+expireSubscription = (accountId, callback) ->
+  url = "/payments/customers/#{accountId}/expire"
+  post url, {}, callback
 
 post = (url, data, callback)->
   getNextApiURL (err, apiurl)->
@@ -506,7 +506,7 @@ module.exports = {
   getSiteMap
   deleteChannel
   checkOwnership
-  getCustomers
+  expireSubscription
   post
   get
   deleteReq


### PR DESCRIPTION
- Send only email confirmed list of paying customers in /-/payments/customers
- Expose api for user (in non prod) environs to expire their own subscription
- Close kite connections when worker goes down (attempt to fix bug where worker doesn't restart properly between version changes)

Ping @canthefason 
