### PR TITLE
fix bug: saveAs dialog display filetree for each active Vms [fixes #84387436]

### DIFF
--- a/client/ace/lib/aceview.coffee
+++ b/client/ace/lib/aceview.coffee
@@ -190,7 +190,7 @@ module.exports = class AceView extends JView
 
         @getDelegate().openSavedFile newFile, contents
 
-    , { inputDefaultValue: file.name }
+    , { inputDefaultValue: file.name, machine: file.machine }
 
   _windowDidResize:->
     height = @getHeight()

--- a/client/ace/lib/aceview.coffee
+++ b/client/ace/lib/aceview.coffee
@@ -162,6 +162,7 @@ module.exports = class AceView extends JView
     file = @getData()
     container = @getOptions().delegate or this
 
+
     showSaveDialog container, (input, finderController, dialog) =>
 
       [node] = finderController.treeController.selectedNodes

--- a/client/app/lib/util/showSaveDialog.coffee
+++ b/client/app/lib/util/showSaveDialog.coffee
@@ -53,6 +53,7 @@ module.exports = (container, callback = kd.noop, options = {}) ->
     foldersOnly       : yes
     contextMenu       : no
     loadFilesOnInit   : yes
+    machineToMount    : options.machine
 
   finder = finderController.getView()
   finderController.reset()


### PR DESCRIPTION
fix for related bug(https://www.pivotaltracker.com/story/show/84387436)
it is http://recordit.co/kTKwMSnTHL

cc: @sinan @usirin @szkl 
