### PR TITLE
analytics: send user info from client side to segment

### DIFF
--- a/client/Main/mixpanel.coffee
+++ b/client/Main/mixpanel.coffee
@@ -1,45 +1,47 @@
 # We decided to move to segment.io which multiplexes to many
 # services. This is still named mixpanel for legacy reasons.
 if KD.config.logToExternal then do ->
-  KD.getSingleton('mainController').on "AccountChanged", (account) ->
-    return  unless KD.isLoggedIn() and account and analytics
-
+  identifyUser = (account)->
     {_id, meta, profile} = account
     return  unless profile
 
-    KD.utils.defer ->
-      KD.remote.api.JUser.fetchUser (err, user)->
-        return  if err or not user
+    KD.remote.api.JUser.fetchUser (err, user)->
+      return  if err or not user
 
-        {firstName, lastName, nickname} = profile
-        {email, lastLoginDate, status, emailFrequency, foreignAuth, sshKeys} = user
+      {firstName, lastName, nickname} = profile
+      {email, lastLoginDate, status, emailFrequency, foreignAuth, sshKeys} = user
 
-        # only care about existence of 3rd party auth, not the values
-        providers = {}
-        if foreignAuth
-          for own provider, providerInfo of foreignAuth
-            # check if values isn't empty object
-            providers[provider] = yes  if Object.keys(providerInfo).length > 0
+      # only care about existence of 3rd party auth, not the values
+      providers = {}
+      if foreignAuth
+        for own provider, providerInfo of foreignAuth
+          # check if values isn't empty object
+          providers[provider] = yes  if Object.keys(providerInfo).length > 0
 
-        KD.singletons.paymentController.subscriptions (err, currentSub)->
-          plan = "error fetching plan" if err
-          args =
-            "$id"          : _id
-            "$username"    : nickname
-            "$first_name"  : firstName
-            "$last_name"   : lastName
-            "$created"     : meta?.createdAt
-            "$email"       : email
-            subscription   : currentSub
-            lastLoginDate  : lastLoginDate
-            status         : status
-            emailFrequency :
-              marketing    : emailFrequency?.marketing
-              global       : emailFrequency?.global
-            foreignAuth    : providers      if Object.keys(providers).length > 0
-            sshKeysCount   : sshKeys.length if sshKeys?.length > 0
+      KD.singletons.paymentController.subscriptions (err, currentSub)->
+        plan = "error fetching plan" if err
+        args =
+          "$id"          : _id
+          "$username"    : nickname
+          "$first_name"  : firstName
+          "$last_name"   : lastName
+          "$created"     : meta?.createdAt
+          "$email"       : email
+          subscription   : currentSub
+          lastLoginDate  : lastLoginDate
+          status         : status
+          emailFrequency :
+            marketing    : emailFrequency?.marketing
+            global       : emailFrequency?.global
+          foreignAuth    : providers      if Object.keys(providers).length > 0
+          sshKeysCount   : sshKeys.length if sshKeys?.length > 0
 
-          analytics.identify nickname, args
+        analytics.identify nickname, args
+
+  KD.getSingleton('mainController').on "AccountChanged", (account) ->
+    return  unless KD.isLoggedIn() and account and analytics
+
+    KD.utils.defer -> identifyUser account
 
 # Access control wrapper around mixpanel object.
 KD.mixpanel = (args...)->

--- a/client/Main/mixpanel.coffee
+++ b/client/Main/mixpanel.coffee
@@ -21,7 +21,7 @@ if KD.config.logToExternal then do ->
             # check if values isn't empty object
             providers[provider] = yes  if Object.keys(providerInfo).length > 0
 
-        KD.singletons.paymentController.subscriptions (err, subscription)->
+        KD.singletons.paymentController.subscriptions (err, currentSub)->
           plan = "error fetching plan" if err
           args =
             "$id"          : _id
@@ -30,7 +30,7 @@ if KD.config.logToExternal then do ->
             "$last_name"   : lastName
             "$created"     : meta?.createdAt
             "$email"       : email
-            subscription   : subscription
+            subscription   : currentSub
             lastLoginDate  : lastLoginDate
             status         : status
             emailFrequency :

--- a/go/src/socialapi/workers/payment/payment.go
+++ b/go/src/socialapi/workers/payment/payment.go
@@ -72,6 +72,8 @@ type SubscriptionsResponse struct {
 	PlanInterval       string    `json:"planInterval"`
 	State              string    `json:"state"`
 	Provider           string    `json:"provider"`
+	ExpiredAt          time.Time `json:"expiredAt"`
+	CanceledAt         time.Time `json:"canceledAt"`
 	CurrentPeriodStart time.Time `json:"currentPeriodStart"`
 	CurrentPeriodEnd   time.Time `json:"currentPeriodEnd"`
 }
@@ -128,6 +130,8 @@ func (a *AccountRequest) Subscriptions() (*SubscriptionsResponse, error) {
 		CurrentPeriodEnd:   currentSubscription.CurrentPeriodEnd,
 		State:              currentSubscription.State,
 		Provider:           currentSubscription.Provider,
+		ExpiredAt:          currentSubscription.ExpiredAt,
+		CanceledAt:         currentSubscription.CanceledAt,
 	}
 
 	return resp, nil


### PR DESCRIPTION
- Not sending empty values or non truthy items as value with exception of `emailFrequency`, hence the check for count of keys in `foreignAuth` and `sshKeys`.
- Tried to be defensive about existence of keys and values due to lack of schema in `JUser` and `JAccount`
- Exposing currentSubscription#canceledAt & expiredAt fields to client.

cc @sinan 
