### PR TITLE
Free payment plan fix [fixes #87608006]

### DIFF
--- a/client/Pricing/AppView.coffee
+++ b/client/Pricing/AppView.coffee
@@ -214,7 +214,9 @@ class PricingAppView extends KDView
         options.planTitle     is PaymentConstants.planTitle.FREE) and
         'expired'             isnt @state.subscriptionState
 
-      return KD.showError "That's already your current plan."  if isCurrentPlan
+      if isCurrentPlan
+        inProcess = no
+        return KD.showError "That's already your current plan."
 
       @setState options
 

--- a/client/Pricing/AppView.coffee
+++ b/client/Pricing/AppView.coffee
@@ -209,9 +209,10 @@ class PricingAppView extends KDView
       inProcess = yes
 
       isCurrentPlan =
-        options.planTitle    is @state.currentPlan and
-        options.planInterval is @state.currentPlanInterval and
-        'expired'          isnt @state.subscriptionState
+        options.planTitle     is @state.currentPlan and
+        (options.planInterval is @state.currentPlanInterval or
+        options.planTitle     is PaymentConstants.planTitle.FREE) and
+        'expired'             isnt @state.subscriptionState
 
       return KD.showError "That's already your current plan."  if isCurrentPlan
 


### PR DESCRIPTION
@usirin, can you please review this fix? It's about a bug when logged out user with free plan selects a free plan on pricing page but with another payment interval. Incorrect modal is shown in this case after he has logged in
