### PR TITLE
Fix for current payment plan state [fixes #87412220]

### DIFF
--- a/client/Main/payment/workflow.coffee
+++ b/client/Main/payment/workflow.coffee
@@ -224,11 +224,7 @@ class PaymentWorkflow extends KDController
 
   finish: (state) ->
 
-    initiatorView = @getDelegate()
-
     @emit 'PaymentWorkflowFinishedSuccessfully', state
-
-    initiatorView.state.currentPlan = state.currentPlan
 
     @modal.destroy()
 

--- a/client/Pricing/AppView.coffee
+++ b/client/Pricing/AppView.coffee
@@ -224,6 +224,7 @@ class PricingAppView extends KDView
       @workflowController.once 'PaymentWorkflowFinishedSuccessfully', (state) =>
 
         @state.currentPlan = state.planTitle
+        @state.currentPlanInterval = state.planInterval
         @plans.setState @state
 
         KD.singletons


### PR DESCRIPTION
@usirin, can you please review this change? It fixes 2 issues:
- `initiatorView.state.currentPlan = state.currentPlan` in `client/Main/payment/workflow.coffee, line 231` sets currentPlan to the value that it had before user changed payment plan. Result of this bug is described in https://www.pivotaltracker.com/n/projects/1217662. That's why I removed this record. It seems it's not used anywhere else. currentPlan is correctly updated in `client/Pricing/AppView.coffee, line 226`
- after user has changed payment plan, it's necessary to update currentPlanInterval too in `client/Pricing/AppView.coffee, line 227`. If not to do that and return to the page after the plan change, in some cases current plan is not highlighted
