### PR TITLE
environments: set max width for domain's suffix [fixes #85207696]

### DIFF
--- a/client/app/lib/domains/managedomainsview.coffee
+++ b/client/app/lib/domains/managedomainsview.coffee
@@ -33,6 +33,8 @@ module.exports = class ManageDomainsView extends KDView
         spellcheck      : no
       callback          : @bound 'addDomain'
 
+    @input.on 'EscapePerformed', @bound 'resetInput'
+
     @inputView.addSubView new KDView
       partial           : @domainSuffix
       cssClass          : 'domain-suffix'
@@ -105,9 +107,7 @@ module.exports = class ManageDomainsView extends KDView
         @domainController.addItem { domain, machineId }
         computeController.domains = []
 
-        @input.setValue ""
-        @inputView.hide()
-        @emit "DomainInputCancelled"
+        @hideInput()
 
       .catch (err)=>
         kd.warn "Failed to create domain:", err
@@ -244,6 +244,18 @@ module.exports = class ManageDomainsView extends KDView
           callback  : -> modal.cancel()
 
 
+  resetInput:->
+
+    @input.setValue('')
+    @hideInput()
+
+
+  hideInput:->
+
+    @inputView.hide()
+    @warning.hide()
+    @emit "DomainInputCancelled"
+
   toggleInput:->
 
     @inputView.toggleClass 'hidden'
@@ -253,11 +265,12 @@ module.exports = class ManageDomainsView extends KDView
     windowController.addLayer @input
     @input.setFocus()
 
-    @input.off  "ReceivedClickElsewhere"
-    @input.once "ReceivedClickElsewhere", (event)=>
+    @input.off "ReceivedClickElsewhere"
+    @input.on "ReceivedClickElsewhere", (event)=>
+
+      if $(event.target).hasClass 'domain-suffix'
+        windowController.addLayer @input
+        return
+
       return  if $(event.target).hasClass 'domain-toggle'
-      @emit "DomainInputCancelled"
-      @inputView.hide()
-      @warning.hide()
-
-
+      @hideInput()

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -757,6 +757,7 @@ div.nominateicon
       .domain-suffix
         color             #999
         width             auto
+        max-width         140px
         display           inline-block
         float             left
         box-shadow        none


### PR DESCRIPTION
added width limit to prevent moving domain's suffix under input:
![domain](https://cloud.githubusercontent.com/assets/295206/6178267/45e42738-b31e-11e4-87a4-67a2ba07373e.png)
@burakcan Could you check this?
