### PR TITLE
gulp/scripts: be more verbose

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -3,12 +3,10 @@ BIN=./node_modules/.bin
 .PHONY: landing
 
 all:
-	@clear
-	@DEBUG=client:* $(BIN)/gulp --devMode
+	@DEBUG=client:* $(BIN)/gulp --devMode --watchMode
 
 scripts:
-	@clear
-	@DEBUG=client:* $(BIN)/gulp scripts --devMode
+	@DEBUG=client:* $(BIN)/gulp scripts --devMode --watchMode
 
 build: landing
 	@DEBUG=client:* $(BIN)/gulp

--- a/client/Makefile
+++ b/client/Makefile
@@ -3,10 +3,10 @@ BIN=./node_modules/.bin
 .PHONY: landing
 
 all:
-	@DEBUG=client:* $(BIN)/gulp --devMode --watchMode
+	@DEBUG=client:*,bant:* $(BIN)/gulp --devMode --watchMode
 
 scripts:
-	@DEBUG=client:* $(BIN)/gulp scripts --devMode --watchMode
+	@DEBUG=client:*,bant:* $(BIN)/gulp scripts --devMode --watchMode
 
 build: landing
 	@DEBUG=client:* $(BIN)/gulp

--- a/client/gulpfile.coffee
+++ b/client/gulpfile.coffee
@@ -30,6 +30,7 @@ styleHelper    = require './gulptasks/style'
 concat         = require 'gulp-concat'
 
 devMode        = argv.devMode?
+watchMode      = argv.watchMode?
 version        = argv.ver? or 1
 
 log            = (color, message) -> gutil.log gutil.colors[color] message
@@ -166,19 +167,20 @@ gulp.task 'scripts', ['set-remote-api', 'set-config-apps', 'copy-thirdparty', 'c
   modules.forEach (name) -> mapping[name] = "../#{name}/lib"
 
   # opts.globals.modules = modules
-  opts.browserify.debug = yes
+  opts.browserify.debug = yes  if devMode
 
-  b = browserify xtend opts.browserify, watchify.args
-    .transform coffeeify, global: yes
-    .transform pistachioify, global: yes
-    .transform rewritify,
+  if watchMode
+    b = watchify(browserify(xtend(opts.browserify, watchify.args)))
+  else
+    b = browserify opts.browserify
+
+  b.transform coffeeify, global: yes
+   .transform pistachioify, global: yes
+   .transform rewritify,
       global: yes
       extensions: ['coffee']
       basedir: __dirname
       mapping: mapping
-
-  b = watchify b  if devMode
-
 
   bant = build b, globals: opts.globals
     .on 'bundle', (bundle) ->

--- a/client/package.json
+++ b/client/package.json
@@ -36,7 +36,7 @@
     "sockjs-client": "kd-shim-sockjs-client"
   },
   "devDependencies": {
-    "bant-build": "^0.1.3",
+    "bant-build": "^0.1.7",
     "browserify": "git://github.com/tetsuo/node-browserify#hotfix-dedupe-json",
     "coffee-script": "1.8.0",
     "coffeeify": "^1.0.0",


### PR DESCRIPTION
- separate --devMode and --watchMode. dev mode activates browserify debug option, watch mode wraps browserify instance with watchify.
- include bant debug messages (make)
- bump up bant-build to 0.1.7 which writes errors into both console and to common.js file
