### PR TITLE
gulp: freeze bant-build version (0.1.7)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -36,7 +36,7 @@
     "sockjs-client": "kd-shim-sockjs-client"
   },
   "devDependencies": {
-    "bant-build": "^0.1.7",
+    "bant-build": "0.1.7",
     "browserify": "git://github.com/tetsuo/node-browserify#hotfix-dedupe-json",
     "coffee-script": "1.8.0",
     "coffeeify": "^1.0.0",


### PR DESCRIPTION
[cli-spinner](https://www.npmjs.com/package/cli-spinner) causes problems when used within `./run`
