### PR TITLE
Appmanager: add shouldLoadApp for checking to see if an app should be loaded

### DIFF
--- a/client/app/lib/applicationmanager.coffee
+++ b/client/app/lib/applicationmanager.coffee
@@ -47,6 +47,8 @@ module.exports = class ApplicationManager extends KDObject
   isAppInternal : (name='')->
     return globals.config.apps[name] and (name not in Object.keys globals.appClasses)
 
+  isAppLoaded: (name = '') -> (name in Object.keys globals.appClasses)
+
   open: do ->
 
     createOrShow = (appOptions = {}, appParams, callback = kd.noop)->

--- a/client/app/lib/applicationmanager.coffee
+++ b/client/app/lib/applicationmanager.coffee
@@ -44,10 +44,11 @@ module.exports = class ApplicationManager extends KDObject
         break
       return safeToUnload ? yes
 
-  isAppInternal : (name='')->
-    return globals.config.apps[name] and (name not in Object.keys globals.appClasses)
+  isAppInternal: (name = '') -> globals.config.apps[name]?
 
   isAppLoaded: (name = '') -> (name in Object.keys globals.appClasses)
+
+  shouldLoadApp: (name = '') -> (@isAppInternal name) and not (@isAppLoaded name)
 
   open: do ->
 
@@ -98,7 +99,7 @@ module.exports = class ApplicationManager extends KDObject
 
       if not appOptions? and not options.avoidRecursion?
 
-        if @isAppInternal name
+        if @shouldLoadApp name
           return KodingAppsController.loadInternalApp name, (err)=>
             return kd.warn err  if err
             kd.utils.defer => @open name, options, callback
@@ -179,7 +180,7 @@ module.exports = class ApplicationManager extends KDObject
     appOptions.params     = params
     @register appInstance = new AppClass appOptions  if AppClass
 
-    if @isAppInternal name
+    if @shouldLoadApp name
       return KodingAppsController.loadInternalApp name, (err)=>
         return kd.warn err  if err
         kd.utils.defer => @create name, params, callback

--- a/client/app/lib/kodingrouter.coffee
+++ b/client/app/lib/kodingrouter.coffee
@@ -53,7 +53,7 @@ module.exports = class KodingRouter extends KDRouter
       name = _slug
 
     appManager = kd.getSingleton 'appManager'
-    if appManager.isAppInternal name
+    if appManager.shouldLoadApp name
       return KodingAppsController.loadInternalApp name, (err, res) =>
         return kd.warn err  if err
         kd.utils.defer => @handleRoute route, options


### PR DESCRIPTION
`isAppInternal` wasn't just checking to see if an app is internal, it was also checking if an app should be loaded.

This PR includes the following:
- [x] Refactors `isAppInternal` to do only what its name is indicating.
- [x] Extracts the functionality that checks if an app is loaded into `isAppLoaded` method.
- [x] Adds a new method called `shouldLoadApp` to determine if an app should be loaded, which is basically what `isAppInternal` did before. To achieve this it utilizes the new versions of `isAppInternal` and `isAppLoaded` methods.
- [x] Replaces the places where `isAppInternal` is being used with `shouldLoadApp` method.
