### PR TITLE
gulpfile/Makefile improvements (WIP - do not merge)

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -1,18 +1,20 @@
 BIN=./node_modules/.bin
+DEBUG_TARGETS?=client:*,bant:*
+GULP_ARGS=
+ifeq ($(watch),1)
+	GULP_ARGS+=--watchMode
+endif
+ifeq ($(debug),1)
+	GULP_ARGS+=--devMode
+endif
 
-.PHONY: landing
-
-all: landing
-	@DEBUG=client:*,bant:* $(BIN)/gulp --devMode --watchMode
+all: 
+	@DEBUG=$(DEBUG_TARGETS) $(BIN)/gulp $(GULP_ARGS)
 
 scripts:
-	@DEBUG=client:*,bant:* $(BIN)/gulp scripts --devMode --watchMode
-
-build: landing
-	@DEBUG=client:* $(BIN)/gulp
+	@DEBUG=$(DEBUG_TARGETS) $(BIN)/gulp scripts $(GULP_ARGS)
 
 landing:
-	@cd landing && npm install --unsafe-perm --silent
-	@cd landing && rm -rf node_modules/gulp.spritesmith/node_modules/spritesmith/node_modules/canvassmith
-	@cd landing && gulp build-all-sites --koding-version=$(git rev-parse HEAD)
-	@cd landing && rsync -av static/a/ ../../website/a/
+	@$(MAKE) -C landing all
+
+.PHONY: landing

--- a/client/gulpfile.coffee
+++ b/client/gulpfile.coffee
@@ -45,7 +45,6 @@ opts =
   rev: null
   browserify:
     extensions: ['.coffee', '.js', '.json']
-    # debug: true
   globals:
     config: {}
     appClasses: {}
@@ -166,6 +165,8 @@ gulp.task 'scripts', ['set-remote-api', 'set-config-apps', 'copy-thirdparty', 'c
   mapping = {}
   modules.forEach (name) -> mapping[name] = "../#{name}/lib"
 
+  opts.browserify.debug = yes  if devMode
+
   if watchMode
     b = watchify(browserify(xtend(opts.browserify, watchify.args)))
   else
@@ -179,15 +180,12 @@ gulp.task 'scripts', ['set-remote-api', 'set-config-apps', 'copy-thirdparty', 'c
       basedir: __dirname
       mapping: mapping
 
-
   bant = build b, globals: opts.globals
     .on 'bundle', (bundle) ->
       outfile = path.join opts.outdir, "#{bundle.name}.js"
       fs.writeFile outfile, bundle.source, (err, res) ->
         debug "could not write #{outfile}"  if err
         debug "#{pretty bundle.source.length} written to #{path.basename outfile}"
-
-  #b.require(require.resolve('kd.js'), { expose: 'kd' })
 
   gulp.src(['*/bant.json']).pipe bant
 

--- a/client/gulpfile.coffee
+++ b/client/gulpfile.coffee
@@ -45,6 +45,7 @@ opts =
   rev: null
   browserify:
     extensions: ['.coffee', '.js', '.json']
+    debug: yes  if devMode
   globals:
     config: {}
     appClasses: {}
@@ -164,8 +165,6 @@ gulp.task 'scripts', ['set-remote-api', 'set-config-apps', 'copy-thirdparty', 'c
 
   mapping = {}
   modules.forEach (name) -> mapping[name] = "../#{name}/lib"
-
-  opts.browserify.debug = yes  if devMode
 
   if watchMode
     b = watchify(browserify(xtend(opts.browserify, watchify.args)))


### PR DESCRIPTION
- Bringing back `gulp --devMode` to enable sourcemaps
- `DEBUG_TARGETS` can be overwritten from command-line. It is `client:*,bant:*` by default.
  `DEBUG_TARGETS=* make` 
- Moved landing tasks to landing submodule https://github.com/koding/landing/pull/112, this file is now a sub Makefile and should be treated as such.
- In my computer gulp always hangs after finishing its job for some reason, this breaks client's gulp, so I had to remove `landing` from `all`'s dependencies. 
- `gulp --watchMode` and `gulp --devMode` can now be enabled with make. They are disabled by default, should be set to 1 to enable.
  `make watch=1 debug=1 scripts`
