### PR TITLE
Start using collaboration social channel

### DIFF
--- a/client/activity/lib/styl/activity.pm.styl
+++ b/client/activity/lib/styl/activity.pm.styl
@@ -11,6 +11,7 @@ deleteRed  = rgba(217, 58, 55, 0.9)
 timeColor  = #d2d2d2
 timeColor2 = #5F9E5E
 
+.kdlistview-collaboration
 .kdlistview-privatemessage
   opacity                   1
   vendor                    transition, opacity .177s ease-in

--- a/client/activity/lib/styl/activity.pm.styl
+++ b/client/activity/lib/styl/activity.pm.styl
@@ -11,6 +11,30 @@ deleteRed  = rgba(217, 58, 55, 0.9)
 timeColor  = #d2d2d2
 timeColor2 = #5F9E5E
 
+.kdlistview-privatemessage
+  opacity                   1
+  vendor                    transition, opacity .177s ease-in
+  margin-top                0
+
+  &.padded
+    height                  auto
+    abs                     0 0 0px 0
+    kalc                    width (100%\-34px)
+
+
+  > section
+    &:last-child
+      margin-bottom         16px
+
+    > time
+      color                 timeColor2
+      display               block
+      margin                8px 0 0 34px
+      line-height           30px
+      font-size             11px
+      z-index               1
+      text-transform        uppercase
+
 #content-page-activity
 
   > .kdtabview.privatemessage
@@ -204,30 +228,6 @@ timeColor2 = #5F9E5E
     display             block
     margin              4px 0 0 34px
     noTextDeco()
-
-  .kdlistview-privatemessage
-    opacity               1
-    vendor                transition, opacity .177s ease-in
-    margin-top            0
-
-    &.padded
-      height              auto
-      abs                 0 0 0px 0
-      kalc                width (100%\-34px)
-
-
-    > section
-      &:last-child
-        margin-bottom     16px
-
-      > time
-        color             timeColor2
-        display           block
-        margin            8px 0 0 34px
-        line-height       30px
-        font-size         11px
-        z-index           1
-        text-transform    uppercase
 
   .kdlistitemview-activity.privatemessage
     padding               0

--- a/client/activity/lib/views/messagepane.coffee
+++ b/client/activity/lib/views/messagepane.coffee
@@ -43,19 +43,8 @@ module.exports = class MessagePane extends KDTabPaneView
 
     {typeConstant} = @getData()
 
-    # this hack is mainly for css.
-    # collaboration chat pane depends on the css
-    # from activity private message, especially
-    # the specifity of the list items.
-    # This way, the activity list controller of collaboration
-    # chat window will have `kdlistview-privatemessage`
-    # cssClass. ~Umut
-    listType = if typeConstant is 'collaboration'
-    then 'privatemessage'
-    else typeConstant
-
     @listController = new ActivityListController {
-      type          : listType
+      type          : typeConstant
       viewOptions   :
         itemOptions : {channelId}
       wrapper

--- a/client/activity/lib/views/messagepane.coffee
+++ b/client/activity/lib/views/messagepane.coffee
@@ -43,8 +43,19 @@ module.exports = class MessagePane extends KDTabPaneView
 
     {typeConstant} = @getData()
 
+    # this hack is mainly for css.
+    # collaboration chat pane depends on the css
+    # from activity private message, especially
+    # the specifity of the list items.
+    # This way, the activity list controller of collaboration
+    # chat window will have `kdlistview-privatemessage`
+    # cssClass. ~Umut
+    listType = if typeConstant is 'collaboration'
+    then 'privatemessage'
+    else typeConstant
+
     @listController = new ActivityListController {
-      type          : typeConstant
+      type          : listType
       viewOptions   :
         itemOptions : {channelId}
       wrapper

--- a/client/app/lib/socialapicontroller.coffee
+++ b/client/app/lib/socialapicontroller.coffee
@@ -444,10 +444,14 @@ module.exports = class SocialApiController extends KDController
       kallback err, data
 
     return switch type
-      when 'topic'                     then @channel.byName {name: id}, topicChannelKallback
-      when 'activity'                  then @message.bySlug {slug: id}, kallback
-      when 'channel', 'privatemessage' then @channel.byId {id}, topicChannelKallback
-      when 'post', 'message'           then @message.byId {id}, kallback
+      when 'topic'
+        @channel.byName {name: id}, topicChannelKallback
+      when 'activity'
+        @message.bySlug {slug: id}, kallback
+      when 'channel', 'privatemessage', 'collaboration'
+        @channel.byId {id}, topicChannelKallback
+      when 'post', 'message'
+        @message.byId {id}, kallback
       else callback { message: "#{type} not implemented in revive" }
 
   getMessageEvents = ->


### PR DESCRIPTION
This is the initial PR for integrating social channel capabilities into system when try to keep the focus in Collaboration Chat Pane changes.

SocialApiController was already caching the collaboration type channels, there weren't any revive case for collaboration type channels, i added those.

P.S: This PR tries to be backwards compatible, that's why any other `collaboration` related checks in private messages or sidebar aren't changed/fixed.

/cc @sinan @fatihacet 
