### PR TITLE
Check existence of remote_syslog program

### DIFF
--- a/.ebextensions/006_eb_env_name.config
+++ b/.ebextensions/006_eb_env_name.config
@@ -9,7 +9,10 @@ files:
     group: root
     content: |
       #!/bin/sh
-      cp /home/ec2-user/remote_syslog/remote_syslog /usr/local/bin || echo remote_syslog already installed
+
+      if [ ! -x /usr/local/bin/remote_syslog ]; then
+        cp /home/ec2-user/remote_syslog/remote_syslog /usr/local/bin/
+      fi
 
       /sbin/chkconfig remote_syslog on
 


### PR DESCRIPTION
Following error was in deployment logs.

```
[root directoryHooksExecutor info] Output from script: cp: cannot create regular file /usr/local/bin/remote_syslog: Text file busy
```

This was probably interrupting directory-hooks-executor to skip rest of the script, preventing starting of the remote_syslog service.
