### PR TITLE
WebtermView: do not trigger resize for hidden screens [fixes #87833330]

### DIFF
--- a/client/app/lib/terminal/webtermview.coffee
+++ b/client/app/lib/terminal/webtermview.coffee
@@ -285,6 +285,9 @@ module.exports = class WebTermView extends KDCustomScrollView
   triggerFitToWindow: ->
 
     return  unless @terminal?.server?
+    # bc a hidden terminal has 1 col and 1 row
+    # we assume that the terminal is hidden and do not trigger resize
+    # maybe, better would be to check if the dom element is in the body - SY
     return  if @terminal.sizeX + @terminal.sizeY <= 2
 
     @terminal.server.controlSequence String.fromCharCode 2

--- a/client/app/lib/terminal/webtermview.coffee
+++ b/client/app/lib/terminal/webtermview.coffee
@@ -285,6 +285,7 @@ module.exports = class WebTermView extends KDCustomScrollView
   triggerFitToWindow: ->
 
     return  unless @terminal?.server?
+    return  if @terminal.sizeX + @terminal.sizeY <= 2
 
     @terminal.server.controlSequence String.fromCharCode 2
     @terminal.server.input 'F'


### PR DESCRIPTION
This is not a perfect solution for this, but we need to re-write this triggering
flow from scratch, it's now in a not fixable state. Too many component depended
on this flow and fixing one breaking other, so instead I put a filter for
requesting to fitWindow on hidden terminals which has sizeX and sizeY as 1
