### PR TITLE
Elastic Beanstalk: Configure deployment version on server

### DIFF
--- a/.ebextensions/004_files_config_updaters.config
+++ b/.ebextensions/004_files_config_updaters.config
@@ -15,6 +15,7 @@ files:
 
       echo "setting ulimit"
       ulimit -n 10000
+
       rm -rf ./node_modules
 
       echo "loading npm modules"
@@ -22,6 +23,9 @@ files:
       HOME=/home/user-ec2 npm i --unsafe-perm
 
       HOME=/home/user-ec2 npm i -g gulp
+
+      CONFIG=$(cat CONFIG)
+      ./configure --config $CONFIG --projectRoot /opt/koding
 
       echo "build client"
       cd client

--- a/wercker.yml
+++ b/wercker.yml
@@ -225,7 +225,7 @@ deploy:
         code: |
           cd $WERCKER_ROOT
 
-          ./configure --config $CONFIG --projectRoot /opt/koding
+          echo $CONFIG > CONFIG
 
           rm -rf .git .build node_modules client/node_modules
           rm -rf go/bin go/pkg


### PR DESCRIPTION
@cihangir I've spent 3/4 of my day on deployment failure on sandbox and latest today. Same issue occurred last week started to happen again. When I was investigating what is going wrong I noticed `deployment/generated_files` directory has files produced with development configuration which later copied to their respective paths in `/etc/`.

I couldn't find anything breaking deployment in diff of pre-commonjs to master of today [1]. It generates configuration files for development, so `configure` script must be invoked somewhere but that does not happen in scripts under `.ebextensions`. Deploying latest version prior to latest production deployment was succeeding, however. I tried reverting recent changes regarding deployment but nothing has changed. I've read logs. I've inspected zip archives uploaded to Elastic Beanstalk. `deployment/generated_files` was containing files configured for development. I have exhausted my ideas on this.

So, instead of spending time what else is breaking it I thought this patch would resolve the issue. I couldn't test this yet because there is an ongoing test cycle. Basically, I ran configure with proper options and copied generated configuration files and restarted supervisord and nginx services to not interrupt test cycles.

I can deploy this later today and see if it does the trick.

[1] https://gist.github.com/szkl/4ec7b21a52c9a6549be5
