### PR TITLE
client/gulpfile: expose 'kd' unless we are in watch mode

### DIFF
--- a/client/gulpfile.coffee
+++ b/client/gulpfile.coffee
@@ -187,7 +187,7 @@ gulp.task 'scripts', ['set-remote-api', 'set-config-apps', 'copy-thirdparty', 'c
         debug "could not write #{outfile}"  if err
         debug "#{pretty bundle.source.length} written to #{path.basename outfile}"
 
-  #b.require(require.resolve('kd.js'), { expose: 'kd' })
+  b.require(require.resolve('kd.js'), { expose: 'kd' })  unless watchMode
 
   gulp.src(['*/bant.json']).pipe bant
 


### PR DESCRIPTION
this is breaking watchify when used with bant 0.1.x https://github.com/koding/koding/pull/2881 going to be resolved with 0.2.0

until then we have to disable exposing kd.js as kd in watch mode
