### PR TITLE
SocialChannel State Machine

### DIFF
--- a/client/app/lib/collaboration/statemachines/channel.coffee
+++ b/client/app/lib/collaboration/statemachines/channel.coffee
@@ -22,7 +22,7 @@ create = (channelId) ->
           return @transition 'uninitialized'  unless channelId
           @transition 'busy'
           @_fetchChannel channelId,
-            success : => @handle 'channelReady'
+            success : (channel) => @handle 'channelReady'
             error   : (error) => handleError error
 
       ###*
@@ -60,7 +60,7 @@ create = (channelId) ->
         init: ->
           @transition 'busy'
           @_initChannel
-            success : => @handle 'channelReady'
+            success : (channel) => @handle 'channelReady', channel
             error   : (error) => handleError error
 
         '*': -> @deferUntilTransition()
@@ -79,13 +79,13 @@ create = (channelId) ->
         addParticipant: (userId) ->
           @transition 'busy'
           @_addParticipant userId,
-            success : => @handle 'participantAdded'; console.log 'hello'
+            success : (userId) => @handle 'participantAdded', userId
             error   : (error) -> handleError error
 
         removeParticipant: (userId) ->
           @transition 'busy'
           @_removeParticipant userId,
-            success : => @handle 'participantRemoved'
+            success : (userId) => @handle 'participantRemoved'
             error   : (error) -> handleError error
 
         '*': ->
@@ -156,7 +156,6 @@ create = (channelId) ->
         return callback.error()  if err
         @channel = channel
         callbacks.success()
-        @emit 'ChannelReady', { channel }
 
 
     ###*
@@ -172,7 +171,6 @@ create = (channelId) ->
         return callbacks.error()  if err
         @channel = null
         callbacks.success()
-        @emit 'ChannelDeleted'
 
     ###*
      * Fetch social channel with given id.
@@ -188,7 +186,6 @@ create = (channelId) ->
         return callbacks.error err  if err
         @channel = channel
         callbacks.success()
-        @emit 'ChannelReady', { channel }
 
 
     ###*
@@ -207,7 +204,6 @@ create = (channelId) ->
         addParticipants opts, (err) =>
           return callbacks.error err  if err
           callbacks.success account
-          @emit 'ParticipantAdded', { account }
 
 
     ###*
@@ -225,7 +221,6 @@ create = (channelId) ->
         removeParticipants opts, (err) =>
           return callbacks.error err  if err
           callbacks.success()
-          @emit 'ParticipantRemoved', { id: userId }
 
   return channelMachine
 

--- a/client/app/lib/collaboration/statemachines/channel.coffee
+++ b/client/app/lib/collaboration/statemachines/channel.coffee
@@ -1,0 +1,271 @@
+machina = require 'machina'
+kd      = require 'kd'
+getNick = require 'app/util/nick'
+
+remote = require('app/remote').getInstance()
+
+create = (channelId) ->
+
+  channelMachine = new machina.Fsm
+    initialState: 'loading'
+    states:
+      ###*
+       * Initial decide state.
+       *
+       * It will:
+       * - fetch the channel with given id if `channelId` is present.
+       * or
+       * - switch state to 'uninitialized' if no `channelId` is present.
+      ###
+      loading:
+        _onEnter: ->
+          if channelId
+          then @_fetchChannel channelId
+          else @transition 'uninitialized'
+
+        '*': -> @deferUntilTransition()
+
+      ###*
+       * This state means basically it is ready but still doesn't
+       * have any `SocialChannel` instance. But it means that, it is ready to
+       * be initialized.
+       *
+       * Only `init` action can happen here.
+      ###
+      uninitialized:
+        _onEnter: ->
+          @channel = null
+
+        init: ->
+          @makeBusy => @_initChannel()
+
+        '*': -> @deferUntilTransition()
+
+      ###*
+       * State to indicate that collaboration channel
+       * instance is ready for action.
+      ####
+      ready:
+        terminate: ->
+          @makeBusy => @_destroyChannel()
+
+        addParticipant: (userId) ->
+          @makeBusy => @_addParticipant userId
+
+        removeParticipant: (userId) ->
+          @makeBusy => @_removeParticipant userId
+
+        '*': ->
+          @deferUntilTransition()
+          @transition 'busy'
+
+      ###*
+       * State to indicate that there is some operation happening.
+      ###
+      busy:
+        channelDeleted: 'loading'
+        # following could be written as
+        # '*': 'ready'
+        # keeping them here for clarity. ~Umut
+        channelReady: 'ready'
+        participantAdded: 'ready'
+        participantRemoved: 'ready'
+
+    ###*
+     * Action to get healthcheck from outside.
+     * It's an asyncronous action. Result is dispatched with
+     * an event.
+     *
+     * @event ChannelStateMachine#HealthCheckDone
+     * @type {boolean} success - indicates if result is successful.
+     *
+     * @emits 'HealthCheckDone'
+    ####
+    healthcheck: ->
+      goodStates = ['ready']
+      @emit 'HealthCheckDone', @state in goodStates
+
+    ###*
+     * Action to initiate a collaboration channel.
+     *
+     * @state 'uninitialized'
+     * @nextState 'ready'
+     * @via 'busy'
+    ###
+    init: -> @handle 'init'
+
+    ###*
+     * Action to terminate a collaboration channel.
+     *
+     * @state 'ready'
+     * @nextState 'uninitialized'
+     * @via 'busy'
+    ###
+    terminate: -> @handle 'terminate'
+
+    ###*
+     * Action to add a participant to collaboration channel.
+     *
+     * @state 'ready'
+     * @nextState 'uninitialized'
+     * @via 'busy'
+    ###
+    addParticipant: (userId) -> @handle 'addParticipant', userId
+
+    ###*
+     * Action to remove a participant to collaboration channel.
+     *
+     * @state 'ready'
+     * @nextState 'uninitialized'
+     * @via 'busy'
+    ###
+    removeParticipant: (userId) -> @handle 'removeParticipant', userId
+
+    ###*
+     * Puts machine into `busy` state and executes the callback.
+     *
+     * @param {function=} callback
+    ####
+    makeBusy: (callback) ->
+      @transition 'busy'
+      callback?()
+
+    ###*
+     * Initiate a social channel.
+     *
+     * @emits 'ChannelReady'
+     * @successAction 'channelReady'
+     * @nextState 'ready'
+     *
+     * @api private
+    ###
+    _initChannel: ->
+      initChannel (err, channel) =>
+        return handleError err  if err
+        @channel = channel
+        @handle 'channelReady'
+        @emit 'ChannelReady', { channel }
+
+
+    ###*
+     * Destroy a social channel.
+     *
+     * @emits 'ChannelDeleted'
+     * @successAction 'channelDeleted'
+     * @nextState 'uninitialized'
+     *
+     * @api private
+    ###
+    _destroyChannel: ->
+      destroyChannel @channel, (err) =>
+        return handleError err  if err
+        @channel = null
+        @handle 'channelDeleted'
+        @emit 'ChannelDeleted'
+
+
+    ###*
+     * Fetch social channel with given id.
+     *
+     * @emits 'ChannelReady'
+     * @successAction 'channelReady'
+     * @nextState 'ready'
+     *
+     * @api private
+     *
+     * @param {string} id - channel id
+    ###
+    _fetchChannel: (id) ->
+      fetchChannel id, (err, channel) =>
+        return handleError err  if err
+        @channel = channel
+        @handle 'channelReady'
+        @emit 'ChannelReady', { channel }
+
+
+    ###*
+     * Add user with given id as participant.
+     *
+     * @emits 'ParticipantAdded'
+     * @successAction 'participantAdded'
+     * @nextState 'ready'
+     *
+     * @api private
+     *
+     * @param {string} userId
+    ###
+    _addParticipant: (userId) ->
+      getAccount userId, (err, account) =>
+        return handleError err  if err
+        opts = { channelId: @channel.id, accountIds: [account.socialApiId] }
+        addParticipants opts, (err) =>
+          return handleError err  if err
+          @channel.emit 'AddedToChannel', account
+          @handle 'participantAdded'
+          @emit 'ParticipantAdded', { account }
+
+
+    ###*
+     * Remove participant with given user id.
+     *
+     * @emits 'ParticipantRemoved'
+     * @successAction 'participantRemoved'
+     * @nextState 'ready'
+     *
+     * @api private
+     *
+     * @param {string} userId
+    ###
+    _removeParticipant: (userId) ->
+      getAccount userId, (err, account) =>
+        return handleError err  if err
+        opts = { channelId: @channel.id, accountIds: [userId] }
+        removeParticipants opts, (err) =>
+          return handleError err  if err
+          @channel.emit 'RemovedFromChannel', account
+          @handle 'participantRemoved'
+          @emit 'ParticipantRemoved', { id: userId }
+
+  return channelMachine
+
+###*
+ * Following are convinient functions to wrap
+ * socialapicontroller calls.
+ * Since because those are stateless functions,
+ * tried to use those to keep public api as clean as possible. ~Umut
+###
+addParticipants = (opts, callback) ->
+  kd.singletons.socialapi.channel.addParticipants opts, callback
+
+removeParticipants = (opts, callback) ->
+  kd.singletons.socialapi.channel.removeParticipants opts, callback
+
+fetchChannel = (id, callback) ->
+  kd.singletons.socialapi.cacheable 'channel', id, callback
+
+destroyChannel = (channel, callback) ->
+  {id} = channel
+  kd.singletons.socialapi.channel.delete {channelId: id}, callback
+
+initChannel = (callback) ->
+  {message} = kd.singletons.socialapi
+  nickname  = getNick()
+
+  options =
+    type       : 'collaboration'
+    body       : "@#{nickname} initiated the IDE session."
+    recipients : [ nickname ]
+    payload    : {'system-message': 'initiate'}
+
+  message.initPrivateMessage options, (err, channels) ->
+    return callback err  if err
+    return callback {message: 'error'}  unless channels?.length
+    return callback null, channels[0]
+
+getAccount = (userId, callback) ->
+  remote.cacheable 'JAccount', userId, callback
+
+handleError = (err) ->
+  throw new Error "ChannelStateMachine: #{err.message}"
+
+module.exports = { create }

--- a/client/app/lib/collaboration/statemachines/channel.coffee
+++ b/client/app/lib/collaboration/statemachines/channel.coffee
@@ -221,7 +221,7 @@ create = (channelId) ->
   return channelMachine
 
 ###*
- * Following are convinient functions to wrap
+ * Following are convenient functions to wrap
  * socialapicontroller calls.
  * Since because those are stateless functions,
  * tried to use those to keep public api as clean as possible. ~Umut

--- a/client/app/lib/collaboration/statemachines/channel.coffee
+++ b/client/app/lib/collaboration/statemachines/channel.coffee
@@ -198,7 +198,7 @@ create = (channelId) ->
      * @param {function=} callbacks.error   - error calback
     ###
     _addParticipant: (userId, callbacks) ->
-      getAccount userId, (err, account) =>
+      fetchAccount userId, (err, account) =>
         return handleError err  if err
         opts = { channelId: @channel.id, accountIds: [account.socialApiId] }
         addParticipants opts, (err) =>
@@ -215,7 +215,7 @@ create = (channelId) ->
      * @param {function=} callbacks.error   - error calback
     ###
     _removeParticipant: (userId, callbacks) ->
-      getAccount userId, (err, account) =>
+      fetchAccount userId, (err, account) =>
         return callbacks.error err  if err
         opts = { channelId: @channel.id, accountIds: [account.socialApiId] }
         removeParticipants opts, (err) =>
@@ -258,7 +258,7 @@ initChannel = (callback) ->
     return callback {message: 'error'}  unless channels?.length
     return callback null, channels[0]
 
-getAccount = (userId, callback) ->
+fetchAccount = (userId, callback) ->
   remote.cacheable 'JAccount', userId, callback
 
 handleError = (err) ->

--- a/client/app/lib/collaboration/statemachines/channel.coffee
+++ b/client/app/lib/collaboration/statemachines/channel.coffee
@@ -223,7 +223,7 @@ create = (channelId) ->
 ###*
  * Following are convenient functions to wrap
  * socialapicontroller calls.
- * Since because those are stateless functions,
+ * Since those are stateless functions,
  * tried to use those to keep public api as clean as possible. ~Umut
 ###
 addParticipants = (opts, callback) ->

--- a/client/app/lib/collaboration/statemachines/channel.coffee
+++ b/client/app/lib/collaboration/statemachines/channel.coffee
@@ -26,6 +26,27 @@ create = (channelId) ->
             error   : (error) => handleError error
 
       ###*
+       * State to indicate that there is some operation happening.
+      ###
+      busy:
+        channelReady: (channel) ->
+          @emit 'ChannelReady', { channel }
+          @transition 'ready'
+
+        participantAdded: (userId) ->
+          @emit 'ParticipantAdded', { id: userId }
+          @transition 'ready'
+
+        participantRemoved: (userId) ->
+          @emit 'ParticipantRemoved', { id: userId }
+          @transition 'ready'
+
+        channelDestroyed: ->
+          @emit 'ChannelDestroyed'
+          @transition 'loading'
+
+
+      ###*
        * This state means basically it is ready but still doesn't
        * have any `SocialChannel` instance. But it means that, it is ready to
        * be initialized.
@@ -70,18 +91,6 @@ create = (channelId) ->
         '*': ->
           @deferUntilTransition()
           @transition 'busy'
-
-      ###*
-       * State to indicate that there is some operation happening.
-      ###
-      busy:
-        channelDestroyed: 'loading'
-        # following could be written as
-        # '*': 'ready'
-        # keeping them here for clarity. ~Umut
-        channelReady: 'ready'
-        participantAdded: 'ready'
-        participantRemoved: 'ready'
 
 
     ###*

--- a/client/app/lib/collaboration/statemachines/channel.coffee
+++ b/client/app/lib/collaboration/statemachines/channel.coffee
@@ -10,7 +10,7 @@ create = (channelId) ->
     initialState: 'loading'
     states:
       ###*
-       * Initial decide state.
+       * Initial decision state.
        *
        * It will:
        * - fetch the channel with given id if `channelId` is present.

--- a/client/package.json
+++ b/client/package.json
@@ -25,6 +25,7 @@
     "kite.js": "git://github.com/tetsuo/kite.js#0.4.0",
     "kookies": "^0.1.1",
     "lodash": "^2.4.1",
+    "machina": "^1.0.0-1",
     "marked": "^0.3.2",
     "ndpane": "^0.1.2",
     "node-uuid": "^1.4.2",

--- a/client/package.json
+++ b/client/package.json
@@ -25,7 +25,7 @@
     "kite.js": "git://github.com/tetsuo/kite.js#0.4.0",
     "kookies": "^0.1.1",
     "lodash": "^2.4.1",
-    "machina": "^1.0.0-1",
+    "machina": "1.0.0-1",
     "marked": "^0.3.2",
     "ndpane": "^0.1.2",
     "node-uuid": "^1.4.2",


### PR DESCRIPTION
`ChannelStateMachine` provides a familiar public api, but instead of passing a callback to actions, we just trigger and it will transition it to `busy` state, will do its job, and return back to `ready` state if everything is successful.

This is the first of sequential PRs for solving Collaboration Session operation problems
## Example

``` coffee
ChannelStateMachine = require 'app/collaboration/statemachines/channel'
KDView = require('kd').View

class FooView extends KDView
  constructor: (options = {}, data) ->
    # `loading` state is an intermediate state
    # it will transition to either `uninitialized` or `ready`.
    # all the operations that is happening on this state,
    # will be queued and will happen after the transition is completed.
    # only available action at this point is `init`.
    @channelMachine = ChannelStateMachine.create() # @state === 'loading'

    # at this point we are 100% sure that 
    # channel is ready to user.
    @channelMachine.on 'ChannelReady', (channel) ->
      collaborationButton.updatePartial 'CHAT'

    @channelMachine.on 'ParticipantAdded', (participant) ->
      @cacheParticipant participant
      # ...
```
## State-machine diagram

![channel-state-diagram](https://cloud.githubusercontent.com/assets/1783869/6361112/46408b26-bc34-11e4-92e8-6110f5147c76.png)

/cc @szkl @cihangir @fatihacet @canthefason 
