### PR TITLE
vmwatcher: reconnection improvements

### DIFF
--- a/client/legal/lib/userpolicyview.coffee
+++ b/client/legal/lib/userpolicyview.coffee
@@ -108,6 +108,11 @@ module.exports = class UserPolicyView extends JView
         </li>
 
         <li>
+          Use of any kind of VOIP related software, including but not limited to Teamspeak,
+          Asterisk, FreePBX;
+        </li>
+
+        <li>
           Other material, products or services that violate or encourage conduct
           that would violate any criminal laws, any other applicable laws, or any
           third-party rights;

--- a/go/src/koding/vmwatcher/action.go
+++ b/go/src/koding/vmwatcher/action.go
@@ -32,6 +32,11 @@ func stopVm(machineId, username, reason string) error {
 }
 
 func blockUserAndDestroyVm(machineId, username, reason string) error {
+	err := modelhelper.BlockUser(username, reason, BlockDuration)
+	if err != nil {
+		return err
+	}
+
 	machines, err := modelhelper.GetMachinesByUsername(username)
 	if err != nil {
 		return err
@@ -51,5 +56,5 @@ func blockUserAndDestroyVm(machineId, username, reason string) error {
 		Log.Debug("Klient not initialized. Not stopping: %s...but blocking user", machineId)
 	}
 
-	return modelhelper.BlockUser(username, reason, BlockDuration)
+	return nil
 }

--- a/go/src/koding/vmwatcher/action.go
+++ b/go/src/koding/vmwatcher/action.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"koding/db/mongodb/modelhelper"
 	"strings"
 	"time"
@@ -48,7 +49,10 @@ func blockUserAndDestroyVm(machineId, username, reason string) error {
 	for _, machine := range machines {
 		err := stopVm(machine.ObjectId.Hex(), username, reason)
 		if err != nil {
-			Log.Error(err.Error())
+			Log.Error(fmt.Sprintf(
+				"Error stopping machine: %s of user: %s: %s", machine.ObjectId,
+				username, err.Error(),
+			))
 		}
 	}
 

--- a/go/src/koding/vmwatcher/cloudwatch.go
+++ b/go/src/koding/vmwatcher/cloudwatch.go
@@ -103,7 +103,7 @@ func (c *Cloudwatch) GetAndSaveData(username string) error {
 	}
 
 	if sum > c.Limits[StopLimitKey] {
-		Log.Debug("'%s' has used: %v '%s'", username, sum, c.Name)
+		Log.Info("'%s' has used: %v '%s'", username, sum, c.Name)
 	}
 
 	return c.Save(username, sum)

--- a/go/src/koding/vmwatcher/init.go
+++ b/go/src/koding/vmwatcher/init.go
@@ -9,6 +9,7 @@ import (
 	kiteConfig "github.com/koding/kite/config"
 	"github.com/koding/multiconfig"
 
+	"github.com/cenkalti/backoff"
 	"github.com/crowdmob/goamz/aws"
 	"github.com/koding/kite"
 	"github.com/koding/redis"
@@ -132,8 +133,12 @@ func initializeKlient(c *VmController) {
 		Key:  KloudSecretKey,
 	}
 
-	// dial the kloud address
-	if err := kiteClient.DialTimeout(time.Second * 10); err != nil {
+	operation := func() error {
+		return kiteClient.DialTimeout(time.Second * 10)
+	}
+
+	err = backoff.Retry(operation, backoff.NewExponentialBackOff())
+	if err != nil {
 		Log.Fatal("%s. Is kloud/kontrol running?", err.Error())
 	}
 

--- a/go/src/koding/vmwatcher/main.go
+++ b/go/src/koding/vmwatcher/main.go
@@ -44,6 +44,9 @@ var (
 func main() {
 	initialize()
 
+	// on disconnect, try to reconnect
+	controller.Klient.OnDisconnect(func() { initializeKlient(controller) })
+
 	startTime := time.Now()
 	defer func() {
 		Log.Info("Exited...ran for: %s", time.Since(startTime))

--- a/go/src/koding/vmwatcher/main.go
+++ b/go/src/koding/vmwatcher/main.go
@@ -41,6 +41,12 @@ var (
 	}
 )
 
+const (
+	every4MinsFrom0 = "0 0-59/4 * * * *"
+	every4MinsFrom1 = "0 1-59/4 * * * *"
+	every3MinsFrom1 = "0 1-59/3 * * * *"
+)
+
 func main() {
 	initialize()
 
@@ -58,7 +64,7 @@ func main() {
 	// the usernames so multiple workers don't queue the same usernames.
 	// this needs to be done at top of hour, so running multiple workers
 	// won't cause a problem.
-	c.AddFunc("0 0-59/4 * * * *", func() {
+	c.AddFunc(every4MinsFrom0, func() {
 		err := queueUsernamesForMetricGet()
 		if err != nil {
 			Log.Fatal(err.Error())
@@ -68,7 +74,7 @@ func main() {
 	// get and save metrics every 4 mins, starting at 1st minute
 	// queue overlimit users for either stop or block depending
 	// on their usage
-	c.AddFunc("0 1-59/4 * * * *", func() {
+	c.AddFunc(every4MinsFrom1, func() {
 		err := getAndSaveQueueMachineMetrics()
 		if err != nil {
 			Log.Fatal(err.Error())
@@ -85,7 +91,7 @@ func main() {
 		}
 	})
 
-	c.AddFunc("0 1-59/3 * * * *", func() {
+	c.AddFunc(every3MinsFrom1, func() {
 		err := dealWithMachinesOverLimit()
 		if err != nil {
 			Log.Fatal(err.Error())

--- a/go/src/koding/vmwatcher/main.go
+++ b/go/src/koding/vmwatcher/main.go
@@ -9,6 +9,7 @@ package main
 
 import (
 	"koding/artifact"
+	"koding/db/mongodb/modelhelper"
 	"net"
 	"net/http"
 	"os"
@@ -124,6 +125,9 @@ func main() {
 			case syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGSTOP, syscall.SIGKILL:
 				listener.Close()
 				controller.Klient.Close()
+				modelhelper.Close()
+				controller.Redis.Client.Close()
+
 				os.Exit(0)
 			}
 		}

--- a/go/src/koding/vmwatcher/main.go
+++ b/go/src/koding/vmwatcher/main.go
@@ -82,6 +82,13 @@ func main() {
 		}
 	})
 
+	c.AddFunc("0 1-59/3 * * * *", func() {
+		err := dealWithMachinesOverLimit()
+		if err != nil {
+			Log.Fatal(err.Error())
+		}
+	})
+
 	c.Start()
 
 	mux := http.NewServeMux()

--- a/website/acceptable.html
+++ b/website/acceptable.html
@@ -110,6 +110,11 @@
         Pornography and Sexually Explicit Content;
       </li>
 
+      <li>
+        Use of any kind of VOIP related software, including but not limited to Teamspeak,
+        Asterisk, FreePBX;
+      </li>
+
       <li class='li2'>
         Other material, products or services that violate or encourage conduct
         that would violate any criminal laws, any other applicable laws, or any


### PR DESCRIPTION
- Use `kloud#TellWithTimeout` when communicating with kloud
- Use exponential backoff when trying to connect to kloud
- On kloud disconnect, reconnect to kloud
- Move dealing with vm over limit to own goroutine
