### PR TITLE
support: add kd.impersonate for super-admin flag owners [fixes #89320924]

### DIFF
--- a/client/app/lib/maincontroller.coffee
+++ b/client/app/lib/maincontroller.coffee
@@ -150,6 +150,7 @@ module.exports = class MainController extends KDController
       kd.registerSingleton 'onboardingController',    new OnboardingController
 
       @emit 'AppIsReady'
+      @prepareSupportShortcuts()
 
       console.timeEnd 'Koding.com loaded'
 
@@ -357,6 +358,11 @@ module.exports = class MainController extends KDController
     idleDetector = new IdleUserDetector { threshold }
     @forwardEvents idleDetector, ['userIdle', 'userBack']
 
+  prepareSupportShortcuts: ->
+
+    return  unless checkFlag ['super-admin']
+
+    kd.impersonate = require './util/impersonate'
 
   startCachingAssets:->
 


### PR DESCRIPTION
 once this is deployed, a flag called ~~impersonator~~ `super-admin` should be added from here http://take.ms/gRlyd for the users who want to use `require('kd').impersonate`
