### PR TITLE
activity: update comment's embed for other users

### DIFF
--- a/client/activity/lib/views/comments/commentlistitemview.coffee
+++ b/client/activity/lib/views/comments/commentlistitemview.coffee
@@ -20,6 +20,7 @@ CustomLinkView = require 'app/customlinkview'
 AvatarView = require 'app/commonviews/avatarviews/avatarview'
 isMyPost = require 'app/util/isMyPost'
 hasPermission = require 'app/util/hasPermission'
+htmlencode = require 'htmlencode'
 
 module.exports = class CommentListItemView extends KDListItemView
 
@@ -47,10 +48,15 @@ module.exports = class CommentListItemView extends KDListItemView
 
   handleUpdate: ->
 
-    { updatedAt, createdAt } = @getData()
+    { updatedAt, createdAt, link, payload } = @getData()
 
     if updatedAt > createdAt
-    then @setClass 'edited'
+      @setClass 'edited'
+      if link?.link_url isnt payload?.link_url and payload?.link_embed
+        link.link_embed =
+          try JSON.parse htmlencode.htmlDecode payload.link_embed
+          catch e then null
+        @updateEmbedBox()
     else @unsetClass 'edited'
 
     kd.utils.defer => emojify.run @getElement()


### PR DESCRIPTION
fix same [problem](https://github.com/koding/koding/pull/2890) for comments

@gokmen @sinan @usirin @szkl 

`commentlistitemview` and `activitylistitemview` contain same functionality. Maybe it's better to create a parent class for this or inherit one from the other
