### PR TITLE
kloud: fix a rare race condition due to AWS eventually consistency

### DIFF
--- a/go/src/koding/kites/kloud/provider/koding/resize.go
+++ b/go/src/koding/kites/kloud/provider/koding/resize.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mitchellh/goamz/ec2"
 )
 
-// Resizes increases the current machines underling volume to a larger volume
+// Resize increases the current machines underling volume to a larger volume
 // without affecting or destroying the users data.
 func (p *Provider) Resize(m *protocol.Machine) (resArtifact *protocol.Artifact, resErr error) {
 	// Please read the steps before you dig into the code and try to change or
@@ -158,15 +158,13 @@ func (p *Provider) Resize(m *protocol.Machine) (resArtifact *protocol.Artifact, 
 		// back the old volume  so it can be used again
 		if resErr != nil {
 			infoLog("(an error occurred) detaching newly created volume volume %s ", newVolumeId)
-			_, err := a.Client.DetachVolume(newVolumeId)
-			if err != nil {
-				a.Log.Error(err.Error())
+			if err := a.DetachVolume(newVolumeId); err != nil {
+				a.Log.Error("[%s] couldn't detach:", m.Id, err.Error())
 			}
 
 			infoLog("(an error occurred) attaching back old volume %s", oldVolumeId)
-			_, err = a.Client.AttachVolume(oldVolumeId, a.Id(), "/dev/sda1")
-			if err != nil {
-				a.Log.Error(err.Error())
+			if err = a.AttachVolume(oldVolumeId, a.Id(), "/dev/sda1"); err != nil {
+				a.Log.Error("[%s] couldn't attach:", m.Id, err.Error())
 			}
 		} else {
 			// if not just delete, it's not used anymore


### PR DESCRIPTION
Suppose resize failed because AWS doesn't have any resource to start the VM or in other cased in the resize code path. In that case resize tries to recover from it by detaching the newly created volume and attach back the old volume, so the user can use it again.

However, even if the new volume is detached AWS doesn't allow to attach the users old Volume. Because in fact AWS didn't still detached the new volume. Because of that attaching the old volume fails with the error: `Invalid value '/dev/sda1' for unixDevice. Attachment point /dev/sda1 is already in use (InvalidParameterValue)`. 

This fix uses our own `DetachVolume` and `AttachVolume`, which are safe to be used with AWS's eventually consistency nature. Now if we try to detach, it'll try to wait until the volume is truly detached. It's doing this by doing a periodic checking and continue only if the volume is really detached (same applies for the attaching method)
