### PR TITLE
ComputeController: fetchStacks after a machine created

### DIFF
--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -77,7 +77,7 @@ module.exports = class ComputeController extends KDController
     @plans    = null
     @_trials  = {}
 
-    if render then @fetchMachines =>
+    if render then @fetchStacks =>
       @info machine for machine in @machines
       @emit "RenderMachines", @machines
 

--- a/client/app/lib/providers/computeplansmodalpaid.coffee
+++ b/client/app/lib/providers/computeplansmodalpaid.coffee
@@ -50,9 +50,9 @@ module.exports = class ComputePlansModalPaid extends ComputePlansModal
       name          : "region"
       selectOptions : [
         { title: "United States (North Virginia)", value: "us-east-1" }
-        { title: "United States (Oregon)", value: "us-west-2" }
-        { title: "Singapore",     value: "ap-southeast-1" }
-        { title: "Ireland",     value: "eu-west-1" }
+        { title: "United States (Oregon)",         value: "us-west-2" }
+        { title: "Singapore",                      value: "ap-southeast-1" }
+        { title: "Ireland",                        value: "eu-west-1" }
       ]
 
     regionContainer.addSubView @regionTextView = new KDView
@@ -138,5 +138,3 @@ module.exports = class ComputePlansModalPaid extends ComputePlansModal
 
       @createVMButton.hideLoader()
       @destroy()
-
-


### PR DESCRIPTION
If we don't fetch stacks here users won't be able to create new machines
until they reload the page.
