### PR TITLE
Improve kloud tests

### DIFF
--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -195,6 +195,10 @@ func TestBuild(t *testing.T) {
 	if err := build(userData.MachineId); err == nil {
 		t.Error("`build` method can not be called on `running` machines.")
 	}
+
+	if err := destroy(userData.MachineId); err != nil {
+		t.Error(err)
+	}
 }
 
 func TestResize(t *testing.T) {

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -201,6 +201,68 @@ func TestBuild(t *testing.T) {
 	}
 }
 
+func TestStop(t *testing.T) {
+	t.Parallel()
+	username := "testuser2"
+	userData, err := createUser(username)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := build(userData.MachineId); err != nil {
+		t.Fatal(err)
+	}
+
+	log.Println("Stopping machine")
+	if err := stop(userData.MachineId); err != nil {
+		t.Fatal(err)
+	}
+
+	// the following calls should give an error, if not there is a problem
+	if err := build(userData.MachineId); err == nil {
+		t.Error("`build` method can not be called on `stopped` machines.")
+	}
+
+	if err := stop(userData.MachineId); err == nil {
+		t.Error("`stop` method can not be called on `stopped` machines.")
+	}
+
+	if err := destroy(userData.MachineId); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestStart(t *testing.T) {
+	t.Parallel()
+	username := "testuser3"
+	userData, err := createUser(username)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := build(userData.MachineId); err != nil {
+		t.Fatal(err)
+	}
+
+	log.Println("Stopping machine")
+	if err := stop(userData.MachineId); err != nil {
+		t.Fatal(err)
+	}
+
+	log.Println("Starting machine")
+	if err := start(userData.MachineId); err != nil {
+		t.Error("`stop` method can not be called on `stopped` machines.")
+	}
+
+	if err := start(userData.MachineId); err == nil {
+		t.Error("`start` method can not be called on `started` machines.")
+	}
+
+	if err := destroy(userData.MachineId); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestResize(t *testing.T) {
 	t.Parallel()
 	username := "testuser"


### PR DESCRIPTION
Main changes from previous tests:
- Create individual tests for each method, such as `build`, `snapshot`, `resize`, `start`, etc.. This allows to just run certain tests and have more control over each method test.
- Parallelized each test. Now when given the flag `-parallel 8` it will execute all tests concurrently.

The change from previous change is, we now test concurrently each method independent of each other. Once parallelized the test, the total test duration is bound to the test with the longest duration (which is currently `resize`, which executes resizing three times).

 On my localhost it takes `15 min` to finish all tests in parallel mode. 
