### PR TITLE
added close icon for find&replace section [fixes #89189404]

### DIFF
--- a/client/ace/lib/styl/aceeditor.styl
+++ b/client/ace/lib/styl/aceeditor.styl
@@ -236,7 +236,7 @@ body.ace
     left                  0
 
   .ace-find-replace-inputs
-    padding               0 194px 0 86px
+    padding               0 213px 0 86px
     width                 auto
 
     .kdinput
@@ -264,7 +264,7 @@ body.ace
         shadow            0 0 3px #7e9ea3
 
   .ace-find-replace-buttons
-    width                 190px
+    width                 207px
     abs()
     right                 0
     top                   3px
@@ -296,7 +296,7 @@ body.ace
     width                 100%
 
   .close-icon
-    r-sprite                app "20-close-tab"
+    r-sprite              app "20-close-tab"
 
   .multiple-choice
     fl()

--- a/client/ace/lib/styl/aceeditor.styl
+++ b/client/ace/lib/styl/aceeditor.styl
@@ -296,7 +296,7 @@ body.ace
     width                 100%
 
   .close-icon
-    bg                    position,-80px -222px
+    r-sprite                app "20-close-tab"
 
   .multiple-choice
     fl()


### PR DESCRIPTION
@burakcan @sinan @gokmen @szkl 

![close-icon](https://cloud.githubusercontent.com/assets/295206/6513616/377a362c-c38d-11e4-9cee-de00bf7b42ed.png)
