### PR TITLE
Environment: Pass string to JSON.parse function [fixes #89889232]

### DIFF
--- a/client/app/lib/userenvironmentdataprovider.coffee
+++ b/client/app/lib/userenvironmentdataprovider.coffee
@@ -17,7 +17,15 @@ module.exports = UserEnvironmentDataProvider =
 
 
   get: ->
-    return @setDefaults_ globals.userEnvironmentData
+
+    switch typeof globals.userEnvironmentData
+      when 'string'
+        data = try
+          JSON.parse globals.userEnvironmentData
+        catch
+          null
+
+    return @setDefaults_ data
 
 
   setDefaults_: (data = {}) ->


### PR DESCRIPTION
This is due to lack of web server's ability to print JavaScript values as they are.

[IDE is not displayed](https://www.pivotaltracker.com/story/show/89889232)
