### PR TITLE
TTL decrease for domains

### DIFF
--- a/go/src/koding/kites/kloud/dnsclient/dnsclient.go
+++ b/go/src/koding/kites/kloud/dnsclient/dnsclient.go
@@ -1,4 +1,4 @@
-package koding
+package dnsclient
 
 import (
 	"errors"
@@ -21,8 +21,8 @@ type DNS struct {
 	Log        logging.Logger
 }
 
-// NewDNSClient initializes a new DNS instance with default Koding credentials
-func NewDNSClient(hostedZone string, auth aws.Auth) *DNS {
+// New initializes a new DNS instance with default Koding credentials
+func New(hostedZone string, auth aws.Auth) *DNS {
 	// our route53 is based on this region, so we use it
 	dns := route53.New(auth, aws.USEast)
 

--- a/go/src/koding/kites/kloud/dnsclient/dnsclient_test.go
+++ b/go/src/koding/kites/kloud/dnsclient/dnsclient_test.go
@@ -80,8 +80,13 @@ func TestCreate(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	err := dns.Delete(testDomain, testIP)
+	err := dns.Delete(testDomain)
 	if err != nil {
 		t.Error(err)
+	}
+
+	_, err = dns.Get(testDomain)
+	if err != ErrNoRecord {
+		t.Errorf("Domain '%s' is deleted, but got a different error: %s", testDomain, err)
 	}
 }

--- a/go/src/koding/kites/kloud/dnsclient/dnsclient_test.go
+++ b/go/src/koding/kites/kloud/dnsclient/dnsclient_test.go
@@ -2,9 +2,6 @@ package dnsclient
 
 import (
 	"fmt"
-	"io"
-	"log"
-	"net/http"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -18,8 +15,8 @@ var (
 	dns         *DNS
 	testDomain  = "kloud-test.dev.koding.io"
 	testDomain2 = "kloud-test2.dev.koding.io"
-	testIP      = "192.168.1.1"
-	testIP2     = "192.168.1.2"
+	testIP      = "127.0.0.1"
+	testIP2     = "127.0.0.2"
 )
 
 func init() {
@@ -29,13 +26,6 @@ func init() {
 	}
 
 	dns = New("dev.koding.io", auth)
-
-	go func() {
-		err := http.ListenAndServe(":8888", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			io.WriteString(w, "hello, world!\n")
-		}))
-		log.Println(err)
-	}()
 }
 
 func TestCreate(t *testing.T) {
@@ -52,19 +42,6 @@ func TestCreate(t *testing.T) {
 	equals(t, testDomain, strings.TrimSuffix(record.Name, "."))
 	equals(t, testIP, record.IP)
 	equals(t, 30, record.TTL)
-
-	// resp, err := http.Get("http://" + testDomain)
-	// if err != nil {
-	// 	t.Fatal(err)
-	// }
-	// defer resp.Body.Close()
-	//
-	// data, err := ioutil.ReadAll(resp.Body)
-	// if err != nil {
-	// 	t.Fatal(err)
-	// }
-	//
-	// fmt.Printf("string(data) = %+v\n", string(data))
 }
 
 func TestUpdate(t *testing.T) {

--- a/go/src/koding/kites/kloud/dnsclient/dnsclient_test.go
+++ b/go/src/koding/kites/kloud/dnsclient/dnsclient_test.go
@@ -23,9 +23,9 @@ var (
 )
 
 func init() {
-	auth := aws.Auth{
-		AccessKey: "AKIAJFKDHRJ7Q5G4MOUQ",
-		SecretKey: "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",
+	auth, err := aws.EnvAuth()
+	if err != nil {
+		panic(err)
 	}
 
 	dns = New("dev.koding.io", auth)

--- a/go/src/koding/kites/kloud/dnsclient/dnsclient_test.go
+++ b/go/src/koding/kites/kloud/dnsclient/dnsclient_test.go
@@ -17,7 +17,8 @@ import (
 var (
 	dns        *DNS
 	testDomain = "kloud-test.dev.koding.io"
-	testIP     = "192.168.1.2"
+	testIP     = "192.168.1.1"
+	testIP2    = "192.168.1.2"
 )
 
 func init() {
@@ -77,6 +78,37 @@ func TestCreate(t *testing.T) {
 	// }
 	//
 	// fmt.Printf("string(data) = %+v\n", string(data))
+}
+
+func TestUpdate(t *testing.T) {
+	err := dns.Update(testDomain, testIP, testIP2)
+	if err != nil {
+		t.Error(err)
+	}
+
+	record, err := dns.Get(testDomain)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(testDomain, strings.TrimSuffix(record.Name, ".")) {
+		_, file, line, _ := runtime.Caller(0)
+		fmt.Printf("%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\n\n", filepath.Base(file), line, testDomain, strings.TrimSuffix(record.Name, "."))
+		t.FailNow()
+	}
+
+	if !reflect.DeepEqual(testIP2, record.IP) {
+		_, file, line, _ := runtime.Caller(0)
+		fmt.Printf("%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\n\n", filepath.Base(file), line, testIP2, record.IP)
+		t.FailNow()
+	}
+
+	if !reflect.DeepEqual(30, record.TTL) {
+		_, file, line, _ := runtime.Caller(0)
+		fmt.Printf("%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\n\n", filepath.Base(file), line, 30, record.TTL)
+		t.FailNow()
+	}
+
 }
 
 func TestDelete(t *testing.T) {

--- a/go/src/koding/kites/kloud/dnsclient/dnsclient_test.go
+++ b/go/src/koding/kites/kloud/dnsclient/dnsclient_test.go
@@ -38,7 +38,7 @@ func init() {
 }
 
 func TestCreate(t *testing.T) {
-	err := dns.Create(testDomain, testIP)
+	err := dns.Upsert(testDomain, testIP)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,23 +48,9 @@ func TestCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !reflect.DeepEqual(testIP, record.IP) {
-		_, file, line, _ := runtime.Caller(0)
-		fmt.Printf("%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\n\n", filepath.Base(file), line, testIP, record.IP)
-		t.FailNow()
-	}
-
-	if !reflect.DeepEqual(30, record.TTL) {
-		_, file, line, _ := runtime.Caller(0)
-		fmt.Printf("%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\n\n", filepath.Base(file), line, 30, record.TTL)
-		t.FailNow()
-	}
-
-	if !reflect.DeepEqual(testDomain, strings.TrimSuffix(record.Name, ".")) {
-		_, file, line, _ := runtime.Caller(0)
-		fmt.Printf("%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\n\n", filepath.Base(file), line, testDomain, record.Name)
-		t.FailNow()
-	}
+	equals(t, testDomain, strings.TrimSuffix(record.Name, "."))
+	equals(t, testIP, record.IP)
+	equals(t, 30, record.TTL)
 
 	// resp, err := http.Get("http://" + testDomain)
 	// if err != nil {
@@ -81,7 +67,7 @@ func TestCreate(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	err := dns.Update(testDomain, testIP, testIP2)
+	err := dns.Upsert(testDomain, testIP2)
 	if err != nil {
 		t.Error(err)
 	}
@@ -91,23 +77,9 @@ func TestUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !reflect.DeepEqual(testDomain, strings.TrimSuffix(record.Name, ".")) {
-		_, file, line, _ := runtime.Caller(0)
-		fmt.Printf("%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\n\n", filepath.Base(file), line, testDomain, strings.TrimSuffix(record.Name, "."))
-		t.FailNow()
-	}
-
-	if !reflect.DeepEqual(testIP2, record.IP) {
-		_, file, line, _ := runtime.Caller(0)
-		fmt.Printf("%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\n\n", filepath.Base(file), line, testIP2, record.IP)
-		t.FailNow()
-	}
-
-	if !reflect.DeepEqual(30, record.TTL) {
-		_, file, line, _ := runtime.Caller(0)
-		fmt.Printf("%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\n\n", filepath.Base(file), line, 30, record.TTL)
-		t.FailNow()
-	}
+	equals(t, testDomain, strings.TrimSuffix(record.Name, "."))
+	equals(t, testIP2, record.IP)
+	equals(t, 30, record.TTL)
 
 }
 
@@ -120,5 +92,14 @@ func TestDelete(t *testing.T) {
 	_, err = dns.Get(testDomain)
 	if err != ErrNoRecord {
 		t.Errorf("Domain '%s' is deleted, but got a different error: %s", testDomain, err)
+	}
+}
+
+// equals fails the test if exp is not equal to act.
+func equals(tb testing.TB, exp, act interface{}) {
+	if !reflect.DeepEqual(exp, act) {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n", filepath.Base(file), line, exp, act)
+		tb.FailNow()
 	}
 }

--- a/go/src/koding/kites/kloud/dnsclient/dnsclient_test.go
+++ b/go/src/koding/kites/kloud/dnsclient/dnsclient_test.go
@@ -1,0 +1,61 @@
+package dnsclient
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"testing"
+
+	"github.com/mitchellh/goamz/aws"
+)
+
+var (
+	dns        *DNS
+	testDomain = "kloud-test.dev.koding.io"
+	testIP     = "192.168.1.1"
+)
+
+func init() {
+	auth := aws.Auth{
+		AccessKey: "AKIAJFKDHRJ7Q5G4MOUQ",
+		SecretKey: "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",
+	}
+
+	dns = New("dev.koding.io", auth)
+
+	go func() {
+		err := http.ListenAndServe(":8888", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			io.WriteString(w, "hello, world!\n")
+		}))
+		log.Println(err)
+	}()
+}
+
+func TestCreate(t *testing.T) {
+	err := dns.Create(testDomain, testIP)
+	if err != nil {
+		t.Error(err)
+	}
+
+	resp, err := http.Get("http://" + testDomain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Printf("string(data) = %+v\n", string(data))
+}
+
+func TestDelete(t *testing.T) {
+	err := dns.Delete(testDomain, testIP)
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/go/src/koding/kites/kloud/dnsclient/dnsclient_test.go
+++ b/go/src/koding/kites/kloud/dnsclient/dnsclient_test.go
@@ -15,10 +15,11 @@ import (
 )
 
 var (
-	dns        *DNS
-	testDomain = "kloud-test.dev.koding.io"
-	testIP     = "192.168.1.1"
-	testIP2    = "192.168.1.2"
+	dns         *DNS
+	testDomain  = "kloud-test.dev.koding.io"
+	testDomain2 = "kloud-test2.dev.koding.io"
+	testIP      = "192.168.1.1"
+	testIP2     = "192.168.1.2"
 )
 
 func init() {
@@ -83,13 +84,30 @@ func TestUpdate(t *testing.T) {
 
 }
 
-func TestDelete(t *testing.T) {
-	err := dns.Delete(testDomain)
+func TestRename(t *testing.T) {
+	err := dns.Rename(testDomain, testDomain2)
 	if err != nil {
 		t.Error(err)
 	}
 
-	_, err = dns.Get(testDomain)
+	record, err := dns.Get(testDomain2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	equals(t, testDomain2, strings.TrimSuffix(record.Name, "."))
+	equals(t, testIP2, record.IP)
+	equals(t, 30, record.TTL)
+
+}
+
+func TestDelete(t *testing.T) {
+	err := dns.Delete(testDomain2)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = dns.Get(testDomain2)
 	if err != ErrNoRecord {
 		t.Errorf("Domain '%s' is deleted, but got a different error: %s", testDomain, err)
 	}

--- a/go/src/koding/kites/kloud/kloud/domain.go
+++ b/go/src/koding/kites/kloud/kloud/domain.go
@@ -53,7 +53,7 @@ func (k *Kloud) DomainAdd(r *kite.Request) (resp interface{}, reqErr error) {
 		}
 
 		// now assign the machine ip to the given domain name
-		if err := k.Domainer.Create(args.DomainName, m.IpAddress); err != nil {
+		if err := k.Domainer.Upsert(args.DomainName, m.IpAddress); err != nil {
 			return nil, err
 		}
 
@@ -76,7 +76,7 @@ func (k *Kloud) DomainAdd(r *kite.Request) (resp interface{}, reqErr error) {
 func (k *Kloud) DomainRemove(r *kite.Request) (resp interface{}, reqErr error) {
 	removeFunc := func(m *protocol.Machine, args *domainArgs) (interface{}, error) {
 		// do not return on error because it might be already delete via unset
-		k.Domainer.Delete(args.DomainName, m.IpAddress)
+		k.Domainer.Delete(args.DomainName)
 
 		if err := k.DomainStorage.Delete(args.DomainName); err != nil {
 			return nil, err
@@ -95,7 +95,7 @@ func (k *Kloud) DomainUnset(r *kite.Request) (resp interface{}, reqErr error) {
 			return nil, fmt.Errorf("domain does not exists in DB")
 		}
 
-		if err := k.Domainer.Delete(args.DomainName, m.IpAddress); err != nil {
+		if err := k.Domainer.Delete(args.DomainName); err != nil {
 			return nil, err
 		}
 
@@ -121,7 +121,7 @@ func (k *Kloud) DomainSet(r *kite.Request) (resp interface{}, reqErr error) {
 		record, err := k.Domainer.Get(args.DomainName)
 		if err != nil && strings.Contains(err.Error(), "no records available") {
 			k.Log.Debug("[%s] setting domain '%s' to IP '%s'", m.Id, args.DomainName, m.IpAddress)
-			if err := k.Domainer.Create(args.DomainName, m.IpAddress); err != nil {
+			if err := k.Domainer.Upsert(args.DomainName, m.IpAddress); err != nil {
 				return nil, err
 			}
 		} else if err != nil {
@@ -133,7 +133,7 @@ func (k *Kloud) DomainSet(r *kite.Request) (resp interface{}, reqErr error) {
 		if err == nil && record.IP != m.IpAddress {
 			k.Log.Debug("[%s] setting domain '%s' from old IP '%s' to new Ip '%s'",
 				m.Id, args.DomainName, record.IP, m.IpAddress)
-			if err := k.Domainer.Update(args.DomainName, record.IP, m.IpAddress); err != nil {
+			if err := k.Domainer.Upsert(args.DomainName, m.IpAddress); err != nil {
 				fmt.Printf("err = %+v\n", err)
 				return nil, err
 			}

--- a/go/src/koding/kites/kloud/main.go
+++ b/go/src/koding/kites/kloud/main.go
@@ -14,6 +14,7 @@ import (
 
 	"koding/artifact"
 	"koding/db/mongodb/modelhelper"
+	"koding/kites/kloud/dnsclient"
 	"koding/kites/kloud/keys"
 	"koding/kites/kloud/multiec2"
 	"koding/kites/kloud/provider/koding"
@@ -172,7 +173,7 @@ func newKite(conf *Config) *kite.Kite {
 		panic(err)
 	}
 
-	dnsInstance := koding.NewDNSClient(conf.HostedZone, auth)
+	dnsInstance := dnsclient.New(conf.HostedZone, auth)
 	domainStorage := koding.NewDomainStorage(db)
 
 	kodingProvider := &koding.Provider{

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -58,6 +58,7 @@ import (
 
 	"koding/db/models"
 	"koding/db/mongodb/modelhelper"
+	"koding/kites/kloud/dnsclient"
 	"koding/kites/kloud/keys"
 	"koding/kites/kloud/kloud"
 	"koding/kites/kloud/machinestate"
@@ -774,7 +775,7 @@ func newKodingProvider() *koding.Provider {
 			"us-west-2",
 			"eu-west-1",
 		}),
-		DNS:           koding.NewDNSClient("dev.koding.io", auth),
+		DNS:           dnsclient.New("dev.koding.io", auth),
 		DomainStorage: domainStorage,
 		Bucket:        koding.NewBucket("koding-klient", "development/latest", auth),
 		KeyName:       keys.DeployKeyName,

--- a/go/src/koding/kites/kloud/protocol/domain.go
+++ b/go/src/koding/kites/kloud/protocol/domain.go
@@ -23,19 +23,16 @@ type Domain struct {
 
 // Domainer is responsible of managing DNS records
 type Domainer interface {
-	// Create creates a new domain record with the given name to the new IP
-	Create(name, newIP string) error
+	// Upsert updates or creates a new domain record with the given name to the
+	// new IP
+	Upsert(name, newIP string) error
 
-	// Delete deletes the given domain name which was associated to the old IP
-	Delete(name, oldIP string) error
+	// Delete deletes the given domain name.
+	Delete(name string) error
 
-	// Update updates the given domain name which was associated to the old IP
-	// with the new IP
-	Update(name, oldIP, newIP string) error
-
-	// Rename renames the given old domain name with the new domain name for
-	// the given IP
-	Rename(oldName, newName, currentIp string) error
+	// Rename renames the given old domain name with the new domain name. To
+	// change the IP, use the Upsert command.
+	Rename(oldName, newName string) error
 
 	// Get returns a domain record for the given domain name
 	Get(name string) (*Record, error)

--- a/go/src/koding/kites/kloud/provider/koding/domain.go
+++ b/go/src/koding/kites/kloud/provider/koding/domain.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"koding/db/models"
 	"koding/db/mongodb"
+	"koding/kites/kloud/dnsclient"
 	"koding/kites/kloud/protocol"
 	"time"
 
@@ -169,7 +170,7 @@ func (p *Provider) UpdateDomain(ip, domain, username string) error {
 
 	// Check if the record exist, if yes update the ip instead of creating a new one.
 	record, err := p.DNS.Get(domain)
-	if err == ErrNoRecord {
+	if err == dnsclient.ErrNoRecord {
 		if err := p.DNS.Create(domain, ip); err != nil {
 			return err
 		}

--- a/go/src/koding/kites/kloud/provider/koding/provider.go
+++ b/go/src/koding/kites/kloud/provider/koding/provider.go
@@ -9,6 +9,7 @@ import (
 	"koding/db/mongodb"
 
 	amazonClient "koding/kites/kloud/api/amazon"
+	"koding/kites/kloud/dnsclient"
 	"koding/kites/kloud/eventer"
 	"koding/kites/kloud/klient"
 	"koding/kites/kloud/kloud"
@@ -48,7 +49,7 @@ type Provider struct {
 
 	// AWS related references and settings
 	EC2Clients *multiec2.Clients
-	DNS        *DNS
+	DNS        *dnsclient.DNS
 	Bucket     *Bucket
 
 	KontrolURL        string

--- a/go/src/koding/kites/kloud/provider/koding/provider.go
+++ b/go/src/koding/kites/kloud/provider/koding/provider.go
@@ -349,7 +349,7 @@ func (p *Provider) Stop(m *protocol.Machine) error {
 	}
 
 	a.Push("Deleting domain", 85, machinestate.Stopping)
-	if err := p.DNS.Delete(m.Domain.Name, m.IpAddress); err != nil {
+	if err := p.DNS.Delete(m.Domain.Name); err != nil {
 		a.Log.Warning("couldn't delete domain %s", err)
 	}
 
@@ -360,7 +360,7 @@ func (p *Provider) Stop(m *protocol.Machine) error {
 	}
 
 	for _, domain := range domains {
-		if err := p.DNS.Delete(domain.Name, m.IpAddress); err != nil {
+		if err := p.DNS.Delete(domain.Name); err != nil {
 			a.Log.Error("couldn't delete domain: %s", err.Error())
 		}
 	}
@@ -461,7 +461,7 @@ func (p *Provider) Destroy(m *protocol.Machine) error {
 	}
 
 	a.Push("Deleting base domain", 85, machinestate.Terminating)
-	if err := p.DNS.Delete(m.Domain.Name, m.IpAddress); err != nil {
+	if err := p.DNS.Delete(m.Domain.Name); err != nil {
 		// if it's already deleted, for example because of a STOP, than we just
 		// log it here instead of returning the error
 		a.Log.Error("deleting domain during destroying err: %s", err.Error())
@@ -469,7 +469,7 @@ func (p *Provider) Destroy(m *protocol.Machine) error {
 
 	a.Push("Deleting custom domain", 90, machinestate.Terminating)
 	for _, domain := range domains {
-		if err := p.DNS.Delete(domain.Name, m.IpAddress); err != nil {
+		if err := p.DNS.Delete(domain.Name); err != nil {
 			a.Log.Error("couldn't delete domain: %s", err.Error())
 		}
 


### PR DESCRIPTION
- Decrease TTL from `300` seconds to `30` seconds
- Move dns struct to an independent package called `dnsclient` to enable testing
- Add tests for dns operations
- Removed `create` and `update`, replaced it with `upsert`
- Simplified `rename` and `delete`, we don't need anymore an IP.
- Update kloud code with the new `dnsclient` package

![image](https://cloud.githubusercontent.com/assets/438920/6601893/f10db0b8-c820-11e4-9b75-b776aee756f3.png)
