### PR TITLE
analytics: send orderId after order is completed

### DIFF
--- a/client/app/lib/payment/paymentmodal.coffee
+++ b/client/app/lib/payment/paymentmodal.coffee
@@ -41,9 +41,12 @@ module.exports = class PaymentModal extends PaymentBaseModal
 
     super options, data
 
+    {planTitle, planInterval} = @state
+
     trackEvent 'Viewed Product',
-      interval : @state.planInterval
-      name     : @state.planTitle
+      id       : "#{planTitle}-#{planInterval}"
+      title    : planTitle
+      interval : planInterval
 
 
   initViews: ->

--- a/client/app/lib/payment/paymentworkflow.coffee
+++ b/client/app/lib/payment/paymentworkflow.coffee
@@ -206,11 +206,20 @@ module.exports = class PaymentWorkflow extends KDController
         action   : 'microConversions'
         label    : 'upgradeFreeAccount'
 
-    trackEvent 'Completed Order', products: [{
-      name     : @state.planTitle
-      category : @state.provider
-      interval : @state.planInterval
-      quantity : 1
+    me = whoami().getId()
+    {planTitle, provider, planInterval} = @state
+
+    planId  = "#{planTitle}-#{planInterval}"
+    orderId = "#{me}-#{planId}"
+
+    trackEvent 'Completed Order',
+      orderId  : orderId
+      products : [{
+        id       : planId
+        title    : planTitle
+        interval : planInterval
+        category : provider
+        quantity : 1
     }]
 
 


### PR DESCRIPTION
`orderId` is required by segment to send events to google analytics. Since we don't have `orderId`, I'm faking it with `userId` and `planId`.
