### PR TITLE
go: update sendgrid-go, fixes a nasty bug of accumulating CLOSE_WAIT

### DIFF
--- a/go/src/github.com/sendgrid/sendgrid-go/README.md
+++ b/go/src/github.com/sendgrid/sendgrid-go/README.md
@@ -2,6 +2,10 @@
 [![Build Status](https://travis-ci.org/sendgrid/sendgrid-go.svg?branch=master)](https://travis-ci.org/sendgrid/sendgrid-go)
 SendGrid Helper Library to send emails very easily using Go.
 
+### Warning
+
+Version ``1.1.x``, behaves differently in the ``AddTo`` method. In the past this method defaulted to using the ``SMTPAPI`` header. Now you must explicitly call the ``SMTPAPIHeader.AddTo`` method. More on the ``SMTPAPI`` section.
+
 ## Installation
 
 ```bash
@@ -59,8 +63,8 @@ message.AddRecipient(address) // Receives a vaild mail.Address
 
 Same concept as regular recipient excepts the methods are:
 
-*   AddBCC
-*   AddRecipientBCC
+*   AddBcc
+*   AddBccRecipient
 
 ### Setting the Subject
 
@@ -85,7 +89,7 @@ message.SetFrom("example@lol.com")
 ```go
 message.AddAttachment("text.txt", file) // file needs to implement the io.Reader interface
 //or
-message.AddAttachmentStream("filename", []byte("some file content"))
+message.AddAttachmentFromStream("filename", []byte("some file content"))
 ```
 ### Adding ContentIDs
 
@@ -101,12 +105,12 @@ If you wish to use the X-SMTPAPI on your own app, you can use the [SMTPAPI Go li
 ### Recipients
 
 ```go
-message.AddTo("addTo@mailinator.com")
+message.SMTPAPIHeader.AddTo("addTo@mailinator.com")
 // or
 tos := []string{"test@test.com", "test@email.com"}
-message.AddTos(tos)
+message.SMTPAPIHeader.AddTos(tos)
 // or
-message.SetTos(tos)
+message.SMTPAPIHeader.SetTos(tos)
 ```
 
 ### [Substitutions](http://sendgrid.com/docs/API_Reference/SMTP_API/substitution_tags.html)

--- a/go/src/github.com/sendgrid/sendgrid-go/mail.go
+++ b/go/src/github.com/sendgrid/sendgrid-go/mail.go
@@ -2,17 +2,19 @@ package sendgrid
 
 import (
 	"encoding/json"
-	"github.com/sendgrid/smtpapi-go"
 	"io"
 	"io/ioutil"
 	"net/mail"
 	"time"
+
+	"github.com/sendgrid/smtpapi-go"
 )
 
 // SGMail is representation of a valid SendGrid Mail
 type SGMail struct {
 	To       []string
 	ToName   []string
+	Cc       []string
 	Subject  string
 	Text     string
 	HTML     string
@@ -54,7 +56,6 @@ func (m *SGMail) AddTos(emails []string) error {
 
 // AddRecipient will add mail.Address emails to recipients.
 func (m *SGMail) AddRecipient(recipient *mail.Address) {
-	m.SMTPAPIHeader.AddTo(recipient.String())
 	m.To = append(m.To, recipient.Address)
 	if recipient.Name != "" {
 		m.ToName = append(m.ToName, recipient.Name)
@@ -76,6 +77,38 @@ func (m *SGMail) AddToName(name string) {
 // AddToNames sets the "pretty" name for multiple recipients
 func (m *SGMail) AddToNames(names []string) {
 	m.ToName = append(m.ToName, names...)
+}
+
+// AddCc ...
+func (m *SGMail) AddCc(cc string) error {
+	address, err := mail.ParseAddress(cc)
+	if err != nil {
+		return err
+	}
+	m.AddCcRecipient(address)
+	return nil
+}
+
+// AddCcs ...
+func (m *SGMail) AddCcs(ccs []string) error {
+	for i := 0; i < len(ccs); i++ {
+		if err := m.AddCc(ccs[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// AddCcRecipient ...
+func (m *SGMail) AddCcRecipient(recipient *mail.Address) {
+	m.Cc = append(m.Cc, recipient.Address)
+}
+
+// AddCcRecipients ...
+func (m *SGMail) AddCcRecipients(recipients []*mail.Address) {
+	for i := 0; i < len(recipients); i++ {
+		m.AddCcRecipient(recipients[i])
+	}
 }
 
 // SetSubject sets the email's subject

--- a/go/src/github.com/sendgrid/sendgrid-go/mail_test.go
+++ b/go/src/github.com/sendgrid/sendgrid-go/mail_test.go
@@ -24,8 +24,6 @@ func TestAddTo(t *testing.T) {
 		t.Errorf("AddTo should append to SGMail.To")
 	case len(m.ToName) != 1:
 		t.Errorf("AddTo should append to SGMail.ToName on a valid email")
-	case len(m.SMTPAPIHeader.To) != 1:
-		t.Errorf("AddTo should also modify the SMTPAPIHeader.To")
 	}
 }
 
@@ -65,8 +63,6 @@ func TestAddRecipients(t *testing.T) {
 		t.Errorf("AddRecipients should append to SGMail.To")
 	case len(m.ToName) != 2:
 		t.Errorf("AddRecipients should append to SGMail.ToName if a valid email is supplied")
-	case len(m.SMTPAPIHeader.To) != 2:
-		t.Errorf("AddRecipients should append to SMTPAPIHeader.To")
 	}
 }
 
@@ -83,6 +79,47 @@ func TestAddToNames(t *testing.T) {
 	m.AddToNames([]string{"Name", "Name2"})
 	if len(m.ToName) != 2 {
 		t.Errorf("AddToNames should append to SG.ToName")
+	}
+}
+
+func TestAddCc(t *testing.T) {
+	m := NewMail()
+	m.AddCc("Email Name<email@email.com>")
+	if len(m.Cc) != 1 {
+		t.Errorf("AddCc should append to SGMail.Cc")
+	}
+}
+
+func TestAddCcFail(t *testing.T) {
+	m := NewMail()
+	err := m.AddCc(".com")
+	if err == nil {
+		t.Errorf("AddCc should fail on invalid email addresses")
+	}
+}
+
+func TestAddCcs(t *testing.T) {
+	m := NewMail()
+	m.AddCcs([]string{"Email Name <email+1@email.com>", "email+2@email.com"})
+	if len(m.Cc) != 2 {
+		t.Errorf("AddCcs should append to SGMail.Cc")
+	}
+}
+
+func TestAddCcsFail(t *testing.T) {
+	m := NewMail()
+	err := m.AddCcs([]string{".co", "email+2@email.com"})
+	if err == nil {
+		t.Errorf("AddCcs should fail in invalid email address")
+	}
+}
+
+func TestAddCcRecipients(t *testing.T) {
+	m := NewMail()
+	emails, _ := mail.ParseAddressList("Joe <email+1@email.com>, Doe <email+2@email.com>")
+	m.AddCcRecipients(emails)
+	if len(m.Cc) != 2 {
+		t.Errorf("AddCcRecipients should append to SGMail.Cc")
 	}
 }
 
@@ -278,5 +315,13 @@ func TestHeaderString(t *testing.T) {
 	m.AddHeader("Cc", "hello@test.com")
 	if _, err := m.HeadersString(); err != nil {
 		t.Errorf("Error parsing headers: %v", err)
+	}
+}
+
+func TestAddToSMTPAPI(t *testing.T) {
+	m := NewMail()
+	m.SMTPAPIHeader.AddTo("example@email.com")
+	if len(m.SMTPAPIHeader.To) != 1 {
+		t.Error("SMTPAPIHeader To should be len of 1")
 	}
 }

--- a/go/src/github.com/sendgrid/sendgrid-go/sendgrid.go
+++ b/go/src/github.com/sendgrid/sendgrid-go/sendgrid.go
@@ -7,8 +7,11 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
+
+const Version = "1.1.0"
 
 func timeoutHandler(network, address string) (net.Conn, error) {
 	return net.DialTimeout(network, address, time.Duration(5*time.Second))
@@ -57,6 +60,9 @@ func (sg *SGClient) buildURL(m *SGMail) (url.Values, error) {
 	for i := 0; i < len(m.To); i++ {
 		values.Add("to[]", m.To[i])
 	}
+	for i := 0; i < len(m.Cc); i++ {
+		values.Add("cc[]", m.Cc[i])
+	}
 	for i := 0; i < len(m.Bcc); i++ {
 		values.Add("bcc[]", m.Bcc[i])
 	}
@@ -87,14 +93,24 @@ func (sg *SGClient) Send(m *SGMail) error {
 	if e != nil {
 		return e
 	}
-	r, e := sg.Client.PostForm(sg.APIMail, values)
+	req, e := http.NewRequest("POST", sg.APIMail, strings.NewReader(values.Encode()))
 	if e != nil {
-		return fmt.Errorf("sendgrid.go: error:%v; response:%v", e, r)
+		return e
 	}
-	if r.StatusCode == http.StatusOK {
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", "sendgrid/"+Version+";go")
+	res, e := sg.Client.Do(req)
+	if e != nil {
+		return fmt.Errorf("sendgrid.go: error:%v; response:%v", e, res)
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode == http.StatusOK {
 		return nil
 	}
-	body, _ := ioutil.ReadAll(r.Body)
-	r.Body.Close()
-	return fmt.Errorf("sendgrid.go: code:%d error:%v body:%s", r.StatusCode, e, body)
+
+	body, _ := ioutil.ReadAll(res.Body)
+
+	return fmt.Errorf("sendgrid.go: code:%d error:%v body:%s", res.StatusCode, e, body)
 }

--- a/go/src/github.com/sendgrid/sendgrid-go/sendgrid_test.go
+++ b/go/src/github.com/sendgrid/sendgrid-go/sendgrid_test.go
@@ -30,5 +30,8 @@ func TestSend(t *testing.T) {
 	m.AddTo("Test! <test@email.com>")
 	m.SetSubject("Test")
 	m.SetText("Text")
-	client.Send(m)
+
+	if e := client.Send(m); e != nil {
+		t.Errorf("Send failed to send email. Returned error: %v", e)
+	}
 }


### PR DESCRIPTION
So we had this graph this morning:

![image](https://cloud.githubusercontent.com/assets/438920/6614079/513af8b0-c89e-11e4-9eaa-5b8cde534692.png)

Once logged in into the server, we saw there was many sockets in `CLOSE_WAIT` state:

![image](https://cloud.githubusercontent.com/assets/438920/6614088/6de4257c-c89e-11e4-94c3-67fb2fccbeac.png)

Once sorted according according to the process names we had saw that one application was in that state:

```
1034 19440/privatemessag
```

We checked on which PID it was running and found out it was `privatemessageemailsender` worker: 

```
root     19440  0.0  0.6 637120 105044 ?       Sl   Mar05   1:44 /opt/koding/go/bin/privatemessageemailsender -c /opt/koding/go/src/socialapi/config/prod.toml
```

After this step it was obvious that something was wrong with this worker, we digged in and saw that we were creating in a for loop hundreds of `http.Client` instances via the `sendgrid` Go package:

![image](https://cloud.githubusercontent.com/assets/438920/6614150/27cb09c4-c89f-11e4-97c2-48419db98112.png)

![image](https://cloud.githubusercontent.com/assets/438920/6614173/50baf25e-c89f-11e4-89bc-9d4e2e17e7b1.png)

Checking that function, we saw this:

![image](https://cloud.githubusercontent.com/assets/438920/6614186/8a10251a-c89f-11e4-9534-08ec35328fa0.png)

As you see the body was never closed on our side. That's why sendgrid was closing the connection on behalf of us. We had thousands of connections lying there with `CLOSE_WAIT` sockets. This was fixed actually **one year ago** in the official sendgrid package:

https://github.com/sendgrid/sendgrid-go/commit/75c90498c9b6f3270eb74f611b309d99ff763f6c

However because we were using the old package, we never had this fix. We hot patched the servers and the result was obvious immediately:

![image](https://cloud.githubusercontent.com/assets/438920/6614205/d899261e-c89f-11e4-97de-788ffa6bba75.png)

So the question why is it suddenly increased ? Because **we started to use Koding!**. Because we are using Koding chat, the worker started to send a lot of e-mails. Due this increase we started to see the increase in the graph too. 

Thanks to @cihangir on working on this. This was a nice debugging session :)
