### PR TITLE
kloud: lower cleanup timeout, two minutes is to high!

### DIFF
--- a/go/src/koding/kites/kloud/main.go
+++ b/go/src/koding/kites/kloud/main.go
@@ -211,7 +211,7 @@ func newKite(conf *Config) *kite.Kite {
 	var _ kloudprotocol.Provider = kodingProvider
 
 	go kodingProvider.RunChecker(checkInterval)
-	go kodingProvider.RunCleaners(time.Minute * 2)
+	go kodingProvider.RunCleaners(time.Minute * 60)
 
 	kld := kloud.New()
 	kld.Storage = kodingProvider


### PR DESCRIPTION
So I've debugged Kloud for the high CPU usage. We have cleaners 
that are running to clean up certain things. They are running every 
two minute and every time they are causing a huge CPU pressure
on Kloud.

In the past week only three machines were deleted due the cleaner
(NotInitialized). However we run it every two minutes. So just increase
it to run it every 60 minutes. Which is way more better.

I've hotpatched all servers already to see how it's being affected.
