### PR TITLE
KDStateMachine

### DIFF
--- a/client/app/lib/statemachine.coffee
+++ b/client/app/lib/statemachine.coffee
@@ -48,7 +48,7 @@ module.exports = class StateMachine extends machina.Fsm
   ###*
    * Adds extra guards to machina's original transition method.
    *
-   * It checks `transitions` object to see if it's ok to transition to next method.
+   * It checks `transitions` object to see if it's ok to transition to next state.
    * If not throws an error.
    * Check happens as following:
    *

--- a/client/app/lib/statemachine.coffee
+++ b/client/app/lib/statemachine.coffee
@@ -1,0 +1,110 @@
+machina = require 'machina'
+_ = require 'lodash'
+
+module.exports = class KDStateMachine extends machina.Fsm
+
+  ###*
+   * Abstract StateMachine class.
+   *
+   * Usage Example:
+   *
+   *     class FooMachine extends KDStateMachine
+   *       states: ['Loading', 'Activating', 'Active', 'Terminating', 'Terminated']
+   *       transitions:
+   *         Loading     : ['Activating', 'Terminated']
+   *         Activating  : ['Active']
+   *         Active      : ['Terminating']
+   *         Terminating : ['Terminated']
+   *
+   *      machine = new FooMachine
+   *        stateHandlers:
+   *          Loading : -> console.log 'onLoadingState'
+   *          Active  : -> console.log 'onActiveState'
+  ###
+  constructor: (options = {}, data) ->
+
+    options = @transformOptions options
+
+    super options
+
+
+  ###*
+   * Gets regular options,
+   *   - Machinafy states
+   *   - assigns the first state.
+   *
+   * @param {object} options
+   * @param {object} options.stateHandlers - an object that holds handlers for states.
+   * @return {object} transformedOptions - machina ready options to be passed.
+  ###
+  transformOptions: (options) ->
+
+    states  = machinafyStates @states, options.stateHandlers
+    options = _.assign {}, options, { states, initialState: @states[0] }
+
+    return options
+
+
+  ###*
+   * Adds extra guards to machina's original transition method.
+   *
+   * It checks `transitions` object to see if it's ok to transition to next method.
+   * If not throws an error.
+   * Check happens as following:
+   *
+   *     class FooStateMachine extends KDStateMachine
+   *       states: ['loading', 'active', 'terminating', 'terminated']
+   *       transitions:
+   *         { loading: ['active', 'terminated'] }
+   *
+   *     # initial state is first state from array
+   *     machine = new FooStateMachine
+   *
+   *     # this will throw an error because it's not
+   *     # in the transitions array of loading state.
+   *     # and state will not be changed.
+   *     machine.transition 'terminating'
+   *     console.log machine.state # => 'loading'
+   *
+   *     # this will work as usual, active state is present
+   *     # in the transitions array of loading state.
+   *     machine.transition 'active'
+   *
+   * @param {string} next - state name to be transitioned into
+  ###
+  transition: (next) ->
+
+    if @state
+      unless next in @transitions[@state]
+        throw new Error "illegal state transition from: #{@state}, to: #{next}"
+
+    super next
+
+
+###*
+ * Transforms states array into machina ready states object.
+ * If a handler with the key of state name is present, it attaches
+ * that handler into machina-ready-options-object's `_onEnter` method.
+ *
+ * @param {Array.<string>} states - KDStateMachine states array
+ * @param {object=} stateHandlers - handlers for states
+ * @return {object} machinafiedStates
+###
+machinafyStates = (states, stateHandlers = {}) ->
+
+  states = states.reduce (newStates, stateName) ->
+
+    newStates[stateName] = state = {}
+
+    # if a handler is present attach that into
+    # `_onEnter` method so that machina will call it
+    # automatically.
+    if handler = stateHandlers[stateName]
+      state._onEnter = handler
+
+    return newStates
+  , {}
+
+  return states
+
+

--- a/client/app/lib/statemachine.coffee
+++ b/client/app/lib/statemachine.coffee
@@ -1,7 +1,7 @@
 machina = require 'machina'
 _ = require 'lodash'
 
-module.exports = class KDStateMachine extends machina.Fsm
+module.exports = class StateMachine extends machina.Fsm
 
   ###*
    * Abstract StateMachine class.

--- a/client/app/test/statemachine.test.coffee
+++ b/client/app/test/statemachine.test.coffee
@@ -1,0 +1,88 @@
+{ expect } = require 'chai'
+
+KDStateMachine = require '../lib/statemachine'
+
+describe 'StateMachine', ->
+
+  class FooMachine extends KDStateMachine
+    states: [
+      'Loading'
+      'Activating'
+      'Active'
+      'Terminating'
+      'Terminated'
+    ]
+    transitions:
+      Loading     : ['Activating', 'Terminated']
+      Activating  : ['Active']
+      Active      : ['Terminating']
+      Terminating : ['Terminated']
+      # Terminated  : null
+
+  it 'reads states from prototype', ->
+
+    machine = new FooMachine
+
+    expect(machine.states['Loading']).to.be.ok
+
+
+  it 'reads stateHandlers from options to connect state transitions with outside', ->
+
+    flags = {}
+    class FooModel extends KDObject
+      constructor: (options = {}) ->
+        @machine = new FooMachine
+          stateHandlers:
+            Loading     : @bound 'onFooLoading'
+            Activating  : @bound 'onFooActivating'
+            Active      : @bound 'onFooActive'
+            Terminating : @bound 'onFooTerminating'
+            Terminated  : @bound 'onFooTerminated'
+      onFooLoading     : -> flags['loading'] = yes
+      onFooActivating  : -> flags['activating'] = yes
+      onFooActive      : -> flags['active'] = yes
+      onFooTerminating : -> flags['terminating'] = yes
+      onFooTerminated  : -> flags['terminated'] = yes
+
+      model = new FooModel
+      expect(flags.loading).to.equal yes
+
+      model.machine.transition 'Activating'
+      expect(flags.activating).to.equal yes
+
+      model.machine.transition 'Active'
+      expect(flags.active).to.equal yes
+
+      model.machine.transition 'Terminating'
+      expect(flags.terminating).to.equal yes
+
+      model.machine.transition 'Terminated'
+      expect(flags.terminated).to.equal yes
+
+
+  describe '#transition', ->
+
+    it "only transitions if only it's in the transitions array", ->
+
+      machine = new FooMachine
+
+      expect(machine.state).to.equal 'Loading'
+      expect(-> machine.transition 'Terminating').to.throw /illegal/
+      expect(machine.state).to.equal 'Loading'
+
+      machine.transition 'Activating'
+      expect(machine.state).to.equal 'Activating'
+
+      expect(-> machine.transition 'Terminated').to.throw /illegal/
+      expect(machine.state).to.equal 'Activating'
+
+
+
+class KDObject
+
+  constructor: (options = {}) ->
+    @options = options
+
+  bound: (fnName) -> return this[fnName].bind this
+
+

--- a/client/app/test/statemachine.test.coffee
+++ b/client/app/test/statemachine.test.coffee
@@ -1,10 +1,10 @@
 { expect } = require 'chai'
 
-KDStateMachine = require '../lib/statemachine'
+StateMachine = require '../lib/statemachine'
 
 describe 'StateMachine', ->
 
-  class FooMachine extends KDStateMachine
+  class FooMachine extends StateMachine
     states: [
       'Loading'
       'Activating'

--- a/client/package.json
+++ b/client/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "bant-build": "0.1.7",
     "browserify": "git://github.com/tetsuo/node-browserify#hotfix-dedupe-json",
+    "chai": "^2.1.1",
     "coffee-script": "1.8.0",
     "coffeeify": "^1.0.0",
     "debug": "^2.1.1",


### PR DESCRIPTION
Wrapper around [machina](https://github.com/ifandelse/machina.js)

I've used mochify to run the tests with the following command:

```
~ koding/client ✓ ❯ npm i mochify -g
~ koding/client ✓ ❯ mochify --transform coffeeify --extension .coffee ./app/test/*.coffee
```

I didn't try to integrate mochify or come up with a solution how to run tests, but instead I wrote the tests and just ran them.

Example shows how to use `KDStateMachine`(straight from tests):

``` coffee
class FooMachine extends KDStateMachine
  states: [ 'Loading', 'Activating', 'Active', 'Terminating', 'Terminated' ]
  transitions:
    Loading     : ['Activating', 'Terminated']
    Activating  : ['Active']
    Active      : ['Terminating']
    Terminating : ['Terminated']

flags = {}
class FooModel extends KDObject
  constructor: (options = {}) ->
    @machine = new FooMachine
      stateHandlers:
        Loading     : @bound 'onFooLoading'
        Activating  : @bound 'onFooActivating'
        Active      : @bound 'onFooActive'
        Terminating : @bound 'onFooTerminating'
        Terminated  : @bound 'onFooTerminated'

  onFooLoading     : -> flags['loading'] = yes
  onFooActivating  : -> flags['activating'] = yes
  onFooActive      : -> flags['active'] = yes
  onFooTerminating : -> flags['terminating'] = yes
  onFooTerminated  : -> flags['terminated'] = yes

  model = new FooModel
  expect(flags.loading).to.equal yes

  expect(-> model.machine.transition 'Terminating').to.throw /illegal state transition/
  expect(model.machine.state).to.equal 'Loading'

  model.machine.transition 'Activating'
  expect(flags.activating).to.equal yes

  model.machine.transition 'Active'
  expect(flags.active).to.equal yes

  model.machine.transition 'Terminating'
  expect(flags.terminating).to.equal yes

  model.machine.transition 'Terminated'
  expect(flags.terminated).to.equal yes
```

/cc @fatihacet @szkl @gokmen 
