### PR TITLE
Environment: Omit default workspace when terminating a machine

### DIFF
--- a/workers/social/lib/social/models/workspace.coffee
+++ b/workers/social/lib/social/models/workspace.coffee
@@ -137,6 +137,7 @@ module.exports = class JWorkspace extends Module
     selector     =
       originId   : client.connection.delegate._id
       machineUId : uid
+      slug       : $ne: 'my-workspace'
 
     JWorkspace.remove selector, (err)->
       callback err


### PR DESCRIPTION
This is just a hotfix. It will be reverted in https://github.com/koding/koding/pull/3094
