### PR TITLE
Editor: Pass editor element to `ace.edit` method [fixes #89643432]

### DIFF
--- a/client/ace/lib/ace.coffee
+++ b/client/ace/lib/ace.coffee
@@ -57,9 +57,9 @@ module.exports = class Ace extends KDView
 
     @fetchContents (err, contents)=>
       notification?.destroy()
-      id = "editor#{@getId()}"
-      return  unless @getElement().querySelector "##{id}"
-      @editor = ace.edit id
+      element = @getElement().querySelector "#editor#{@getId()}"
+      return  unless element
+      @editor = ace.edit element
       @prepareEditor()
       if contents
         @setContents contents


### PR DESCRIPTION
[If the participant opens a file when the host is viewing another workspace or VM, the host gets an error on the console and cannot view the contents of the file when he switched back to the shared VM](https://www.pivotaltracker.com/story/show/89643432)
