### PR TITLE
FSFile: Fix isDummyFile method. [Fixes #89791398]

### DIFF
--- a/client/app/lib/util/fs/fsfile.coffee
+++ b/client/app/lib/util/fs/fsfile.coffee
@@ -187,7 +187,7 @@ module.exports = class FSFile extends FSItem
   abort: -> @emit "AbortRequested"
 
 
-  isDummyFile: -> return @path.indexOf('localfile:/Untitled.txt') is 0
+  isDummyFile: -> return @path.indexOf('localfile:/Untitled') is 0
 
 
   save: (contents = '', callback = null, useEncoding = yes) ->


### PR DESCRIPTION
We are appending -number suffix into file names like Untitled-1.txt and Untitled-2.txt.

https://www.pivotaltracker.com/story/show/89791398
