### PR TITLE
Workspace: Defer request to avoid duplicates [#90430458]

### DIFF
--- a/client/app/lib/userenvironmentdataprovider.coffee
+++ b/client/app/lib/userenvironmentdataprovider.coffee
@@ -217,15 +217,17 @@ module.exports = UserEnvironmentDataProvider =
 
         =>
 
-          for workspace in workspaces when workspace.isDefault
-            return queue.fin()
+          kd.utils.defer =>
 
-          @createDefaultWorkspace machine, (err, workspace) ->
+            for workspace in workspaces when workspace.isDefault
+              return queue.fin()
 
-            return queue.fin()  if err
+            @createDefaultWorkspace machine, (err, workspace) ->
 
-            workspaces.push workspace  if workspace
-            queue.fin()
+              return queue.fin()  if err
+
+              workspaces.push workspace  if workspace
+              queue.fin()
 
     sinkrow.dash queue, callback
 


### PR DESCRIPTION
I'm going to add an unique compound index on database to not allow such records to be inserted. This patch is a naive approach to improve handling of that condition since we can't prevent how many requests can be made to backend
