### PR TITLE
migrator: create public channel by default

### DIFF
--- a/go/src/socialapi/workers/migrator/controller/groupmigrator.go
+++ b/go/src/socialapi/workers/migrator/controller/groupmigrator.go
@@ -85,6 +85,19 @@ func (mwc *Controller) createChangelogChannel() {
 	}
 }
 
+func (mwc *Controller) createPublicChannel() {
+	c := models.NewChannel()
+	c.Name = "public"
+	c.GroupName = "koding"
+	c.TypeConstant = models.Channel_TYPE_GROUP
+	c.PrivacyConstant = models.Channel_PRIVACY_PUBLIC
+	c.CreatorId = 1
+	err := c.Create()
+	if err != nil {
+		mwc.log.Error("Could not create public channel: %s", err)
+	}
+}
+
 func (mwc *Controller) createGroupChannel(groupName string) (*models.Channel, error) {
 	c := models.NewChannel()
 	c.Name = groupName

--- a/go/src/socialapi/workers/migrator/controller/migrator.go
+++ b/go/src/socialapi/workers/migrator/controller/migrator.go
@@ -70,6 +70,8 @@ func (mwc *Controller) Start() {
 
 	mwc.migrateAllGroups()
 
+	mwc.createPublicChannel()
+
 	mwc.createChangelogChannel()
 
 	mwc.GrantPublicAccess()


### PR DESCRIPTION
Creating the public channel in `buildservices` call
