### PR TITLE
sidebar: remove default workspace from machine link [fixes #90812088]

### DIFF
--- a/client/app/lib/navigation/navigationmachineitem.coffee
+++ b/client/app/lib/navigation/navigationmachineitem.coffee
@@ -26,9 +26,9 @@ module.exports = class NavigationMachineItem extends JView
     machineOwner     = machine.getOwner()
     isMyMachine      = machine.isMine()
     machineRoutes    =
-      own            : "/IDE/#{@alias}/my-workspace"
+      own            : "/IDE/#{@alias}"
       collaboration  : "/IDE/#{workspaces.first?.channelId}"
-      permanentShare : "/IDE/#{machine.uid}/my-workspace"
+      permanentShare : "/IDE/#{machine.uid}"
 
     machineType = 'own'
 

--- a/tests/src/environments/paidaccount.coffee
+++ b/tests/src/environments/paidaccount.coffee
@@ -27,7 +27,7 @@ module.exports =
   makeAlwaysOnForNotPaidUser: (browser) ->
 
     buttonSelector = '.more-form .alwayson'
-    vmSelector     = 'a[href="/IDE/koding-vm-1/my-workspace"]'
+    vmSelector     = 'a[href="/IDE/koding-vm-1"]'
 
     helpers.beginTest(browser)
 
@@ -50,7 +50,7 @@ module.exports =
   # addVM: (browser) ->
 
   #   freeModalSelector = '.computeplan-modal.free-plan'
-  #   vmSelector        = 'a[href="/IDE/koding-vm-1/my-workspace"]'
+  #   vmSelector        = 'a[href="/IDE/koding-vm-1"]'
 
   #   helpers.beginTest(browser)
   #   helpers.waitForVMRunning(browser)
@@ -83,7 +83,7 @@ module.exports =
   # turnOnNewPaidVM: (browser) ->
 
   #   vmName     = 'koding-vm-1'
-  #   vmSelector = 'a[href="/IDE/' + vmName + '/my-workspace"]'
+  #   vmSelector = 'a[href="/IDE/' + vmName + '"]'
 
   #   helpers.beginTest(browser)
 
@@ -124,4 +124,3 @@ module.exports =
   #           browser
   #             .waitForElementVisible   '.more-form .alwayson .koding-on-off.on', 20000
   #             .end()
-

--- a/tests/src/helpers/environmenthelpers.coffee
+++ b/tests/src/helpers/environmenthelpers.coffee
@@ -11,7 +11,7 @@ module.exports =
     if not vmName
       vmName = 'koding-vm-0'
 
-    vmSelector = '.activity-sidebar a[href="/IDE/' + vmName + '/my-workspace"].running'
+    vmSelector = '.activity-sidebar a[href="/IDE/' + vmName + '"].running'
 
     browser
       .waitForElementVisible   vmSelector, 20000
@@ -80,6 +80,5 @@ module.exports =
       .waitForElementVisible    '.env-modal.paid-plan', 25000
       .click                    '.env-modal.paid-plan button'
       .waitForElementNotVisible '.env-modal.paid-plan', 250000
-      .waitForElementVisible    'a[href="/IDE/koding-vm-1/my-workspace"]', 25000
+      .waitForElementVisible    'a[href="/IDE/koding-vm-1"]', 25000
       .end()
-

--- a/tests/src/helpers/helpers.coffee
+++ b/tests/src/helpers/helpers.coffee
@@ -52,7 +52,7 @@ module.exports =
     unless machineName
       machineName = 'koding-vm-0'
 
-    vmSelector     = '[href="/IDE/'+machineName+'/my-workspace"].running.vm'
+    vmSelector     = '[href="/IDE/' + machineName + '"].running.vm'
     modalSelector  = '.env-modal.env-machine-state'
     loaderSelector = modalSelector + ' .kdloader'
     buildingLabel  = modalSelector + ' .state-label.building'

--- a/tests/src/impersonate/paidusers.coffee
+++ b/tests/src/impersonate/paidusers.coffee
@@ -57,8 +57,8 @@ module.exports =
         password : 'xXbeDUPwtYhmw9KNKXiD8jf'
 
       machineName     = vms[0]
-      machineLink     = '/IDE/' + machineName + '/my-workspace'
-      machineSelector = "a[href='" + machineLink + "']"
+      machineLink     = "/IDE/#{machineName}"
+      machineSelector = "a[href='#{machineLink}']"
 
       unless machineName
         postToSlack username + " doesn't have a always on VM, ignoring user..."


### PR DESCRIPTION
@szkl, @fatihacet, can you guys review this fix? When user opens VM in sidebar, it's necessary to open the last visited workspace in the VM. Currently default workspace is always opened
