### PR TITLE
sidebar: hide public channel's unread count on click [fixes #82537702]

### DIFF
--- a/client/app/lib/activity/sidebar/sidebartopicitem.coffee
+++ b/client/app/lib/activity/sidebar/sidebartopicitem.coffee
@@ -37,12 +37,13 @@ module.exports = class SidebarTopicItem extends SidebarItem
 
     if typeConstant is 'group'
 
+      @setUnreadCount 0
+
       # if the public channel is visited before
       # find the exact route that last visited
       # and navigate to there
       for route in visitedRoutes by -1 when route.search('/Public') isnt -1
         kd.utils.stopDOMEvent event
-        @setUnreadCount 0
         router.handleRoute route
         return no
 


### PR DESCRIPTION
@usirin, can you please review this fix? It's about hiding unread count on public channel for brand new user once he clicks on public channel's link
