### PR TITLE
(WIP) Video collaboration

### DIFF
--- a/client/app/lib/videocollaboration/model.coffee
+++ b/client/app/lib/videocollaboration/model.coffee
@@ -1,0 +1,213 @@
+kd             = require 'kd'
+_              = require 'lodash'
+OpenTokService = require './services/opentok'
+
+module.exports = class VideoCollaborationModel extends kd.Object
+
+  # @param {SocialChannel} options.channel
+  constructor: (options = {}, data) ->
+
+    super options, data
+
+    @_service = OpenTokService.getInstance()
+
+    { @channel, @view } = options
+
+    @session     = null
+    @publisher   = null
+    @stream      = null
+    @subscribers = {}
+
+    @_service.whenReady().then @bound 'init'
+
+
+  getView: -> @view
+  getChannel: -> @channel
+
+
+  ###*
+   * Gives the initial kick-off for video-chat process.
+   *
+   * @param {Function=} callback
+   * @listens OpenTokService~SessionCreated
+  ###
+  init: (callback = kd.noop) ->
+
+    @_service.on 'SessionCreated', @bound 'handleSessionCreated'
+
+    @_service.connect @channel
+    @subscribe()
+
+
+  ###*
+   * Starts publishing video.
+   *
+   * It ensures that OpenTokService instance
+   * is ready to work via its whenReady method.
+   * The options argument is just a convinient way to extend
+   * publisher options when starting publishing.
+   * `OpenTokService#createPublisher` has necessary defaults already.
+   *
+   * @param {Object=} options - publisher options to be passed.
+   * @listens OpenTokService~CameraAccessAllowed
+   * @listens OpenTokService~CameraAccessDenied
+   * @listens OpenTokService~CameraQuestionAsked
+   * @listens OpenTokService~CameraQuestionAnswered
+   * @listens OpenTokService~StreamDestroyed
+  ####
+  startPublishing: (options) -> @_service.whenReady().then =>
+
+    @_service
+      .on 'CameraAccessAllowed',          @view.bound 'show'
+      .on 'CameraAccessDenied',           @view.bound 'hide'
+      .on 'CameraAccessQuestionAsked',    @view.bound 'showAccessModal'
+      .on 'CameraAccessQuestionAnswered', @view.bound 'hideAccessModal'
+      .on 'StreamDestroyed',              @bound 'handleStreamDestroyed'
+
+    @publisher = @_service.createPublisher @view.getElement(), options
+
+    @session.publish @publisher, (err) =>
+
+      return warn { message: 'Publishing error.' }  if err
+
+      { @stream } = @publisher
+      me = KD.nick()
+
+      @fixParticipantVideo subscriber  for _, subscriber of @subscribers
+      @switchTo me
+
+
+  ###*
+   * Subscribes to channel video session.
+   *
+   * It ensures that OpenTokService instance is ready.
+   *
+   * @listens OpenTokService~NewSubscriber
+  ####
+  subscribe: -> @_service.whenReady().then =>
+
+    @_service.on 'NewSubscriber', @bound 'handleNewSubscriber'
+
+    @_service.subscribeToVideoUpdates @channel, @view
+
+
+  ###*
+   * Session creation handler.
+   *
+   * @param {OT.Session} session
+  ####
+  handleSessionCreated: (session) ->
+
+    @session = session
+
+
+  ###*
+   * New subscriber handler.
+   * It sets a value with the nickname of
+   * user in the `subscribers` object.
+   *
+   * @param {OT.Subscriber} subscriber
+  ####
+  handleNewSubscriber: (subscriber) ->
+
+    { nick, video } = subscriber
+
+    @subscribers[nick] = subscriber
+
+
+  ###*
+   * Stream destroy handler. Sets back some defaults.
+   * TODO: Destroy maybe?
+   *
+   * @param {OT.StreamDestroyedEvent} event
+  ####
+  handleStreamDestroyed: (event) ->
+
+    @publisher = null
+
+
+  ###*
+   * Returns all the participants including the publisher(Logged in user).
+   *
+   * @return {Object} participants
+  ####
+  getParticipants: ->
+
+    participants = assign {}, @subscribers
+    participants[KD.nick()] = { video: @publisher }
+
+    return participants
+
+
+  ###*
+   * Switch to given users video feed.
+   *
+   * @param {String} nick
+  ####
+  switchTo: (nick) ->
+
+    participants = @getParticipants()
+    participant  = participants[nick]
+
+    return  unless participant
+
+    @hideAll()
+    @showParticipant participant
+
+
+  ###*
+   * Hides all video feeds.
+  ####
+  hideAll: ->
+
+    participants = @getParticipants()
+
+    @hideParticipant participant  for own _, participant of participants
+
+
+  ###*
+   * Hides given participant's video feed.
+   *
+   * @param {OT.Subscriber|OT.Publisher} participant
+  ####
+  hideParticipant: (participant) ->
+
+    { video } = participant
+
+    video.element.style.display = 'none'
+
+
+  ###*
+   * Shows given participant's video feed.
+   *
+   * @param {OT.Subscriber|OT.Publisher} participant
+  ####
+  showParticipant: (participant) ->
+
+    { video } = participant
+
+    { element } = video
+
+    element.style.display = 'block'
+    @fixParticipantVideo participant
+
+
+  ###*
+   * This is a convinient method.
+   * This is probably wrong but the way _service sessions
+   * are working makes all subscriber videos invisible.
+   * This method's pure existence is to support it.
+   * p.s.: 173 is weird.
+   *
+   * @param {OT.Subscriber|OT.Publisher} participant
+  ####
+  fixParticipantVideo: (participant) ->
+
+    { video } = participant
+
+    KD.utils.wait 173, ->
+      vElement = video.videoElement()
+      vElement.style.left   = '-14px'
+      vElement.style.height = '265px'
+      vElement.style.width  = '355px'
+

--- a/client/app/lib/videocollaboration/model.coffee
+++ b/client/app/lib/videocollaboration/model.coffee
@@ -54,7 +54,7 @@ module.exports = class VideoCollaborationModel extends kd.Object
    * @listens OpenTokService~CameraQuestionAsked
    * @listens OpenTokService~CameraQuestionAnswered
    * @listens OpenTokService~StreamDestroyed
-  ####
+  ###
   startPublishing: (options) -> @_service.whenReady =>
 
     @_service
@@ -83,7 +83,7 @@ module.exports = class VideoCollaborationModel extends kd.Object
    * It ensures that OpenTokService instance is ready.
    *
    * @listens OpenTokService~NewSubscriber
-  ####
+  ###
   subscribe: -> @_service.whenReady =>
 
     @_service.on 'NewSubscriber', @bound 'handleNewSubscriber'
@@ -95,7 +95,7 @@ module.exports = class VideoCollaborationModel extends kd.Object
    * Session creation handler.
    *
    * @param {OT.Session} session
-  ####
+  ###
   handleSessionCreated: (session) ->
 
     @session = session
@@ -107,20 +107,16 @@ module.exports = class VideoCollaborationModel extends kd.Object
    * user in the `subscribers` object.
    *
    * @param {OT.Subscriber} subscriber
-  ####
+  ###
   handleNewSubscriber: (subscriber) ->
 
     { nick, video } = subscriber
-
-    @subscribers[nick] = subscriber
 
 
   ###*
    * Stream destroy handler. Sets back some defaults.
    * TODO: Destroy maybe?
-   *
-   * @param {OT.StreamDestroyedEvent} event
-  ####
+  ###
   handleStreamDestroyed: (event) ->
 
     @publisher = null
@@ -130,10 +126,10 @@ module.exports = class VideoCollaborationModel extends kd.Object
    * Returns all the participants including the publisher(Logged in user).
    *
    * @return {Object} participants
-  ####
+  ###
   getParticipants: ->
 
-    participants = assign {}, @subscribers
+    participants = _.assign {}, @subscribers
     participants[KD.nick()] = { video: @publisher }
 
     return participants
@@ -143,13 +139,10 @@ module.exports = class VideoCollaborationModel extends kd.Object
    * Switch to given users video feed.
    *
    * @param {String} nick
-  ####
+  ###
   switchTo: (nick) ->
 
-    participants = @getParticipants()
-    participant  = participants[nick]
-
-    return  unless participant
+    return  unless participant = @getParticipants()[nick]
 
     @hideAll()
     @showParticipant participant
@@ -157,23 +150,20 @@ module.exports = class VideoCollaborationModel extends kd.Object
 
   ###*
    * Hides all video feeds.
-  ####
+  ###
   hideAll: ->
 
-    participants = @getParticipants()
-
-    @hideParticipant participant  for own _, participant of participants
+    @hideParticipant participant  for own _, participant of @getParticipants()
 
 
   ###*
    * Hides given participant's video feed.
    *
    * @param {OT.Subscriber|OT.Publisher} participant
-  ####
+  ###
   hideParticipant: (participant) ->
 
     { video } = participant
-
     video.element.style.display = 'none'
 
 
@@ -181,26 +171,24 @@ module.exports = class VideoCollaborationModel extends kd.Object
    * Shows given participant's video feed.
    *
    * @param {OT.Subscriber|OT.Publisher} participant
-  ####
+  ###
   showParticipant: (participant) ->
 
-    { video } = participant
-
-    { element } = video
-
+    { element } = participant.video
     element.style.display = 'block'
+
     @fixParticipantVideo participant
 
 
   ###*
    * This is a convinient method.
-   * This is probably wrong but the way _service sessions
+   * This is probably wrong but the way openTok sessions
    * are working makes all subscriber videos invisible.
    * This method's pure existence is to support it.
    * p.s.: 173 is weird.
    *
    * @param {OT.Subscriber|OT.Publisher} participant
-  ####
+  ###
   fixParticipantVideo: (participant) ->
 
     { video } = participant

--- a/client/app/lib/videocollaboration/model.coffee
+++ b/client/app/lib/videocollaboration/model.coffee
@@ -18,7 +18,7 @@ module.exports = class VideoCollaborationModel extends kd.Object
     @stream      = null
     @subscribers = {}
 
-    @_service.whenReady().then @bound 'init'
+    @_service.whenReady @bound 'init'
 
 
   getView: -> @view
@@ -55,7 +55,7 @@ module.exports = class VideoCollaborationModel extends kd.Object
    * @listens OpenTokService~CameraQuestionAnswered
    * @listens OpenTokService~StreamDestroyed
   ####
-  startPublishing: (options) -> @_service.whenReady().then =>
+  startPublishing: (options) -> @_service.whenReady =>
 
     @_service
       .on 'CameraAccessAllowed',          @view.bound 'show'
@@ -84,7 +84,7 @@ module.exports = class VideoCollaborationModel extends kd.Object
    *
    * @listens OpenTokService~NewSubscriber
   ####
-  subscribe: -> @_service.whenReady().then =>
+  subscribe: -> @_service.whenReady =>
 
     @_service.on 'NewSubscriber', @bound 'handleNewSubscriber'
 

--- a/client/app/lib/videocollaboration/services/opentok.coffee
+++ b/client/app/lib/videocollaboration/services/opentok.coffee
@@ -1,0 +1,253 @@
+kd                   = require 'kd'
+$                    = require 'jquery'
+helper               = require '../helper'
+KodingAppsController = require '../../kodingappscontroller'
+
+module.exports = class OpenTokService extends kd.Object
+
+  ###*
+   * This class needs to be used as a singleton. This can either be temp,
+   * or a real use case. It can be added onto `KD.singletons` object or
+   * this method does exactly that.
+   *
+   * @return {OpenTokService} singleton instance of the class.
+  ###
+  @getInstance: do ->
+
+    instance = null
+    return -> instance or= new OpenTokService
+
+
+  constructor: (options = {}, data) ->
+
+    super options, data
+
+    ### @type {Object} ###
+    @sessions = {}
+
+    ### @type {Object} ###
+    @publishers = {}
+
+    ###* @type {Object} ###
+    @subscribers = {}
+
+    ###* @type {Boolean} ###
+    @_loaded = no
+
+    @initOpenTokClient()
+
+
+  ###*
+   * Initializes the client library of OpenTok.
+   * TODO: It may be wise to include this in our bundle?
+   *
+   * @emits OpenTokService#ClientLoaded
+  ###
+  initOpenTokClient: ->
+
+    options =
+      identifier : 'open-tok'
+      url        : '//static.opentok.com/webrtc/v2.2/js/opentok.min.js'
+
+    KodingAppsController.appendHeadElement 'script', options, =>
+      @emit 'ClientLoaded'
+      @_loaded = yes
+
+
+  whenReady: ->
+
+    new Promise (resolve) =>
+      if @isClientLoaded
+      then resolve()
+      else @once 'ClientLoaded', -> resolve()
+
+
+  ###*
+   * It makes a request to the backend and gets session id
+   * and creates a session with that session id.
+   *
+   * @param {SocialChannel} channel - Session will be generated based on channel.
+   * @param {Function=} callback - it will be called on success.
+   * @private
+  ###
+  generateChannelSession = (channel, callback) ->
+
+    $.ajax
+      url      : '/-/video-chat/session'
+      method   : 'post'
+      dataType : 'JSON'
+      data     : { channelId: channel.id }
+      success  : callback
+
+
+  ###*
+   * It makes a request to the backend and gets the token for given session id.
+   *
+   * @param {string} options.sessionId - session id for token to be generated.
+   * @param {string=} options.role - role of user in video chat.  (e.g 'publisher', 'moderator')
+   * @param {number=} options.expireTime - expiration time for a token. Needs to be lower than 30 days.
+   * @param {Function=} callback - callback to be called with token from backend.
+   * @see {@link https://tokbox.com/opentok/concepts/token_creation.html}
+  ###
+  getToken = (options, callback) ->
+
+    { sessionId, role } = options
+
+    role or= 'publisher'
+
+    $.ajax
+      url      : "/-/video-chat/token"
+      method   : 'post'
+      dataType : 'JSON'
+      data     : { role, sessionId }
+      success  : (options) -> callback options.token
+
+
+  ###*
+   * It gets the session for channel and calls the callback with it.
+   *
+   * It can call the callback with following:
+   *
+   *  - Generate the session if it doesn't exist and call with it.
+   *  - Call the callback with cached session isntance for that channel.
+   *
+   * @param {SocialChannel} channel - Pair channel of session.
+   * @param {Function=} callback - it will be called with the session object.
+  ###
+  getChannelSession: (channel, callback) ->
+
+    # TODO: move this to config.
+    API_KEY = '45082272'
+
+    { id } = channel
+
+    return callback @sessions[id]  if @sessions[id]
+
+    generateChannelSession channel, (session) =>
+
+      { sessionId } = session
+
+      session = @sessions[channel.id] = OT.initSession API_KEY, sessionId
+
+      session.sessionId = sessionId
+
+      callback session
+
+
+  ###*
+   * This method is necessary to be called before everything to be able
+   * to get updates from tokbox. It registers the given view's dom element
+   * as a container for the video chat session.
+   *
+   * When publishing from a client, we are adding `KD.nick()` as `name`
+   * in `publisherOptions`, when we want to cache the subscribers for easy
+   * access later, we are getting that published name from stream's name property
+   * when we are listening session's `streamCreated` event. And we are using it
+   * as a key to write instance's `subscribers` object when the subscriber is created.
+   * So that we can be able to switch the main video to subscriber videos, by
+   * just using user's `nickname`.
+   *
+   * @param {SocialChannel} channel
+   * @param {KDView} view - container view for video chat.
+   * @param {Object} options - options to be passed to subscribe event
+   * @listens OT.session~streamCreated
+  ###
+  subscribeToVideoUpdates: (channel, view, options = {}) ->
+
+    @getChannelSession channel, (session) =>
+
+      { sessionId } = session
+
+      session.on 'streamCreated', (event) =>
+
+        options.height     or= "100%"
+        options.width      or= "100%"
+        options.insertMode or= 'append'
+
+        { stream } = event
+        nick       = stream.name
+        element    = view.getElement()
+        subscriber = session.subscribe stream, element, options
+
+        @emit 'NewSubscriber', { nick, video: subscriber }
+
+
+  ###*
+   * Connects to a video-chat session.
+   * It doesn't start to send video or audio, anything.
+   * Simply subscribes to the updates, creates the session.
+   * When the session is created it will be emitted.
+   *
+   * @param {SocialChannel} channel
+   * @param {String} role
+  ###
+  connect: (channel, role) ->
+
+    @getChannelSession channel, (session) =>
+      { sessionId } = session
+      getToken { sessionId, role }, (token) =>
+        session.connect token, (err) =>
+          return warn { err }  if err
+          @emit 'SessionCreated', session
+
+          session.on 'connectionCreated', \
+            @lazyBound 'emit', 'ConnectionCreated'
+
+
+  ###*
+   * Sends a signal with type to given subscriber
+   * through given session.
+   *
+   * @param {OT.Session} session
+   * @param {String} type
+   * @param {OT.Subscriber} to
+   * @param {Object=} data
+  ###
+  sendSignal: (session, type, to, data = {})->
+
+    data.to = to
+
+    # TODO: proper signal error handling maybe?
+    session.signal data, _errorSignal
+
+
+  ###*
+   * Default error signal.
+  ###
+  _errorSignal = (error) ->
+
+    log "signal error #{error.reason}"  if error
+
+
+  ###*
+   * It creates the `OT.Publisher` instance for sending video/audio.
+   * It listens to publisher events and emits KDEvents to the passed view.
+   *
+   * @param {KDView} view - view instance for publisher.
+   * @param {Object=} publisherOptions - Options to pass to `OT.initPublisher` method
+   * @param {string=} publisherOptions.insertMode
+   * @param {string=} publisherOptions.name
+   * @param {Object=} publisherOptions.style
+   * @return {OT.Publisher} publisher
+   * @see {@link https://tokbox.com/opentok/libraries/client/js/reference/OT.html#initPublisher}
+  ###
+  createPublisher: (element, publisherOptions = {}) ->
+
+    publisherOptions.name       or= KD.nick()
+    publisherOptions.style      or= { nameDisplayMode: on }
+    publisherOptions.insertMode or= 'append'
+
+    publisherOptions.height = 265
+    publisherOptions.width  = 325
+
+    publisher = OT.initPublisher element, publisherOptions
+
+    publisher.on
+      accessAllowed      : (event) => @emit 'CameraAccessAllowed'
+      accessDenied       : (event) => @emit 'CameraAccessDenied'
+      accessDialogOpened : (event) => @emit 'CameraAccessQuestionAsked'
+      accessDialogClosed : (event) => @emit 'CameraAccessQuestionAnswered'
+
+    return publisher
+
+

--- a/client/app/lib/videocollaboration/services/opentok.coffee
+++ b/client/app/lib/videocollaboration/services/opentok.coffee
@@ -54,12 +54,11 @@ module.exports = class OpenTokService extends kd.Object
       @_loaded = yes
 
 
-  whenReady: ->
+  whenReady: (callback) ->
 
-    new Promise (resolve) =>
-      if @isClientLoaded
-      then resolve()
-      else @once 'ClientLoaded', -> resolve()
+    if @_loaded
+    then callback()
+    else @once 'ClientLoaded', callback
 
 
   ###*

--- a/client/app/lib/videocollaboration/services/opentok.coffee
+++ b/client/app/lib/videocollaboration/services/opentok.coffee
@@ -242,10 +242,10 @@ module.exports = class OpenTokService extends kd.Object
     publisher = OT.initPublisher element, publisherOptions
 
     publisher.on
-      accessAllowed      : (event) => @emit 'CameraAccessAllowed'
-      accessDenied       : (event) => @emit 'CameraAccessDenied'
-      accessDialogOpened : (event) => @emit 'CameraAccessQuestionAsked'
-      accessDialogClosed : (event) => @emit 'CameraAccessQuestionAnswered'
+      accessAllowed      : => @emit 'CameraAccessAllowed'
+      accessDenied       : => @emit 'CameraAccessDenied'
+      accessDialogOpened : => @emit 'CameraAccessQuestionAsked'
+      accessDialogClosed : => @emit 'CameraAccessQuestionAnswered'
 
     return publisher
 

--- a/config/main.dev.coffee
+++ b/config/main.dev.coffee
@@ -173,6 +173,7 @@ Configuration = (options={}) ->
     googleapiServiceAccount        : googleapiServiceAccount
     siftScience                    : 'a41deacd57929378'
     prerenderToken                 : 'St4CU4a5hvfYCEOboftc'
+    tokbox                         : { API_KEY: '45082272', API_SECRET: 'fb232a623fa9936ace8d8f9826c3e4a942d457b8' }
 
     collaboration :
       timeout     : 1 * 60 * 1000

--- a/config/main.prod.coffee
+++ b/config/main.prod.coffee
@@ -163,6 +163,7 @@ Configuration = (options={}) ->
     googleapiServiceAccount        : googleapiServiceAccount
     siftScience                    : 'e6c3413236e08107'
     prerenderToken                 : 'St4CU4a5hvfYCEOboftc'
+    tokbox                         : { API_KEY: '45082272', API_SECRET: 'fb232a623fa9936ace8d8f9826c3e4a942d457b8' }
 
     collaboration :
       timeout     : 1 * 60 * 1000

--- a/config/main.sandbox.coffee
+++ b/config/main.sandbox.coffee
@@ -164,7 +164,7 @@ Configuration = (options={}) ->
     googleapiServiceAccount        : googleapiServiceAccount
     siftScience                    : 'a41deacd57929378'
     prerenderToken                 : 'St4CU4a5hvfYCEOboftc'
-   tokbox                         : { API_KEY: '45082272', API_SECRET: 'fb232a623fa9936ace8d8f9826c3e4a942d457b8' }
+    tokbox                         : { API_KEY: '45082272', API_SECRET: 'fb232a623fa9936ace8d8f9826c3e4a942d457b8' }
 
     collaboration :
       timeout     : 1 * 60 * 1000

--- a/config/main.sandbox.coffee
+++ b/config/main.sandbox.coffee
@@ -164,6 +164,7 @@ Configuration = (options={}) ->
     googleapiServiceAccount        : googleapiServiceAccount
     siftScience                    : 'a41deacd57929378'
     prerenderToken                 : 'St4CU4a5hvfYCEOboftc'
+   tokbox                         : { API_KEY: '45082272', API_SECRET: 'fb232a623fa9936ace8d8f9826c3e4a942d457b8' }
 
     collaboration :
       timeout     : 1 * 60 * 1000

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "nodemailer": "0.5.15",
     "noxmox": "0.1.8",
     "oauth": "0.9.10",
+    "opentok": "2.2.5",
     "optimist": "0.3.1",
     "pistachio-compiler": "~0.0.3",
     "pkgcloud": "^0.9.6",

--- a/servers/lib/server/index.coffee
+++ b/servers/lib/server/index.coffee
@@ -136,6 +136,46 @@ app.get '/-/google-api/authorize/drive', (req, res) ->
     res.status(200).send authToken
 
 
+videoSessions = {}
+app.post '/-/video-chat/session', (req, res) ->
+
+  { channelId } = req.body
+
+  return res.status(400).send { err: 'Channel ID is required.'      }  unless channelId
+
+  return res.status(200).send { sessionId: videoSessions[channelId] }  if videoSessions[channelId]
+
+  { API_KEY, API_SECRET } = KONFIG.tokbox
+
+  OpenTok = require 'opentok'
+
+  opentok = new OpenTok API_KEY, API_SECRET
+
+  opentok.createSession (err, session) ->
+
+    videoSessions[channelId] = session.sessionId
+
+    res.status(200).send { sessionId: session.sessionId }
+
+
+app.post '/-/video-chat/token', (req, res) ->
+
+  { role, sessionId } = req.body
+
+  return res.status(400).send { err: "Session ID is required." } unless sessionId
+  return res.status(400).send { err: "Role is required"        } unless role
+
+  { API_KEY, API_SECRET } = KONFIG.tokbox
+
+  OpenTok = require 'opentok'
+
+  opentok = new OpenTok API_KEY, API_SECRET
+
+  token = opentok.generateToken sessionId, { role }
+
+  return res.status(200).send { token }
+
+
 app.get "/-/subscription/check/:kiteToken?/:user?/:groupId?", (req, res) ->
   {kiteToken, user, groupId} = req.params
   {JAccount, JKite, JGroup}  = koding.models


### PR DESCRIPTION
## This is the revived version of `Video Chat`(#2676) PR. Feature development will continue here:

This **WIP** PR introduces the video chat feature implementation with OpekTok.js/tokbox.

The feature works like the following:
- [x] Client connects to TokBox servers with the generated tokens (Initialization and connecting to TokBox servers).
- [x] There is no request for inviting people to join to video chat, but instead a public channel that you can connect with your video.
- [ ] You can switch between other users' videos by clicking their avatar's from the chat window.
- [ ] There is an (X) amounts of user limit. _(This requires a decision /cc @sinan)_
- [ ] When the admin/owner is free user, the video chat is limited to 2 people.
- [ ] User videos switch automatically when a user is speaking.
- [ ] You can Mute/Unmute yourself.
- [ ] Session owner can mute/unmute everybody.
- [ ] You can Open/Close your camera.
- [ ] You can hide/show chat window when you are in video chat.

There will be following tasks and related PR links with them.
### The flow

There are 2 endpoints: (This part requires attention from @cihangir and @canthefason)
- [x] `/-/video-chat/token` is for generating an access token for other TokBox operations.
- [x] `/-/video-chat/session` is for session generation process from TokBox for them to keep track of the process.
#### Initialization and connecting to TokBox servers (Tasks are here for reference, those will be redefined)
- [x] Create `VideoChatModel` by passing the necessary `SocialChannel` instance.
- [x] `VideoChatModel` will kick off `OpenTokService`.
- [x] `VideoChatModel` will create a new `VideoChatView` instance and attaches to itself for lazy-access.
- [x] `OpenTokService` acts a wrapper class around `opentok.js`.
- [x] `VideoChatModel` connects to a opentok session.
- [x] `VideoChatModel` shows video chat via `VideoChatView`
- [x] `VideoChatModel` switchs to given user's video.
- [ ] `VideoChatModel` provides an api for mute/unmute yourself.
- [ ] `VideoChatModel` provides an api for mute/unmute others for admins.
- [ ] `VideoChatModel` controls the amount of people can join to video session? (This may be extracted into its own class)
