### PR TITLE
account settings: close modal view on click 'Upgrade' [fixes #91072650]

### DIFF
--- a/client/account/lib/index.coffee
+++ b/client/account/lib/index.coffee
@@ -74,6 +74,7 @@ module.exports = class AccountAppController extends AppController
     wrapper = new AccountListWrapper
       cssClass : "settings-list-wrapper #{kd.utils.slugify title}"
       , itemData
+
     wrapper.on 'ModalCloseRequested', @bound 'closeModal'
 
     new KDTabPaneView

--- a/client/account/lib/index.coffee
+++ b/client/account/lib/index.coffee
@@ -74,7 +74,7 @@ module.exports = class AccountAppController extends AppController
     wrapper = new AccountListWrapper
       cssClass : "settings-list-wrapper #{kd.utils.slugify title}"
       , itemData
-    wrapper.on 'ModalNeedToBeClose', @bound 'closeModal'
+    wrapper.on 'ModalCloseRequested', @bound 'closeModal'
 
     new KDTabPaneView
       view       : wrapper

--- a/client/account/lib/index.coffee
+++ b/client/account/lib/index.coffee
@@ -71,11 +71,17 @@ module.exports = class AccountAppController extends AppController
 
     {title, listType} = itemData
 
-    new KDTabPaneView
-      view       : new AccountListWrapper
-        cssClass : "settings-list-wrapper #{kd.utils.slugify title}"
+    wrapper = new AccountListWrapper
+      cssClass : "settings-list-wrapper #{kd.utils.slugify title}"
       , itemData
+    wrapper.on 'ModalNeedToBeClose', @bound 'closeModal'
 
+    new KDTabPaneView
+      view       : wrapper
+
+  closeModal: ->
+
+    @mainView.destroy()
 
   openSection: (section) ->
 

--- a/client/account/lib/views/accountbilling.coffee
+++ b/client/account/lib/views/accountbilling.coffee
@@ -54,6 +54,7 @@ module.exports = class AccountBilling extends KDView
 
     @on 'ChangeSubscriptionRequested', ->
       kd.singletons.router.handleRoute '/Pricing'
+      @parent.emit 'ModalNeedToBeClose'
 
       trackEvent 'Account Upgrade, click',
         path     : '/Account/Billing'

--- a/client/account/lib/views/accountbilling.coffee
+++ b/client/account/lib/views/accountbilling.coffee
@@ -54,7 +54,7 @@ module.exports = class AccountBilling extends KDView
 
     @on 'ChangeSubscriptionRequested', ->
       kd.singletons.router.handleRoute '/Pricing'
-      @parent.emit 'ModalNeedToBeClose'
+      @parent.emit 'ModalCloseRequested'
 
       trackEvent 'Account Upgrade, click',
         path     : '/Account/Billing'


### PR DESCRIPTION
fixes for [bug](https://www.pivotaltracker.com/story/show/91072650)

`AccountBilling` doesn't contain any reference to `ModalView`, so i decided to use event functionality.

@sinan @usirin @szkl @gokmen Could you review this?
