### PR TITLE
static pages: do not process urls with unnecessary query params [fixes #91396226]

### DIFF
--- a/deployment/nginx.coffee
+++ b/deployment/nginx.coffee
@@ -306,10 +306,10 @@ module.exports.create = (KONFIG, environment)->
         if ($http_user_agent ~* "baiduspider|twitterbot|facebookexternalhit|rogerbot|linkedinbot|embedly|quora link preview|showyoubot|outbrain|pinterest|slackbot|vkShare|W3C_Validator") {
           set $prerender 1;
         }
-        if ($request_uri !~ "(^(\/)?$)|(\/(Pricing|About|Legal|Features)(\/|$))") {
+        if ($request_uri !~ "(^(\/)?$)|(\/(Pricing|About|Legal|Features)(\/[A-Za-z]*$|$))") {
           set $prerender 0;
         }
-        if ($args ~ "_escaped_fragment_=$|(\/(Pricing|About|Legal|Features)(\/|$))") {
+        if ($args ~ "^_escaped_fragment_=($|(\/(Pricing|About|Legal|Features)(\/[A-Za-z]*$|$)))") {
           set $prerender 1;
         }
         if ($http_user_agent ~ "Prerender") {


### PR DESCRIPTION
@cihangir, can you review this fix? This change prevents urls with unnecessary query params from processing by prerender.io. For example, urls like http://koding.com/?test=1&_escaped_fragment_= and https://koding.com/?_escaped_fragment_=/Features/IDE&test=1 won't be processing with this fix
