### PR TITLE
Video utilities

### DIFF
--- a/client/app/lib/videocollaboration/helper.coffee
+++ b/client/app/lib/videocollaboration/helper.coffee
@@ -1,0 +1,77 @@
+$ = require 'jquery'
+
+###*
+ * It makes a request to the backend and gets session id
+ * and creates a session with that session id.
+ *
+ * TODO: add proper error handling
+ *
+ * @param {SocialChannel} channel - Session will be generated based on channel.
+ * @param {function(session: object)} callback - it will be called on success.
+###
+generateSession = (channel, callback) ->
+
+  $.ajax
+    url      : '/-/video-chat/session'
+    method   : 'post'
+    dataType : 'JSON'
+    data     : { channelId: channel.id }
+    success  : callback
+
+
+###*
+ * It makes a request to the backend and gets the token for given session id.
+ *
+ * TODO: add proper error handling and expireTime support.
+ *
+ * @param {string} options.sessionId - session id for token to be generated.
+ * @param {string=} options.role - role of user in video chat.  (e.g 'publisher', 'moderator')
+ * @param {number=} options.expireTime - expiration time for a token. Needs to be lower than 30 days.
+ * @param {function(token: string)} callback - callback to be called with token from backend.
+ * @see {@link https://tokbox.com/opentok/concepts/token_creation.html}
+###
+generateToken = (options, callback) ->
+
+  { sessionId, role } = options
+
+  role or= 'publisher'
+
+  $.ajax
+    url      : "/-/video-chat/token"
+    method   : 'post'
+    dataType : 'JSON'
+    data     : { role, sessionId }
+    success  : (options) -> callback options.token
+
+
+###*
+ * Transforms map with `connectionId`s as keys into a map
+ * with nicknames as key.
+ *
+ * @param {object<string, ParticipantType.Subscriber>} subscribers - keys are connectionIds.
+ * @param {ParticipantType.Publisher} publisher
+###
+toNickKeyedMap = (subscribers, publisher) ->
+
+  map = {}
+  map[subscriber.nick] = subscriber  for own cId, subscriber of subscribers
+  map[publisher.nick] = publisher
+  return map
+
+
+###*
+ * Default error signal.
+ *
+ * @param {object} error
+###
+_errorSignal = (error) ->
+
+  console.error "signal error #{error.reason}"  if error
+
+
+module.exports = {
+  generateSession
+  generateToken
+  toNickKeyedMap
+  _errorSignal
+}

--- a/client/app/lib/videocollaboration/types/participant.coffee
+++ b/client/app/lib/videocollaboration/types/participant.coffee
@@ -1,0 +1,48 @@
+###*
+ * Base class for representing a video participant.
+ * OpenTok has 2 different idea of users. `Publisher` and `Subscriber`.
+ * `Publisher` is logged in user. `Subscriber`s are other users that are
+ * connected to OpenTok session.
+ *
+ * This class acts as an Abstract class and is not even exported.
+ * @see {Publisher}
+ * @see {Subscriber}
+ *
+ * @class ParticipantType.BaseVideoParticipant
+###
+class BaseVideoParticipant
+
+  constructor: (nick, videoData) ->
+    @nick = nick
+    @videoData = videoData
+    @type = null
+
+  getType: -> @type
+
+
+###*
+ * Transformation from OpenTok Publisher -> Koding ChatVideoPublisher
+ *
+ * @class ParticipantType.Publisher
+###
+class Publisher extends BaseVideoParticipant
+
+  constructor: (nick, videoData) ->
+    super nick, videoData
+    @type = 'publisher'
+
+
+###*
+ * Transformation from OpenTok Subscriber -> Koding ChatVideoSubscriber
+ *
+ * @class ParticipantType.Subscriber
+###
+class Subscriber extends BaseVideoParticipant
+
+  constructor: (nick, videoData) ->
+    super nick, videoData
+    @type = 'subscriber'
+
+
+module.exports = participantTypes = { Publisher, Subscriber }
+

--- a/client/app/lib/videocollaboration/viewmodel.coffee
+++ b/client/app/lib/videocollaboration/viewmodel.coffee
@@ -1,0 +1,83 @@
+kd = require 'kd'
+
+module.exports = class VideoCollaborationViewModel extends kd.Object
+
+  constructor: (options = {}, data) ->
+
+    super options, data
+
+    {@view, @model} = options
+
+    @model.on 'ActiveParticipantChanged', @bound 'switchTo'
+    @model.on 'VideoCollaborationActive', @bound 'fixParticipantVideoElements'
+
+
+  ###*
+   * First hide all participants, then show participant with given nickname.
+   *
+   * @param {string} nick
+  ###
+  switchTo: (nick) ->
+
+    hideAll @model.getParticipants()
+    showParticipant nick
+
+
+  ###*
+   * Fix all participant videos.
+  ###
+  fixParticipantVideoElements: ->
+
+    fixParticipantVideo participant  for _, participant of @model.getParticipants()
+
+
+###*
+ * Hides all participants videos.
+ *
+ * @param {object<string, ParticipantType.Participant>} participants
+###
+hideAll = (participants) ->
+
+  hideParticipant participant  for _, participant of participants
+
+
+###*
+ * Hides given participant's video element.
+ *
+ * @param {ParticipantType.Participant} participant
+###
+hideParticipant = (participant) ->
+
+  participant.videoData.element.style.display = 'none'
+
+
+###*
+ * Shows given participant's video element. Then fixes that participant's video.
+ *
+ * @param {ParticipantType.Participant} participant
+###
+showParticipant = (participant) ->
+
+  participant.videoData.element.style.display = 'block'
+
+  fixParticipantVideo participant
+
+
+###*
+  * This is a workaround.
+  * This is probably wrong but the way OpenTok sessions are working makes all
+  * subscriber videos invisible. This method's pure existence is to get around
+  * it. This probably requires a FIXME tag.
+  * p.s.: 173 is weird.
+  *
+  * @param {ParticipantType.Participant} participant
+###
+fixParticipantVideo = (participant) ->
+
+  kd.utils.wait 173, ->
+    element = participant.videoData.videoElement()
+    element.style.left   = '-14px'
+    element.style.height = '265px'
+    element.style.widht  = '355px'
+
+


### PR DESCRIPTION
This PR adds
- `helper`: utility functions to help.
- `ParticipantTypes`: exports `Publisher` and `Subscriber` classes for our internal use. Instead of OpenTok's own data structures, we are casting them into our own data structures.
- `VideoCollaborationViewModel`: A dedicated class to handle `DOM` manipulations of `OpenTok` and video chat session overall.
