### PR TITLE
Video collaboration state transition improvements

### DIFF
--- a/client/app/lib/videocollaboration/helper.coffee
+++ b/client/app/lib/videocollaboration/helper.coffee
@@ -55,7 +55,7 @@ toNickKeyedMap = (subscribers, publisher) ->
 
   map = {}
   map[subscriber.nick] = subscriber  for own cId, subscriber of subscribers
-  map[publisher.nick] = publisher
+  map[publisher.nick] = publisher  if publisher
   return map
 
 

--- a/client/app/lib/videocollaboration/model.coffee
+++ b/client/app/lib/videocollaboration/model.coffee
@@ -16,6 +16,7 @@ module.exports = class VideoCollaborationModel extends kd.Object
     connectedToSession : no
     maxConnectionCount : 999
     activeParticipant  : null
+    connectionCount    : 0
 
   # @param {SocialChannel} options.channel
   # @param {BaseChatVideoView} options.view
@@ -126,10 +127,13 @@ module.exports = class VideoCollaborationModel extends kd.Object
       @emit 'ParticipantLeft', { nick: event.stream.name }
 
     session.on 'connectionCreated', (event) =>
+      count = @state.connectionCount
+      @setState { connectionCount: count + 1 }
 
-      # TODO: this may not be necessary.
-      data = { nick: getNick() }
-      @_service.sendSignal session, 'initialize', data
+    session.on 'connectionDestroyed', (event) =>
+      count = @state.connectionCount
+      @setState { connectionCount: count - 1 }
+
 
     session.on 'sessionDisconnected', (event) =>
       @setState { connectedToSession: no }

--- a/client/app/lib/videocollaboration/model.coffee
+++ b/client/app/lib/videocollaboration/model.coffee
@@ -105,6 +105,10 @@ module.exports = class VideoCollaborationModel extends kd.Object
   bindSessionEvents: (session) ->
 
     session.on 'streamCreated', (event) =>
+      # When a stream is dispatched to the session it means there is a new
+      # video feed. We want every user to see the video if a stream is
+      # dispatched (probably from host, but doesn't matter).
+      @setVideoActive()  unless @state.active
 
       options    = { height: '100%', width: '100%', insertMode: 'append' }
       { stream } = event

--- a/client/app/lib/videocollaboration/model.coffee
+++ b/client/app/lib/videocollaboration/model.coffee
@@ -259,6 +259,7 @@ module.exports = class VideoCollaborationModel extends kd.Object
   ####
   changeActiveParticipant: (nick) ->
 
+    return  unless @state.active
     return  unless @getParticipant nick
 
     @setState { activeParticipant: nick }

--- a/client/app/lib/videocollaboration/model.coffee
+++ b/client/app/lib/videocollaboration/model.coffee
@@ -225,10 +225,9 @@ module.exports = class VideoCollaborationModel extends kd.Object
   handlePublishSuccess: (publisher) ->
 
     @registerPublisher publisher
-
     @setState { publishing: on }
 
-    @emit 'VideoCollaborationActive', @publisher
+    @setVideoActive()
     @changeActiveParticipant getNick()
 
 

--- a/client/app/lib/videocollaboration/model.coffee
+++ b/client/app/lib/videocollaboration/model.coffee
@@ -10,10 +10,11 @@ helper          = require './helper'
 module.exports = class VideoCollaborationModel extends kd.Object
 
   defaultState:
-    video              : on
-    audio              : on
+    publishVideo       : on
+    publishAudio       : on
     publishing         : off
-    connectedToSession : no
+    active             : no
+    connected          : no
     maxConnectionCount : 999
     activeParticipant  : null
     connectionCount    : 0
@@ -82,7 +83,7 @@ module.exports = class VideoCollaborationModel extends kd.Object
 
     @session = session
     @bindSessionEvents session
-    @setState { connectedToSession: yes }
+    @setState { connected: yes }
     @emit 'SessionConnected', session
 
 
@@ -104,10 +105,8 @@ module.exports = class VideoCollaborationModel extends kd.Object
   bindSessionEvents: (session) ->
 
     session.on 'streamCreated', (event) =>
-      return  if @state.connectedToSession is no
 
-      options = { height: '100%', width: '100%', insertMode: 'append' }
-
+      options    = { height: '100%', width: '100%', insertMode: 'append' }
       { stream } = event
       nick       = stream.name
       element    = @getView().getElement()
@@ -136,7 +135,7 @@ module.exports = class VideoCollaborationModel extends kd.Object
 
 
     session.on 'sessionDisconnected', (event) =>
-      @setState { connectedToSession: no }
+      @setState { connected: no }
       eventName = switch event.reason
         when 'forceDisconnected'   then 'HostKickedLoggedInUser'
         when 'clientDisconnected'  then 'VideoCollaborationEnded'
@@ -248,8 +247,8 @@ module.exports = class VideoCollaborationModel extends kd.Object
   startPublishing: (options, callbacks) ->
 
     defaults =
-      publishAudio: @state.audio
-      publishVideo: @state.video
+      publishAudio: @state.publishAudio
+      publishVideo: @state.publishVideo
 
     options = _.assign {}, defaults, options
 

--- a/client/app/lib/videocollaboration/model.coffee
+++ b/client/app/lib/videocollaboration/model.coffee
@@ -187,6 +187,19 @@ module.exports = class VideoCollaborationModel extends kd.Object
 
 
   ###*
+   * Action to trigger activation of video collaboration.
+   * If given publisher is `null` it means that the video collaboration started
+   * without the user publishing his/her video. It's not a concern of neither
+   * this method's nor this entire class, because simply it will emit an event
+   * with given publisher and it will change set the state to active.
+  ###
+  setVideoActive: ->
+
+    @emit 'VideoCollaborationActive', @publisher
+    @setState { active: yes }
+
+
+  ###*
    * Action for joining to VideoCollaboration session. It calls
    * `startPublishing` method and connects handlers for success and error states.
    *


### PR DESCRIPTION
This PR
- Refines the state property names
- Changes the way activation/publishing events are emitted. 

This way whenever a video session has people in it, it will be shown.
