### PR TITLE
npm: bump up bant (0.2.3)

### DIFF
--- a/client/builder/package.json
+++ b/client/builder/package.json
@@ -7,7 +7,7 @@
     "JSONStream": "^0.10.0",
     "as-stream": "^0.1.1",
     "async": "^0.9.0",
-    "bant": "^0.2.2",
+    "bant": "^0.2.3",
     "bundle-collapser": "^1.1.4",
     "chalk": "^1.0.0",
     "chokidar": "^1.0.0-rc4",


### PR DESCRIPTION
browserify latest release is broken, bumped up bant to 0.2.3 to pin down to version before.
