### PR TITLE
Kloud improvements

### DIFF
--- a/go/src/koding/kites/kloud/klient/klient.go
+++ b/go/src/koding/kites/kloud/klient/klient.go
@@ -128,6 +128,7 @@ func ConnectTimeout(k *kite.Kite, queryString string, t time.Duration) (*Klient,
 	remoteKite.ReadBufferSize = 512
 	remoteKite.WriteBufferSize = 512
 	if err := remoteKite.DialTimeout(t); err != nil {
+		k.Log.Debug("Dialing kite failed: %s", err)
 		return nil, ErrDialingFailed
 	}
 

--- a/go/src/koding/kites/kloud/provider/koding/build.go
+++ b/go/src/koding/kites/kloud/provider/koding/build.go
@@ -621,39 +621,6 @@ func (m *Machine) isKlientReady() bool {
 	return true
 }
 
-func isCapacityError(err error) bool {
-	ec2Error, ok := err.(*ec2.Error)
-	if !ok {
-		return false // return back if it's not an ec2.Error type
-	}
-
-	fallbackErrors := []string{
-		"InsufficientInstanceCapacity",
-		"InstanceLimitExceeded",
-	}
-
-	// check wether the incoming error code is one of the fallback
-	// errors
-	for _, fbErr := range fallbackErrors {
-		if ec2Error.Code == fbErr {
-			return true
-		}
-	}
-
-	// return for non fallback errors, because we can't do much
-	// here and probably it's need a more tailored solution
-	return false
-}
-
-func isAddressNotFoundError(err error) bool {
-	ec2Error, ok := err.(*ec2.Error)
-	if !ok {
-		return false
-	}
-
-	return ec2Error.Code == "InvalidAddress.NotFound"
-}
-
 // switchAWSRegion switches to the given AWS region. This should be only used when
 // you know what to do, otherwiese never, never change the region of a machine.
 func (m *Machine) switchAWSRegion(region string) error {

--- a/go/src/koding/kites/kloud/provider/koding/build.go
+++ b/go/src/koding/kites/kloud/provider/koding/build.go
@@ -620,28 +620,3 @@ func (m *Machine) isKlientReady() bool {
 
 	return true
 }
-
-// switchAWSRegion switches to the given AWS region. This should be only used when
-// you know what to do, otherwiese never, never change the region of a machine.
-func (m *Machine) switchAWSRegion(region string) error {
-	m.Meta.InstanceId = "" // we neglect any previous instanceId
-	m.QueryString = ""     //
-	m.Meta.Region = "us-east-1"
-
-	client, err := m.Session.AWSClients.Region("us-east-1")
-	if err != nil {
-		return err
-	}
-	m.Session.AWSClient.Client = client
-
-	return m.Session.DB.Run("jMachines", func(c *mgo.Collection) error {
-		return c.UpdateId(
-			m.Id,
-			bson.M{"$set": bson.M{
-				"meta.instanceId": "",
-				"queryString":     "",
-				"meta.region":     "us-east-1",
-			}},
-		)
-	})
-}

--- a/go/src/koding/kites/kloud/provider/koding/queue.go
+++ b/go/src/koding/kites/kloud/provider/koding/queue.go
@@ -98,11 +98,11 @@ func (p *Provider) CheckUsage(m *Machine) error {
 	// lock so it doesn't interfere with others.
 	p.Lock(m.Id.Hex())
 	defer func() {
-		p.Log.Info("[%s] ======> STOP finished <======", m.Id.Hex())
+		p.Log.Info("[%s] ======> STOP finished (closing inactive machine)<======", m.Id.Hex())
 		p.Unlock(m.Id.Hex())
 	}()
 
-	p.Log.Info("[%s] ======> STOP started <======", m.Id.Hex())
+	p.Log.Info("[%s] ======> STOP started (closing inactive machine)<======", m.Id.Hex())
 	// Hasta la vista, baby!
 	return m.Stop(ctx)
 }

--- a/go/src/koding/kites/kloud/provider/koding/queue.go
+++ b/go/src/koding/kites/kloud/provider/koding/queue.go
@@ -2,7 +2,6 @@ package koding
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/koding/kite"
@@ -98,21 +97,12 @@ func (p *Provider) CheckUsage(m *Machine) error {
 
 	// lock so it doesn't interfere with others.
 	p.Lock(m.Id.Hex())
-
-	// mark our state as stopping so others know what we are doing
-	stoppingReason := fmt.Sprintf("Stopping process started due inactivity of %.f minutes",
-		planTimeout.Minutes())
-
-	m.UpdateState(stoppingReason, machinestate.Stopping)
-
 	defer func() {
-		// call it in defer, so even if "Stop" fails it should reset the state
-		stopReason := fmt.Sprintf("Stopped due inactivity of %.f minutes",
-			planTimeout.Minutes())
-		m.UpdateState(stopReason, machinestate.Stopping)
+		p.Log.Info("[%s] ======> STOP finished <======", m.Id.Hex())
 		p.Unlock(m.Id.Hex())
 	}()
 
+	p.Log.Info("[%s] ======> STOP started <======", m.Id.Hex())
 	// Hasta la vista, baby!
 	return m.Stop(ctx)
 }

--- a/go/src/koding/kites/kloud/provider/koding/start.go
+++ b/go/src/koding/kites/kloud/provider/koding/start.go
@@ -44,6 +44,31 @@ func (m *Machine) Start(ctx context.Context) (err error) {
 	}
 
 	instance, err := m.Session.AWSClient.Instance()
+	if err == amazon.ErrNoInstances {
+		// This means the instanceId stored in MongoDB doesn't exist anymore in
+		// AWS. Probably it was deleted and the state was not updated. Let us
+		// recover from that state by cleaning up all necessary fields and
+		// marking the VM as notinitialized so the User can build it again.
+		m.Log.Warning("Instance is not available. Marking it as NotInitialized")
+		latestState = machinestate.NotInitialized
+		return m.Session.DB.Run("jMachines", func(c *mgo.Collection) error {
+			return c.UpdateId(
+				m.Id,
+				bson.M{"$set": bson.M{
+					"ipAddress":         "",
+					"queryString":       "",
+					"meta.instanceType": "",
+					"meta.instanceName": "",
+					"meta.instanceId":   "",
+					"status.state":      machinestate.NotInitialized.String(),
+					"status.modifiedAt": time.Now().UTC(),
+					"status.reason":     "Machine is marked as NotInitialized",
+				}},
+			)
+		})
+	}
+
+	// if it's something else return it back
 	if err != nil {
 		return err
 	}

--- a/go/src/koding/kites/kloud/provider/koding/start.go
+++ b/go/src/koding/kites/kloud/provider/koding/start.go
@@ -59,15 +59,29 @@ func (m *Machine) Start(ctx context.Context) (err error) {
 			instance.InstanceType, m.Meta.InstanceType)
 
 		opts := &ec2.ModifyInstance{InstanceType: plans.Instances[m.Meta.InstanceType].String()}
-
 		if _, err := m.Session.AWSClient.Client.ModifyInstance(m.Meta.InstanceId, opts); err != nil {
 			m.Log.Warning("couldn't change instance to '%s' again. err: %s",
 				m.Meta.InstanceType, err)
 		}
 
-		// Because of AWS's eventually consistency state, we wait to get the
-		// final and correct answer.
-		time.Sleep(time.Second * 2)
+		// Because of AWS's eventually consistency state, we wait for maximum
+		// three minutes to get the final and correct answer. We don't check
+		// for the error and just continue (even if it means the user has still
+		// the wrong instance type) to have a seamles experience on the client
+		// side, rather than aborting it.
+		retry(3*time.Minute, func() error {
+			instance, err := m.Session.AWSClient.Instance()
+			if err != nil {
+				return err
+			}
+
+			if instance.InstanceType != m.Meta.InstanceType {
+				return fmt.Errorf("Instance is still '%s', waiting until it changed to '%s'",
+					instance.InstanceType, m.Meta.InstanceType)
+			}
+
+			return nil
+		})
 	}
 
 	infoState := amazon.StatusToState(instance.State.Name)

--- a/go/src/koding/kites/kloud/provider/koding/start.go
+++ b/go/src/koding/kites/kloud/provider/koding/start.go
@@ -80,6 +80,7 @@ func (m *Machine) Start(ctx context.Context) (err error) {
 					instance.InstanceType, m.Meta.InstanceType)
 			}
 
+			m.Log.Debug("Instance type successfully changed to %s", m.Meta.InstanceType)
 			return nil
 		})
 	}

--- a/go/src/koding/kites/kloud/provider/koding/utils.go
+++ b/go/src/koding/kites/kloud/provider/koding/utils.go
@@ -1,0 +1,55 @@
+package koding
+
+import (
+	"time"
+
+	"github.com/cenkalti/backoff"
+	"github.com/mitchellh/goamz/ec2"
+)
+
+// retry is a function who calls the given function until it returns a nil
+// error for the given totalDuration. The retry mechanism is based on the
+// exponential backoff algorithm. If the totalDuration pass, the last error
+// from the function is returned.
+func retry(totalDuration time.Duration, fn func() error) error {
+	opts := backoff.NewExponentialBackOff()
+
+	// don't start immediately, take it slow
+	opts.InitialInterval = time.Duration(time.Second * 2)
+	opts.MaxElapsedTime = totalDuration
+
+	return backoff.Retry(fn, opts)
+}
+
+func isCapacityError(err error) bool {
+	ec2Error, ok := err.(*ec2.Error)
+	if !ok {
+		return false // return back if it's not an ec2.Error type
+	}
+
+	fallbackErrors := []string{
+		"InsufficientInstanceCapacity",
+		"InstanceLimitExceeded",
+	}
+
+	// check wether the incoming error code is one of the fallback
+	// errors
+	for _, fbErr := range fallbackErrors {
+		if ec2Error.Code == fbErr {
+			return true
+		}
+	}
+
+	// return for non fallback errors, because we can't do much
+	// here and probably it's need a more tailored solution
+	return false
+}
+
+func isAddressNotFoundError(err error) bool {
+	ec2Error, ok := err.(*ec2.Error)
+	if !ok {
+		return false
+	}
+
+	return ec2Error.Code == "InvalidAddress.NotFound"
+}


### PR DESCRIPTION
- Fix state when stopping inactive machines
- Failover mechanism for starting a  machine document with an instanceID that is not empty. If the machine is not avaialbine on AWS, kloud fixes the state and marks it as NotInitialized so it can be re-built.
- Improve state checking when instance type is changing via retry mechanism
- Small code refactoring, move code into other files to make more sense
