### PR TITLE
pricing: fix leaking typo, name -> title

### DIFF
--- a/client/pricing/lib/views/singleplanview.coffee
+++ b/client/pricing/lib/views/singleplanview.coffee
@@ -79,7 +79,7 @@ module.exports = class SinglePlanView extends KDView
     @addSubView @buyButton = new KDButtonView
       style     : 'plan-buy-button'
       title     : 'SELECT'
-      state     : { name, monthPrice, yearPrice }
+      state     : { title, monthPrice, yearPrice }
       callback  : @bound 'select'
 
 


### PR DESCRIPTION
`name` was leaking, but not sure if it should be set to `title` or not. looked like a typo to me
