### PR TITLE
Change activity shortcuts display order

### DIFF
--- a/client/app/lib/shortcuts/config/activity.json
+++ b/client/app/lib/shortcuts/config/activity.json
@@ -3,12 +3,12 @@
     "name": "nextwindow",
     "binding": [
       [
-        "alt+]",
-        "alt+down"
+        "alt+down",
+        "alt+]"
       ],
       [
-        "alt+]",
-        "alt+down"
+        "alt+down",
+        "alt+]"
       ]
     ],
     "description": "Next window",

--- a/client/app/lib/shortcuts/config/activity.json
+++ b/client/app/lib/shortcuts/config/activity.json
@@ -20,12 +20,12 @@
     "name": "prevwindow",
     "binding": [
       [
-        "alt+[",
-        "alt+up"
+        "alt+up",
+        "alt+["
       ],
       [
-        "alt+[",
-        "alt+up"
+        "alt+up",
+        "alt+["
       ]
     ],
     "description": "Previous window",


### PR DESCRIPTION
- displays alt+down for activity/nextwindow instead of alt+] in the list
- displays alt+up for activity/prevwindow instead of alt+[ in the list
