### PR TITLE
Hide and remove obsolete ace shortcuts

### DIFF
--- a/client/ace/lib/ace.coffee
+++ b/client/ace/lib/ace.coffee
@@ -110,8 +110,9 @@ class Ace extends KDView
         'gotoline'         # overriding this
         'sortlines'        # using same mapping for 'save all' action. XXX: re-map sortlines
         'showSettingsMenu' # f ace default settings menu
-        'findprevious',    # we have our own find and replace dialogs
+        'findprevious'     # we have our own find and replace dialogs
         'findnext'         # ace default for findnext is cmd+g (mapped to gotoline)
+        'findAll'          # not used and collides with toggle filetree
       ]
 
       @focus()

--- a/client/ace/lib/ace.coffee
+++ b/client/ace/lib/ace.coffee
@@ -110,6 +110,8 @@ class Ace extends KDView
         'gotoline'         # overriding this
         'sortlines'        # using same mapping for 'save all' action. XXX: re-map sortlines
         'showSettingsMenu' # f ace default settings menu
+        'findprevious',    # we have our own find and replace dialogs
+        'findnext'         # ace default for findnext is cmd+g (mapped to gotoline)
       ]
 
       @focus()

--- a/client/ace/lib/ace.coffee
+++ b/client/ace/lib/ace.coffee
@@ -113,6 +113,22 @@ class Ace extends KDView
         'findprevious'     # we have our own find and replace dialogs
         'findnext'         # ace default for findnext is cmd+g (mapped to gotoline)
         'findAll'          # not used and collides with toggle filetree
+        'restartSearch'
+        'iSearch'
+        'iSearchAndGo'
+        'iSearchBackwardsAndGo'
+        'recenterTopBottom'
+        'selectAllMatches'
+        'searchAsRegExp'
+        'yankNextChar'
+        'yankNextWord'
+        'occurisearch'
+        'cancelSearch'
+        'confirmSearch'
+        'shrinkSearchTerm'
+        'extendSearchTermSpace'
+        'searchBackward'
+        'searchForward'
       ]
 
       @focus()

--- a/client/ace/lib/acefindandreplaceview.coffee
+++ b/client/ace/lib/acefindandreplaceview.coffee
@@ -44,7 +44,7 @@ module.exports = class AceFindAndReplaceView extends JView
       validate     :
         rules      :
           required : yes
-      keydown      : _.bind @handleKeyDown, this
+      keydown      : _.bind @handleKeyDown, this, no
       callback     : => @replace()
 
     @replaceButton = new KDButtonView

--- a/client/app/lib/shortcuts/config/ace.json
+++ b/client/app/lib/shortcuts/config/ace.json
@@ -1119,7 +1119,8 @@
         ]
       ],
       "options": {
-        "custom": true
+        "custom": true,
+        "hidden": true
       }
     },
     {
@@ -1138,7 +1139,8 @@
         ]
       ],
       "options": {
-        "custom": true
+        "custom": true,
+        "hidden": true
       }
     },
     {

--- a/client/app/lib/shortcuts/config/ace.json
+++ b/client/app/lib/shortcuts/config/ace.json
@@ -225,7 +225,8 @@
       ],
       "options": {
         "custom": true,
-        "ace_ro": true
+        "ace_ro": true,
+        "hidden": true
       }
     },
     {

--- a/client/app/lib/shortcuts/config/ace.json
+++ b/client/app/lib/shortcuts/config/ace.json
@@ -242,7 +242,8 @@
       ],
       "options": {
         "custom": true,
-        "ace_ro": true
+        "ace_ro": true,
+        "hidden": true
       }
     },
     {

--- a/client/app/lib/shortcuts/config/ace.json
+++ b/client/app/lib/shortcuts/config/ace.json
@@ -1523,7 +1523,8 @@
       ],
       "options": {
         "custom": true,
-        "ace_ro": true
+        "ace_ro": true,
+        "hidden": true
       }
     }
   ],
@@ -1560,7 +1561,8 @@
       ],
       "options": {
         "custom": true,
-        "ace_ro": true
+        "ace_ro": true,
+        "hidden": true
       }
     },
     {
@@ -1578,7 +1580,8 @@
       ],
       "options": {
         "custom": true,
-        "ace_ro": true
+        "ace_ro": true,
+        "hidden": true
       }
     },
     {
@@ -1596,7 +1599,8 @@
       ],
       "options": {
         "custom": true,
-        "ace_ro": true
+        "ace_ro": true,
+        "hidden": true
       }
     },
     {
@@ -1612,7 +1616,8 @@
       ],
       "options": {
         "custom": true,
-        "ace_ro": true
+        "ace_ro": true,
+        "hidden": true
       }
     },
     {
@@ -1628,7 +1633,8 @@
       ],
       "options": {
         "custom": true,
-        "ace_ro": true
+        "ace_ro": true,
+        "hidden": true
       }
     },
     {
@@ -1644,7 +1650,8 @@
       ],
       "options": {
         "custom": true,
-        "ace_ro": true
+        "ace_ro": true,
+        "hidden": true
       }
     },
     {
@@ -1656,7 +1663,8 @@
       ],
       "options": {
         "custom": true,
-        "ace_ro": true
+        "ace_ro": true,
+        "hidden": true
       }
     },
     {
@@ -1689,7 +1697,8 @@
       ],
       "options": {
         "custom": true,
-        "ace_ro": true
+        "ace_ro": true,
+        "hidden": true
       }
     },
     {
@@ -1705,7 +1714,8 @@
       ],
       "options": {
         "custom": true,
-        "ace_ro": true
+        "ace_ro": true,
+        "hidden": true
       }
     },
     {
@@ -1738,7 +1748,8 @@
       ],
       "options": {
         "custom": true,
-        "ace_ro": true
+        "ace_ro": true,
+        "hidden": true
       }
     },
     {
@@ -1754,7 +1765,8 @@
       ],
       "options": {
         "custom": true,
-        "ace_ro": true
+        "ace_ro": true,
+        "hidden": true
       }
     }
   ],


### PR DESCRIPTION
- hides all ace default find/search/incremental search shortcuts from the display list and removes the corresponding ace commands since we have our own find and replace dialogs.
- hides backspace and delete shortcuts from display list
