### PR TITLE
kloud: improve klient checking

### DIFF
--- a/go/src/koding/kites/kloud/klient/klient.go
+++ b/go/src/koding/kites/kloud/klient/klient.go
@@ -146,7 +146,7 @@ func NewWithTimeout(k *kite.Kite, queryString string, t time.Duration) (*Klient,
 	k.Log.Debug("Querying for Klient: %s", queryString)
 	for {
 		select {
-		case <-time.Tick(time.Second * 2):
+		case <-time.Tick(time.Second * 4):
 			if klient, err := Connect(k, queryString); err == nil {
 				return klient, nil
 			}

--- a/go/src/koding/kites/kloud/provider/koding/start.go
+++ b/go/src/koding/kites/kloud/provider/koding/start.go
@@ -155,9 +155,6 @@ func (m *Machine) Start(ctx context.Context) (err error) {
 		}
 	}
 
-	// now we can assume that the machine is running
-	latestState = machinestate.Running
-
 	// Assign a Elastic IP for a paying customer if it doesn't have any
 	// assigned yet (Elastic IP's are assigned only during the Build). We
 	// lookup the IP from the Elastic IPs, if it's not available (returns an
@@ -202,7 +199,9 @@ func (m *Machine) Start(ctx context.Context) (err error) {
 	}
 
 	m.push("Checking remote machine", 90, machinestate.Starting)
-	m.checkKite()
+	if !m.isKlientReady() {
+		return errors.New("klient is not ready")
+	}
 
 	return m.Session.DB.Run("jMachines", func(c *mgo.Collection) error {
 		return c.UpdateId(


### PR DESCRIPTION
Problem:
If a klient didn't yet register to Kontrol, we were saying that it's ok
and would return non error state for the methods build, start and
resize. On the client side, the user would see that VM is ready, bu in
fact it's not. This means even if the VM is running, because there is
no Klient running the User would see a blank terminal in those cases.

Solution:
This PR fixes this state, we no longer mark it as healthy if we can't
reach it. Also we increase the time to check the existence from
Kontrol, this is especially an improvement in development environments
when there is an high latency in ngrok or if it's a slow AWS instance
that it takes long to get in a stable state.
