### PR TITLE
kloud: improve state handling in various situations

### DIFF
--- a/go/src/koding/kites/kloud/kloud/controller.go
+++ b/go/src/koding/kites/kloud/kloud/controller.go
@@ -124,7 +124,6 @@ func (k *Kloud) coreMethods(r *kite.Request, fn machineFunc) (result interface{}
 	if !ok {
 		return nil, NewError(ErrStaterNotImplemented)
 	}
-	currentState := stater.State()
 
 	// Check if the given method is in valid methods of that current state. For
 	// example if the method is "build", and the state is "stopped" than this
@@ -161,7 +160,7 @@ func (k *Kloud) coreMethods(r *kite.Request, fn machineFunc) (result interface{}
 		if err != nil {
 			k.Log.Error("[%s][%s] %s error: %s", args.Provider, args.MachineId, r.Method, err)
 			finalEvent.Error = strings.ToTitle(r.Method) + " failed. Please contact support."
-			finalEvent.Status = currentState // fallback to to old state
+			finalEvent.Status = stater.State() // fallback to to old state
 		}
 
 		k.Log.Info("[%s] ======> %s finished (time: %s) <======",

--- a/go/src/koding/kites/kloud/kloud/methods.go
+++ b/go/src/koding/kites/kloud/kloud/methods.go
@@ -52,7 +52,7 @@ func (k *Kloud) Info(r *kite.Request) (interface{}, error) {
 	}
 
 	var response *InfoResponse
-	if err := mapstructure.Decode(infoData, response); err != nil {
+	if err := mapstructure.Decode(infoData, &response); err != nil {
 		return nil, err
 	}
 

--- a/go/src/koding/kites/kloud/provider/koding/info.go
+++ b/go/src/koding/kites/kloud/provider/koding/info.go
@@ -95,6 +95,17 @@ func (m *Machine) Info(ctx context.Context) (map[string]string, error) {
 		}
 	}
 
+	// This happens when a machine was destroyed recently in one hour span.
+	// The machine is still available in AWS but it's been marked as
+	// Terminated. Because we still have the machine document, mark it as
+	// NotInitialized so the user can build again.
+	if resultState == machinestate.Terminated {
+		resultState = machinestate.NotInitialized
+		if err := m.markAsNotInitialized(); err != nil {
+			return nil, err
+		}
+	}
+
 	m.Log.Debug("Info result: '%s'. Username: %s", resultState, m.Username)
 	return map[string]string{
 		"State": resultState.String(),

--- a/go/src/koding/kites/kloud/provider/koding/start.go
+++ b/go/src/koding/kites/kloud/provider/koding/start.go
@@ -21,6 +21,17 @@ func (m *Machine) Start(ctx context.Context) (err error) {
 		return err
 	}
 
+	instance, err := m.Session.AWSClient.Instance()
+	if err == amazon.ErrNoInstances {
+		// This means the instanceId stored in MongoDB doesn't exist anymore in
+		// AWS. Probably it was deleted and the state was not updated.
+		if err := m.markAsNotInitialized(); err != nil {
+			return err
+		}
+
+		return errors.New("instance is not available anymore.")
+	}
+
 	// update the state to intiial state if something goes wrong, we are going
 	// to change latestate to a more safe state if we passed a certain step
 	// below
@@ -30,6 +41,12 @@ func (m *Machine) Start(ctx context.Context) (err error) {
 			m.UpdateState("Machine is marked as "+latestState.String(), latestState)
 		}
 	}()
+
+	// if it's something else (the error from Instance() call above) return it
+	// back
+	if err != nil {
+		return err
+	}
 
 	if err := m.Checker.AlwaysOn(m.Username); err != nil {
 		return err
@@ -41,19 +58,6 @@ func (m *Machine) Start(ctx context.Context) (err error) {
 
 	if strings.ToLower(m.Payment.State) == "expired" {
 		return fmt.Errorf("[%s] Plan is expired", m.Id.Hex())
-	}
-
-	instance, err := m.Session.AWSClient.Instance()
-	if err == amazon.ErrNoInstances {
-		latestState = machinestate.NotInitialized
-		// This means the instanceId stored in MongoDB doesn't exist anymore in
-		// AWS. Probably it was deleted and the state was not updated.
-		return m.markAsNotInitialized()
-	}
-
-	// if it's something else return it back
-	if err != nil {
-		return err
 	}
 
 	m.push("Starting machine", 10, machinestate.Starting)

--- a/go/src/koding/kites/kloud/provider/koding/start.go
+++ b/go/src/koding/kites/kloud/provider/koding/start.go
@@ -22,9 +22,12 @@ func (m *Machine) Start(ctx context.Context) (err error) {
 	}
 
 	instance, err := m.Session.AWSClient.Instance()
-	if err == amazon.ErrNoInstances {
+	if (err == nil && amazon.StatusToState(instance.State.Name) == machinestate.Terminated) ||
+		err == amazon.ErrNoInstances {
 		// This means the instanceId stored in MongoDB doesn't exist anymore in
-		// AWS. Probably it was deleted and the state was not updated.
+		// AWS. Probably it was deleted and the state was not updated (possible
+		// due a human interaction or a non kloud interaction done somewhere
+		// else.)
 		if err := m.markAsNotInitialized(); err != nil {
 			return err
 		}


### PR DESCRIPTION
1.
Problem:
Unmarshalling would return an error always in Info method.

Solution
Fix unmarshalling into non pointer struct by passing the address.
Because client side is handling Info errors itself, it was shadowing
this error and we wouldn't see it.

2.
Problem:
If there is no instance available during Start method we would mark it
as NotInitialized. But the Start method would return a nil error. If we
don't return an error, the Kloud controller (the dispatcher for all
methods) is returning an OK state to the eventer. That's why even if we
mark the state as NotInitialized, on the UI it would be seen as Running
and a blank screen. The user was required to refresh the page, so it
would see the NotInitialized state (aka Turn On button). This is a case
only introduced by human errors or non Kloud interaction.

Solution:
Return an error if the instance is not avaialable anymore in Start
method. Now the eventer is returning an error and the UI can act
correctly. Also we change the order of the defer to avoid double update
query to MongoDB.

3.
Problem:
If an AWS machine is destroyed without calling Kloud's destroy
method, the machine document would be still available. If someone calls
Info, it would fetch the state Terminated (because the machine is still
there). And return that particular state. The UI shows a "Creat VM"
modal if it's receives a Terminated state. But because the Machine
document is still there we would receive a "Free VM's can't create more
than one VM". This is a very rare case only introduced by human errors
or non Kloud interaction.

Solution:
We fix it by marking the machine document as NotInitialized (self heal)
so the UI side can immediately start to build.
