### PR TITLE
Rewards: Keep rewards after registration and confirm them when emails [#91625346]

### DIFF
--- a/workers/social/lib/social/models/rewards/index.coffee
+++ b/workers/social/lib/social/models/rewards/index.coffee
@@ -45,6 +45,7 @@ module.exports = class JReward extends jraphical.Message
       originId        : 'sparse'
       sourceCampaign  : 'sparse'
       providedBy      : 'sparse'
+      confirmed       : 'sparse'
 
     schema            :
       # for now we only have disk space
@@ -65,6 +66,9 @@ module.exports = class JReward extends jraphical.Message
       originId        :
         type          : ObjectId
         required      : yes
+      confirmed       :
+        type          : Boolean
+        default       : -> no
 
 
   # Helpers
@@ -91,7 +95,7 @@ module.exports = class JReward extends jraphical.Message
     { originId, unit, type } = useDefault options
 
     JReward.aggregate
-      $match     : { unit, type, originId }
+      $match     : { unit, type, originId, confirmed: yes }
     ,
       $group     :
         _id      : "$originId"
@@ -175,6 +179,7 @@ module.exports = class JReward extends jraphical.Message
       reward = new JReward {
         amount         : options.amount         or 512
         sourceCampaign : options.sourceCampaign or "register"
+        confirmed      : yes
         providedBy, originId, type, unit
       }
 

--- a/workers/social/lib/social/models/rewards/rewardcampaign.coffee
+++ b/workers/social/lib/social/models/rewards/rewardcampaign.coffee
@@ -6,6 +6,9 @@ module.exports = class JRewardCampaign extends jraphical.Module
 
   # Examples for working with campaigns
   #
+  # Warning: if campaign initial amount is 0
+  #          then this is an infinite campaign
+  #
   # # Create
   #
   # KD.remote.api.JRewardCampaign.create(
@@ -248,4 +251,3 @@ module.exports = class JRewardCampaign extends jraphical.Module
   remove$: permit 'manage campaign',
     success: (client, data, callback)->
       @remove callback
-

--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -1041,6 +1041,10 @@ module.exports = class JUser extends jraphical.Module
           queue.next()
 
       ->
+        JUser.emit "UserRegistered", {user, account}
+        queue.next()
+
+      ->
         # Auto confirm accounts for development environment
         # This config should be no for production! ~ GG
         if KONFIG.autoConfirmAccounts


### PR DESCRIPTION
Before we weren't keep any not confirmed rewards, we were trying to mix referrer field in JAccounts and the confirmed rewards to show a simple list of referrals. Which was causing lots of process for showing simple data, instead of process time now we have more data instead.

I need this for https://github.com/koding/koding/pull/3253 
