### PR TITLE
Disable topic moderation need for non koding teams

### DIFF
--- a/config/main.dev.coffee
+++ b/config/main.dev.coffee
@@ -68,6 +68,13 @@ Configuration = (options={}) ->
   googleapiServiceAccount = {clientId       :  "753589381435-irpve47dabrj9sjiqqdo2k9tr8l1jn5v.apps.googleusercontent.com", clientSecret : "1iNPDf8-F9bTKmX8OWXlkYra" , serviceAccountEmail    : "753589381435-irpve47dabrj9sjiqqdo2k9tr8l1jn5v@developer.gserviceaccount.com", serviceAccountKeyFile : "#{projectRoot}/keys/googleapi-privatekey.pem"}
 
   segment                 = 'kb2hfdgf20'
+  
+  # if you want to disable a feature add here with "true" value do not forget
+  # to add corresponding go struct properties "true" value is used because of
+  # Go's default value for boolean properties is false, so all the features are
+  # enabled as default
+  disabledFeatures =
+    moderation : yes
 
   socialapi =
     proxyUrl                : "#{customDomain.local}/api/social"
@@ -97,6 +104,7 @@ Configuration = (options={}) ->
     paymentwebhook          : paymentwebhook
     googleapiServiceAccount : googleapiServiceAccount
     segment                 : segment
+    disabledFeatures        : disabledFeatures
 
   userSitesDomain     = "dev.koding.io"
   socialQueueName     = "koding-social-#{configName}"

--- a/config/main.prod.coffee
+++ b/config/main.prod.coffee
@@ -55,6 +55,9 @@ Configuration = (options={}) ->
 
   segment                 = '4c570qjqo0'
 
+  disabledFeatures =
+   moderation : yes
+  
   socialapi =
     proxyUrl                : "#{customDomain.local}/api/social"
     port                    : "7000"
@@ -83,6 +86,7 @@ Configuration = (options={}) ->
     paymentwebhook          : paymentwebhook
     googleapiServiceAccount : googleapiServiceAccount
     segment                 : segment
+    disabledFeatures        : disabledFeatures
 
   userSitesDomain     = "koding.io"
   socialQueueName     = "koding-social-#{configName}"

--- a/config/main.sandbox.coffee
+++ b/config/main.sandbox.coffee
@@ -56,6 +56,10 @@ Configuration = (options={}) ->
 
   segment                 = 'kb2hfdgf20'
 
+  
+  disabledFeatures =
+    moderation : yes
+
   socialapi =
     proxyUrl                : "#{customDomain.local}/api/social"
     port                    : "7000"
@@ -84,6 +88,7 @@ Configuration = (options={}) ->
     paymentwebhook          : paymentwebhook
     googleapiServiceAccount : googleapiServiceAccount
     segment                 : segment
+    disabledFeatures        : disabledFeatures
 
   userSitesDomain     = "sandbox.koding.io"
   socialQueueName     = "koding-social-#{configName}"

--- a/go/src/socialapi/config/configtypes.go
+++ b/go/src/socialapi/config/configtypes.go
@@ -47,6 +47,8 @@ type (
 		CustomDomain CustomDomain
 
 		GoogleapiServiceAccount GoogleapiServiceAccount
+
+		DisabledFeatures DisabledFeatures
 	}
 
 	// Email holds Email Workers' config
@@ -137,5 +139,9 @@ type (
 		ClientSecret          string `env:"key=KONFIG_SOCIALAPI_GOOGLEAPISERVICEACCOUNT_CLIENTSECRET"`
 		ServiceAccountEmail   string `env:"key=KONFIG_SOCIALAPI_GOOGLEAPISERVICEACCOUNT_SERVICEACCOUNTEMAIL"`
 		ServiceAccountKeyFile string `env:"key=KONFIG_SOCIALAPI_GOOGLEAPISERVICEACCOUNT_SERVICEACCOUNTKEYFILE"`
+	}
+
+	DisabledFeatures struct {
+		Moderation bool
 	}
 )

--- a/go/src/socialapi/workers/cmd/topicfeed/main.go
+++ b/go/src/socialapi/workers/cmd/topicfeed/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"socialapi/config"
 	"socialapi/models"
 	"socialapi/workers/topicfeed"
 
@@ -19,7 +20,8 @@ func main() {
 		return
 	}
 
-	r.SetContext(topicfeed.New(r.Log))
+	appConfig := config.MustRead(r.Conf.Path)
+	r.SetContext(topicfeed.New(r.Log, appConfig))
 	r.Register(models.ChannelMessage{}).OnUpdate().Handle((*topicfeed.Controller).MessageUpdated)
 	r.Register(models.ChannelMessage{}).OnDelete().Handle((*topicfeed.Controller).MessageDeleted)
 	r.Register(models.ChannelMessage{}).OnCreate().Handle((*topicfeed.Controller).MessageSaved)

--- a/go/src/socialapi/workers/cmd/topicmoderation/main.go
+++ b/go/src/socialapi/workers/cmd/topicmoderation/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"fmt"
+	"socialapi/config"
 	"socialapi/models"
 	"socialapi/workers/moderation/topic"
 
@@ -21,7 +22,8 @@ func main() {
 		return
 	}
 
-	r.SetContext(topic.NewController(r.Log))
+	appConfig := config.MustRead(r.Conf.Path)
+	r.SetContext(topic.NewController(r.Log, appConfig))
 	r.Register(models.ChannelLink{}).OnCreate().Handle((*topic.Controller).Create)
 	r.Register(models.ChannelLink{}).OnDelete().Handle((*topic.Controller).Delete)
 	r.Register(models.ChannelLink{}).On(models.ModerationChannelBlacklist).Handle((*topic.Controller).Blacklist)

--- a/go/src/socialapi/workers/moderation/topic/moderation.go
+++ b/go/src/socialapi/workers/moderation/topic/moderation.go
@@ -3,6 +3,7 @@ package topic
 
 import (
 	"errors"
+	"socialapi/config"
 	"socialapi/models"
 
 	"github.com/koding/logging"
@@ -13,13 +14,15 @@ const processCount = 100
 
 // Controller holds the required parameters for moderation async operations
 type Controller struct {
-	log logging.Logger
+	log    logging.Logger
+	config *config.Config
 }
 
 // NewController creates a handler for consuming async operations of moderation
-func NewController(log logging.Logger) *Controller {
+func NewController(log logging.Logger, config *config.Config) *Controller {
 	return &Controller{
-		log: log,
+		log:    log,
+		config: config,
 	}
 }
 

--- a/go/src/socialapi/workers/moderation/topic/moderation_test.go
+++ b/go/src/socialapi/workers/moderation/topic/moderation_test.go
@@ -30,7 +30,7 @@ func TestProcess(t *testing.T) {
 
 	Convey("given a controller", t, func() {
 
-		controller := NewController(r.Log)
+		controller := NewController(r.Log, appConfig)
 
 		Convey("controller should be set", func() {
 			So(controller, ShouldNotBeNil)

--- a/go/src/socialapi/workers/topicfeed/topicfeed.go
+++ b/go/src/socialapi/workers/topicfeed/topicfeed.go
@@ -2,6 +2,7 @@ package topicfeed
 
 import (
 	"fmt"
+	"socialapi/config"
 	"socialapi/models"
 
 	"github.com/koding/bongo"
@@ -11,12 +12,14 @@ import (
 )
 
 type Controller struct {
-	log logging.Logger
+	log    logging.Logger
+	config *config.Config
 }
 
-func New(log logging.Logger) *Controller {
+func New(log logging.Logger, config *config.Config) *Controller {
 	return &Controller{
-		log: log,
+		log:    log,
+		config: config,
 	}
 }
 
@@ -350,7 +353,8 @@ func (f *Controller) createTopicChannel(creatorId int64, groupName, channelName,
 	c.TypeConstant = models.Channel_TYPE_TOPIC
 	c.PrivacyConstant = privacy
 	// add moderation needed flag only for koding group
-	if c.GroupName == models.Channel_KODING_NAME {
+	// and if feature is not disabled
+	if !f.config.DisabledFeatures.Moderation && c.GroupName == models.Channel_KODING_NAME {
 		// newly created channels need moderation
 		c.MetaBits.Mark(models.NeedsModeration)
 	}

--- a/go/src/socialapi/workers/topicfeed/topicfeed.go
+++ b/go/src/socialapi/workers/topicfeed/topicfeed.go
@@ -349,8 +349,11 @@ func (f *Controller) createTopicChannel(creatorId int64, groupName, channelName,
 	c.Purpose = fmt.Sprintf("Channel for %s topic", channelName)
 	c.TypeConstant = models.Channel_TYPE_TOPIC
 	c.PrivacyConstant = privacy
-	// newly created channels need moderation
-	c.MetaBits.Mark(models.NeedsModeration)
+	// add moderation needed flag only for koding group
+	if c.GroupName == models.Channel_KODING_NAME {
+		// newly created channels need moderation
+		c.MetaBits.Mark(models.NeedsModeration)
+	}
 	err := c.Create()
 	if err == nil {
 		return c, nil

--- a/go/src/socialapi/workers/topicfeed/topicfeed_test.go
+++ b/go/src/socialapi/workers/topicfeed/topicfeed_test.go
@@ -2,6 +2,7 @@ package topicfeed
 
 import (
 	"math/rand"
+	"socialapi/config"
 	"socialapi/models"
 	"socialapi/request"
 	"socialapi/workers/topicfeed"
@@ -66,7 +67,8 @@ func TestMessageSaved(t *testing.T) {
 	}
 	defer r.Close()
 
-	controller := topicfeed.New(r.Log)
+	appConfig := config.MustRead(r.Conf.Path)
+	controller := topicfeed.New(r.Log, appConfig)
 
 	Convey("while testing MessageSaved", t, func() {
 		Convey("newly created channels of koding group", func() {
@@ -96,7 +98,11 @@ func TestMessageSaved(t *testing.T) {
 				})
 				So(err, ShouldBeNil)
 				So(channel, ShouldNotBeNil)
-				So(channel.MetaBits.Is(models.NeedsModeration), ShouldBeTrue)
+				if appConfig.DisabledFeatures.Moderation {
+					So(channel.MetaBits.Is(models.NeedsModeration), ShouldBeFalse)
+				} else {
+					So(channel.MetaBits.Is(models.NeedsModeration), ShouldBeTrue)
+				}
 			})
 		})
 
@@ -140,7 +146,8 @@ func TestFetchTopicChannel(t *testing.T) {
 	}
 	defer r.Close()
 
-	controller := New(r.Log)
+	appConfig := config.MustRead(r.Conf.Path)
+	controller := New(r.Log, appConfig)
 
 	Convey("while testing fetchTopicChannel", t, func() {
 		account := models.CreateAccountWithTest()


### PR DESCRIPTION
This PR 
- disables topic moderation need for non-koding groups
- added basic feature toggling support to social parts
