### PR TITLE
Video channel-session persistency

### DIFF
--- a/client/app/lib/videocollaboration/helper.coffee
+++ b/client/app/lib/videocollaboration/helper.coffee
@@ -257,6 +257,34 @@ isVideoActive = (channel) -> channel?.payload?.videoEnabled is 'true'
 
 
 ###*
+ * Set videoSessionId to paylod of given channel, then call callback.
+ *
+ * @param {SocialChannel}
+ * @param {string} sessionId
+ * @param {function} callback
+###
+setChannelVideoSession = (channel, sessionId, callback) ->
+
+  { payload } = channel
+
+  options =
+    id      : channel.id
+    payload : _.assign {}, payload, { videoSessionId : sessionId }
+
+  kd.singletons.socialapi.channel.update options, callback
+
+
+###*
+ * Return given channel's video session id. It can be used for boolean checks
+ * as if it's a `hasSessionId` named method.
+ *
+ * @param {SocialChannel} channel
+ * @return {string|undefined} id
+###
+getChannelSessionId = (channel) -> channel?.payload?.videoSessionId
+
+
+###*
  * @param {KDView} container
  * @param {string} nickname
  * @param {function(err: object)}
@@ -291,6 +319,8 @@ module.exports = {
   enableVideo
   disableVideo
   isVideoActive
+  setChannelVideoSession
   showOfflineParticipant
+  getChannelSessionId
   _errorSignal
 }

--- a/client/app/lib/videocollaboration/helper.coffee
+++ b/client/app/lib/videocollaboration/helper.coffee
@@ -121,6 +121,13 @@ createPublisher = (view, options = {}, callback) ->
     callback null, publisher
 
 
+###*
+ * Fix given participant's background image.
+ * TODO: investigate if this method is more suitable for VideoViewModel
+ *
+ * @param {ParticipantType.Participant} participant
+ * @param {JAccount} account
+###
 fixParticipantBackgroundImage = (participant, account) ->
 
   poster = participant.element.querySelector '.OT_video-poster'
@@ -134,6 +141,11 @@ fixParticipantBackgroundImage = (participant, account) ->
   poster.appendChild el
 
 
+###*
+ * Return nickname if present, or firstname + lastname, from given account.
+ *
+ * @param {JAccount} account
+###
 getNicename = (account) ->
 
   { firstName, lastName, nickname } = account.profile

--- a/client/app/lib/videocollaboration/helper.coffee
+++ b/client/app/lib/videocollaboration/helper.coffee
@@ -1,4 +1,5 @@
 $ = require 'jquery'
+_ = require 'lodash'
 kd = require 'kd'
 remote = require('app/remote').getInstance()
 whoami = require 'app/util/whoami'
@@ -219,9 +220,11 @@ _getGravatarUri = (account, size = 355) ->
 ###
 setVideoState = (channel, state, callback) ->
 
+  { payload } = channel
+
   options =
     id      : channel.id
-    payload : { videoEnabled : state }
+    payload : _.assign {}, payload, { videoEnabled : state }
 
   kd.singletons.socialapi.channel.update options, callback
 

--- a/client/app/lib/videocollaboration/helper.coffee
+++ b/client/app/lib/videocollaboration/helper.coffee
@@ -4,6 +4,8 @@ remote = require('app/remote').getInstance()
 whoami = require 'app/util/whoami'
 getNick = require 'app/util/nick'
 
+ProfileTextView = require 'app/commonviews/linkviews/profiletextview'
+
 ###*
  * It makes a request to the backend and gets session id
  * and creates a session with that session id.
@@ -119,7 +121,6 @@ createPublisher = (view, options = {}, callback) ->
     callback null, publisher
 
 
-ProfileTextView = require 'app/commonviews/linkviews/profiletextview'
 fixParticipantBackgroundImage = (participant, account) ->
 
   poster = participant.element.querySelector '.OT_video-poster'

--- a/client/app/lib/videocollaboration/model.coffee
+++ b/client/app/lib/videocollaboration/model.coffee
@@ -184,7 +184,7 @@ module.exports = class VideoCollaborationModel extends kd.Object
       @emit 'ParticipantStartedTalking', nick
       @changeActiveParticipant nick  unless @state.selectedParticipant
 
-     _subscriber.on 'TalkingDidStop', =>
+    _subscriber.on 'TalkingDidStop', =>
       @emit 'ParticipantStoppedTalking', nick
 
     return _subscriber
@@ -217,6 +217,7 @@ module.exports = class VideoCollaborationModel extends kd.Object
       @emit 'ParticipantStartedTalking', getNick()
 
     _publisher.on 'TalkingDidStop', =>
+      return  unless @state.active
       @emit 'ParticipantStoppedTalking', getNick()
 
     return _publisher

--- a/client/app/lib/videocollaboration/services/opentok.coffee
+++ b/client/app/lib/videocollaboration/services/opentok.coffee
@@ -103,9 +103,9 @@ module.exports = class OpenTokService extends kd.Object
     # first generate a sessionId, then assign that sessionId to channel, and
     # then initiate a new OT.Session.
     else
-      helper.generateSession channel, (result) =>
+      helper.generateSession channel, (result) ->
         { sessionId } = result
-        helper.setChannelVideoSession channel, sessionId, (err) =>
+        helper.setChannelVideoSession channel, sessionId, (err) ->
           kallback sessionId
 
 
@@ -121,9 +121,9 @@ module.exports = class OpenTokService extends kd.Object
   ###
   connect: (channel, callbacks) ->
 
-    @fetchChannelSession channel, (session) =>
-      helper.generateToken session, (token) =>
-        session.connect token, (err) =>
+    @fetchChannelSession channel, (session) ->
+      helper.generateToken session, (token) ->
+        session.connect token, (err) ->
           if err
           then callbacks.error err
           else callbacks.success session
@@ -139,7 +139,7 @@ module.exports = class OpenTokService extends kd.Object
   ###
   sendSignal: (channel, type, callback) ->
 
-    @fetchChannelSession channel, (session) =>
+    @fetchChannelSession channel, (session) ->
       session.signal { type }, callback
 
 

--- a/client/app/lib/videocollaboration/services/opentok.coffee
+++ b/client/app/lib/videocollaboration/services/opentok.coffee
@@ -86,18 +86,27 @@ module.exports = class OpenTokService extends kd.Object
 
     { id } = channel
 
-    return callback @sessions[id]  if @sessions[id]
-
-    helper.generateSession channel, (session) =>
-
-      { sessionId } = session
+    kallback = (sessionId) =>
       { apiKey } = globals.config.tokbox
-
       session = @sessions[channel.id] = OT.initSession apiKey, sessionId
-
       session.sessionId = sessionId
+      return callback session
 
-      callback session
+    # return cached OT.session if that session exists.
+    if session = @sessions[id]
+      return callback session
+
+    # initate a OT.Session with channel's sessionId if it's present.
+    else if sessionId = helper.getChannelSessionId channel
+      kallback sessionId
+
+    # first generate a sessionId, then assign that sessionId to channel, and
+    # then initiate a new OT.Session.
+    else
+      helper.generateSession channel, (result) =>
+        { sessionId } = result
+        helper.setChannelVideoSession channel, sessionId, (err) =>
+          kallback sessionId
 
 
   ###*

--- a/client/app/lib/videocollaboration/services/opentok.coffee
+++ b/client/app/lib/videocollaboration/services/opentok.coffee
@@ -106,6 +106,8 @@ module.exports = class OpenTokService extends kd.Object
       helper.generateSession channel, (result) ->
         { sessionId } = result
         helper.setChannelVideoSession channel, sessionId, (err) ->
+          # TODO: requires proper error handling.
+          return console.error err  if err
           kallback sessionId
 
 


### PR DESCRIPTION
Initial implementation was really silly and naive (_:facepalm:_) implementation for association between opentok sessions and social channels. this fixes that. it persists the `videoSessionId` at `SocialChannel` payload, it will be on Postgres from that on, and every participant can read from there, instead of relying on an in-memory object ( :disappointed::gun: ), we are reading it from `SocialChannel`.

/cc @cihangir @canthefason 
