### PR TITLE
Sidebar: Fix missing participant representation [fixes #92208712]

### DIFF
--- a/client/app/lib/activity/sidebar/sidebarmessageitemtext.coffee
+++ b/client/app/lib/activity/sidebar/sidebarmessageitemtext.coffee
@@ -52,7 +52,7 @@ module.exports = class SidebarMessageItemText extends JView
 
   createSingle: (origin) ->
 
-    origin = { constructorName : 'JAccount', id : origin._id }
+    origin.id = origin._id  if origin
     @text  = new ProfileTextView {origin}
 
 


### PR DESCRIPTION
[Sidebar breaks page load if SocialMessage participant data is inconsistent](https://www.pivotaltracker.com/story/show/92208712)
