### PR TITLE
algolia: clear query cache every 10 seconds for each index

### DIFF
--- a/client/app/lib/searchcontroller.coffee
+++ b/client/app/lib/searchcontroller.coffee
@@ -154,6 +154,10 @@ module.exports = class SearchController extends KDObject
   getIndex: (indexName) ->
     unless @indexes[indexName]?
       index = @algolia.initIndex indexName
+      # this is for clearing the query cache every 10 seconds
+      setInterval =>
+        index.clearCache()
+      , 10000
       # index.setSettings attributesForFaceting: 'channel'
       @indexes[indexName] = index
     @indexes[indexName]


### PR DESCRIPTION
Not sure if it is directly related with failing algolia tests, but it could maybe slightly improve the process:

1- I made a search with a query string for a nonexisting post: 'hehe'
2- It could not find any result
3- I posted a message with body 'hehe'
4- When I searched again for the word 'hehe', it was still not returning any result. 
5- Refreshed the page 
6- Searched for 'hehe' and it returned with my message

With this PR started clearing the [query cache](https://github.com/algolia/algoliasearch-client-js#cache) for each index every 10 seconds.
