### PR TITLE
kloudctl: use XHR instead of WebSocket to pass ELB

### DIFF
--- a/go/src/koding/kites/kloud/kloudctl/command/kloudhandler.go
+++ b/go/src/koding/kites/kloud/kloudctl/command/kloudhandler.go
@@ -53,12 +53,13 @@ func kloudWrapper(args []string, actioner Actioner) error {
 
 func kloudClient() (*kite.Client, error) {
 	k := kite.New("kloudctl", "0.0.1")
-	config, err := config.Get()
+	c, err := config.Get()
 	if err != nil {
 		return nil, err
 	}
 
-	k.Config = config
+	k.Config = c
+	k.Config.Transport = config.XHRPolling
 	k.SetLogLevel(kite.WARNING)
 
 	remoteKite := k.NewClient(flagKloudAddr)


### PR DESCRIPTION
This is just a small change to let use `kloudctl`XHR instead of default WebSocket. Now we can connect to kloud from localhost because our workers are behind ELB and it doesn't play well with WebSocket.
