### PR TITLE
vmwatcher: don't initalize new 2nd kloud conn on disconnect,

### DIFF
--- a/go/src/koding/vmwatcher/main.go
+++ b/go/src/koding/vmwatcher/main.go
@@ -51,9 +51,6 @@ const (
 func main() {
 	initialize()
 
-	// on disconnect, try to reconnect
-	controller.Klient.OnDisconnect(func() { initializeKlient(controller) })
-
 	startTime := time.Now()
 	defer func() {
 		Log.Info("Exited...ran for: %s", time.Since(startTime))


### PR DESCRIPTION
 kloud#Reconnect is set to true already
