### PR TITLE
remove manually modify of computeController's machines list [fixes #92341494]

### DIFF
--- a/client/app/lib/providers/computeplansmodalpaid.coffee
+++ b/client/app/lib/providers/computeplansmodalpaid.coffee
@@ -134,7 +134,5 @@ module.exports = class ComputePlansModalPaid extends ComputePlansModal
 
       return  if showError err
 
-      globals.userMachines.push machine
-
       @createVMButton.hideLoader()
       @destroy()


### PR DESCRIPTION
fixes for [bug](https://www.pivotaltracker.com/story/show/92341494)

`globals.userMachines` is `ComputeController .machines` https://github.com/koding/koding/blob/master/client/app/lib/providers/computecontroller.coffee#L197

@sinan @usirin @gokmen @szkl Could you review this, plz
