### PR TITLE
paymentwebhook: when > 1 invoice line item in stripe webhook, use the last one [fixes #92134118]

### DIFF
--- a/go/src/socialapi/workers/payment/paymentwebhook/stripe_invoice.go
+++ b/go/src/socialapi/workers/payment/paymentwebhook/stripe_invoice.go
@@ -24,19 +24,11 @@ func stripePaymentSucceeded(raw []byte, c *Controller) error {
 }
 
 func stripePaymentSucceededEmail(req *webhookmodels.StripeInvoice, c *Controller) error {
-	if req.Lines.Data == nil {
-		return fmt.Errorf(
-			"Invoice: %s for %s has nil line items", req.ID, req.CustomerId,
-		)
+	planName, err := getNewPlanName(req)
+	if err != nil {
+		return err
 	}
 
-	if len(req.Lines.Data) < 0 {
-		return fmt.Errorf(
-			"Invoice: %s for %s has 0 line items", req.ID, req.CustomerId,
-		)
-	}
-
-	planName := req.Lines.Data[0].Plan.Name
 	opts := map[string]interface{}{
 		"planName":  planName,
 		"price":     formatStripeAmount(req.Currency, req.AmountDue),
@@ -44,4 +36,23 @@ func stripePaymentSucceededEmail(req *webhookmodels.StripeInvoice, c *Controller
 	}
 
 	return SendEmail(req.CustomerId, PaymentCreated, opts)
+}
+
+func getNewPlanName(req *webhookmodels.StripeInvoice) (string, error) {
+	if req.Lines.Data == nil {
+		return "", fmt.Errorf(
+			"Invoice: %s for %s has nil line items", req.ID, req.CustomerId,
+		)
+	}
+
+	if req.Lines.Count < 1 {
+		return "", fmt.Errorf(
+			"Invoice: %s for %s has 0 line items", req.ID, req.CustomerId,
+		)
+	}
+
+	last := req.Lines.Count - 1
+	planName := req.Lines.Data[last].Plan.Name
+
+	return planName, nil
 }

--- a/go/src/socialapi/workers/payment/paymentwebhook/stripe_invoice.go
+++ b/go/src/socialapi/workers/payment/paymentwebhook/stripe_invoice.go
@@ -51,7 +51,7 @@ func getNewPlanName(req *webhookmodels.StripeInvoice) (string, error) {
 		)
 	}
 
-	last := req.Lines.Count - 1
+	last := len(req.Lines.Data) - 1
 	planName := req.Lines.Data[last].Plan.Name
 
 	return planName, nil

--- a/go/src/socialapi/workers/payment/paymentwebhook/stripe_invoice_test.go
+++ b/go/src/socialapi/workers/payment/paymentwebhook/stripe_invoice_test.go
@@ -29,7 +29,7 @@ func TestStripeInvoiceGetPlanName(t *testing.T) {
 
 		Convey("When 1 line items", func() {
 			Convey("Then it should return plan name of 1st item", func() {
-				invoice := raw_one_lineitems_invoice()
+				invoice := rawOneLineitemsInvoice()
 				planName, err := getNewPlanName(invoice)
 
 				So(err, ShouldBeNil)
@@ -39,7 +39,7 @@ func TestStripeInvoiceGetPlanName(t *testing.T) {
 
 		Convey("When 2 line items", func() {
 			Convey("Then it should return plan name of 2nd item", func() {
-				invoice := raw_two_lineitems_invoice()
+				invoice := rawTwoLineitemsInvoice()
 				planName, err := getNewPlanName(invoice)
 
 				So(err, ShouldBeNil)
@@ -75,7 +75,7 @@ func raw_empty_lineitems_invoice() *webhookmodels.StripeInvoice {
 	}
 }
 
-func raw_one_lineitems_invoice() *webhookmodels.StripeInvoice {
+func rawOneLineitemsInvoice() *webhookmodels.StripeInvoice {
 	return &webhookmodels.StripeInvoice{
 		ID:         "ID_000",
 		CustomerId: "Cus_000",
@@ -95,7 +95,7 @@ func raw_one_lineitems_invoice() *webhookmodels.StripeInvoice {
 	}
 }
 
-func raw_two_lineitems_invoice() *webhookmodels.StripeInvoice {
+func rawTwoLineitemsInvoice() *webhookmodels.StripeInvoice {
 	return &webhookmodels.StripeInvoice{
 		ID:         "evt_15rcA7Dy8g9bkw8y4opMBcgB",
 		CustomerId: "cus_61nef0wiQMSCGY",

--- a/go/src/socialapi/workers/payment/paymentwebhook/stripe_invoice_test.go
+++ b/go/src/socialapi/workers/payment/paymentwebhook/stripe_invoice_test.go
@@ -11,7 +11,7 @@ func TestStripeInvoiceGetPlanName(t *testing.T) {
 	Convey("Given invoice webhook from stripe", t, func() {
 		Convey("When no line item data", func() {
 			Convey("Then it should return err", func() {
-				invoice := raw_no_lineitems_invoice()
+				invoice := rawNoLineItemsInvoice()
 				_, err := getNewPlanName(invoice)
 
 				So(err, ShouldNotBeNil)
@@ -20,7 +20,7 @@ func TestStripeInvoiceGetPlanName(t *testing.T) {
 
 		Convey("When empty line items", func() {
 			Convey("Then it should return err", func() {
-				invoice := raw_empty_lineitems_invoice()
+				invoice := rawEmptyLineitemsInvoice()
 				_, err := getNewPlanName(invoice)
 
 				So(err, ShouldNotBeNil)
@@ -29,7 +29,7 @@ func TestStripeInvoiceGetPlanName(t *testing.T) {
 
 		Convey("When 1 line items", func() {
 			Convey("Then it should return plan name of 1st item", func() {
-				invoice := rawOneLineitemsInvoice()
+				invoice := rawOneLineItemsInvoice()
 				planName, err := getNewPlanName(invoice)
 
 				So(err, ShouldBeNil)
@@ -49,7 +49,7 @@ func TestStripeInvoiceGetPlanName(t *testing.T) {
 	})
 }
 
-func raw_no_lineitems_invoice() *webhookmodels.StripeInvoice {
+func rawNoLineItemsInvoice() *webhookmodels.StripeInvoice {
 	return &webhookmodels.StripeInvoice{
 		ID:         "evt_15rcA7Dy8g9bkw8y4opMBcgB",
 		CustomerId: "cus_61nef0wiQMSCGY",
@@ -62,7 +62,7 @@ func raw_no_lineitems_invoice() *webhookmodels.StripeInvoice {
 	}
 }
 
-func raw_empty_lineitems_invoice() *webhookmodels.StripeInvoice {
+func rawEmptyLineitemsInvoice() *webhookmodels.StripeInvoice {
 	return &webhookmodels.StripeInvoice{
 		ID:         "evt_15rcA7Dy8g9bkw8y4opMBcgB",
 		CustomerId: "cus_61nef0wiQMSCGY",
@@ -75,7 +75,7 @@ func raw_empty_lineitems_invoice() *webhookmodels.StripeInvoice {
 	}
 }
 
-func rawOneLineitemsInvoice() *webhookmodels.StripeInvoice {
+func rawOneLineItemsInvoice() *webhookmodels.StripeInvoice {
 	return &webhookmodels.StripeInvoice{
 		ID:         "ID_000",
 		CustomerId: "Cus_000",

--- a/go/src/socialapi/workers/payment/paymentwebhook/stripe_invoice_test.go
+++ b/go/src/socialapi/workers/payment/paymentwebhook/stripe_invoice_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"socialapi/workers/payment/paymentwebhook/webhookmodels"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestStripeInvoiceGetPlanName(t *testing.T) {
+	Convey("Given invoice webhook from stripe", t, func() {
+		Convey("When no line item data", func() {
+			Convey("Then it should return err", func() {
+				invoice := raw_no_lineitems_invoice()
+				_, err := getNewPlanName(invoice)
+
+				So(err, ShouldNotBeNil)
+			})
+		})
+
+		Convey("When empty line items", func() {
+			Convey("Then it should return err", func() {
+				invoice := raw_empty_lineitems_invoice()
+				_, err := getNewPlanName(invoice)
+
+				So(err, ShouldNotBeNil)
+			})
+		})
+
+		Convey("When 1 line items", func() {
+			Convey("Then it should return plan name of 1st item", func() {
+				invoice := raw_one_lineitems_invoice()
+				planName, err := getNewPlanName(invoice)
+
+				So(err, ShouldBeNil)
+				So(planName, ShouldEqual, "Pla_000")
+			})
+		})
+
+		Convey("When 2 line items", func() {
+			Convey("Then it should return plan name of 2nd item", func() {
+				invoice := raw_two_lineitems_invoice()
+				planName, err := getNewPlanName(invoice)
+
+				So(err, ShouldBeNil)
+				So(planName, ShouldEqual, "Pla_001")
+			})
+		})
+	})
+}
+
+func raw_no_lineitems_invoice() *webhookmodels.StripeInvoice {
+	return &webhookmodels.StripeInvoice{
+		ID:         "evt_15rcA7Dy8g9bkw8y4opMBcgB",
+		CustomerId: "cus_61nef0wiQMSCGY",
+		AmountDue:  0,
+		Currency:   "usd",
+		Lines: webhookmodels.StripeInvoiceLines{
+			Count: 0,
+			Data:  nil,
+		},
+	}
+}
+
+func raw_empty_lineitems_invoice() *webhookmodels.StripeInvoice {
+	return &webhookmodels.StripeInvoice{
+		ID:         "evt_15rcA7Dy8g9bkw8y4opMBcgB",
+		CustomerId: "cus_61nef0wiQMSCGY",
+		AmountDue:  0,
+		Currency:   "usd",
+		Lines: webhookmodels.StripeInvoiceLines{
+			Count: 0,
+			Data:  []webhookmodels.StripeInvoiceData{},
+		},
+	}
+}
+
+func raw_one_lineitems_invoice() *webhookmodels.StripeInvoice {
+	return &webhookmodels.StripeInvoice{
+		ID:         "ID_000",
+		CustomerId: "Cus_000",
+		AmountDue:  0,
+		Currency:   "usd",
+		Lines: webhookmodels.StripeInvoiceLines{
+			Count: 1,
+			Data: []webhookmodels.StripeInvoiceData{
+				webhookmodels.StripeInvoiceData{
+					SubscriptionId: "Sub_000",
+					Plan: webhookmodels.StripePlan{
+						Name: "Pla_000",
+					},
+				},
+			},
+		},
+	}
+}
+
+func raw_two_lineitems_invoice() *webhookmodels.StripeInvoice {
+	return &webhookmodels.StripeInvoice{
+		ID:         "evt_15rcA7Dy8g9bkw8y4opMBcgB",
+		CustomerId: "cus_61nef0wiQMSCGY",
+		AmountDue:  0,
+		Currency:   "usd",
+		Lines: webhookmodels.StripeInvoiceLines{
+			Count: 2,
+			Data: []webhookmodels.StripeInvoiceData{
+				webhookmodels.StripeInvoiceData{
+					SubscriptionId: "Sub_000",
+					Plan: webhookmodels.StripePlan{
+						Name: "Pla_000",
+					},
+				},
+				webhookmodels.StripeInvoiceData{
+					SubscriptionId: "Sub_001",
+					Plan: webhookmodels.StripePlan{
+						Name: "Pla_001",
+					},
+				},
+			},
+		},
+	}
+}

--- a/go/src/socialapi/workers/payment/paymentwebhook/webhookmodels/stripe.go
+++ b/go/src/socialapi/workers/payment/paymentwebhook/webhookmodels/stripe.go
@@ -31,7 +31,7 @@ type StripeInvoiceData struct {
 
 type StripeInvoiceLines struct {
 	Data  []StripeInvoiceData `json:"data"`
-	Count int                 `json:"count"`
+	Count int                 `json:"total_count"`
 }
 
 type StripeInvoice struct {

--- a/go/src/socialapi/workers/payment/paymentwebhook/webhookmodels/stripe_test.go
+++ b/go/src/socialapi/workers/payment/paymentwebhook/webhookmodels/stripe_test.go
@@ -83,7 +83,7 @@ var invoiceCreatedWebhookRequest = []byte(`{
 					"metadata": {}
 				}
 			],
-			"count": 1,
+			"total_count": 1,
 			"object": "list",
 			"url": "/v1/invoices/in_15QSl7Dy8g9bkw8yWuzjCCA0/lines"
 		},

--- a/go/src/socialapi/workers/payment/stripe/checkers.go
+++ b/go/src/socialapi/workers/payment/stripe/checkers.go
@@ -56,9 +56,5 @@ func IsLineCountAllowed(count int) bool {
 		return false
 	}
 
-	if count > 1 {
-		Log.Notice("Received more than 1 line item for invoice.created webhook.")
-	}
-
 	return true
 }


### PR DESCRIPTION
This happens if you go from lower plan in yearly interval to higher plan in monthly interval because the first plan has left over credit when going to second plan.
