### PR TITLE
kloud/controller: pass certain errors to client side

### DIFF
--- a/client/app/lib/providers/environmentsmachinestatemodal.coffee
+++ b/client/app/lib/providers/environmentsmachinestatemodal.coffee
@@ -95,9 +95,9 @@ module.exports = class EnvironmentsMachineStateModal extends EnvironmentsModalVi
     else
       @state = status
 
-      if error?.length > 0
+      if error
 
-        if /NetworkOut overlimit/i.test event.message
+        if /NetworkOut/i.test error
           @customErrorMessage = "
             <p>You've reached your outbound network usage
             limit for this week.</p><span>

--- a/go/src/koding/kites/kloud/kloud/errors.go
+++ b/go/src/koding/kites/kloud/kloud/errors.go
@@ -7,6 +7,20 @@ import (
 	"github.com/koding/kite"
 )
 
+type EventerError struct {
+	Msg string
+}
+
+func NewEventerError(msg string) *EventerError {
+	return &EventerError{
+		Msg: msg,
+	}
+}
+
+func (e *EventerError) Error() string {
+	return e.Msg
+}
+
 const (
 	ErrMachineInitialized    = 100
 	ErrMachineNotInitialized = 101

--- a/go/src/koding/kites/kloud/kloud/methods.go
+++ b/go/src/koding/kites/kloud/kloud/methods.go
@@ -98,17 +98,18 @@ func (k *Kloud) Start(r *kite.Request) (resp interface{}, reqErr error) {
 		}
 
 		err := starter.Start(ctx)
+		if err != nil {
+			// special case `NetworkOut` error since client relies on this
+			// to show a modal
+			if strings.Contains(err.Error(), "NetworkOut") {
+				err = NewEventerError(err.Error())
+			}
 
-		// special case `NetworkOut` error since client relies on this
-		// to show a modal
-		if strings.Contains(err.Error(), "NetworkOut") {
-			err = NewEventerError(err.Error())
-		}
-
-		// special case `plan is expired` error since client relies on this to
-		// show a modal
-		if strings.Contains(strings.ToLower(err.Error()), "plan is expired") {
-			err = NewEventerError(err.Error())
+			// special case `plan is expired` error since client relies on this to
+			// show a modal
+			if strings.Contains(strings.ToLower(err.Error()), "plan is expired") {
+				err = NewEventerError(err.Error())
+			}
 		}
 
 		return err

--- a/go/src/koding/kites/kloud/kloud/methods.go
+++ b/go/src/koding/kites/kloud/kloud/methods.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"koding/kites/kloud/contexthelper/request"
 	"koding/kites/kloud/machinestate"
+	"strings"
 
 	"github.com/koding/kite"
 	"github.com/mitchellh/mapstructure"
@@ -96,19 +97,21 @@ func (k *Kloud) Start(r *kite.Request) (resp interface{}, reqErr error) {
 			return fmt.Errorf("Provider doesn't implement %s interface", r.Method)
 		}
 
-		// TODO: fix this out
+		err := starter.Start(ctx)
+
 		// special case `NetworkOut` error since client relies on this
 		// to show a modal
-		// if strings.Contains(err.Error(), "NetworkOut") {
-		// 	msg = err.Error()
-		// }
+		if strings.Contains(err.Error(), "NetworkOut") {
+			err = NewEventerError(err.Error())
+		}
 
-		// special case `plan is expired` error since client relies on this
-		// to show a modal
-		// if strings.Contains(strings.ToLower(err.Error()), "plan is expired") {
-		// 	msg = err.Error()
-		// }
-		return starter.Start(ctx)
+		// special case `plan is expired` error since client relies on this to
+		// show a modal
+		if strings.Contains(strings.ToLower(err.Error()), "plan is expired") {
+			err = NewEventerError(err.Error())
+		}
+
+		return err
 	}
 
 	return k.coreMethods(r, startFunc)


### PR DESCRIPTION
We have some errors we want to pass to the client side, such as Network
Limit or plan expired. We are usually not passing anything to avoid
leaking errors to client side.

We use a a new `error` type called `NewEventerError` which is used to
pass errors explicitly to the client side. We are using it to pass
certain errors from the start method to the client side.
