### PR TITLE
account settings: adjust modal height for SSH key's tab [fixes #92340352]

### DIFF
--- a/client/account/lib/styl/account.styl
+++ b/client/account/lib/styl/account.styl
@@ -236,7 +236,7 @@ app.settings.styl
       margin-bottom         24px
 
       textarea.kdinput
-        height                   180px
+        height                   154px
 
   li ~ li
     .ssh-key-item


### PR DESCRIPTION
fixes for [bug](https://www.pivotaltracker.com/story/show/92340352)
@sinan @usirin @fatihacet @gokmen plz review this PR

![account_modal](https://cloud.githubusercontent.com/assets/295206/7155250/e5f10e0e-e365-11e4-9374-d7b095619332.jpg)
