### PR TITLE
Fix the mysterious Access Denied in the social logs \o/

### DIFF
--- a/workers/social/lib/social/models/group/index.coffee
+++ b/workers/social/lib/social/models/group/index.coffee
@@ -916,7 +916,13 @@ module.exports = class JGroup extends Module
         if err then callback err
         else policy.update $set: formData, callback
 
-  canEditGroup: permit 'grant permissions'
+
+  canEditGroup: permit 'grant permissions',
+    success: (client, callback)->
+      callback null, yes
+    failure: (client, callback)->
+      callback null, no
+
 
   @canReadGroupActivity = permit 'read group activity'
   canReadGroupActivity  : permit 'read group activity'


### PR DESCRIPTION
I had to debug to find what is it causing to those access denied logs, finally found them. It will be the new era for Koding :8ball: 

![](http://take.ms/M2Z0d)
