### PR TITLE
Improve cookie management in logging out [fixes #92422948]

### DIFF
--- a/client/app/lib/maincontroller.coffee
+++ b/client/app/lib/maincontroller.coffee
@@ -275,7 +275,7 @@ class MainController extends KDController
       cookieMatches     = cookie is (kookies.get 'clientId')
 
       if not cookieExists or (cookieExists and not cookieMatches)
-        global.location.reload '/'
+        global.location.href = '/'
 
       kd.utils.wait 1000, cookieChangeHandler
 

--- a/client/app/lib/maincontroller.coffee
+++ b/client/app/lib/maincontroller.coffee
@@ -266,7 +266,7 @@ class MainController extends KDController
     kd.utils.wait 15000, ->
       remote.api?.JSystemStatus.on 'forceReload', ->
         global.removeEventListener 'beforeunload', wc.bound 'beforeUnload'
-        global.location.reload()
+        global.location.reload yes
 
     # async clientId change checking procedures causes
     # race conditions between window reloading and post-login callbacks

--- a/client/app/lib/maincontroller.coffee
+++ b/client/app/lib/maincontroller.coffee
@@ -275,7 +275,7 @@ class MainController extends KDController
       cookieMatches     = cookie is (kookies.get 'clientId')
 
       if not cookieExists or (cookieExists and not cookieMatches)
-        location.reload '/'
+        global.location.reload '/'
 
       kd.utils.wait 1000, cookieChangeHandler
 

--- a/client/app/lib/maincontroller.coffee
+++ b/client/app/lib/maincontroller.coffee
@@ -254,7 +254,7 @@ class MainController extends KDController
       kd.utils.wait 1000, =>
         @swapAccount replacementAccount: null
         storage.setValue 'loggingOut', '1'
-        global.location.reload()
+        global.location.href = '/'
 
 
   attachListeners:->

--- a/config/main.dev.coffee
+++ b/config/main.dev.coffee
@@ -221,7 +221,7 @@ Configuration = (options={}) ->
     embedly              : {apiKey       : "94991069fb354d4e8fdb825e52d4134a"     }
     github               : {clientId     : "f8e440b796d953ea01e5" }
     newkontrol           : {url          : "#{kontrol.url}"}
-    sessionCookie        : {maxAge       : 1000 * 60 * 60 * 24 * 14 , secure: no   }
+    sessionCookie        : KONFIG.sessionCookie
     troubleshoot         : {idleTime     : 1000 * 60 * 60           , externalUrl  : "https://s3.amazonaws.com/koding-ping/healthcheck.json"}
     recaptcha            : '6LdLAPcSAAAAAG27qiKqlnowAM8FXfKSpW1wx_bU'
     stripe               : { token: 'pk_test_S0cUtuX2QkSa5iq0yBrPNnJF' }

--- a/config/main.prod.coffee
+++ b/config/main.prod.coffee
@@ -207,7 +207,7 @@ Configuration = (options={}) ->
     embedly              : {apiKey       : "94991069fb354d4e8fdb825e52d4134a"     }
     github               : {clientId     : "5891e574253e65ddb7ea" }
     newkontrol           : {url          : kontrol.url}
-    sessionCookie        : {maxAge       : 1000 * 60 * 60 * 24 * 14  , secure: no   }
+    sessionCookie        : KONFIG.sessionCookie
     troubleshoot         : {idleTime     : 1000 * 60 * 60            , externalUrl  : "https://s3.amazonaws.com/koding-ping/healthcheck.json"}
     recaptcha            : '6LfFAPcSAAAAAHRGr1Tye4tD-yLz0Ll-EN0yyQ6l'
     stripe               : { token: 'pk_live_XLpjQ93roiM0jGFXfvSTal9Y' }

--- a/config/main.sandbox.coffee
+++ b/config/main.sandbox.coffee
@@ -209,7 +209,7 @@ Configuration = (options={}) ->
     embedly              : {apiKey       : "94991069fb354d4e8fdb825e52d4134a"     }
     github               : {clientId     : "d3b586defd01c24bb294" }
     newkontrol           : {url          : "#{kontrol.url}"}
-    sessionCookie        : {maxAge       : 1000 * 60 * 60 * 24 * 14  , secure: no   }
+    sessionCookie        : KONFIG.sessionCookie
     troubleshoot         : {idleTime     : 1000 * 60 * 60            , externalUrl  : "https://s3.amazonaws.com/koding-ping/healthcheck.json"}
     recaptcha            : '6LfZL_kSAAAAABDrxNU5ZAQk52jx-2sJENXRFkTO'
     stripe               : { token: 'pk_test_S0cUtuX2QkSa5iq0yBrPNnJF' }


### PR DESCRIPTION
[User is not directed to homepage after logout on sandbox](https://www.pivotaltracker.com/story/show/92422948)

On sandbox `clientId` cookie gets overwritten by a `GET` request to `/Logout` which is issued by a call to function `location.reload` unlike any other environment. That makes `clientId` cookie modification timer go in an infinite loop.

In other words, environment's condition (a quicker/slower response) was triggering an infinite loop hole in the code.
