### PR TITLE
Otatoken support for managed vm install script [#92465426]

### DIFF
--- a/client/app/lib/providers/managed/basemodal.coffee
+++ b/client/app/lib/providers/managed/basemodal.coffee
@@ -1,5 +1,6 @@
-kd = require 'kd'
-view = require './viewhelpers'
+kd     = require 'kd'
+view   = require './viewhelpers'
+whoami = require 'app/util/whoami'
 
 module.exports = class ManagedVMBaseModal extends kd.ModalView
 
@@ -29,7 +30,18 @@ module.exports = class ManagedVMBaseModal extends kd.ModalView
 
 
   viewAppended: ->
-    @switchTo 'initial'
+
+    view.addTo @container, waiting: 'Generating token...'
+
+    @fetchOtaToken (err, token) =>
+
+      console.warn "Couldn't fetch otatoken:", err  if err
+
+      view._otatoken = if err or not token
+      then '# Failed to fetch one time access token.'
+      else token
+
+      @switchTo 'initial'
 
 
   fetchKites: ->
@@ -44,3 +56,16 @@ module.exports = class ManagedVMBaseModal extends kd.ModalView
       .catch (err) =>
         console.warn "Error:", err
         @switchTo 'retry', 'Failed to query kites'
+
+
+  ###*
+   * Fetches one time accesstoken from JAccount
+   *
+   * @param {Function(err, token)} callback
+  ###
+  fetchOtaToken: (callback)->
+
+    kd.singletons.mainController.ready =>
+      whoami().fetchOtaToken (err, token) =>
+        if err then callback err
+        else callback null, token

--- a/client/app/lib/providers/managed/basemodal.coffee
+++ b/client/app/lib/providers/managed/basemodal.coffee
@@ -31,7 +31,7 @@ module.exports = class ManagedVMBaseModal extends kd.ModalView
 
   viewAppended: ->
 
-    view.addTo @container, waiting: 'Generating token...'
+    view.addTo @container, waiting: ''
 
     @fetchOtaToken (err, token) =>
 

--- a/client/app/lib/providers/managed/viewhelpers.coffee
+++ b/client/app/lib/providers/managed/viewhelpers.coffee
@@ -15,13 +15,12 @@ addTo = (parent, views)->
 
 globals = require 'globals'
 kontrolUrl = if globals.config.environment in ['dev', 'sandbox'] \
-             then "KONTROLURL=#{globals.config.newkontrol.url} " else ''
+             then "\n$ export KONTROLURL=#{globals.config.newkontrol.url}" else ''
 
 contents  =
-  install : """bash
+  install : """bash#{kontrolUrl}
     $ curl -sO https://s3.amazonaws.com/koding-klient/install.sh
-    $ #{kontrolUrl}bash ./install.sh
-    # Enter your koding.com credentials when asked for
+    $ bash ./install.sh %%TOKEN%%
   """
 
 module.exports   = view =
@@ -47,6 +46,8 @@ module.exports   = view =
 
   instructions   : (content) ->
     content      = contents[content] ? content
+    if view._otatoken
+      content    = content.replace '%%TOKEN%%', view._otatoken
     container    = new kd.View
     addTo container,
       header     : 'Instructions'

--- a/client/app/lib/providers/managed/viewhelpers.coffee
+++ b/client/app/lib/providers/managed/viewhelpers.coffee
@@ -18,10 +18,11 @@ kontrolUrl = if globals.config.environment in ['dev', 'sandbox'] \
              then "\n$ export KONTROLURL=#{globals.config.newkontrol.url}" else ''
 
 contents  =
-  install : """bash#{kontrolUrl}
+  install : """#{kontrolUrl}
     $ curl -sO https://s3.amazonaws.com/koding-klient/install.sh
-    $ bash ./install.sh %%TOKEN%%
+    $ bash ./install.sh
   """
+  # Add %%TOKEN%% to install instructions to enable tokens
 
 module.exports   = view =
   message        : ({text, cssClass}) -> new kd.View

--- a/go/src/koding/db/mongodb/modelhelper/session.go
+++ b/go/src/koding/db/mongodb/modelhelper/session.go
@@ -46,7 +46,7 @@ func RemoveToken(clientId string) error {
 	}
 
 	query := func(c *mgo.Collection) error {
-		return c.Update(bson.M{"clientId": clientId}, bson.M{"$set": updateData})
+		return c.Update(bson.M{"clientId": clientId}, bson.M{"$unset": updateData})
 	}
 
 	err := Mongo.Run("jSessions", query)

--- a/workers/social/lib/social/models/account.coffee
+++ b/workers/social/lib/social/models/account.coffee
@@ -1399,18 +1399,18 @@ module.exports = class JAccount extends jraphical.Module
   ###
   fetchOtaToken: secure (client, callback) ->
 
-    { sessionToken, context: {user} } = client
+    { sessionToken } = client
 
     errorCallback = ->
       callback new KodingError 'Invalid session'
 
-    if not sessionToken or not user
+    unless sessionToken
       return errorCallback()
 
     JSession         = require './session'
     { v4: createId } = require 'node-uuid'
 
-    JSession.one {clientId: sessionToken, username: user}, (err, session) ->
+    JSession.one {clientId: sessionToken}, (err, session) ->
 
       if err or not session
         return errorCallback()

--- a/workers/social/lib/social/models/account.coffee
+++ b/workers/social/lib/social/models/account.coffee
@@ -210,6 +210,8 @@ module.exports = class JAccount extends jraphical.Module
           (signature Object, Function)
         expireSubscription:
           (signature Function)
+        fetchOtaToken:
+          (signature Function)
 
     schema                  :
       shareLocation         : Boolean
@@ -936,7 +938,7 @@ module.exports = class JAccount extends jraphical.Module
       @update op, (err) =>
         JAccount.sendUpdateInstanceEvent this, op  unless err
         SocialAccount  = require './socialapi/socialaccount'
-        
+
         SocialAccount.update {
           id            : @socialApiId
           nick          : @profile.nickname
@@ -1386,3 +1388,37 @@ module.exports = class JAccount extends jraphical.Module
 
     {expireSubscription} = require "./socialapi/requests"
     expireSubscription connection.delegate.getId(), callback
+
+
+  ###*
+   * Fetches one time access token from active session
+   * If accesstoken used before (not exists) it creates
+   * and returns new one while updating the session.
+   *
+   * @param  {Function(err, token)} callback
+  ###
+  fetchOtaToken: secure (client, callback) ->
+
+    { sessionToken, context: {user} } = client
+
+    errorCallback = ->
+      callback new KodingError 'Invalid session'
+
+    if not sessionToken or not user
+      return errorCallback()
+
+    JSession         = require './session'
+    { v4: createId } = require 'node-uuid'
+
+    JSession.one {clientId: sessionToken, username: user}, (err, session) ->
+
+      if err or not session
+        return errorCallback()
+
+      if session.otaToken?
+        callback null, session.otaToken
+      else
+        otaToken = createId()
+        session.update $set: {otaToken}, (err)->
+          if err then errorCallback()
+          else callback null, otaToken

--- a/workers/social/lib/social/models/session.coffee
+++ b/workers/social/lib/social/models/session.coffee
@@ -1,13 +1,5 @@
 {Model} = require 'bongo'
 
-class JToken extends Model
-
-  @setSchema
-    token       : String
-    expires     : Date
-    authority   : String
-    requester   : String
-
 module.exports = class JSession extends Model
 
   { v4: createId } = require 'node-uuid'
@@ -21,8 +13,6 @@ module.exports = class JSession extends Model
       clientId      : String
       clientIP      : String
       username      : String
-      guestId       : Number
-      terminalId    : String
       sessionBegan  :
         type        : Date
         default     : -> new Date
@@ -83,6 +73,7 @@ module.exports = class JSession extends Model
       return callback err  if err
       return callback null, session
 
+
   @fetchSession = (clientId, callback)->
 
     return @createSession callback  unless clientId
@@ -94,6 +85,7 @@ module.exports = class JSession extends Model
         callback null, { session }
       else
         @createSession callback
+
 
   @updateClientIP = (clientId, ipAddress, callback)->
 

--- a/workers/social/lib/social/models/session.coffee
+++ b/workers/social/lib/social/models/session.coffee
@@ -7,7 +7,7 @@ module.exports = class JSession extends Model
   @set
     indexes         :
       clientId      : 'unique'
-      otaToken      : 'unique'
+      otaToken      : 'sparse' # unique is also required
       username      : 'descending'
       clientIP      : 'sparse'
     schema          :
@@ -49,7 +49,6 @@ module.exports = class JSession extends Model
 
     JUser    = require './user'
     clientId = createId()
-    otaToken = createId()
 
     JUser.fetchGuestUser (err, resp) =>
 
@@ -61,7 +60,7 @@ module.exports = class JSession extends Model
 
       {account} = resp
       username  = JUser.createGuestUsername()
-      session   = new JSession { clientId, username, otaToken }
+      session   = new JSession { clientId, username }
 
       session.save (err)->
         if err then callback err
@@ -71,9 +70,8 @@ module.exports = class JSession extends Model
   @createNewSession = (username, callback) ->
 
     clientId = createId()
-    otaToken = createId()
 
-    session = new JSession { clientId, username, otaToken }
+    session = new JSession { clientId, username }
     session.save (err) ->
       return callback err  if err
       return callback null, session

--- a/workers/social/lib/social/models/session.coffee
+++ b/workers/social/lib/social/models/session.coffee
@@ -7,12 +7,14 @@ module.exports = class JSession extends Model
   @set
     indexes         :
       clientId      : 'unique'
+      otaToken      : 'unique'
       username      : 'descending'
       clientIP      : 'sparse'
     schema          :
       clientId      : String
       clientIP      : String
       username      : String
+      otaToken      : String
       sessionBegan  :
         type        : Date
         default     : -> new Date
@@ -45,8 +47,9 @@ module.exports = class JSession extends Model
   # TODO not sure why we are creating session only for guest user
   @createSession = (callback) ->
 
-    JUser = require './user'
+    JUser    = require './user'
     clientId = createId()
+    otaToken = createId()
 
     JUser.fetchGuestUser (err, resp) =>
 
@@ -58,7 +61,7 @@ module.exports = class JSession extends Model
 
       {account} = resp
       username  = JUser.createGuestUsername()
-      session   = new JSession { clientId, username }
+      session   = new JSession { clientId, username, otaToken }
 
       session.save (err)->
         if err then callback err
@@ -66,9 +69,11 @@ module.exports = class JSession extends Model
 
 
   @createNewSession = (username, callback) ->
-    clientId = createId()
 
-    session = new JSession { clientId, username }
+    clientId = createId()
+    otaToken = createId()
+
+    session = new JSession { clientId, username, otaToken }
     session.save (err) ->
       return callback err  if err
       return callback null, session


### PR DESCRIPTION
Instead of creating a new collection, and instead of using `sessionId` as is, I decided to put another field called `otaToken` into `JSession`. So, when needed `JAccount::fetchOtaToken` can be called, with no arguments (except `callback`) and that will return a **one time access token** from active `JSession`, if there is no `otaToken` set on session (or if it's used once) it will create a new one, update the session then return it back to client side. After those changes managed vm install script will look like this;

![](http://take.ms/GDyYs)
_`export` line will be visible only for `dev` and `sandbox` environments_

We can update the text as we wish, and in `Kontrol` we need to check this `otaToken` from `JSession` collection, after validation we also need to delete it from that session object to make it a real **one time access token**

_Note: I've created a new `otaToken` when a new `JSession` created but we actually don't need this, since we are creating it when needed._

cc/ @fatih @cihangir 
