### PR TITLE
Token kontrol

### DIFF
--- a/go/src/github.com/koding/kite/kontrol/handlers.go
+++ b/go/src/github.com/koding/kite/kontrol/handlers.go
@@ -187,6 +187,18 @@ func (k *Kontrol) handleMachine(r *kite.Request) (interface{}, error) {
 		}
 	}
 
-	username := r.Args.One().MustString() // username should be send as an argument
-	return k.registerUser(username)
+	// username should be send as an argument
+	var args struct {
+		Username string
+	}
+
+	if err := r.Args.One().Unmarshal(&args); err != nil {
+		return nil, err
+	}
+
+	if args.Username == "" {
+		return nil, errors.New("usename is empty")
+	}
+
+	return k.registerUser(args.Username)
 }

--- a/go/src/github.com/koding/kite/kontrol/handlers.go
+++ b/go/src/github.com/koding/kite/kontrol/handlers.go
@@ -181,15 +181,9 @@ func (k *Kontrol) handleGetToken(r *kite.Request) (interface{}, error) {
 }
 
 func (k *Kontrol) handleMachine(r *kite.Request) (interface{}, error) {
-	if k.MachineAuthenticate != nil {
-		if err := k.MachineAuthenticate(r); err != nil {
-			return nil, errors.New("cannot authenticate user")
-		}
-	}
-
-	// username should be send as an argument
 	var args struct {
 		Username string
+		AuthType string
 	}
 
 	if err := r.Args.One().Unmarshal(&args); err != nil {
@@ -198,6 +192,14 @@ func (k *Kontrol) handleMachine(r *kite.Request) (interface{}, error) {
 
 	if args.Username == "" {
 		return nil, errors.New("usename is empty")
+	}
+
+	if k.MachineAuthenticate != nil {
+		// an empty authType is ok, the implementer is responsible of it. It
+		// can care of it or it can return an error
+		if err := k.MachineAuthenticate(args.AuthType, r); err != nil {
+			return nil, errors.New("cannot authenticate user")
+		}
 	}
 
 	return k.registerUser(args.Username)

--- a/go/src/github.com/koding/kite/kontrol/kontrol.go
+++ b/go/src/github.com/koding/kite/kontrol/kontrol.go
@@ -55,8 +55,10 @@ type Kontrol struct {
 	// MachineAuthenticate is used to authenticate the request in the
 	// "handleMachine" method.  The reason for a separate auth function is, the
 	// request must not be authenticated because clients do not have a kite.key
-	// before they register to this machine.
-	MachineAuthenticate func(r *kite.Request) error
+	// before they register to this machine. Also the requester can send a
+	// authType argument which can be used to distinguish between several
+	// authentication methods
+	MachineAuthenticate func(authType string, r *kite.Request) error
 
 	// RSA keys
 	publicKey  string // for validating tokens

--- a/go/src/koding/db/models/session.go
+++ b/go/src/koding/db/models/session.go
@@ -8,4 +8,5 @@ type Session struct {
 	Username      string        `bson:"username"`
 	GuestId       int           `bson:"guestId"`
 	Impersonating bool          `bson:"impersonating"`
+	OtaToken      string        `bson:"otaToken"`
 }

--- a/go/src/koding/db/mongodb/modelhelper/session.go
+++ b/go/src/koding/db/mongodb/modelhelper/session.go
@@ -10,22 +10,37 @@ import (
 	"labix.org/v2/mgo/bson"
 )
 
-func GetSession(token string) (*models.Session, error) {
+func GetSession(clientId string) (*models.Session, error) {
 	session := new(models.Session)
 
 	query := func(c *mgo.Collection) error {
-		return c.Find(bson.M{"clientId": token}).One(&session)
+		return c.Find(bson.M{"clientId": clientId}).One(&session)
 	}
 
 	err := Mongo.Run("jSessions", query)
 	if err != nil {
-		return nil, fmt.Errorf("sessionID '%s' is not validated; err: %s", token, err)
+		return nil, fmt.Errorf("sessionID '%s' is not validated; err: %s", clientId, err)
 	}
 
 	return session, nil
 }
 
-func UpdateSessionIP(token string, ip string) (error) {
+func GetSessionFromToken(token string) (*models.Session, error) {
+	session := new(models.Session)
+
+	query := func(c *mgo.Collection) error {
+		return c.Find(bson.M{"otaToken": token}).One(&session)
+	}
+
+	err := Mongo.Run("jSessions", query)
+	if err != nil {
+		return nil, fmt.Errorf("otaToken '%s' is not validated; err: %s", token, err)
+	}
+
+	return session, nil
+}
+
+func UpdateSessionIP(token string, ip string) error {
 	updateData := bson.M{
 		"clientIP": ip,
 	}

--- a/go/src/koding/db/mongodb/modelhelper/session.go
+++ b/go/src/koding/db/mongodb/modelhelper/session.go
@@ -40,6 +40,23 @@ func GetSessionFromToken(token string) (*models.Session, error) {
 	return session, nil
 }
 
+func RemoveToken(clientId string) error {
+	updateData := bson.M{
+		"otaToken": "",
+	}
+
+	query := func(c *mgo.Collection) error {
+		return c.Update(bson.M{"clientId": clientId}, bson.M{"$set": updateData})
+	}
+
+	err := Mongo.Run("jSessions", query)
+	if err != nil {
+		return fmt.Errorf("failed to remove the ota token for sessionID '%s'; err: %s", clientId, err)
+	}
+
+	return nil
+}
+
 func UpdateSessionIP(token string, ip string) error {
 	updateData := bson.M{
 		"clientIP": ip,

--- a/go/src/koding/kites/kontrol/kontrol/kontrol.go
+++ b/go/src/koding/kites/kontrol/kontrol/kontrol.go
@@ -127,5 +127,9 @@ func authenticateFromOneTimeToken(r *kite.Request) error {
 		return errors.New("user is not validated to use this token")
 	}
 
+	// everything seems to be ok, try to delete the token before we return an
+	// OK
+	panic("implement removing the token")
+
 	return nil
 }

--- a/go/src/koding/kites/kontrol/kontrol/kontrol.go
+++ b/go/src/koding/kites/kontrol/kontrol/kontrol.go
@@ -128,8 +128,8 @@ func authenticateFromOneTimeToken(r *kite.Request) error {
 	}
 
 	// everything seems to be ok, try to delete the token before we return an
-	// OK
-	panic("implement removing the token")
+	// OK. Don't return the error, because we already validated the user.
+	modelhelper.RemoveToken(session.ClientId)
 
 	return nil
 }


### PR DESCRIPTION
Our Koding kontrol was allowed to authenticated machines only via password. This PR makes it more flexible by providing a new way of authenticating (based on one time tokens). It needs a kontrol modification (includes: https://github.com/koding/kite/pull/110). 

The related Klient chanes are here, needed to work with this new Kontrol: https://github.com/koding/klient/pull/52
