### PR TITLE
account: account modal fixes [fixes #93023998]

### DIFF
--- a/client/account/lib/styl/account.styl
+++ b/client/account/lib/styl/account.styl
@@ -70,7 +70,16 @@ app.settings.styl
       r-sprite              'account' 'terminate-active'
 
   .AppModal-content
-    min-height               530px
+    min-height               570px
+
+  .AppModal-form
+    padding-top              20px
+
+    .formline
+      margin-bottom          15px
+
+      &.AppModal-form-sectionHeader
+        padding-top          20px
 
 .AppModal--account-avatarArea
   overflow                  hidden
@@ -309,7 +318,7 @@ app.settings.styl
     .ssh-machine-list
 
       .ssh-machine-list-header
-        padding-bottom         15px
+        padding-bottom         8px
         position               relative
 
         .ssh-machine-list-tooltip-icon

--- a/client/account/lib/views/accounteditusername.coffee
+++ b/client/account/lib/views/accounteditusername.coffee
@@ -107,7 +107,7 @@ module.exports = class AccountEditUsername extends JView
           cssClass         : 'AppModal-form-sectionHeader'
         shareLocationLabel :
           itemClass        : KDCustomHTMLView
-          partial          : 'Share my location while posting'
+          partial          : 'Share my location when I post something on Koding Channels'
           tagName          : 'ul'
           cssClass         : 'AppModal--account-switchList left-aligned'
           name             : 'shareLocationLabel'


### PR DESCRIPTION
@gokmen, can you review these changes? They are for [this task](https://www.pivotaltracker.com/story/show/93023998). A new section `LOCATION SERVICES` was added to `User Profile` tab and Account modal started changing its height when switching from `User Profile` to another tabs
