### PR TITLE
social: sanitize emails for common abuses; check if email is available in db when registering

### DIFF
--- a/client/test/Readme.md
+++ b/client/test/Readme.md
@@ -55,7 +55,7 @@ Commands:
   browser    configure browser tests
 
 Options:
-  --help, -h        show this message                                                                                        
+  --help, -h        show this message
   --url             specify a url that koding webserver is running on
   --nightwatch      specify a nightwatch config blueprint file.
                     actual config file will be written to client/.nightwatch.json
@@ -117,6 +117,11 @@ Run `activity/likeunlike` suite
 ```sh
 λ client/test ./test activity likeunlike
 ```
+
+Gravatar:
+
+username: kodingtestuser1 / kodingtestuser@koding.com
+password: passfortestuser
 
 # license
 

--- a/client/test/lib/helpers/helpers.coffee
+++ b/client/test/lib/helpers/helpers.coffee
@@ -153,7 +153,7 @@ module.exports =
 
     if user.gravatar
       browser
-        .assert.valueContains 'input[name=username]',  'kodingtestuser'
+        .assert.valueContains 'input[name=username]',  'kodingtestuser1'
         .assert.valueContains 'input[name=firstName]', 'Koding'
         .assert.valueContains 'input[name=lastName]',  'Testuser'
     else

--- a/client/test/lib/register/register.coffee
+++ b/client/test/lib/register/register.coffee
@@ -15,7 +15,7 @@ module.exports =
   registerUserWithGravatarEmail: (browser) ->
 
     user =
-      email    : 'kodingtestuser@gmail.com'
+      email    : 'kodingtestuser@koding.com'
       username : 'kodingtestuser'
       password : 'passwordfortestuser'
       gravatar : yes

--- a/client/test/lib/utils/utils.coffee
+++ b/client/test/lib/utils/utils.coffee
@@ -19,7 +19,7 @@ module.exports =
 
       password = @getPassword()
 
-      email = "kodingtestuser+#{username}@gmail.com"
+      email = "kodingtestuser+#{username}@koding.com"
 
       users.push { name, email, username, password }
 

--- a/package.json
+++ b/package.json
@@ -107,7 +107,9 @@
   },
   "devDependencies": {
     "crypto": "0.0.3",
-    "which": "1.0.5"
+    "which": "1.0.5",
+    "chai": "2.2.0",
+    "mocha": "2.2.4"
   },
   "optionalDependencies": {},
   "engines": {

--- a/wercker.yml
+++ b/wercker.yml
@@ -108,6 +108,11 @@ build:
     #       cd go/src/koding/kites/terraformer
     #       go test -c && mv terraformer.test ./../../../../bin/ &&  CONFIG_PORT=1234 CONFIG_REGION="dev" CONFIG_ENVIRONMENT="dev" ./../../../../bin/terraformer.test
     - script:
+        name: test socialworker
+        code: |
+          cd ./workers/social/lib/social/tests
+          ./tests.sh
+    - script:
         name: testing backend finished
         code: |
           scripts/notify-cebeci.sh "build" "<$WERCKER_BUILD_URL|build> of $WERCKER_GIT_BRANCH - test backend finished" "building" 45

--- a/workers/social/lib/social/models/user/emailsanitize.coffee
+++ b/workers/social/lib/social/models/user/emailsanitize.coffee
@@ -1,5 +1,7 @@
 module.exports = emailSanitize = (email)->
 
+  email = email.toLowerCase()
+
   # Special rules for Gmail and Googlemail. Googlemail is for users
   # in Germany, Poland and Russia.
   if /^(.)+@(gmail|googlemail).com/.test email

--- a/workers/social/lib/social/models/user/emailsanitize.coffee
+++ b/workers/social/lib/social/models/user/emailsanitize.coffee
@@ -1,0 +1,18 @@
+module.exports = emailSanitize = (email)->
+
+  # Special rules for Gmail and Googlemail. Googlemail is for users
+  # in Germany, Poland and Russia.
+  if /^(.)+@(gmail|googlemail).com/.test email
+    [name, domain] = email.split '@'
+
+    # . have no meaning, they're being abused to create fake accounts
+    name = name.replace '.', ''
+
+    # + have meaning, but they ultimately belong to email before +
+    # so we check for uniqueness before +, but let user save + in email
+    if email.indexOf('+') > -1
+      name = (name.split '+')[0]
+
+    email = "#{name}@#{domain}"
+
+  return email

--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -1203,7 +1203,6 @@ module.exports = class JUser extends jraphical.Module
     unless typeof email is 'string'
       return callback createKodingError 'Not a valid email!'
 
-    email = email.toLowerCase()
     email = (require "./emailSanitize")(email)
 
     @count {email}, (err, count)->

--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -1202,7 +1202,10 @@ module.exports = class JUser extends jraphical.Module
   @emailAvailable = (email, callback)->
     unless typeof email is 'string'
       return callback createKodingError 'Not a valid email!'
+
     email = email.toLowerCase()
+    email = (require "./emailSanitize")(email)
+
     @count {email}, (err, count)->
       callback err, count is 0
 

--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -956,6 +956,16 @@ module.exports = class JUser extends jraphical.Module
           queue.next()
 
       =>
+        @emailAvailable email, (err, res)=>
+          if err
+            return callback createKodingError "Something went wrong"
+
+          if res is no
+            return callback createKodingError "Email is already in use!"
+          else
+            queue.next()
+
+      =>
         if aNewRegister
 
           userInfo = { username, firstName, lastName, email, password }

--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -1203,7 +1203,7 @@ module.exports = class JUser extends jraphical.Module
     unless typeof email is 'string'
       return callback createKodingError 'Not a valid email!'
 
-    email = (require "./emailSanitize")(email)
+    email = (require "./emailsanitize")(email)
 
     @count {email}, (err, count)->
       callback err, count is 0

--- a/workers/social/lib/social/tests/emailsanitize.test.coffee
+++ b/workers/social/lib/social/tests/emailsanitize.test.coffee
@@ -1,0 +1,35 @@
+{expect}      = require "chai"
+emailSanitize = require "../models/user/emailsanitize"
+
+describe 'Gmail Validation', ->
+  it 'removes dots', ->
+    expected = 'indiana.jones@gmail.com'
+    equals   = 'indianajones@gmail.com'
+
+    expect(emailSanitize(expected)).to.equal equals
+
+  it 'removes pluses and characters till @', ->
+    expected = 'indiana+jones@gmail.com'
+    equals   = 'indiana@gmail.com'
+
+    expect(emailSanitize(expected)).to.equal equals
+
+  it 'removes dots & plus and characters till @', ->
+    expected = 'ind.iana+jones@gmail.com'
+    equals   = 'indiana@gmail.com'
+
+    expect(emailSanitize(expected)).to.equal equals
+
+  it 'ignores other domains', ->
+    expected = 'ind.iana+jones@koding.com'
+    expect(emailSanitize(expected)).to.equal expected
+
+  it 'removes dots & plus in googlemail as well', ->
+    expected = 'ind.iana+jones@googlemail.com'
+    equals   = 'indiana@googlemail.com'
+
+    expect(emailSanitize(expected)).to.equal equals
+
+  it 'ignores other google domains', ->
+    expected = 'ind.iana+jones@gmail.uk'
+    expect(emailSanitize(expected)).to.equal expected

--- a/workers/social/lib/social/tests/emailsanitize.test.coffee
+++ b/workers/social/lib/social/tests/emailsanitize.test.coffee
@@ -2,6 +2,10 @@
 emailSanitize = require "../models/user/emailsanitize"
 
 describe 'Gmail Validation', ->
+  it 'downcases', ->
+    expected = 'INDIANAJONES@gmail.com'
+    expect(emailSanitize(expected)).to.equal expected.toLowerCase()
+
   it 'removes dots', ->
     expected = 'indiana.jones@gmail.com'
     equals   = 'indianajones@gmail.com'

--- a/workers/social/lib/social/tests/tests.sh
+++ b/workers/social/lib/social/tests/tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mocha --compilers coffee:coffee-script/register --require coffee-script *.test.coffee
+../../../../../node_modules/mocha/bin/mocha --compilers coffee:coffee-script/register --require coffee-script *.test.coffee

--- a/workers/social/lib/social/tests/tests.sh
+++ b/workers/social/lib/social/tests/tests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+mocha --compilers coffee:coffee-script/register --require coffee-script *.test.coffee


### PR DESCRIPTION
- Added mocha & chai for running tests
- Sanitizing emails is only during checks, if user has + or . in the name, it'll be saved as such in db
