### PR TITLE
Fetch group from session where needed

### DIFF
--- a/client/app/lib/index.coffee
+++ b/client/app/lib/index.coffee
@@ -40,10 +40,11 @@ bootup = ->
     global._kd      = kd
     global._remote  = remote
 
+  globals.config.entryPoint.slug = globals.currentGroup.slug
+
   remote.once 'ready', ->
     globals.currentGroup           = remote.revive globals.currentGroup
     globals.userAccount            = remote.revive globals.userAccount
-    globals.config.entryPoint.slug = globals.currentGroup.slug
 
     setupAnalytics()
 

--- a/client/app/lib/index.coffee
+++ b/client/app/lib/index.coffee
@@ -40,11 +40,13 @@ bootup = ->
     global._kd      = kd
     global._remote  = remote
 
-  globals.config.entryPoint.slug = globals.currentGroup.slug
+  if globals.currentGroup?
+    globals.config.entryPoint.slug = globals.currentGroup.slug
 
   remote.once 'ready', ->
     globals.currentGroup           = remote.revive globals.currentGroup
     globals.userAccount            = remote.revive globals.userAccount
+    globals.config.entryPoint.slug = globals.currentGroup.slug
 
     setupAnalytics()
 

--- a/servers/lib/server/bongo.coffee
+++ b/servers/lib/server/bongo.coffee
@@ -17,15 +17,16 @@ module.exports = koding = new Bongo
   fetchClient : (sessionToken, context, callback)->
 
     { JUser, JAccount } = koding.models
-    [callback, context] = [context, callback] unless callback
-    context             ?= group: 'koding'
-    callback            ?= ->
+    [callback, context] = [context, callback]  unless callback
 
-    JUser.authenticateClient sessionToken, context, (err, res = {})->
+    callback ?= ->
+
+    JUser.authenticateClient sessionToken, (err, res = {})->
 
       return console.error err  if err
 
       { account, session } = res
+      context ?= { group: session?.groupName ? 'koding' }
 
       if account instanceof JAccount
 

--- a/servers/lib/server/index.coffee
+++ b/servers/lib/server/index.coffee
@@ -1,17 +1,10 @@
 process.title = 'koding-webserver'
 {argv}        = require 'optimist'
 
-Object.defineProperty global, 'KONFIG', value : require('koding-config-manager').load "main.#{argv.c}"
+Object.defineProperty global, \
+  'KONFIG', value : require('koding-config-manager').load "main.#{argv.c}"
 
-{
-  webserver
-  projectRoot
-  basicAuth
-} = KONFIG
-
-
-
-
+{ webserver, projectRoot, basicAuth } = KONFIG
 
 koding                = require './bongo'
 express               = require 'express'
@@ -22,7 +15,6 @@ app                   = express()
 webPort               = argv.p ? webserver.port
 { error_500 }         = require './helpers'
 { generateHumanstxt } = require "./humanstxt"
-
 
 do ->
   cookieParser = require 'cookie-parser'
@@ -54,10 +46,8 @@ do ->
 # handle basic auth
 app.use express.basicAuth basicAuth.username, basicAuth.password  if basicAuth
 
-
 # capture/log exceptions
 process.on 'uncaughtException', require './handlers/uncaughtexception'
-
 
 # this is for creating session for incoming user if it doesnt have
 app.use require './setsession'

--- a/workers/log/lib/log/main.coffee
+++ b/workers/log/lib/log/main.coffee
@@ -49,11 +49,12 @@ koding = new Bongo {
     JAccount = require_koding_model "account"
 
     [callback, context] = [context, callback] unless callback
-    context             ?= group: 'koding'
-    callback            ?= ->
-    JUser.authenticateClient sessionToken, context, (err, res = {})->
+    callback ?= ->
+
+    JUser.authenticateClient sessionToken, (err, res = {})->
 
       { account, session } = res
+      context ?= { group: session?.groupName ? 'koding' }
 
       if err
         console.error "bongo.fetchClient", {err, sessionToken, context}

--- a/workers/social/lib/social/main.coffee
+++ b/workers/social/lib/social/main.coffee
@@ -66,14 +66,17 @@ koding = new Bongo {
         if account instanceof JAccount
           callback null, { context, connection:delegate:account }
 
-  fetchClient :(sessionToken, context, callback)->
+  fetchClient: (sessionToken, context, callback)->
+
     { JUser, JAccount } = koding.models
     [callback, context] = [context, callback] unless callback
-    context             ?= group: 'koding'
     callback            ?= ->
-    JUser.authenticateClient sessionToken, context, (err, res = {})->
+
+    JUser.authenticateClient sessionToken, (err, res = {})->
 
       { account, session } = res
+
+      context ?= { group: session?.groupName ? 'koding' }
 
       if err
         console.error "bongo.fetchClient", {err, sessionToken, context}

--- a/workers/social/lib/social/models/session.coffee
+++ b/workers/social/lib/social/models/session.coffee
@@ -17,7 +17,7 @@ module.exports = class JSession extends Model
       otaToken      : String
       groupName     :
         type        : String
-        default     : 'koding'
+        default     : -> 'koding'
       guestId       : Number
       terminalId    : String
       sessionBegan  :

--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -444,6 +444,7 @@ module.exports = class JUser extends jraphical.Module
     session               = null
     username              = null
     user                  = null
+    groupName            ?= 'koding'
 
     queue = [ =>
       @normalizeLoginId loginId, (err, username_) ->

--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -294,7 +294,7 @@ module.exports = class JUser extends jraphical.Module
       callback err? or prefs?.isRegistrationEnabled or no
 
 
-  @authenticateClient: (clientId, context, callback)->
+  @authenticateClient: (clientId, callback)->
 
     logError = (message, rest...) ->
       console.error "[JUser::authenticateClient] #{message}", rest...
@@ -366,6 +366,8 @@ module.exports = class JUser extends jraphical.Module
             logout "no user found with #{username} and sessionId", clientId, callback
 
           else
+
+            context = { group: session?.groupName ? 'koding' }
 
             user.fetchAccount context, (err, account)->
 


### PR DESCRIPTION
We need this change for where we need to use `client.context.group` since we are now keeping group in the session we can fetch it from there instead passing hardcoded.

Without this `client` in the backend method passed under `secure` or `permit` will have `koding` as a group name which breaks every code where group context is needed.

cc/ @sinan @szkl 
