### PR TITLE
analytics: send page events on direct page load, other fixes

### DIFF
--- a/client/app/lib/setupanalytics.coffee
+++ b/client/app/lib/setupanalytics.coffee
@@ -60,5 +60,9 @@ module.exports = ->
 
         analytics?.identify nickname, args
 
+        path  = window.location.pathname
+        title = getFirstPartOfpath(path)
+        analytics?.page(title, {title:document.title, path})
+
   getFirstPartOfpath = (path) -> return path.split("/")[1] or path
 

--- a/workers/social/lib/social/render/loggedout/kodinghome.coffee
+++ b/workers/social/lib/social/render/loggedout/kodinghome.coffee
@@ -37,9 +37,11 @@ module.exports = (options, callback)->
 
       <!-- SEGMENT.IO -->
       <script type="text/javascript">
-        window.analytics||(window.analytics=[]),window.analytics.methods=["identify","track","trackLink","trackForm","trackClick","trackSubmit","page","pageview","ab","alias","ready","group","on","once","off"],window.analytics.factory=function(t){return function(){var a=Array.prototype.slice.call(arguments);return a.unshift(t),window.analytics.push(a),window.analytics}};for(var i=0;window.analytics.methods.length>i;i++){var method=window.analytics.methods[i];window.analytics[method]=window.analytics.factory(method)}window.analytics.load=function(t){var a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=("https:"===document.location.protocol?"https://":"http://")+"d2dq2ahtl5zl1z.cloudfront.net/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n)},window.analytics.SNIPPET_VERSION="2.0.8",
-        window.analytics.load("4c570qjqo0");
-        window.analytics.page();
+        if (location.host === "koding.com") {
+          !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.0.1";
+            analytics.load("4c570qjqo0");
+          }}();
+        };
       </script>
 
       #{addSiteScripts site}

--- a/workers/social/lib/social/render/scriptblock.coffee
+++ b/workers/social/lib/social/render/scriptblock.coffee
@@ -39,11 +39,9 @@ module.exports = (options = {}, callback)->
 
     """
     <script type="text/javascript">
-      if (location.host === "koding.com") {
         !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.0.1";
-          analytics.load("#{segment}");
+          analytics.load("kb2hfdgf20");
         }}();
-     };
     </script>
 
     <script>
@@ -90,7 +88,11 @@ module.exports = (options = {}, callback)->
         socialapidata = data
         queue.fin()
     ->
-      bongoModels.JGroup.one {slug : session.groupName or 'koding'}, (err, group) ->
+      {groupName} = session.data
+      groupName or= 'koding'
+      if groupName is 'undefined' then groupName = 'koding'
+
+      bongoModels.JGroup.one {slug : groupName}, (err, group) ->
         console.log err  if err
 
         currentGroup = group  if group

--- a/workers/social/lib/social/render/scriptblock.coffee
+++ b/workers/social/lib/social/render/scriptblock.coffee
@@ -39,9 +39,11 @@ module.exports = (options = {}, callback)->
 
     """
     <script type="text/javascript">
+      if (location.host === "koding.com") {
         !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.0.1";
-          analytics.load("kb2hfdgf20");
+          analytics.load("#{segment}");
         }}();
+      };
     </script>
 
     <script>

--- a/workers/social/lib/social/render/scriptblock.coffee
+++ b/workers/social/lib/social/render/scriptblock.coffee
@@ -92,6 +92,10 @@ module.exports = (options = {}, callback)->
     ->
       {groupName} = session.data
       groupName or= 'koding'
+
+      # due to some reason, I suspect JSON.stringify somewhere, undefined
+      # is stringified as 'undefined', this check makes sure, it defaults
+      # to 'koding', ie default group in that case
       if groupName is 'undefined' then groupName = 'koding'
 
       bongoModels.JGroup.one {slug : groupName}, (err, group) ->


### PR DESCRIPTION
- Update segment version on logged out home page
- Fix bug in populating group in page load, groupName had string `undefined`, so it couldn't fetch `koding` group
- Send page events when page such as /Pricing is loaded directly. It regressed since `RouteInfoHandled` for firing for direct load also before, but isn't anymore.
