### PR TITLE
kloud: several kloud <-> terraform improvements

### DIFF
--- a/go/src/koding/kites/kloud/terraformer/terraformer.go
+++ b/go/src/koding/kites/kloud/terraformer/terraformer.go
@@ -3,6 +3,7 @@ package terraformer
 import (
 	"fmt"
 	"koding/kites/terraformer"
+	"koding/kites/terraformer/secretkey"
 	"time"
 
 	"github.com/hashicorp/terraform/terraform"
@@ -17,12 +18,12 @@ type Terraformer struct {
 
 // Connect connects to a remote terraformer instance with the given kite instance
 func Connect(k *kite.Kite) (*Terraformer, error) {
-	terraformerURL := "http://127.0.0.1:3001/kite"
+	terraformerURL := "http://127.0.0.1:2300/kite"
 
 	tfKite := k.NewClient(terraformerURL)
 	tfKite.Auth = &kite.Auth{
 		Type: "kloud",
-		Key:  "123qwe123qwe", // TODO: replace this
+		Key:  secretkey.TerraformSecretKey,
 	}
 
 	connected, err := tfKite.DialForever()

--- a/go/src/koding/kites/terraformer/config.go
+++ b/go/src/koding/kites/terraformer/config.go
@@ -11,8 +11,8 @@ type Config struct {
 	// Environment
 	Environment string `required:"true"`
 
-	// Enable debug mode
-	Debug bool
+	Debug bool // Enable debug mode
+	Test  bool // Enable test mode (go test)
 
 	// AWS secret and key
 	AWS AWS

--- a/go/src/koding/kites/terraformer/kite_test.go
+++ b/go/src/koding/kites/terraformer/kite_test.go
@@ -25,6 +25,9 @@ func withKite(t *testing.T, f func(k *kite.Kite) error) {
 	// Load the config, reads environment variables or from flags
 	multiconfig.New().MustLoad(conf)
 
+	// enable test mode
+	conf.Test = true
+
 	if !conf.Debug {
 		// hashicorp.terraform outputs many logs, discard them
 		log.SetOutput(ioutil.Discard)

--- a/go/src/koding/kites/terraformer/kodingcontext/plan.go
+++ b/go/src/koding/kites/terraformer/kodingcontext/plan.go
@@ -57,6 +57,7 @@ func (c *Context) Plan(content io.Reader, destroy bool) (*terraform.Plan, error)
 		// "-detailed-exitcode", // give more info on exit
 		"-out", planFilePath, // save plan to a file
 		"-state", stateFilePath,
+		"-input=false", // do not ask for any input
 		outputDir,
 	}
 

--- a/go/src/koding/kites/terraformer/secretkey/secretkey.go
+++ b/go/src/koding/kites/terraformer/secretkey/secretkey.go
@@ -1,0 +1,4 @@
+package secretkey
+
+// used to authenticate with Terraform directly
+const TerraformSecretKey = "nNLHjZRLsagHP3njoFVHzJkhkVpAhbKFH4umTjthzHgXRkUnAJ"


### PR DESCRIPTION
- Add `secretkey` to be used between `kloud` and `terraformer`
- Add `test` mode for Terraformer so disabling authentication during test can work
- Change TerraformURL port in Kloud helper from `3001` to `2300`
- Disable `input mode` in Packer for `plan` method by passing the `input=false` flag
