### PR TITLE
client: show explanation text if user has no machines

### DIFF
--- a/client/app/lib/providers/environmentsmachinestatemodal.coffee
+++ b/client/app/lib/providers/environmentsmachinestatemodal.coffee
@@ -355,7 +355,15 @@ module.exports = class EnvironmentsMachineStateModal extends EnvironmentsModalVi
     @container.destroySubViews()
     @progressBar = null
 
-    @createStateLabel()
+    if @state is 'NotFound'
+      @createStateLabel "
+        <h1>No machine found!</h1>
+        <span>
+          This can happen if you have deleted all your VMs or if your VM was automatically deleted due to inactivity. <a href='http://learn.koding.com/faq/inactive-vms' target='_blank'>Learn more</a> about inactive VM cleanup.
+        </span>
+      "
+    else
+      @createStateLabel()
 
     if @state in [ Stopped, NotInitialized, Unknown, 'NotFound' ]
       @createStateButton()

--- a/client/app/lib/providers/environmentsmachinestatemodal.coffee
+++ b/client/app/lib/providers/environmentsmachinestatemodal.coffee
@@ -357,7 +357,7 @@ module.exports = class EnvironmentsMachineStateModal extends EnvironmentsModalVi
 
     if @state is 'NotFound'
       @createStateLabel "
-        <h1>You don't have any machines!</h1>
+        <h1>You don't have any VM!</h1>
         <span>
           This can happen if you have deleted all your VMs or if your VM was automatically deleted due to inactivity. <a href='http://learn.koding.com/faq/inactive-vms' target='_blank'>Learn more</a> about inactive VM cleanup.
         </span>

--- a/client/app/lib/providers/environmentsmachinestatemodal.coffee
+++ b/client/app/lib/providers/environmentsmachinestatemodal.coffee
@@ -357,7 +357,7 @@ module.exports = class EnvironmentsMachineStateModal extends EnvironmentsModalVi
 
     if @state is 'NotFound'
       @createStateLabel "
-        <h1>No machine found!</h1>
+        <h1>You don't have any machines!</h1>
         <span>
           This can happen if you have deleted all your VMs or if your VM was automatically deleted due to inactivity. <a href='http://learn.koding.com/faq/inactive-vms' target='_blank'>Learn more</a> about inactive VM cleanup.
         </span>

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -1559,6 +1559,13 @@ paymentGrayLighter  = #f8f8f8
     &.running
       .icon
         r-sprite        'ide', 'vm-state-running'
+    &.notfound
+      h1
+        margin-bottom   25px
+      span
+        font-size       16px
+      a
+        color           #1aaf5d
 
   .footer
     .upgrade-link


### PR DESCRIPTION
![Screenshot](http://take.ms/CDgen)

Link points to http://learn.koding.com/faq/inactive-vms/ and opens in new tab. Thanks to @usirin for css.

cc @sinan 
