### PR TITLE
Kloud terraform apply

### DIFF
--- a/go/src/koding/kites/kloud/kloud/apply.go
+++ b/go/src/koding/kites/kloud/kloud/apply.go
@@ -28,7 +28,15 @@ func (k *Kloud) Apply(r *kite.Request) (interface{}, error) {
 	}
 
 	if len(args.PublicKeys) == 0 {
-		return nil, errors.New("credential ids are not passed")
+		return nil, errors.New("publicKeys are not passed")
+	}
+
+	if len(args.MachineIds) == 0 {
+		return nil, errors.New("machine ids are not passed")
+	}
+
+	if len(args.MachineIds) != len(args.PublicKeys) {
+		return nil, errors.New("machineIds and publicKeys do not match")
 	}
 
 	ctx := k.ContextCreator(context.Background())

--- a/go/src/koding/kites/kloud/kloud/apply.go
+++ b/go/src/koding/kites/kloud/kloud/apply.go
@@ -1,0 +1,52 @@
+package kloud
+
+import (
+	"errors"
+	"fmt"
+	"koding/kites/kloud/contexthelper/session"
+	"koding/kites/kloud/terraformer"
+
+	"golang.org/x/net/context"
+
+	"github.com/koding/kite"
+)
+
+func (k *Kloud) Apply(r *kite.Request) (interface{}, error) {
+	if r.Args == nil {
+		return nil, NewError(ErrNoArguments)
+	}
+
+	var args *PlanRequest
+	if err := r.Args.One().Unmarshal(&args); err != nil {
+		return nil, err
+	}
+
+	if args.TerraformContext == "" {
+		return nil, NewError(ErrTerraformContextIsMissing)
+	}
+
+	if len(args.PublicKeys) == 0 {
+		return nil, errors.New("credential ids are not passed")
+	}
+
+	ctx := k.ContextCreator(context.Background())
+
+	sess, ok := session.FromContext(ctx)
+	if !ok {
+		return nil, errors.New("session context is not passed")
+	}
+
+	tfKite, err := terraformer.Connect(sess.Kite)
+	if err != nil {
+		return nil, err
+	}
+	defer tfKite.Close()
+
+	plan, err := tfKite.Apply(args.TerraformContext)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("plan = %+v\n", plan)
+	return nil, errors.New("not implemented yet")
+}

--- a/go/src/koding/kites/kloud/kloud/apply.go
+++ b/go/src/koding/kites/kloud/kloud/apply.go
@@ -9,6 +9,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/hashicorp/terraform/terraform"
 	"github.com/koding/kite"
 )
 
@@ -17,7 +18,7 @@ func (k *Kloud) Apply(r *kite.Request) (interface{}, error) {
 		return nil, NewError(ErrNoArguments)
 	}
 
-	var args *PlanRequest
+	var args *TerraformKloudRequest
 	if err := r.Args.One().Unmarshal(&args); err != nil {
 		return nil, err
 	}
@@ -54,19 +55,33 @@ func (k *Kloud) Apply(r *kite.Request) (interface{}, error) {
 		return nil, err
 	}
 
-	fmt.Printf("state = %+v\n", state)
-
-	// out, err := machineFromPlan(plan)
-	// if err != nil {
-	// 	return nil, err
-	// }
+	if err := machineFromState(state); err != nil {
+		return nil, err
+	}
 
 	d, err := json.MarshalIndent(state, "", " ")
 	if err != nil {
 		return nil, err
 	}
 
-	fmt.Printf(string(d))
+	fmt.Printf("string(d) = %+v\n", string(d))
 
 	return nil, errors.New("not implemented yet")
+}
+
+func machineFromState(state *terraform.State) error {
+	fmt.Printf("state = %+v\n", state)
+
+	if state.Modules == nil {
+		return errors.New("state modules is empty")
+	}
+
+	for _, m := range state.Modules {
+		fmt.Printf("m.Output = %+v\n", m.Outputs)
+		fmt.Printf("m.Dependencis = %+v\n", m.Dependencies)
+		fmt.Printf("m.Path = %+v\n", m.Path)
+		fmt.Printf("m.Resources = %+v\n", m.Resources)
+	}
+
+	return nil
 }

--- a/go/src/koding/kites/kloud/kloud/plan.go
+++ b/go/src/koding/kites/kloud/kloud/plan.go
@@ -61,7 +61,7 @@ func (k *Kloud) Plan(r *kite.Request) (interface{}, error) {
 	}
 
 	if len(args.PublicKeys) == 0 {
-		return nil, errors.New("credential ids are not passed")
+		return nil, errors.New("publicKeys are not passed")
 	}
 
 	ctx := k.ContextCreator(context.Background())

--- a/go/src/koding/kites/kloud/kloud/plan.go
+++ b/go/src/koding/kites/kloud/kloud/plan.go
@@ -27,7 +27,9 @@ type PlanOutput struct {
 	Machines []PlanMachine `json:"machines"`
 }
 
-type PlanRequest struct {
+type TerraformKloudRequest struct {
+	MachineIds []string `json:"machineIds"`
+
 	// Terraform template file
 	TerraformContext string `json:"terraformContext"`
 
@@ -49,7 +51,7 @@ func (k *Kloud) Plan(r *kite.Request) (interface{}, error) {
 		return nil, NewError(ErrNoArguments)
 	}
 
-	var args *PlanRequest
+	var args *TerraformKloudRequest
 	if err := r.Args.One().Unmarshal(&args); err != nil {
 		return nil, err
 	}

--- a/go/src/koding/kites/kloud/main.go
+++ b/go/src/koding/kites/kloud/main.go
@@ -255,6 +255,7 @@ func newKite(conf *Config) *kite.Kite {
 
 	// Machine handling methods
 	k.HandleFunc("plan", kld.Plan)
+	k.HandleFunc("apply", kld.Apply)
 	k.HandleFunc("build", kld.Build)
 	k.HandleFunc("destroy", kld.Destroy)
 	k.HandleFunc("stop", kld.Stop)

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -214,6 +214,7 @@ func TestTerraformApply(t *testing.T) {
 	remote := userData.Remote
 
 	args := &kloud.TerraformKloudRequest{
+		MachineIds: []string{userData: userData.MachineId},
 		TerraformContext: `
 provider "aws" {
     access_key = "${var.access_key}"

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -143,6 +143,7 @@ func init() {
 	// Add Kloud handlers
 	kld := kloudWithKodingProvider(provider)
 	kloudKite.HandleFunc("plan", kld.Plan)
+	kloudKite.HandleFunc("apply", kld.Apply)
 	kloudKite.HandleFunc("build", kld.Build)
 	kloudKite.HandleFunc("destroy", kld.Destroy)
 	kloudKite.HandleFunc("stop", kld.Stop)
@@ -179,6 +180,10 @@ provider "aws" {
 resource "aws_instance" "example" {
     ami = "ami-d05e75b8"
     instance_type = "t2.micro"
+    subnet_id = "subnet-b47692ed"
+    tags {
+        Name = "KloudTerraform"
+    }
 }`,
 		PublicKeys: map[string]string{
 			"aws": userData.CredentialPublicKey,
@@ -186,6 +191,50 @@ resource "aws_instance" "example" {
 	}
 
 	resp, err := remote.Tell("plan", args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var result *kloud.PlanOutput
+	if err := resp.Unmarshal(&result); err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Printf("result = %+v\n", result)
+}
+
+func TestTerraformApply(t *testing.T) {
+	t.Parallel()
+	username := "testuser10"
+	userData, err := createUser(username)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	remote := userData.Remote
+
+	args := &kloud.PlanRequest{
+		TerraformContext: `
+provider "aws" {
+    access_key = "${var.access_key}"
+    secret_key = "${var.secret_key}"
+    region = "us-east-1"
+}
+
+resource "aws_instance" "example" {
+    ami = "ami-d05e75b8"
+    instance_type = "t2.micro"
+    subnet_id = "subnet-b47692ed"
+    tags {
+        Name = "KloudTerraform"
+    }
+}`,
+		PublicKeys: map[string]string{
+			"aws": userData.CredentialPublicKey,
+		},
+	}
+
+	resp, err := remote.Tell("apply", args)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -169,7 +169,7 @@ func TestTerraformPlan(t *testing.T) {
 
 	remote := userData.Remote
 
-	args := &kloud.PlanRequest{
+	args := &kloud.TerraformKloudRequest{
 		TerraformContext: `
 provider "aws" {
     access_key = "${var.access_key}"
@@ -213,7 +213,7 @@ func TestTerraformApply(t *testing.T) {
 
 	remote := userData.Remote
 
-	args := &kloud.PlanRequest{
+	args := &kloud.TerraformKloudRequest{
 		TerraformContext: `
 provider "aws" {
     access_key = "${var.access_key}"

--- a/go/src/koding/kites/kloud/provider/generic/machine.go
+++ b/go/src/koding/kites/kloud/provider/generic/machine.go
@@ -1,0 +1,42 @@
+package generic
+
+import (
+	"koding/db/models"
+	"koding/kites/kloud/machinestate"
+	"time"
+
+	"labix.org/v2/mgo/bson"
+)
+
+// Machine represents a single MongoDB document from the jMachine collection.
+// Any Provider is satisfied.
+type Machine struct {
+	Id          bson.ObjectId `bson:"_id" json:"-"`
+	Label       string        `bson:"label"`
+	Domain      string        `bson:"domain"`
+	QueryString string        `bson:"queryString"`
+	IpAddress   string        `bson:"ipAddress"`
+	Assignee    struct {
+		InProgress bool      `bson:"inProgress"`
+		AssignedAt time.Time `bson:"assignedAt"`
+	} `bson:"assignee"`
+	Status struct {
+		State      string    `bson:"state"`
+		Reason     string    `bson:"reason"`
+		ModifiedAt time.Time `bson:"modifiedAt"`
+	} `bson:"status"`
+	Provider   string               `bson:"provider"`
+	Credential string               `bson:"credential"`
+	CreatedAt  time.Time            `bson:"createdAt"`
+	Meta       bson.M               `bson:"meta"`
+	Users      []models.Permissions `bson:"users"`
+	Groups     []models.Permissions `bson:"groups"`
+}
+
+func (m *Machine) State() machinestate.State {
+	return machinestate.States[m.Status.State]
+}
+
+func (m *Machine) PublicIpAddress() string {
+	return m.IpAddress
+}

--- a/go/src/koding/kites/kloud/provider/koding/machine.go
+++ b/go/src/koding/kites/kloud/provider/koding/machine.go
@@ -14,8 +14,8 @@ import (
 	"labix.org/v2/mgo/bson"
 )
 
-// Machine represents a single MongodDB document from the jMachines
-// collection.
+// Machine represents a single MongodDB document that represents a Koding
+// Provider from the jMachines collection.
 type Machine struct {
 	Id          bson.ObjectId `bson:"_id" json:"-"`
 	Label       string        `bson:"label"`

--- a/go/src/koding/kites/kloud/terraformer/terraformer.go
+++ b/go/src/koding/kites/kloud/terraformer/terraformer.go
@@ -62,8 +62,22 @@ func (t *Terraformer) Plan(context string) (*terraform.Plan, error) {
 	return plan, nil
 }
 
-func (t *Terraformer) Apply() error {
-	return nil
+func (t *Terraformer) Apply(context string) (*terraform.Plan, error) {
+	req := terraformer.TerraformRequest{
+		Content: context,
+	}
+
+	resp, err := t.Client.Tell("apply", req)
+	if err != nil {
+		return nil, err
+	}
+
+	var plan *terraform.Plan
+	if err := resp.Unmarshal(&plan); err != nil {
+		return nil, err
+	}
+
+	return plan, nil
 }
 
 func (t *Terraformer) Destroy() error {

--- a/go/src/koding/kites/kloud/terraformer/terraformer.go
+++ b/go/src/koding/kites/kloud/terraformer/terraformer.go
@@ -62,7 +62,7 @@ func (t *Terraformer) Plan(context string) (*terraform.Plan, error) {
 	return plan, nil
 }
 
-func (t *Terraformer) Apply(context string) (*terraform.Plan, error) {
+func (t *Terraformer) Apply(context string) (*terraform.State, error) {
 	req := terraformer.TerraformRequest{
 		Content: context,
 	}
@@ -72,12 +72,12 @@ func (t *Terraformer) Apply(context string) (*terraform.Plan, error) {
 		return nil, err
 	}
 
-	var plan *terraform.Plan
-	if err := resp.Unmarshal(&plan); err != nil {
+	var state *terraform.State
+	if err := resp.Unmarshal(&state); err != nil {
 		return nil, err
 	}
 
-	return plan, nil
+	return state, nil
 }
 
 func (t *Terraformer) Destroy() error {

--- a/go/src/koding/kites/terraformer/kodingcontext/apply.go
+++ b/go/src/koding/kites/terraformer/kodingcontext/apply.go
@@ -14,7 +14,7 @@ import (
 // Apply applies the incoming terraform content to the remote system
 func (c *Context) Apply(content io.Reader, destroy bool) (*terraform.State, error) {
 	cmd := command.ApplyCommand{
-		ShutdownCh: makeShutdownCh(),
+		ShutdownCh: makeShutdownCh(), // TODO(fatih): this prevents us to kill terraformer with a SIGINT
 		Meta: command.Meta{
 			ContextOpts: c.TerraformContextOpts(),
 			Ui:          c.ui,
@@ -60,6 +60,7 @@ func (c *Context) Apply(content io.Reader, destroy bool) (*terraform.State, erro
 		"-no-color", // dont write with color
 		"-state", stateFilePath,
 		"-state-out", stateFilePath,
+		"-input=false", // do not ask for any input
 		outputDir,
 	}
 

--- a/go/src/koding/kites/terraformer/kodingcontext/apply.go
+++ b/go/src/koding/kites/terraformer/kodingcontext/apply.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Apply applies the incoming terraform content to the remote system
-func (c *Context) Apply(content io.Reader, destroy bool) (*terraform.Plan, error) {
+func (c *Context) Apply(content io.Reader, destroy bool) (*terraform.State, error) {
 	cmd := command.ApplyCommand{
 		ShutdownCh: makeShutdownCh(),
 		Meta: command.Meta{
@@ -33,7 +33,6 @@ func (c *Context) Apply(content io.Reader, destroy bool) (*terraform.Plan, error
 
 	outputDir := path.Join(basePath, c.ContentID)
 	mainFileRelativePath := path.Join(c.ContentID, mainFileName+terraformFileExt)
-	planFilePath := path.Join(outputDir, planFileName+terraformPlanFileExt)
 	stateFilePath := path.Join(outputDir, stateFileName+terraformStateFileExt)
 
 	// override the current main file
@@ -80,18 +79,18 @@ func (c *Context) Apply(content io.Reader, destroy bool) (*terraform.Plan, error
 		)
 	}
 
-	planFile, err := os.Open(planFilePath)
+	stateFile, err := os.Open(stateFilePath)
 	if err != nil {
 		return nil, err
 	}
-	defer planFile.Close()
+	defer stateFile.Close()
 
 	// copy all contents from local to remote for later operating
 	if err := c.LocalStorage.Clone(c.ContentID, c.RemoteStorage); err != nil {
 		return nil, err
 	}
 
-	return terraform.ReadPlan(planFile)
+	return terraform.ReadState(stateFile)
 }
 
 // makeShutdownCh creates an interrupt listener and returns a channel.

--- a/go/src/koding/kites/terraformer/terraformer.go
+++ b/go/src/koding/kites/terraformer/terraformer.go
@@ -107,12 +107,12 @@ func (t *Terraformer) Apply(r *kite.Request) (interface{}, error) {
 	c := t.Context.Clone()
 	defer c.Close()
 
-	plan, err := t.apply(c, r, false)
+	state, err := t.apply(c, r, false)
 	if err != nil {
 		return nil, err
 	}
 
-	return plan, nil
+	return state, nil
 }
 
 // Destroy provides a kite call for destroy operation
@@ -155,7 +155,7 @@ func (t *Terraformer) plan(c *kodingcontext.Context, r *kite.Request, destroy bo
 	return c.Plan(content, destroy)
 }
 
-func (t *Terraformer) apply(c *kodingcontext.Context, r *kite.Request, destroy bool) (*terraform.Plan, error) {
+func (t *Terraformer) apply(c *kodingcontext.Context, r *kite.Request, destroy bool) (*terraform.State, error) {
 	args := TerraformRequest{}
 	if err := r.Args.One().Unmarshal(&args); err != nil {
 		return nil, err


### PR DESCRIPTION
Changes:
- A new `apply` method for Kloud
- Add tests to kloud for testing `apply`
- Changed `terraformerkite`s return type for `apply`. It returns now `state` instead of `plan` which was wrong. 
- Added a new `generic` provider, this will be used to match instances built with terraform to the sent machine ids.

The tests is working and I can see the `state` results successfully. We can merge this before this get's bigger and bigger :) The next steps will be : 
- Match the state results to the respective machineIds. Populate the jMachine documents
- Attach `userdata` to the Terraform Context file. So we can install Klient inside the machine.
