### PR TITLE
account: fix for new ssh key item [fixes #92339756]

### DIFF
--- a/client/account/lib/views/accountsshkeylistcontroller.coffee
+++ b/client/account/lib/views/accountsshkeylistcontroller.coffee
@@ -64,8 +64,15 @@ module.exports = class AccountSshKeyListController extends AccountListViewContro
 
   deleteItem: (item) ->
 
+    isNew = item instanceof AccountNewSshKeyView
+
     @cancelItem item
     @removeItem item
+
+    # If item is new, just remove it from DOM
+    # It doesn't have data in DB, so there is no need to update items
+    return  if isNew
+
     @saveItems()
     @showDeleteModal()
 
@@ -104,6 +111,7 @@ module.exports = class AccountSshKeyListController extends AccountListViewContro
       else
         @addItem { key, title }
         @deleteItem item
+        @saveItems()
 
 
   editItem: (item) ->


### PR DESCRIPTION
@sinan, can you please review this fix? It's related to [this task](https://www.pivotaltracker.com/story/show/92339756) 
The problem is that `deleteItem()` method is called in two cases - when we delete existent ssh key and when an item for new ssh key is removed from DOM. We need to show a modal in the first case only.
