### PR TITLE
Terraform updates

### DIFF
--- a/go/build.sh
+++ b/go/build.sh
@@ -73,17 +73,33 @@ cd $GOPATH
 mkdir -p build/broker
 cp bin/broker build/broker/broker
 
+# build terraform services
+terraformservices=(
+  github.com/hashicorp/terraform/builtin/bins/provider-aws
+  github.com/hashicorp/terraform/builtin/bins/provider-terraform
 
-#
-# terraform related build operations
-# TODO ~ this should be done in a more elegant way
-#
-# tldflags="-X main.GitCommit ${version:0:8}"
+  github.com/hashicorp/terraform/builtin/bins/provisioner-file
+  github.com/hashicorp/terraform/builtin/bins/provisioner-local-exec
+  github.com/hashicorp/terraform/builtin/bins/provisioner-remote-exec
 
-# `which go` build -o bin/terraform-provider-aws -v -ldflags "$tldflags" github.com/hashicorp/terraform/builtin/bins/provider-aws
-# `which go` build -o bin/terraform-provider-terraform -v -ldflags "$tldflags" github.com/hashicorp/terraform/builtin/bins/provider-terraform
+)
 
-# `which go` build -o bin/terraform-provisioner-file -v -ldflags "$tldflags" github.com/hashicorp/terraform/builtin/bins/provisioner-file
-# `which go` build -o bin/terraform-provisioner-local-exec -v -ldflags "$tldflags" github.com/hashicorp/terraform/builtin/bins/provisioner-local-exec
-# `which go` build -o bin/terraform-provisioner-remote-exec -v -ldflags "$tldflags" github.com/hashicorp/terraform/builtin/bins/provisioner-remote-exec
+tldflags="-X main.GitCommit ${version:0:8}"
+`which go` install -v -ldflags "$tldflags"  "${terraformservices[@]}"
 
+for i in "${terraformservices[@]}"
+do
+  # split each entry from `/` to an array of strings from a string
+  IFS='/ ' read -a paths <<< "$i"
+
+  # if GOBIN is not set, generate it from GOPATH
+  if [[ -z "$GOBIN" ]]; then
+    GOBIN=$GOPATH/bin
+  fi
+
+  FILE=${paths[${#paths[@]}-1]} # only use the last folder name
+
+  # rename files with terraform prefix
+  # cp instead of mv because build tool will always try to build again and again
+  cp $GOBIN/$FILE $GOBIN/terraform-$FILE
+done

--- a/go/src/koding/kites/cmd/terraformer/main.go
+++ b/go/src/koding/kites/cmd/terraformer/main.go
@@ -29,11 +29,11 @@ func main() {
 
 	k, err := terraformer.NewKite(t, conf)
 	if err != nil {
-		return err
+		log.Fatal(err.Error())
 	}
 
 	if err := k.RegisterForever(k.RegisterURL(true)); err != nil {
-		return err
+		log.Fatal(err.Error())
 	}
 
 	go k.Run()

--- a/go/src/koding/kites/cmd/terraformer/main.go
+++ b/go/src/koding/kites/cmd/terraformer/main.go
@@ -27,5 +27,23 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
-	t.Run()
+	k, err := terraformer.NewKite(t, conf)
+	if err != nil {
+		return err
+	}
+
+	if err := k.RegisterForever(k.RegisterURL(true)); err != nil {
+		return err
+	}
+
+	go k.Run()
+	<-k.ServerReadyNotify()
+	log.Debug("Kite Started Listening")
+
+	// terraformer can only be closed with signals, wait for any signal
+	if err := t.Wait(); err != nil {
+		log.Error("Err after waiting terraformer %s", err)
+	}
+
+	k.Close()
 }

--- a/go/src/koding/kites/cmd/terraformer/main.go
+++ b/go/src/koding/kites/cmd/terraformer/main.go
@@ -26,18 +26,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err.Error())
 	}
-	defer t.Close()
 
-	// init terraformer's kite
-	k, err := t.Kite()
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-	defer k.Close()
-
-	if err := k.RegisterForever(k.RegisterURL(true)); err != nil {
-		log.Fatal(err.Error())
-	}
-
-	k.Run()
+	t.Run()
 }

--- a/go/src/koding/kites/terraformer/kite.go
+++ b/go/src/koding/kites/terraformer/kite.go
@@ -10,6 +10,7 @@ import (
 	"github.com/koding/metrics"
 )
 
+// NewKite creates a new kite for serving terraformer
 func NewKite(t *Terraformer, conf *Config) (*kite.Kite, error) {
 	var err error
 	k := kite.New(Name, Version)

--- a/go/src/koding/kites/terraformer/kite.go
+++ b/go/src/koding/kites/terraformer/kite.go
@@ -10,7 +10,7 @@ import (
 	"github.com/koding/metrics"
 )
 
-func (t *Terraformer) newKite(conf *Config) (*kite.Kite, error) {
+func NewKite(t *Terraformer, conf *Config) (*kite.Kite, error) {
 	var err error
 	k := kite.New(Name, Version)
 	k.Config, err = kiteconfig.Get()
@@ -18,7 +18,7 @@ func (t *Terraformer) newKite(conf *Config) (*kite.Kite, error) {
 		return nil, err
 	}
 
-	k = t.setupKite(k, conf)
+	k = setupKite(k, conf)
 
 	// handle current status of terraformer
 	k.PostHandleFunc(t.handleState)
@@ -46,7 +46,7 @@ func (t *Terraformer) newKite(conf *Config) (*kite.Kite, error) {
 	return k, nil
 }
 
-func (t *Terraformer) setupKite(k *kite.Kite, conf *Config) *kite.Kite {
+func setupKite(k *kite.Kite, conf *Config) *kite.Kite {
 
 	k.Config.Port = conf.Port
 
@@ -58,7 +58,7 @@ func (t *Terraformer) setupKite(k *kite.Kite, conf *Config) *kite.Kite {
 		k.Config.Environment = conf.Environment
 	}
 
-	if t.Debug {
+	if conf.Debug {
 		k.SetLogLevel(kite.DEBUG)
 	}
 
@@ -87,15 +87,4 @@ func createTracker(metrics *metrics.DogStatsD) kite.HandlerFunc {
 
 		return true, nil
 	}
-}
-
-func (t *Terraformer) handleState(r *kite.Request) (interface{}, error) {
-	t.rwmu.RLock()
-	defer t.rwmu.RUnlock()
-
-	if t.closing {
-		return false, errors.New("terraformer is closing")
-	}
-
-	return true, nil
 }

--- a/go/src/koding/kites/terraformer/kite_test.go
+++ b/go/src/koding/kites/terraformer/kite_test.go
@@ -1,6 +1,7 @@
 package terraformer
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"testing"
@@ -81,9 +82,17 @@ func TestApplyAndDestroy(t *testing.T) {
 			return err
 		}
 
-		res := terraform.Plan{}
+		res := terraform.State{}
 		if err := response.Unmarshal(&res); err != nil {
 			return err
+		}
+
+		if len(res.Modules) != 1 {
+			return fmt.Errorf("expected Modules to have length 1, got: %d", len(res.Modules))
+		}
+
+		if len(res.Modules[0].Resources) != 7 {
+			return fmt.Errorf("Expected Resources to have length 7, got: %d", len(res.Modules[0].Resources))
 		}
 
 		response, err = tfr.Tell("destroy", req)
@@ -91,9 +100,17 @@ func TestApplyAndDestroy(t *testing.T) {
 			return err
 		}
 
-		res = terraform.Plan{}
+		res = terraform.State{}
 		if err := response.Unmarshal(&res); err != nil {
 			return err
+		}
+
+		if len(res.Modules) != 1 {
+			return fmt.Errorf("expected Modules to have length 1, got: %d", len(res.Modules))
+		}
+
+		if len(res.Modules[0].Resources) != 0 {
+			return fmt.Errorf("Expected Resources to have length 0, got: %d", len(res.Modules[0].Resources))
 		}
 
 		return nil

--- a/go/src/koding/kites/terraformer/kite_test.go
+++ b/go/src/koding/kites/terraformer/kite_test.go
@@ -91,7 +91,7 @@ func TestApplyAndDestroy(t *testing.T) {
 		}
 
 		if len(res.Modules[0].Resources) != 7 {
-			return fmt.Errorf("Expected Resources to have length 7, got: %d", len(res.Modules[0].Resources))
+			return fmt.Errorf("expected Resources to have length 7, got: %d", len(res.Modules[0].Resources))
 		}
 
 		response, err = tfr.Tell("destroy", req)
@@ -109,7 +109,7 @@ func TestApplyAndDestroy(t *testing.T) {
 		}
 
 		if len(res.Modules[0].Resources) != 0 {
-			return fmt.Errorf("Expected Resources to have length 0, got: %d", len(res.Modules[0].Resources))
+			return fmt.Errorf("expected Resources to have length 0, got: %d", len(res.Modules[0].Resources))
 		}
 
 		return nil

--- a/go/src/koding/kites/terraformer/kite_test.go
+++ b/go/src/koding/kites/terraformer/kite_test.go
@@ -44,7 +44,7 @@ func withKite(t *testing.T, f func(k *kite.Kite) error) {
 	defer tr.Close()
 
 	// init terraformer's kite
-	k, err := tr.Kite()
+	k, err := NewKite(tr, conf)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -53,7 +53,6 @@ func withKite(t *testing.T, f func(k *kite.Kite) error) {
 	k.Config.DisableAuthentication = true
 
 	go k.Run()
-	defer k.Close()
 	<-k.ServerReadyNotify()
 
 	if err := f(k); err != nil {

--- a/go/src/koding/kites/terraformer/kite_test.go
+++ b/go/src/koding/kites/terraformer/kite_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"sync"
 	"testing"
 
 	"koding/kites/common"
@@ -41,21 +42,21 @@ func withKite(t *testing.T, f func(k *kite.Kite) error) {
 	if err != nil {
 		t.Errorf("err while creating terraformer %s", err.Error())
 	}
-	defer tr.Close()
 
 	// init terraformer's kite
 	k, err := NewKite(tr, conf)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	defer k.Close()
-
 	k.Config.DisableAuthentication = true
-
 	go k.Run()
 	<-k.ServerReadyNotify()
 
-	if err := f(k); err != nil {
+	err = f(k)
+	tr.Close()
+	tr.Wait()
+	k.Close()
+	if err != nil {
 		t.Errorf("failed with %s", err.Error())
 	}
 }
@@ -117,7 +118,7 @@ func TestApplyAndDestroy(t *testing.T) {
 
 }
 
-func TestPlan(t *testing.T) {
+func TestPlanWithMultiReq(t *testing.T) {
 	local := kite.New("testing", "1.0.0")
 	withKite(t, func(k *kite.Kite) error {
 		// Connect to our terraformer kite
@@ -126,23 +127,97 @@ func TestPlan(t *testing.T) {
 
 		tfr.Dial()
 
-		req := TerraformRequest{
-			Content:   SampleTF,
-			Variables: variables,
-			ContentID: "test_file",
+		callCount := 10
+		var wg sync.WaitGroup
+		wg.Add(callCount)
+
+		fail := 0
+		success := 0
+		var mu sync.Mutex
+
+		for i := 0; i < callCount; i++ {
+			go func(seq int) {
+				req := TerraformRequest{
+					Content:   SampleTF,
+					Variables: variables,
+					ContentID: fmt.Sprintf("test_file_%d", seq),
+				}
+
+				_, err := tfr.Tell("plan", req)
+				mu.Lock()
+				if err != nil {
+					fail++
+				} else {
+					success++
+				}
+				mu.Unlock()
+				wg.Done()
+
+			}(i)
 		}
 
-		response, err := tfr.Tell("plan", req)
-		if err != nil {
-			return err
+		wg.Wait()
+
+		if fail > 0 {
+			return fmt.Errorf("fail should be 0, got %d", fail)
 		}
 
-		res := terraform.Plan{}
-		if err := response.Unmarshal(&res); err != nil {
-			return err
+		if success != callCount {
+			return fmt.Errorf("success should be %d, got %d", callCount, success)
 		}
 
 		return nil
 	})
+}
 
+func TestPlanWithLockedResource(t *testing.T) {
+	local := kite.New("testing", "1.0.0")
+	withKite(t, func(k *kite.Kite) error {
+		// Connect to our terraformer kite
+		tfr := local.NewClient(k.RegisterURL(true).String())
+		defer tfr.Close()
+
+		tfr.Dial()
+
+		callCount := 10
+		var wg sync.WaitGroup
+		wg.Add(callCount)
+
+		fail := 0
+		success := 0
+		var mu sync.Mutex
+
+		for i := 0; i < callCount; i++ {
+			go func(seq int) {
+				req := TerraformRequest{
+					Content:   SampleTF,
+					Variables: variables,
+					ContentID: "test_file_locked",
+				}
+
+				_, err := tfr.Tell("plan", req)
+				mu.Lock()
+				if err != nil {
+					fail++
+				} else {
+					success++
+				}
+				mu.Unlock()
+				wg.Done()
+
+			}(i)
+		}
+
+		wg.Wait()
+
+		if fail < callCount-1 {
+			return fmt.Errorf("fail should be lt %d, got %d", callCount-1, fail)
+		}
+
+		if success != 1 {
+			return fmt.Errorf("success should be 1, got %d", success)
+		}
+
+		return nil
+	})
 }

--- a/go/src/koding/kites/terraformer/kodingcontext/apply.go
+++ b/go/src/koding/kites/terraformer/kodingcontext/apply.go
@@ -48,7 +48,7 @@ func (c *KodingContext) populateApplyArgs(paths *paths, destroy bool) []string {
 	for key, val := range c.Variables {
 		// Set a variable in the Terraform configuration. This flag can be set
 		// multiple times.
-		vars = append(vars, []string{"-var", fmt.Sprintf("%s=%s", key, val)}...)
+		vars = append(vars, "-var", fmt.Sprintf("%s=%s", key, val))
 	}
 
 	// prepend vars if there are

--- a/go/src/koding/kites/terraformer/kodingcontext/apply.go
+++ b/go/src/koding/kites/terraformer/kodingcontext/apply.go
@@ -44,7 +44,7 @@ func (c *Context) populateApplyArgs(paths *paths, destroy bool) []string {
 		paths.contentPath,
 	}
 
-	vars := make([]string, 0)
+	var vars []string
 	for key, val := range c.Variables {
 		// Set a variable in the Terraform configuration. This flag can be set
 		// multiple times.

--- a/go/src/koding/kites/terraformer/kodingcontext/apply.go
+++ b/go/src/koding/kites/terraformer/kodingcontext/apply.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 
 	"github.com/hashicorp/terraform/command"
 	"github.com/hashicorp/terraform/terraform"
@@ -12,83 +11,55 @@ import (
 
 // Apply applies the incoming terraform content to the remote system
 func (c *Context) Apply(content io.Reader, destroy bool) (*terraform.State, error) {
-	cmd := command.ApplyCommand{
+	cmd := &command.ApplyCommand{
 		ShutdownCh: c.ShutdownChan,
 		Meta: command.Meta{
 			ContextOpts: c.TerraformContextOpts(),
 			Ui:          c.ui,
 		},
 	}
+	cmd.Destroy = destroy
 
-	// copy all contents from remote to local for operating
-	if err := c.RemoteStorage.Clone(c.ContentID, c.LocalStorage); err != nil {
-		return nil, err
-	}
-
-	basePath, err := c.LocalStorage.BasePath()
+	paths, err := c.run(cmd, content, destroy, c.populateApplyArgs)
 	if err != nil {
 		return nil, err
 	}
 
-	outputDir := path.Join(basePath, c.ContentID)
-	mainFileRelativePath := path.Join(c.ContentID, mainFileName+terraformFileExt)
-	stateFilePath := path.Join(outputDir, stateFileName+terraformStateFileExt)
-
-	// override the current main file
-	if err := c.LocalStorage.Write(mainFileRelativePath, content); err != nil {
-		return nil, err
-	}
-
-	// TODO: doesn't work because Module is not initializde and it panics.
-	// Module is initialized inside cmd.Run, but then it will override
-	// anything we set here. Seems the only way to pass the variable is to
-	// pass with the file it self - arslan
-	//
-	// variables := []*config.Variable{}
-	// for k, v := range c.Variables {
-	//  variables = append(variables, &config.Variable{
-	//      Name:    k,
-	//      Default: v,
-	//  })
-	// }
-	// cmd.ContextOpts.Module.Config().Variables = variables
-
-	cmd.Destroy = destroy
-
-	args := []string{
-		"-no-color", // dont write with color
-		"-state", stateFilePath,
-		"-state-out", stateFilePath,
-		"-input=false", // do not ask for any input
-		outputDir,
-	}
-
-	if destroy {
-		args = append([]string{"-force"}, args...)
-	}
-
-	exitCode := cmd.Run(args)
-
-	fmt.Printf("Debug output: %+v\n", c.Buffer.String())
-
-	if exitCode != 0 {
-		return nil, fmt.Errorf(
-			"apply failed with code: %d, output: %s",
-			exitCode,
-			c.Buffer.String(),
-		)
-	}
-
-	stateFile, err := os.Open(stateFilePath)
+	stateFile, err := os.Open(paths.statePath)
 	if err != nil {
 		return nil, err
 	}
 	defer stateFile.Close()
 
-	// copy all contents from local to remote for later operating
-	if err := c.LocalStorage.Clone(c.ContentID, c.RemoteStorage); err != nil {
-		return nil, err
+	return terraform.ReadState(stateFile)
+}
+
+func (c *Context) populateApplyArgs(paths *paths, destroy bool) []string {
+	// generate base args
+	args := []string{
+		"-no-color", // dont write with color
+		"-state", paths.statePath,
+		"-state-out", paths.statePath,
+		"-input=false", // do not ask for any input
+		paths.contentPath,
 	}
 
-	return terraform.ReadState(stateFile)
+	vars := make([]string, 0)
+	for key, val := range c.Variables {
+		// Set a variable in the Terraform configuration. This flag can be set
+		// multiple times.
+		vars = append(vars, []string{"-var", fmt.Sprintf("%s=%s", key, val)}...)
+	}
+
+	// prepend vars if there are
+	args = append(vars, args...)
+
+	// if this is a destroy operation, terraform destroy accepts force param not
+	// not ask for input for destroy confirmation.
+	if destroy {
+		args = append([]string{"-force"}, args...)
+	}
+
+	return args
+
 }

--- a/go/src/koding/kites/terraformer/kodingcontext/apply.go
+++ b/go/src/koding/kites/terraformer/kodingcontext/apply.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Apply applies the incoming terraform content to the remote system
-func (c *Context) Apply(content io.Reader, destroy bool) (*terraform.State, error) {
+func (c *KodingContext) Apply(content io.Reader, destroy bool) (*terraform.State, error) {
 	cmd := &command.ApplyCommand{
 		ShutdownCh: c.ShutdownChan,
 		Meta: command.Meta{
@@ -34,7 +34,7 @@ func (c *Context) Apply(content io.Reader, destroy bool) (*terraform.State, erro
 	return terraform.ReadState(stateFile)
 }
 
-func (c *Context) populateApplyArgs(paths *paths, destroy bool) []string {
+func (c *KodingContext) populateApplyArgs(paths *paths, destroy bool) []string {
 	// generate base args
 	args := []string{
 		"-no-color", // dont write with color

--- a/go/src/koding/kites/terraformer/kodingcontext/cmd.go
+++ b/go/src/koding/kites/terraformer/kodingcontext/cmd.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mitchellh/cli"
 )
 
-func (c *Context) run(cmd cli.Command, content io.Reader, destroy bool, argsFunc func(paths *paths, destroy bool) []string) (*paths, error) {
+func (c *KodingContext) run(cmd cli.Command, content io.Reader, destroy bool, argsFunc func(paths *paths, destroy bool) []string) (*paths, error) {
 	// copy all contents from remote to local for operating
 	if err := c.RemoteStorage.Clone(c.ContentID, c.LocalStorage); err != nil {
 		return nil, err
@@ -53,7 +53,7 @@ type paths struct {
 	mainRelativePath string
 }
 
-func (c *Context) paths() (*paths, error) {
+func (c *KodingContext) paths() (*paths, error) {
 	basePath, err := c.LocalStorage.BasePath()
 	if err != nil {
 		return nil, err

--- a/go/src/koding/kites/terraformer/kodingcontext/cmd.go
+++ b/go/src/koding/kites/terraformer/kodingcontext/cmd.go
@@ -1,0 +1,73 @@
+package kodingcontext
+
+import (
+	"fmt"
+	"io"
+	"path"
+
+	"github.com/mitchellh/cli"
+)
+
+func (c *Context) run(cmd cli.Command, content io.Reader, destroy bool, argsFunc func(paths *paths, destroy bool) []string) (*paths, error) {
+	// copy all contents from remote to local for operating
+	if err := c.RemoteStorage.Clone(c.ContentID, c.LocalStorage); err != nil {
+		return nil, err
+	}
+
+	// populate paths
+	paths, err := c.paths()
+	if err != nil {
+		return nil, err
+	}
+
+	// override the current main file
+	if err := c.LocalStorage.Write(paths.mainRelativePath, content); err != nil {
+		return nil, err
+	}
+
+	// populate args for apply
+	args := argsFunc(paths, destroy)
+
+	exitCode := cmd.Run(args)
+
+	if exitCode != 0 {
+		return nil, fmt.Errorf(
+			"apply failed with code: %d, output: %s",
+			exitCode,
+			c.Buffer.String(),
+		)
+	}
+
+	// copy all contents from local to remote for later operating
+	if err := c.LocalStorage.Clone(c.ContentID, c.RemoteStorage); err != nil {
+		return nil, err
+	}
+
+	return paths, nil
+}
+
+type paths struct {
+	contentPath      string
+	statePath        string
+	planPath         string
+	mainRelativePath string
+}
+
+func (c *Context) paths() (*paths, error) {
+	basePath, err := c.LocalStorage.BasePath()
+	if err != nil {
+		return nil, err
+	}
+
+	contentPath := path.Join(basePath, c.ContentID)
+	mainFileRelativePath := path.Join(c.ContentID, mainFileName+terraformFileExt)
+	stateFilePath := path.Join(contentPath, stateFileName+terraformStateFileExt)
+	planFilePath := path.Join(contentPath, planFileName+terraformPlanFileExt)
+
+	return &paths{
+		contentPath:      contentPath,
+		statePath:        stateFilePath,
+		mainRelativePath: mainFileRelativePath,
+		planPath:         planFilePath,
+	}, nil
+}

--- a/go/src/koding/kites/terraformer/kodingcontext/cmd.go
+++ b/go/src/koding/kites/terraformer/kodingcontext/cmd.go
@@ -8,7 +8,9 @@ import (
 	"github.com/mitchellh/cli"
 )
 
-func (c *KodingContext) run(cmd cli.Command, content io.Reader, destroy bool, argsFunc func(paths *paths, destroy bool) []string) (*paths, error) {
+type ArgsFunc func(paths *paths, destroy bool) []string
+
+func (c *KodingContext) run(cmd cli.Command, content io.Reader, destroy bool, argsFunc ArgsFunc) (*paths, error) {
 	// copy all contents from remote to local for operating
 	if err := c.RemoteStorage.Clone(c.ContentID, c.LocalStorage); err != nil {
 		return nil, err
@@ -25,11 +27,9 @@ func (c *KodingContext) run(cmd cli.Command, content io.Reader, destroy bool, ar
 		return nil, err
 	}
 
-	// populate args for apply
 	args := argsFunc(paths, destroy)
 
 	exitCode := cmd.Run(args)
-
 	if exitCode != 0 {
 		return nil, fmt.Errorf(
 			"apply failed with code: %d, output: %s",

--- a/go/src/koding/kites/terraformer/kodingcontext/context.go
+++ b/go/src/koding/kites/terraformer/kodingcontext/context.go
@@ -84,7 +84,7 @@ func newContext() *Context {
 	}
 }
 
-// Clone creates a new context out of an existing one, this can be called
+// Get creates a new context out of an existing one, this can be called
 // multiple times instead of creating a new Context with New function
 func (c *Context) Get(contentID string) (*Context, error) {
 	if contentID == "" {
@@ -148,7 +148,7 @@ func (c *Context) Close() error {
 	return c.LocalStorage.Remove(c.ContentID)
 }
 
-// BroadcastShutdown sends a message to the current listeners
+// BroadcastForceShutdown sends a message to the current operations
 func (c *Context) BroadcastForceShutdown() {
 	shutdownChansMu.Lock()
 	for _, shutdownChan := range shutdownChans {

--- a/go/src/koding/kites/terraformer/kodingcontext/context.go
+++ b/go/src/koding/kites/terraformer/kodingcontext/context.go
@@ -5,7 +5,6 @@ package kodingcontext
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -14,7 +13,6 @@ import (
 
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/kr/pretty"
 	"github.com/mitchellh/cli"
 )
 
@@ -139,7 +137,7 @@ func (c *Context) TerraformContextOptsWithPlan(p *terraform.Plan) *terraform.Con
 
 // Close terminates the existing context
 func (c *Context) Close() error {
-	fmt.Printf("c.ContentID %# v", pretty.Formatter(c.ContentID))
+	// content id is null for parent context
 	if c.ContentID != "" {
 		shutdownChansMu.Lock()
 		delete(shutdownChans, c.ContentID)

--- a/go/src/koding/kites/terraformer/kodingcontext/kodingcontext.go
+++ b/go/src/koding/kites/terraformer/kodingcontext/kodingcontext.go
@@ -1,0 +1,74 @@
+// Package kodingcontext provides manages koding specific operations on top of
+// terraform
+package kodingcontext
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/mitchellh/cli"
+)
+
+func newKodingContext(sc <-chan struct{}) *KodingContext {
+	b := new(bytes.Buffer)
+
+	return &KodingContext{
+		Buffer:       b,
+		ui:           NewUI(b),
+		ShutdownChan: sc,
+	}
+}
+
+// Context holds the required operational parameters for any kind of terraform
+// call
+type KodingContext struct {
+	context
+
+	Buffer       *bytes.Buffer
+	ui           *cli.PrefixedUi
+	Variables    map[string]string
+	ShutdownChan <-chan struct{}
+	ContentID    string
+}
+
+// TerraformContextOpts creates a basic context options for terraform itself
+func (c *KodingContext) TerraformContextOpts() *terraform.ContextOpts {
+	return c.TerraformContextOptsWithPlan(nil)
+}
+
+// TerraformContextOptsWithPlan creates a new context out of a given plan
+func (c *KodingContext) TerraformContextOptsWithPlan(p *terraform.Plan) *terraform.ContextOpts {
+	if p == nil {
+		p = &terraform.Plan{}
+	}
+
+	return &terraform.ContextOpts{
+		Destroy:     false,
+		Parallelism: 0,
+
+		Hooks: nil,
+
+		Module: p.Module,
+		State:  p.State,
+		Diff:   p.Diff,
+
+		Providers:    c.Providers,
+		Provisioners: c.Provisioners,
+		Variables:    c.Variables,
+	}
+}
+
+// Close terminates the existing context
+func (c *KodingContext) Close() error {
+	if c.ContentID != "" {
+		return errors.New("contentID is nil")
+	}
+
+	shutdownChansMu.Lock()
+	delete(shutdownChans, c.ContentID)
+	shutdownChansWG.Done()
+	shutdownChansMu.Unlock()
+
+	return c.LocalStorage.Remove(c.ContentID)
+}

--- a/go/src/koding/kites/terraformer/kodingcontext/kodingcontext.go
+++ b/go/src/koding/kites/terraformer/kodingcontext/kodingcontext.go
@@ -61,7 +61,7 @@ func (c *KodingContext) TerraformContextOptsWithPlan(p *terraform.Plan) *terrafo
 
 // Close terminates the existing context
 func (c *KodingContext) Close() error {
-	if c.ContentID != "" {
+	if c.ContentID == "" {
 		return errors.New("contentID is nil")
 	}
 

--- a/go/src/koding/kites/terraformer/kodingcontext/plan.go
+++ b/go/src/koding/kites/terraformer/kodingcontext/plan.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Plan plans the operation accoring to the given content
-func (c *Context) Plan(content io.Reader, destroy bool) (*terraform.Plan, error) {
+func (c *KodingContext) Plan(content io.Reader, destroy bool) (*terraform.Plan, error) {
 	cmd := &command.PlanCommand{
 		Meta: command.Meta{
 			ContextOpts: c.TerraformContextOpts(),
@@ -32,7 +32,7 @@ func (c *Context) Plan(content io.Reader, destroy bool) (*terraform.Plan, error)
 	return terraform.ReadPlan(planFile)
 }
 
-func (c *Context) populatePlanArgs(paths *paths, destroy bool) []string {
+func (c *KodingContext) populatePlanArgs(paths *paths, destroy bool) []string {
 	// generate base args
 	args := []string{
 		"-no-color",            // dont write with color

--- a/go/src/koding/kites/terraformer/kodingcontext/plan.go
+++ b/go/src/koding/kites/terraformer/kodingcontext/plan.go
@@ -51,7 +51,7 @@ func (c *KodingContext) populatePlanArgs(paths *paths, destroy bool) []string {
 	for key, val := range c.Variables {
 		// Set a variable in the Terraform configuration. This flag can be set
 		// multiple times.
-		vars = append(vars, []string{"-var", fmt.Sprintf("%s=%s", key, val)}...)
+		vars = append(vars, "-var", fmt.Sprintf("%s=%s", key, val))
 	}
 
 	// prepend vars if there are

--- a/go/src/koding/kites/terraformer/sample.go
+++ b/go/src/koding/kites/terraformer/sample.go
@@ -2,41 +2,32 @@ package terraformer
 
 // SampleTF holds a sample terraform file
 var SampleTF = `
-// Provider specific configs
-
-provider "aws" {
-    access_key = "AKIAJTDKW5IFUUIWVNAA"
-    secret_key = "BKULK7pWB2crKtBafYnfcPhh7Ak+iR/ChPfkvrLC"
-    region = "sa-east-1"
-}
-
-
 // Template variables
 
 //
 // AWS General Config
 //
 
-//variable "key_name" {
-//    description = "Name of the SSH keypair to use in AWS."
-//}
-
 // set the region which is close to you
 variable "aws_region" {
     description = "Region name in which resources will be created"
-    default     = "sa-east-1"
 }
 
 // set secret key
 variable "aws_secret_key" {
     description = "AWS Secret key"
-    default     = "BKULK7pWB2crKtBafYnfcPhh7Ak+iR/ChPfkvrLC"
 }
 
 // set access key
 variable "aws_access_key" {
     description = "AWS Access key"
-    default     = "AKIAJTDKW5IFUUIWVNAA"
+}
+
+// Provider specific configs, using variables
+provider "aws" {
+    access_key = "${var.aws_access_key}"
+    secret_key = "${var.aws_secret_key}"
+    region = "${var.aws_region}"
 }
 
 //

--- a/go/src/koding/kites/terraformer/secretkey/secretkey.go
+++ b/go/src/koding/kites/terraformer/secretkey/secretkey.go
@@ -1,3 +1,5 @@
+// Package secretkey holds and provides auth credential for communication
+// between terraformer and other kites
 package secretkey
 
 // used to authenticate with Terraform directly

--- a/go/src/koding/kites/terraformer/storage/storage.go
+++ b/go/src/koding/kites/terraformer/storage/storage.go
@@ -1,3 +1,4 @@
+// Package storage provides backend storage systems
 package storage
 
 import "io"

--- a/go/src/koding/kites/terraformer/terraformer.go
+++ b/go/src/koding/kites/terraformer/terraformer.go
@@ -93,6 +93,10 @@ func New(conf *Config, log logging.Logger) (*Terraformer, error) {
 // Close closes the embeded properties of terraformer
 func (t *Terraformer) Close() error {
 	t.rwmu.Lock()
+	if t.closing {
+		defer t.rwmu.Unlock()
+		return errors.New("already closing")
+	}
 	// mark terraformer as closing and stop accepting new requests
 	t.closing = true
 	t.rwmu.Unlock()

--- a/go/src/koding/kites/terraformer/terraformer.go
+++ b/go/src/koding/kites/terraformer/terraformer.go
@@ -85,7 +85,7 @@ func (t *Terraformer) Close() error {
 	if t.Context == nil {
 		return nil
 	}
-	fmt.Println("3333-->", 3333)
+
 	return t.Context.Close()
 }
 
@@ -107,6 +107,7 @@ func (t *Terraformer) Run() error {
 
 	k.Close()
 	t.Close()
+
 	return nil
 }
 


### PR DESCRIPTION
This PR provides:
- build step for terraform plugins that are in use
- unifies cli.Command usage for future refactor flexibility 
- adds graceful shutdown for ongoing operations - waits for all operations to finish 
- terraform variables will be used while operating if provided - no need to append them into terraform template.
- improved tests
- ContentID is required parameter now for terraform kite requests.
