### PR TITLE
client: reduce vm modal font size

### DIFF
--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -1545,7 +1545,7 @@ paymentGrayLighter  = #f8f8f8
     font-size           18px
     color               #7D7D7D
 
-    font-weight         600
+    font-weight         400
     strong
       color             #404040
     .icon


### PR DESCRIPTION
In Safari, everything is bolded with 600: http://take.ms/GHZzy. With this change, now it looks almost the same in both browsers. Done by @sinan, I'm just committing it :)
