### PR TITLE
Set initial participants payload of SocialMessage instance [fixes #93424832]

### DIFF
--- a/client/app/lib/socialapicontroller.coffee
+++ b/client/app/lib/socialapicontroller.coffee
@@ -141,7 +141,7 @@ module.exports = class SocialApiController extends KDController
             catch e then null
 
       if payload.initialParticipants and typeof payload.initialParticipants is 'string'
-        payload.initialParticipants =
+        m.payload.initialParticipants =
           try JSON.parse htmlencode.htmlDecode payload.initialParticipants
           catch e then null
 


### PR DESCRIPTION
[First invited user is displayed incorrectly in the chat](https://www.pivotaltracker.com/story/show/93424832)
