### PR TITLE
Kloud/plan: return region and label

### DIFF
--- a/go/src/koding/kites/kloud/kloud/plan.go
+++ b/go/src/koding/kites/kloud/kloud/plan.go
@@ -20,6 +20,8 @@ import (
 
 type PlanMachine struct {
 	Provider   string            `json:"provider"`
+	Label      string            `json:"label"`
+	Region     string            `json:"region"`
 	Attributes map[string]string `json:"attributes"`
 }
 
@@ -228,14 +230,21 @@ func machineFromPlan(plan *terraform.Plan) (*PlanOutput, error) {
 				attrs[name] = a.New
 			}
 
-			// providerResource is in the form of "aws_instance.foo"
+			// providerResource is in the form of "aws_instance.foo.bar"
 			splitted := strings.Split(providerResource, "_")
-			if len(splitted) == 0 {
+			if len(splitted) < 2 {
 				return nil, fmt.Errorf("provider resource is unknown: %v", splitted)
 			}
 
+			// splitted[1]: instance.foo.bar
+			resourceSplitted := strings.SplitN(splitted[1], ".", 2)
+
+			providerName := splitted[0]          // aws
+			resourceLabel := resourceSplitted[1] // foo.bar
+
 			out.Machines = append(out.Machines, PlanMachine{
-				Provider:   splitted[0],
+				Provider:   providerName,
+				Label:      resourceLabel,
 				Attributes: attrs,
 			})
 		}

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -200,6 +200,16 @@ resource "aws_instance" "example" {
 		t.Fatal(err)
 	}
 
+	for _, machine := range result.Machines {
+		if machine.Label != "example" {
+			t.Errorf("plan label: want: example got: %s\n", machine.Label)
+		}
+
+		if machine.Region != "us-east-1" {
+			t.Errorf("plan region: want: example got: %s\n", machine.Label)
+		}
+	}
+
 	fmt.Printf("result = %+v\n", result)
 }
 

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -214,7 +214,7 @@ func TestTerraformApply(t *testing.T) {
 	remote := userData.Remote
 
 	args := &kloud.TerraformKloudRequest{
-		MachineIds: []string{userData: userData.MachineId},
+		MachineIds: []string{userData.MachineId},
 		TerraformContext: `
 provider "aws" {
     access_key = "${var.access_key}"


### PR DESCRIPTION
Output is now in the form of:

```
 "machines": [
  {
   "provider": "aws",
   "label": "example",
   "region": "us-east-1",
   "attributes": {
    "ami": "ami-d05e75b8",
    "availability_zone": "",
    "ebs_block_device.#": "",
    "ephemeral_block_device.#": "",
    "id": "",
    "instance_type": "t2.micro",
    "key_name": "",
    "private_dns": "",
    "private_ip": "",
    "public_dns": "",
    "public_ip": "",
    "root_block_device.#": "",
    "security_groups.#": "",
    "subnet_id": "subnet-b47692ed",
    "tags.#": "1",
    "tags.Name": "KloudTerraform",
    "tenancy": "",
    "vpc_security_group_ids.#": ""
   }
  }
 ]
```
