### PR TITLE
Removed +1 GB requirement for Snapshot Usage

### DIFF
--- a/workers/social/lib/social/models/computeproviders/snapshot.coffee
+++ b/workers/social/lib/social/models/computeproviders/snapshot.coffee
@@ -73,7 +73,7 @@ module.exports = class JSnapshot extends Module
       return callback err  if err
       return callback new KodingError 'No such snapshot'  unless snapshot
 
-      if +(snapshot.storageSize) + 1 > storage
+      if +(snapshot.storageSize) > storage
         return callback new KodingError \
           'Storage size is not enough for this snapshot', 'SizeError'
 


### PR DESCRIPTION
Previously, a free user could not create a 3GB VM from a 3GB snapshot,
since the verify method required the `snapshot size +1`.

By removing the +1, it allows a free user (3GB VM) to create a snapshot, and
create a new 3GB VM from the given snapshot.
