### PR TITLE
Increased Free user's SnapshotTotalLimit to 1

### DIFF
--- a/client/app/lib/providers/machinesettingssnapshotsview.coffee
+++ b/client/app/lib/providers/machinesettingssnapshotsview.coffee
@@ -38,7 +38,7 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
    * The various snapshot total limits.
   ###
   @snapshotsLimits:
-    free         : 0
+    free         : 1
     hobbyist     : 1
     developer    : 3
     professional : 5

--- a/go/src/koding/kites/kloud/plans/plans.go
+++ b/go/src/koding/kites/kloud/plans/plans.go
@@ -69,7 +69,7 @@ var (
 	Free = &Plan{
 		Name:               "Free",
 		TotalLimit:         1,
-		SnapshotTotalLimit: 0,
+		SnapshotTotalLimit: 1,
 		AlwaysOnLimit:      0,
 		StorageLimit:       3,
 		Timeout:            60 * time.Minute,


### PR DESCRIPTION
As per Nitin's request, the SnapshotTotalLimit for the free plan has been increased to 0.

cc @fatih, @gniting 
