### PR TITLE
snapshot: Decreasing SnapshotTotalLimit Plan Limit

### DIFF
--- a/client/app/lib/providers/machinesettingssnapshotsview.coffee
+++ b/client/app/lib/providers/machinesettingssnapshotsview.coffee
@@ -38,7 +38,7 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
    * The various snapshot total limits.
   ###
   @snapshotsLimits:
-    free         : 1
+    free         : 0
     hobbyist     : 1
     developer    : 3
     professional : 5

--- a/go/src/koding/kites/kloud/plans/plans.go
+++ b/go/src/koding/kites/kloud/plans/plans.go
@@ -69,7 +69,7 @@ var (
 	Free = &Plan{
 		Name:               "Free",
 		TotalLimit:         1,
-		SnapshotTotalLimit: 1,
+		SnapshotTotalLimit: 0,
 		AlwaysOnLimit:      0,
 		StorageLimit:       3,
 		Timeout:            60 * time.Minute,


### PR DESCRIPTION
As per discussed in the Wednesday Meeting. Reverting the change from #3584, to set Free user's back to no snapshots total heh.

cc @fatih 
