### PR TITLE
Snapshot ux consistency/improvement

### DIFF
--- a/client/app/lib/providers/machinesettingssnapshotsview.coffee
+++ b/client/app/lib/providers/machinesettingssnapshotsview.coffee
@@ -175,6 +175,12 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
         @addNewButton.hideLoader()
         return
 
+      # Assign the no-line class if the itemCount is 0. Note that this
+      # will attempt to remove the class repeated times
+      if @listController.getItemCount() is 0
+      then @addViewContainer.setClass 'no-line'
+      else @addViewContainer.unsetClass 'no-line'
+
       @headerAddNewButton.hide()
       @addViewContainer.show()
       kd.utils.defer @addInputView.bound 'setFocus'

--- a/client/app/lib/providers/machinesettingssnapshotsview.coffee
+++ b/client/app/lib/providers/machinesettingssnapshotsview.coffee
@@ -19,12 +19,19 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
     options.addButtonTitle       = 'ADD SNAPSHOT'
     options.headerAddButtonTitle = 'ADD NEW SNAPSHOT'
     options.listViewItemClass    = SnapshotListItem
+    options.noItemFoundWidget    = new kd.CustomHTMLView
+      cssClass : 'no-item'
+      partial  : 'You do not have any snapshots created'
 
     # Trigger the snapshotsLimits fetch, so that we can cache it ahead
     # of time.
     @snapshotsLimit()
 
     super options, data
+
+    @listController.getListView().on 'DeleteSnapshot', =>
+      if @listController.getItemCount() is 0
+        @listController.noItemView.show()
 
 
   ###*

--- a/client/app/lib/providers/machinesettingssnapshotsview.coffee
+++ b/client/app/lib/providers/machinesettingssnapshotsview.coffee
@@ -126,6 +126,14 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
       @listController.addItem snapshot
 
 
+  hideAddView: ->
+
+    super
+
+    if @listController.getItemCount() is 0
+      @listController.noItemView.show()
+
+
   ###*
    * Populate the listController with snapshots fetched from jSnapshot.
   ###
@@ -167,7 +175,6 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
 
         return @emit 'ModalDestroyRequested'
 
-
       kd.warn err  if err
       if not isWithin
         msg = "Your current plan allows for a maximum of #{max} Snapshots"
@@ -178,8 +185,10 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
       # Assign the no-line class if the itemCount is 0. Note that this
       # will attempt to remove the class repeated times
       if @listController.getItemCount() is 0
-      then @addViewContainer.setClass 'no-line'
-      else @addViewContainer.unsetClass 'no-line'
+        @addViewContainer.setClass 'no-line'
+        @listController.noItemView.hide()
+      else
+        @addViewContainer.unsetClass 'no-line'
 
       @headerAddNewButton.hide()
       @addViewContainer.show()

--- a/client/app/lib/providers/machinesettingssnapshotsview.coffee
+++ b/client/app/lib/providers/machinesettingssnapshotsview.coffee
@@ -186,13 +186,7 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
 
         return
 
-      # Assign the no-line class if the itemCount is 0. Note that this
-      # will attempt to remove the class repeated times
-      if @listController.getItemCount() is 0
-        @addViewContainer.setClass 'no-line'
-        @listController.noItemView.hide()
-      else
-        @addViewContainer.unsetClass 'no-line'
+      @listController.noItemView.hide() if @listController.getItemCount() is 0
 
       @headerAddNewButton.hide()
       @addViewContainer.show()

--- a/client/app/lib/providers/machinesettingssnapshotsview.coffee
+++ b/client/app/lib/providers/machinesettingssnapshotsview.coffee
@@ -30,8 +30,7 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
     super options, data
 
     @listController.getListView().on 'DeleteSnapshot', =>
-      if @listController.getItemCount() is 0
-        @listController.noItemView.show()
+      @listController.noItemView.show()  if @listController.getItemCount() is 0
 
 
   ###*
@@ -126,12 +125,14 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
       @listController.addItem snapshot
 
 
+  ###*
+   * Triggered when the header add new snapshot is pressed.
+  ###
   hideAddView: ->
 
     super
 
-    if @listController.getItemCount() is 0
-      @listController.noItemView.show()
+    @listController.noItemView.show()  if @listController.getItemCount() is 0
 
 
   ###*
@@ -166,20 +167,23 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
    * Called when the headerAddNewButton click event fires.
   ###
   showAddView: ->
+
     @isWithinSnapshotLimit (err, isWithin, current, max) =>
+      kd.warn err  if err
+
       # If the max is 0, the user has no allotted snapshots (free plan)
       if max is 0
         new ComputeErrorUsageModal
           plan    : 'free'
-          message : 'VM share feature is only available for paid accounts.'
+          message : 'The Snapshot feature is only available for paid accounts.'
 
         return @emit 'ModalDestroyRequested'
 
-      kd.warn err  if err
       if not isWithin
         msg = "Your current plan allows for a maximum of #{max} Snapshots"
         @showNotification msg, 'error'
         @addNewButton.hideLoader()
+
         return
 
       # Assign the no-line class if the itemCount is 0. Note that this

--- a/client/app/lib/providers/machinesettingssnapshotsview.coffee
+++ b/client/app/lib/providers/machinesettingssnapshotsview.coffee
@@ -3,6 +3,7 @@ Encoder                   = require 'htmlencode'
 kd                        = require 'kd'
 remote                    = require('app/remote').getInstance()
 
+ComputeErrorUsageModal    = require './computeerrorusagemodal'
 MachineSettingsCommonView = require './machinesettingscommonview'
 SnapshotListItem          = require './snapshotlistitem'
 snapshotHelpers           = require './snapshothelpers'
@@ -151,6 +152,15 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
   ###
   showAddView: ->
     @isWithinSnapshotLimit (err, isWithin, current, max) =>
+      # If the max is 0, the user has no allotted snapshots (free plan)
+      if max is 0
+        new ComputeErrorUsageModal
+          plan    : 'free'
+          message : 'VM share feature is only available for paid accounts.'
+
+        return @emit 'ModalDestroyRequested'
+
+
       kd.warn err  if err
       if not isWithin
         msg = "Your current plan allows for a maximum of #{max} Snapshots"

--- a/client/app/lib/providers/machinesettingssnapshotsview.coffee
+++ b/client/app/lib/providers/machinesettingssnapshotsview.coffee
@@ -30,7 +30,7 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
     super options, data
 
     @listController.getListView().on 'DeleteSnapshot', =>
-      @listController.noItemView.show()  if @listController.getItemCount() is 0
+      @listController.showNoItemWidget()
 
 
   ###*
@@ -132,7 +132,7 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
 
     super
 
-    @listController.noItemView.show()  if @listController.getItemCount() is 0
+    @listController.showNoItemWidget()
 
 
   ###*
@@ -186,7 +186,7 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
 
         return
 
-      @listController.noItemView.hide() if @listController.getItemCount() is 0
+      @listController.hideNoItemWidget()
 
       @headerAddNewButton.hide()
       @addViewContainer.show()

--- a/client/app/lib/providers/snapshotlistitem.coffee
+++ b/client/app/lib/providers/snapshotlistitem.coffee
@@ -141,8 +141,8 @@ module.exports = class SnapshotListItem extends kd.ListItemView
     kloud.deleteSnapshot {machineId, snapshotId}
       .then =>
         listView = @getDelegate()
-        listView.emit 'DeleteSnapshot', this
         listView.removeItem this
+        listView.emit 'DeleteSnapshot', this
       .catch (err) -> kd.warn err
 
 

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -2196,6 +2196,14 @@ paymentGrayLighter  = #f8f8f8
   margin-top                -1px !important
 
 
+.machine-settings-modal .snapshots
+  .no-item
+    margin-top              30px
+    color                   #a1a1a1
+    text-align              center
+    font-size               14px
+
+
 .machine-settings-modal .snapshots .add-view
   height                    45px
   line-height               45px

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -2220,6 +2220,9 @@ paymentGrayLighter  = #f8f8f8
     top                     -2px
     margin-right            8px
 
+  &.no-line
+    border-bottom           none
+
 
 .machine-settings-modal .snapshots .snapshot .info
   &:hover .buttons

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -2220,9 +2220,6 @@ paymentGrayLighter  = #f8f8f8
     top                     -2px
     margin-right            8px
 
-  &.no-line
-    border-bottom           none
-
 
 .machine-settings-modal .snapshots .snapshot .info
   &:hover .buttons


### PR DESCRIPTION
After the meeting last night _(affecting free user's & snapshots)_, a ux change was suggested for free users. This PR changes the following:
1. When a free user clicks the add snapshot button, they are presented with the same modal type as the VM Share page. Video: http://take.ms/hCvFg
2. A message is displayed when no snapshots are created. This toggles on/off whenever you open the add input view, and when you delete your last vm. This is also consistent with the VM Share UX. Image: http://take.ms/kV7Hf

cc @sinan 
