### PR TITLE
app: add close/fullscreen handles to ActivityTabHandleHolder

### DIFF
--- a/client/app/lib/commonviews/applicationview/applicationtabhandleholder.coffee
+++ b/client/app/lib/commonviews/applicationview/applicationtabhandleholder.coffee
@@ -7,17 +7,27 @@ module.exports = class ApplicationTabHandleHolder extends KDView
 
   constructor: (options = {}, data) ->
 
-    options.cssClass        = kd.utils.curry "application-tab-handle-holder", options.cssClass
-    options.bind            = "mouseenter mouseleave"
-    options.addPlusHandle  ?= yes
+    options.cssClass            = kd.utils.curry "application-tab-handle-holder", options.cssClass
+    options.bind                = "mouseenter mouseleave"
+    options.addPlusHandle      ?= yes
+    options.addCloseHandle     ?= yes
+    options.addFullscrenHandle ?= yes
 
     super options, data
 
     @tabs = new KDCustomHTMLView cssClass: 'kdtabhandle-tabs clearfix'
 
+    @generalHandlesContainer = new KDCustomHTMLView { cssClass: 'general-handles' }
+
   viewAppended: ->
     @addSubView @tabs
+    @addSubView @generalHandlesContainer
+
     @addPlusHandle()  if @getOptions().addPlusHandle
+
+    @addFullscrenHandle()  if @getOptions().addFullscrenHandle
+    @addCloseHandle()  if @getOptions().addCloseHandle
+
 
   addPlusHandle: ->
     @plusHandle?.destroy()
@@ -27,6 +37,39 @@ module.exports = class ApplicationTabHandleHolder extends KDView
       partial  : "<span class='icon'></span>"
       delegate : this
       click    : => @getDelegate()?.emit "PlusHandleClicked"
+
+
+  addCloseHandle: ->
+    @closeHandle?.destroy()
+
+    @generalHandlesContainer.addSubView @closeHandle = new KDCustomHTMLView
+      cssClass : "kdtabhandle visible-tab-handle close-handle"
+      partial  : "<span class='icon'></span>"
+      delegate : this
+      click    : => @getDelegate()?.emit 'CloseHandleClicked'
+
+
+  addFullscrenHandle: ->
+    @fullscreenHandle?.destroy()
+
+    @generalHandlesContainer.addSubView @fullscreenHandle = new KDCustomHTMLView
+      cssClass : "kdtabhandle visible-tab-handle fullscreen-handle"
+      partial  : "<span class='icon'></span>"
+      delegate : this
+      click    : => @getDelegate()?.emit 'FullscreenHandleClicked'
+
+
+  showCloseHandle: -> @closeHandle?.show()
+
+
+  hideCloseHandle: -> @closeHandle?.hide()
+
+
+  setFullscreenHandleState: (isFullScreen) ->
+
+    if isFullScreen
+    then @fullscreenHandle.setClass 'shrink'
+    else @fullscreenHandle.unsetClass 'shrink'
 
 
   repositionPlusHandle: (handles) ->


### PR DESCRIPTION
![opacityli-close-fullscreen-ide](https://cloud.githubusercontent.com/assets/1783869/7425263/99e877d2-ef62-11e4-8dfe-caa0f9b85482.gif)

prerequisite: koding/ide#359
