### PR TITLE
Remove redundant npm dependency check

### DIFF
--- a/scripts/install-npm.sh
+++ b/scripts/install-npm.sh
@@ -13,14 +13,6 @@ install()
     WORKING_DIR=$(basename $(pwd))
   fi
 
-  echo -e "\033[0;32m${WORKING_DIR}\033[0m: verifying npm dependencies"
-  npm ls > /dev/null 2>&1
-
-  if [ $? -eq 0 ]; then
-    exit 0
-  fi
-
-  echo -e "\033[0;33m${WORKING_DIR}\033[0m: installing npm dependencies"
   npm install $NPM_ARGS
 }
 


### PR DESCRIPTION
`npm` commands other than `install` can't detect outdated dependencies out of `npm` registry (e.g. git repositories). Hence, prevents updating modules to newer versions.
