### PR TITLE
added support for pascal syntax highlighting

### DIFF
--- a/client/ace/lib/settings-syntax-associations.coffee
+++ b/client/ace/lib/settings-syntax-associations.coffee
@@ -33,6 +33,7 @@
     makefile    : ["MAKEFILE"     , "makefile"]
     markdown    : ["Markdown"     , "md|markdown"]
     ocaml       : ["OCaml"        , "ml|mli"]
+    pascal      : ["Pascal"       , "pas|pp"]
     perl        : ["Perl"         , "pl|pm"]
     pgsql       : ["pgSQL"        , "pgsql"]
     php         : ["PHP"          , "php|phtml"]

--- a/client/ace/lib/settings.coffee
+++ b/client/ace/lib/settings.coffee
@@ -105,32 +105,33 @@ module.exports =
   aceToHighlightJsSyntaxMap :
 
     coffee      : "coffee"
-    # coldfusion  : null
+    # coldfusion: null
     csharp      : "cs"
     css         : "css"
     diff        : "diff"
     dart        : "dart"
     golang      : "go"
-    # groovy      : null
-    # haxe        : null
+    # groovy    : null
+    # haxe      : null
     haml        : "haml"
     html        : "xml"
     c_cpp       : "cpp"
-    # clojure     : null
+    # clojure   : null
     jade        : "jade"
     java        : "java"
     javascript  : "javascript"
     json        : "javascript"
-    # json        : "json"
+    # json      : "json"
     latex       : "tex"
     go          : "golang"
     less        : "css"
     lisp        : "lisp"
     livescript  : "ls"
-    # liquid      : null
+    # liquid    : null
     lua         : "lua"
     markdown    : "markdown"
     ocaml       : "ocaml"
+    pascal      : "pascal"
     perl        : "perl"
     pgsql       : "sql"
     php         : "php"
@@ -139,17 +140,17 @@ module.exports =
     r           : "r"
     rhtml       : "rhtml"
     ruby        : "ruby"
-    # scad        : null
+    # scad      : null
     scala       : "scala"
     scss        : "css"
     stylus      : "stylus"
     sh          : "bash"
     sql         : "sql"
     typescript  : "ts"
-    # svg         : null
-    # text        : null
-    # textile     : null
+    # svg       : null
+    # text      : null
+    # textile   : null
     xml         : "xml"
     objectivec  : "objectivec"
-    # xquery      : null
-    # yaml        : null
+    # xquery    : null
+    # yaml      : null


### PR DESCRIPTION
@szkl there's no way for me to test this since I don't have a runnable version of Koding on my VM. can you give this a shot and see if it works? You should be able to save the code below as a .pas file and open in IDE and it should highlight automatically.

``` pascal
program caseRepeat(input, output);

var
   number: integer;

begin
  repeat 
     writeln('Enter year number, between 1 and 5, negative number to finish:');
     read(number);
     if (number >= 1) and (number <= 5) then begin
       case number of
         1: writeln("First year student");
         2: writeln("Sophomore");
         3: writeln("Junior");
         4: writeln("Senior");
         5: begin
              writeln("Congratulations, you have graduated ... ");
              writeln("Graduate student???");
            end
       end
     end
  until number < 0
end.
```
