### PR TITLE
social: send welcome email after signup, not after email is confirmed

### DIFF
--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -1115,8 +1115,15 @@ module.exports = class JUser extends jraphical.Module
         queue.next()
 
       ->
-        # rest are 3rd party api calls, not important to block register
+        # don't block register
 
+        {username, email} = user
+        subject           = Email.types.WELCOME
+        Email.queue username, { to : email, subject }, {}, ->
+
+        queue.next()
+
+      ->
         SiftScience = require "../siftscience"
         SiftScience.createAccount client, referrer, ->
 
@@ -1307,13 +1314,13 @@ module.exports = class JUser extends jraphical.Module
       if err then callback err
       else account.fetchHomepageView options, callback
 
+
   confirmEmail: (callback)->
     @update {$set: status: 'confirmed'}, (err, res)=>
       return callback err if err
       JUser.emit "EmailConfirmed", @
 
-      subject = Email.types.WELCOME
-      Email.queue @username, { to : @email, subject }, {}, callback
+      callback null
 
 
   block:(blockedUntil, callback)->


### PR DESCRIPTION
Too many users ask questions which are answered in welcome email; user confirm email has 60% open rate, welcome email has 40% open rate. We think moving this email ahead will decrease number of questions.
