### PR TITLE
modelhelper: add new helpers, close mongodb#iter when done

### DIFF
--- a/go/src/koding/db/mongodb/modelhelper/accounts.go
+++ b/go/src/koding/db/mongodb/modelhelper/accounts.go
@@ -55,8 +55,7 @@ func RemoveAccountByUsername(username string) error {
 	selector := bson.M{"profile": bson.M{"nickname": username}}
 
 	query := func(c *mgo.Collection) error {
-		err := c.Remove(selector)
-		return err
+		return c.Remove(selector)
 	}
 
 	return Mongo.Run(AccountsColl, query)

--- a/go/src/koding/db/mongodb/modelhelper/accounts.go
+++ b/go/src/koding/db/mongodb/modelhelper/accounts.go
@@ -51,6 +51,28 @@ func RemoveAccount(id bson.ObjectId) error {
 	return RemoveDocument(AccountsColl, id)
 }
 
+func RemoveAccountByUsername(username string) error {
+	selector := bson.M{"profile": bson.M{"nickname": username}}
+
+	query := func(c *mgo.Collection) error {
+		err := c.Remove(selector)
+		return err
+	}
+
+	return Mongo.Run(AccountsColl, query)
+}
+
+func RemoveAllAccountByUsername(username string) error {
+	selector := bson.M{"profile": bson.M{"nickname": username}}
+
+	query := func(c *mgo.Collection) error {
+		_, err := c.RemoveAll(selector)
+		return err
+	}
+
+	return Mongo.Run(AccountsColl, query)
+}
+
 func CreateAccount(a *models.Account) error {
 	query := insertQuery(a)
 	return Mongo.Run(AccountsColl, query)

--- a/go/src/koding/db/mongodb/modelhelper/domain.go
+++ b/go/src/koding/db/mongodb/modelhelper/domain.go
@@ -133,7 +133,7 @@ func GetDomains() []models.Domain {
 			domains = append(domains, domain)
 		}
 
-		return nil
+		return iter.Close()
 	}
 
 	Mongo.Run("jDomains", query)

--- a/go/src/koding/db/mongodb/modelhelper/kontrolclients.go
+++ b/go/src/koding/db/mongodb/modelhelper/kontrolclients.go
@@ -42,7 +42,7 @@ func GetClients() []models.ServerInfo {
 		for iter.Next(&info) {
 			infos = append(infos, info)
 		}
-		return nil
+		return iter.Close()
 	}
 
 	Mongo.Run("jKontrolClients", query)

--- a/go/src/koding/db/mongodb/modelhelper/machine.go
+++ b/go/src/koding/db/mongodb/modelhelper/machine.go
@@ -20,7 +20,7 @@ type MachineContainer struct {
 }
 
 var (
-	MachineColl            = "jMachines"
+	MachinesColl           = "jMachines"
 	MachineConstructorName = "JMachine"
 )
 
@@ -31,7 +31,7 @@ func GetMachines(userId bson.ObjectId) ([]*MachineContainer, error) {
 		return c.Find(bson.M{"users.id": userId}).All(&machines)
 	}
 
-	err := Mongo.Run(MachineColl, query)
+	err := Mongo.Run(MachinesColl, query)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func GetMachineByUid(uid string) (*models.Machine, error) {
 		return c.Find(bson.M{"uid": uid}).One(machine)
 	}
 
-	err := Mongo.Run(MachineColl, query)
+	err := Mongo.Run(MachinesColl, query)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +159,7 @@ func UnshareMachineByUid(uid string) error {
 		return c.Update(s, o)
 	}
 
-	return Mongo.Run(MachineColl, query)
+	return Mongo.Run(MachinesColl, query)
 }
 
 // RemoveUsersFromMachineByIds removes the given users from JMachine document
@@ -195,7 +195,7 @@ func RemoveUsersFromMachineByIds(uid string, ids []bson.ObjectId) error {
 		return c.Update(s, o)
 	}
 
-	return Mongo.Run(MachineColl, query)
+	return Mongo.Run(MachinesColl, query)
 }
 
 func findMachine(query bson.M) ([]*models.Machine, error) {
@@ -215,7 +215,7 @@ func findMachine(query bson.M) ([]*models.Machine, error) {
 		return iter.Close()
 	}
 
-	if err := Mongo.Run(MachineColl, queryFn); err != nil {
+	if err := Mongo.Run(MachinesColl, queryFn); err != nil {
 		return nil, err
 	}
 
@@ -230,7 +230,7 @@ func UpdateMachineAlwaysOn(machineId bson.ObjectId, alwaysOn bool) error {
 		)
 	}
 
-	return Mongo.Run(MachineColl, query)
+	return Mongo.Run(MachinesColl, query)
 }
 
 func CreateMachine(m *models.Machine) error {
@@ -238,7 +238,7 @@ func CreateMachine(m *models.Machine) error {
 		return c.Insert(m)
 	}
 
-	return Mongo.Run(MachineColl, query)
+	return Mongo.Run(MachinesColl, query)
 }
 
 // DeleteMachine deletes the machine from mongodb, it is here just for cleaning
@@ -251,5 +251,24 @@ func DeleteMachine(id bson.ObjectId) error {
 		return c.Remove(selector)
 	}
 
-	return Mongo.Run(MachineColl, query)
+	return Mongo.Run(MachinesColl, query)
+}
+
+func CreateMachineForUser(m *models.Machine, u *models.User) error {
+	m.Users = []models.MachineUser{
+		models.MachineUser{Id: u.ObjectId, Sudo: true, Owner: true},
+	}
+
+	return CreateMachine(m)
+}
+
+func RemoveAllMachinesForUser(userId bson.ObjectId) error {
+	selector := bson.M{"users": bson.M{"id": userId}}
+
+	query := func(c *mgo.Collection) error {
+		_, err := c.RemoveAll(selector)
+		return err
+	}
+
+	return Mongo.Run(MachinesColl, query)
 }

--- a/go/src/koding/db/mongodb/modelhelper/modeltesthelper/user.go
+++ b/go/src/koding/db/mongodb/modelhelper/modeltesthelper/user.go
@@ -13,18 +13,23 @@ func CreateUser(username string) (*models.User, *models.Account, error) {
 		ObjectId: bson.NewObjectId(), Name: username,
 	}
 
+	account, err := CreateUserWithQuery(user)
+	return user, account, err
+}
+
+func CreateUserWithQuery(user *models.User) (*models.Account, error) {
 	userQuery := func(c *mgo.Collection) error {
 		return c.Insert(user)
 	}
 
 	err := modelhelper.Mongo.Run(modelhelper.UserColl, userQuery)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	account := &models.Account{
 		Id:      bson.NewObjectId(),
-		Profile: models.AccountProfile{Nickname: username},
+		Profile: models.AccountProfile{Nickname: user.Name},
 	}
 
 	accQuery := func(c *mgo.Collection) error {
@@ -33,10 +38,10 @@ func CreateUser(username string) (*models.User, *models.Account, error) {
 
 	err = modelhelper.Mongo.Run(modelhelper.AccountsColl, accQuery)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return user, account, nil
+	return account, nil
 }
 
 func DeleteUser(userId bson.ObjectId) error {
@@ -96,5 +101,5 @@ func DeleteUsersAndMachines(username string) error {
 		return err
 	}
 
-	return modelhelper.Mongo.Run(modelhelper.MachineColl, deleteQuery)
+	return modelhelper.Mongo.Run(modelhelper.MachinesColl, deleteQuery)
 }

--- a/go/src/koding/db/mongodb/modelhelper/modeltesthelper/user_machines.go
+++ b/go/src/koding/db/mongodb/modelhelper/modeltesthelper/user_machines.go
@@ -32,7 +32,7 @@ func DeleteMachine(id bson.ObjectId) error {
 		return c.Remove(bson.M{"_id": id})
 	}
 
-	return modelhelper.Mongo.Run(modelhelper.MachineColl, deleteQuery)
+	return modelhelper.Mongo.Run(modelhelper.MachinesColl, deleteQuery)
 }
 
 func CreateMachineForUser(userId bson.ObjectId) (*models.Machine, error) {
@@ -52,7 +52,7 @@ func ShareMachineWithUser(machineId, userId bson.ObjectId, p bool) error {
 		return c.Update(selector, updateQuery)
 	}
 
-	return modelhelper.Mongo.Run(modelhelper.MachineColl, query)
+	return modelhelper.Mongo.Run(modelhelper.MachinesColl, query)
 }
 
 func createMachine(machineUser models.MachineUser) (*models.Machine, error) {
@@ -66,7 +66,7 @@ func createMachine(machineUser models.MachineUser) (*models.Machine, error) {
 		return c.Insert(machine)
 	}
 
-	err := modelhelper.Mongo.Run(modelhelper.MachineColl, insertQuery)
+	err := modelhelper.Mongo.Run(modelhelper.MachinesColl, insertQuery)
 	if err != nil {
 		return nil, err
 	}

--- a/go/src/koding/db/mongodb/modelhelper/proxy.go
+++ b/go/src/koding/db/mongodb/modelhelper/proxy.go
@@ -55,7 +55,7 @@ func GetProxies() []models.Proxy {
 			proxies = append(proxies, proxy)
 		}
 
-		return nil
+		return iter.Close()
 	}
 
 	Mongo.Run("jProxies", query)

--- a/go/src/koding/db/mongodb/modelhelper/services.go
+++ b/go/src/koding/db/mongodb/modelhelper/services.go
@@ -42,7 +42,7 @@ func GetServices() []models.Service {
 		for iter.Next(&service) {
 			services = append(services, service)
 		}
-		return nil
+		return iter.Close()
 	}
 
 	Mongo.Run("jProxyServices", query)

--- a/go/src/koding/db/mongodb/modelhelper/stats.go
+++ b/go/src/koding/db/mongodb/modelhelper/stats.go
@@ -118,7 +118,7 @@ func GetDomainStats() []models.DomainStat {
 			domainstats = append(domainstats, domainstat)
 		}
 
-		return nil
+		return iter.Close()
 	}
 
 	Mongo.Run("jDomainStats", query)
@@ -195,7 +195,7 @@ func GetProxyStats() []models.ProxyStat {
 		for iter.Next(&proxystat) {
 			proxystats = append(proxystats, proxystat)
 		}
-		return nil
+		return iter.Close()
 	}
 
 	Mongo.Run("jProxyStats", query)

--- a/go/src/koding/db/mongodb/modelhelper/user.go
+++ b/go/src/koding/db/mongodb/modelhelper/user.go
@@ -174,8 +174,7 @@ func GetUserByAccountId(id string) (*models.User, error) {
 
 func UpdateUser(selector, update bson.M) error {
 	query := func(c *mgo.Collection) error {
-		err := c.Update(selector, bson.M{"$set": update})
-		return err
+		return c.Update(selector, bson.M{"$set": update})
 	}
 
 	return Mongo.Run(UserColl, query)

--- a/go/src/koding/db/mongodb/modelhelper/vms.go
+++ b/go/src/koding/db/mongodb/modelhelper/vms.go
@@ -43,11 +43,7 @@ func GetUserVMs(username string) ([]models.VM, error) {
 			vms = append(vms, *vm)
 		}
 
-		if err := iter.Close(); err != nil {
-			return err
-		}
-
-		return nil
+		return iter.Close()
 	}
 
 	err := Mongo.Run("jVMs", query)


### PR DESCRIPTION
This is part of janitor pr. I moved all db helper functions into own pr, also fixed couple iter related bugs while I was at it.
