### PR TITLE
kloud: improve stop for better client side handling

### DIFF
--- a/go/src/koding/kites/kloud/provider/koding/queue.go
+++ b/go/src/koding/kites/kloud/provider/koding/queue.go
@@ -102,9 +102,14 @@ func (p *Provider) CheckUsage(m *Machine) error {
 		p.Unlock(m.Id.Hex())
 	}()
 
+	// mark it as stopped, so client side shouldn't ask for any eventer
+	if err := m.markAsStopped(); err != nil {
+		return err
+	}
+
 	p.Log.Info("[%s] ======> STOP started (closing inactive machine)<======", m.Id.Hex())
 	// Hasta la vista, baby!
-	return m.Stop(ctx)
+	return m.stop(ctx)
 }
 
 // FetchOne() fetches a single machine document from mongodb that meets the criterias:


### PR DESCRIPTION
We now directly mark the state as `stopped` for VM's that are stopped due to inactivity. With that, the Koding UI will not show any in progress state (such as `stopping`) when the user opens Koding.com during the time the vm was initialized to be stopped and the final state of being stopped.
