### PR TITLE
snapshots: Added a plan default, to support irregular plans

### DIFF
--- a/client/app/lib/providers/machinesettingssnapshotsview.coffee
+++ b/client/app/lib/providers/machinesettingssnapshotsview.coffee
@@ -227,8 +227,8 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
       return callback err  if err
 
       { snapshotsLimits } = MachineSettingsSnapshotsView
-      {planTitle} = subscription
-      @__snapshotsLimit = snapshotsLimits[planTitle]
+      { planTitle }       = subscription
+      @__snapshotsLimit   = snapshotsLimits[planTitle]
       unless @__snapshotsLimit?
         kd.warn "snapshotsLimit check: Plan title '#{planTitle}'
           unrecognized, using default."

--- a/client/app/lib/providers/machinesettingssnapshotsview.coffee
+++ b/client/app/lib/providers/machinesettingssnapshotsview.coffee
@@ -229,7 +229,7 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
       snapshotsLimits = MachineSettingsSnapshotsView.snapshotsLimits
       {planTitle} = subscription
       @__snapshotsLimit = snapshotsLimits[planTitle]
-      if not @__snapshotsLimit?
+      unless @__snapshotsLimit?
         kd.warn "snapshotsLimit check: Plan title '#{planTitle}'
           unrecognized, using default."
         @__snapshotsLimit =  snapshotsLimits['default']

--- a/client/app/lib/providers/machinesettingssnapshotsview.coffee
+++ b/client/app/lib/providers/machinesettingssnapshotsview.coffee
@@ -42,6 +42,7 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
    * The various snapshot total limits.
   ###
   @snapshotsLimits:
+    default      : 5
     free         : 0
     hobbyist     : 1
     developer    : 3
@@ -213,6 +214,9 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
   ###*
    * Fetch and cache the user's total snapshot limit.
    *
+   * If the user's planTitle is unrecognized, clientside will default to
+   * `snapshotsLimits['default']`, and log a warning.
+   *
    * @param {Function(err:Error, totalLimit:Number)} callback
   ###
   snapshotsLimit: (callback = kd.noop) ->
@@ -222,8 +226,13 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
     paymentController.subscriptions (err, subscription) =>
       return callback err  if err
 
+      snapshotsLimits = MachineSettingsSnapshotsView.snapshotsLimits
       {planTitle} = subscription
-      @__snapshotsLimit = MachineSettingsSnapshotsView.snapshotsLimits[planTitle]
+      @__snapshotsLimit = snapshotsLimits[planTitle]
+      if not @__snapshotsLimit?
+        kd.warn "snapshotsLimit check: Plan title '#{planTitle}'
+          unrecognized, using default."
+        @__snapshotsLimit =  snapshotsLimits['default']
       callback null, @__snapshotsLimit
 
 

--- a/client/app/lib/providers/machinesettingssnapshotsview.coffee
+++ b/client/app/lib/providers/machinesettingssnapshotsview.coffee
@@ -226,7 +226,7 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
     paymentController.subscriptions (err, subscription) =>
       return callback err  if err
 
-      snapshotsLimits = MachineSettingsSnapshotsView.snapshotsLimits
+      { snapshotsLimits } = MachineSettingsSnapshotsView
       {planTitle} = subscription
       @__snapshotsLimit = snapshotsLimits[planTitle]
       unless @__snapshotsLimit?

--- a/client/app/lib/providers/machinesettingssnapshotsview.coffee
+++ b/client/app/lib/providers/machinesettingssnapshotsview.coffee
@@ -232,7 +232,7 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
       unless @__snapshotsLimit?
         kd.warn "snapshotsLimit check: Plan title '#{planTitle}'
           unrecognized, using default."
-        @__snapshotsLimit =  snapshotsLimits['default']
+        @__snapshotsLimit = snapshotsLimits['default']
       callback null, @__snapshotsLimit
 
 


### PR DESCRIPTION
Note that `koding`, `super`, and other irregular plans are not hardcoded. I chose this because i believe it to be the same with other clientside hardcoded plan values (consistency). I can hardcode them all, if preferable, but i do think a fallback is needed regardless.

cc @usirin 
