### PR TITLE
vmsettings: Corrected icon to text alignment

### DIFF
--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -1794,9 +1794,13 @@ paymentGrayLighter  = #f8f8f8
   .AppModal-navItem.general
     &:before
       r-sprite              'app', 'ms-general'
+      position              relative
+      top                   -2px
 
     &.active:before
       r-sprite              'app', 'ms-general-active'
+      position              relative
+      top                   -2px
 
   .AppModal-navItem.advanced
     &:before
@@ -1836,9 +1840,13 @@ paymentGrayLighter  = #f8f8f8
   .AppModal-navItem.vm-sharing
     &:before
       r-sprite              'app', 'ms-shared-vms'
+      position              relative
+      top                   -2px
 
     &.active:before
       r-sprite              'app', 'ms-shared-vm-active'
+      position              relative
+      top                   -2px
 
   .AppModal-navItem.snapshots
     &:before

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -1794,13 +1794,11 @@ paymentGrayLighter  = #f8f8f8
   .AppModal-navItem.general
     &:before
       r-sprite              'app', 'ms-general'
-      position              relative
-      top                   -2px
+      margin-bottom         2px
 
     &.active:before
       r-sprite              'app', 'ms-general-active'
-      position              relative
-      top                   -2px
+      margin-bottom         2px
 
   .AppModal-navItem.advanced
     &:before
@@ -1840,13 +1838,11 @@ paymentGrayLighter  = #f8f8f8
   .AppModal-navItem.vm-sharing
     &:before
       r-sprite              'app', 'ms-shared-vms'
-      position              relative
-      top                   -2px
+      margin-bottom         2px
 
     &.active:before
       r-sprite              'app', 'ms-shared-vm-active'
-      position              relative
-      top                   -2px
+      margin-bottom         2px
 
   .AppModal-navItem.snapshots
     &:before


### PR DESCRIPTION
The icons for general and vm-share were not aligned correctly
(vertically, to the text). This commit moves the icons up by 2
pixels, correcting their alignment relative to the text.

Before and after: http://take.ms/qVHEpa

cc @fatihacet @sinan 
