### PR TITLE
kloud: Add new bootstrap method to bootstrap a new environment

### DIFF
--- a/go/src/koding/db/mongodb/modelhelper/credentials.go
+++ b/go/src/koding/db/mongodb/modelhelper/credentials.go
@@ -35,3 +35,9 @@ func GetCredentialDatasFromPublicKeys(publicKey ...string) ([]*models.Credential
 
 	return credentialData, nil
 }
+
+func UpdateCredentialData(publicKey string, data bson.M) error {
+	return Mongo.Run(CredentialDatasColl, func(c *mgo.Collection) error {
+		return c.Update(bson.M{"publicKey": publicKey}, data)
+	})
+}

--- a/go/src/koding/kites/kloud/kloud/authenticate.go
+++ b/go/src/koding/kites/kloud/kloud/authenticate.go
@@ -1,0 +1,11 @@
+package kloud
+
+import (
+	"errors"
+
+	"github.com/koding/kite"
+)
+
+func (k *Kloud) Authenticate(r *kite.Request) (interface{}, error) {
+	return nil, errors.New("not implemented yet")
+}

--- a/go/src/koding/kites/kloud/kloud/bootstrap.go
+++ b/go/src/koding/kites/kloud/kloud/bootstrap.go
@@ -32,6 +32,8 @@ type TerraformBootstrapRequest struct {
 	// PublicKeys contains publicKeys to be used with terraform
 	PublicKeys []string `json:"publicKeys"`
 
+	// Destroy destroys the bootstrap resource associated with the given public
+	// keys
 	Destroy bool
 }
 

--- a/go/src/koding/kites/kloud/kloud/bootstrap.go
+++ b/go/src/koding/kites/kloud/kloud/bootstrap.go
@@ -1,0 +1,240 @@
+package kloud
+
+import (
+	"encoding/json"
+	"errors"
+	"koding/kites/kloud/contexthelper/session"
+	"koding/kites/kloud/terraformer"
+	tf "koding/kites/terraformer"
+
+	"golang.org/x/net/context"
+
+	"github.com/koding/kite"
+)
+
+type TerraformBootstrapRequest struct {
+	// PublicKeys contains publicKeys to be used with terraform
+	PublicKeys []string `json:"publicKeys"`
+}
+
+func (k *Kloud) Bootstrap(r *kite.Request) (interface{}, error) {
+	if r.Args == nil {
+		return nil, NewError(ErrNoArguments)
+	}
+
+	var args *TerraformBootstrapRequest
+	if err := r.Args.One().Unmarshal(&args); err != nil {
+		return nil, err
+	}
+
+	if len(args.PublicKeys) == 0 {
+		return nil, errors.New("publicKeys are not passed")
+	}
+
+	ctx := k.ContextCreator(context.Background())
+	sess, ok := session.FromContext(ctx)
+	if !ok {
+		return nil, errors.New("session context is not passed")
+	}
+
+	creds, err := fetchCredentials(r.Username, sess.DB, args.PublicKeys)
+	if err != nil {
+		return nil, err
+	}
+
+	tfKite, err := terraformer.Connect(sess.Kite)
+	if err != nil {
+		return nil, err
+	}
+	defer tfKite.Close()
+
+	for _, cred := range creds.Creds {
+		finalBootstrap, err := appendAWSVariable(awsBootstrap, cred.Data["access_key"], cred.Data["secret_key"])
+		if err != nil {
+			return nil, err
+		}
+
+		k.Log.Debug("[%s] Final bootstrap:", cred.PublicKey)
+		k.Log.Debug(finalBootstrap)
+
+		// TODO(arslan): change this once we have group context name
+		groupName := "koding"
+
+		plan, err := tfKite.Plan(&tf.TerraformRequest{
+			Content:   finalBootstrap,
+			ContentID: groupName + "-" + cred.PublicKey,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		k.Log.Debug("[%s] Plan output:", cred.PublicKey)
+		k.Log.Debug("%v", plan)
+	}
+
+	return nil, errors.New("not implemented yet")
+}
+
+func appendAWSVariable(content, accessKey, secretKey string) (string, error) {
+	var data struct {
+		Output   map[string]map[string]interface{} `json:"output"`
+		Resource map[string]map[string]interface{} `json:"resource"`
+		Provider map[string]map[string]interface{} `json:"provider"`
+		Variable map[string]map[string]interface{} `json:"variable"`
+	}
+
+	if err := json.Unmarshal([]byte(content), &data); err != nil {
+		return "", err
+	}
+
+	data.Variable["aws_access_key"] = map[string]interface{}{
+		"default": accessKey,
+	}
+
+	data.Variable["aws_secret_key"] = map[string]interface{}{
+		"default": secretKey,
+	}
+
+	out, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	return string(out), nil
+}
+
+var awsBootstrap = `{
+    "provider": {
+        "aws": {
+            "access_key": "${var.aws_access_key}",
+            "secret_key": "${var.aws_secret_key}",
+            "region": "${var.aws_region}"
+        }
+    },
+    "output": {
+        "vpc": {
+            "value": "${aws_vpc.vpc.id}"
+        },
+        "cidr_block": {
+            "value": "${aws_vpc.vpc.cidr_block}"
+        },
+        "rtb": {
+            "value": "${aws_vpc.vpc.main_route_table_id}"
+        },
+        "acl": {
+            "value": "${aws_vpc.vpc.default_network_acl_id}"
+        },
+        "igw": {
+            "value": "${aws_internet_gateway.main_vpc_igw.id}"
+        },
+        "subnet": {
+            "value": "${aws_subnet.main_koding_subnet.id}"
+        },
+        "sg": {
+            "value": "${aws_security_group.allow_all.id}"
+        },
+        "key_pair": {
+            "value": "${aws_key_pair.koding_key_pair.key_name}"
+        }
+    },
+    "resource": {
+        "aws_vpc": {
+            "vpc": {
+                "cidr_block": "${var.cidr_block}",
+                "tags": {
+                    "Name": "${var.environment_name}"
+                }
+            }
+        },
+        "aws_internet_gateway": {
+            "main_vpc_igw": {
+                "tags": {
+                    "Name": "${var.environment_name}"
+                },
+                "vpc_id": "${aws_vpc.vpc.id}"
+            }
+        },
+        "aws_subnet": {
+            "main_koding_subnet": {
+                "availability_zone": "${lookup(var.aws_availability_zones, var.aws_region)}",
+                "cidr_block": "${var.cidr_block}",
+                "map_public_ip_on_launch": true,
+                "tags": {
+                    "Name": "${var.environment_name}",
+                    "subnet": "public"
+                },
+                "vpc_id": "${aws_vpc.vpc.id}"
+            }
+        },
+        "aws_route_table": {
+            "public": {
+                "route": {
+                    "cidr_block": "0.0.0.0/0",
+                    "gateway_id": "${aws_internet_gateway.main_vpc_igw.id}"
+                },
+                "tags": {
+                    "Name": "${var.environment_name}",
+                    "routeTable": "koding",
+                    "subnet": "public"
+                },
+                "vpc_id": "${aws_vpc.vpc.id}"
+            }
+        },
+        "aws_route_table_association": {
+            "public-1": {
+                "route_table_id": "${aws_route_table.public.id}",
+                "subnet_id": "${aws_subnet.main_koding_subnet.id}"
+            }
+        },
+        "aws_security_group": {
+            "allow_all": {
+                "description": "Allow all inbound and outbound traffic",
+                "ingress": {
+                    "cidr_blocks": [
+                        "0.0.0.0/0"
+                    ],
+                    "from_port": 0,
+                    "protocol": "-1",
+                    "self": true,
+                    "to_port": 65535
+                },
+                "name": "allow_all",
+                "tags": {
+                    "Name": "${var.environment_name}"
+                },
+                "vpc_id": "${aws_vpc.vpc.id}"
+            }
+        },
+        "aws_key_pair": {
+            "koding_key_pair": {
+                "key_name": "kloud-deployment",
+                "public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYFQFq/DEN0B2YbiZqb3jr+iQphLrzW6svvBjQLUXiKA0P0NfgedvNbqqr2WQcQDKqdZQSHJPccfYYvjyy0wEwD7hq8BDkHTv83nMNxJb3hdmo/ibZmGoUBkw3K7E8fzaWzUDDNSlzBk3UrGayaaLxzOw1LhO5XUfesKNWCg4HzdzjjOklNpJ61iQP4u8JRqXJaOV5RPogHYFDlGXPOaBuDxvOZZanEgaKsfFkwEvpU0km5001XVf8spM7o8f2iEalG9CMF1UVk38/BKBngxSLRyYdP/K0ZdRBSq1syKs8/KPrDWQ6eyqG2cW6Zrb8wb2IDg7Na+PfnUlQn9S+jmF9 hello@koding.com"
+            }
+        }
+    },
+    "variable": {
+        "aws_region": {
+            "description": "Region name in which resources will be created",
+            "default": "ap-northeast-1"
+        },
+        "cidr_block": {
+            "default": "10.0.0.0/16"
+        },
+        "environment_name": {
+            "default": "Koding-Bootstrap"
+        },
+        "aws_availability_zones": {
+            "default": {
+                "ap-northeast-1": "ap-northeast-1b",
+                "ap-southeast-1": "ap-southeast-1b",
+                "ap-southeast-2": "ap-southeast-2b",
+                "eu-central-1": "eu-central-1b",
+                "eu-west-1": "eu-west-1b",
+                "sa-east-1": "sa-east-1b",
+                "us-east-1": "us-east-1b",
+                "us-west-1": "us-west-1b",
+                "us-west-2": "us-west-2b"
+            }
+        }
+    }
+}`

--- a/go/src/koding/kites/kloud/kloud/bootstrap.go
+++ b/go/src/koding/kites/kloud/kloud/bootstrap.go
@@ -3,6 +3,7 @@ package kloud
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"koding/db/mongodb/modelhelper"
 	"koding/kites/kloud/contexthelper/session"
 	"koding/kites/kloud/terraformer"
@@ -69,6 +70,11 @@ func (k *Kloud) Bootstrap(r *kite.Request) (interface{}, error) {
 	defer tfKite.Close()
 
 	for _, cred := range creds.Creds {
+		// We are going to support more providers in the future, for now only allow aws
+		if cred.Provider != "aws" {
+			return nil, fmt.Errorf("Bootstrap is only supported for 'aws' provider. Got: '%s'", cred.Provider)
+		}
+
 		finalBootstrap, err := appendAWSVariable(awsBootstrap, cred.Data["access_key"], cred.Data["secret_key"])
 		if err != nil {
 			return nil, err

--- a/go/src/koding/kites/kloud/kloud/plan.go
+++ b/go/src/koding/kites/kloud/kloud/plan.go
@@ -30,8 +30,9 @@ type terraformCredentials struct {
 }
 
 type terraformCredential struct {
-	Provider string
-	Data     map[string]string `mapstructure:"data"`
+	Provider  string
+	PublicKey string
+	Data      map[string]string `mapstructure:"data"`
 }
 
 func (k *Kloud) Plan(r *kite.Request) (interface{}, error) {
@@ -53,7 +54,6 @@ func (k *Kloud) Plan(r *kite.Request) (interface{}, error) {
 	}
 
 	ctx := k.ContextCreator(context.Background())
-
 	sess, ok := session.FromContext(ctx)
 	if !ok {
 		return nil, errors.New("session context is not passed")
@@ -171,7 +171,8 @@ func fetchCredentials(username string, db *mongodb.MongoDB, keys []string) (*ter
 		}
 
 		cred := &terraformCredential{
-			Provider: provider,
+			Provider:  provider,
+			PublicKey: data.PublicKey,
 		}
 
 		if err := mapstructure.Decode(data.Meta, &cred.Data); err != nil {

--- a/go/src/koding/kites/kloud/kloud/terraformutils.go
+++ b/go/src/koding/kites/kloud/kloud/terraformutils.go
@@ -364,7 +364,6 @@ func injectKodingData(ctx context.Context, hclContent, username string, creds *t
 
 // appendVariables appends the given key/value credentials to the hclFile (terraform) file
 func appendVariables(hclFile string, creds *terraformCredentials) (string, error) {
-
 	found := false
 	for _, cred := range creds.Creds {
 		// we only support aws for now

--- a/go/src/koding/kites/kloud/main.go
+++ b/go/src/koding/kites/kloud/main.go
@@ -259,6 +259,9 @@ func newKite(conf *Config) *kite.Kite {
 	// Machine handling methods
 	k.HandleFunc("plan", kld.Plan)
 	k.HandleFunc("apply", kld.Apply)
+	k.HandleFunc("authenticate", kld.Authenticate)
+	k.HandleFunc("bootstrap", kld.Bootstrap)
+
 	k.HandleFunc("build", kld.Build)
 	k.HandleFunc("destroy", kld.Destroy)
 	k.HandleFunc("stop", kld.Stop)

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -176,19 +176,17 @@ func TestTerraformBootstrap(t *testing.T) {
 		PublicKeys: []string{userData.CredentialPublicKey},
 	}
 
-	resp, err := remote.Tell("bootstrap", args)
+	_, err := remote.Tell("bootstrap", args)
 	if err != nil {
 		t.Error(err)
 	}
-	fmt.Printf("resp = %+v\n", resp)
 
+	// now destroy them all
 	args.Destroy = true
-	resp, err = remote.Tell("bootstrap", args)
+	_, err = remote.Tell("bootstrap", args)
 	if err != nil {
 		t.Error(err)
 	}
-
-	fmt.Printf("resp = %+v\n", resp)
 }
 
 func TestTerraformPlan(t *testing.T) {

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -146,6 +146,8 @@ func init() {
 	kld := kloudWithKodingProvider(provider)
 	kloudKite.HandleFunc("plan", kld.Plan)
 	kloudKite.HandleFunc("apply", kld.Apply)
+	kloudKite.HandleFunc("bootstrap", kld.Bootstrap)
+
 	kloudKite.HandleFunc("build", kld.Build)
 	kloudKite.HandleFunc("destroy", kld.Destroy)
 	kloudKite.HandleFunc("stop", kld.Stop)
@@ -159,6 +161,27 @@ func init() {
 
 	go kloudKite.Run()
 	<-kloudKite.ServerReadyNotify()
+}
+
+func TestTerraformBootstrap(t *testing.T) {
+	username := "testuser11"
+	userData, err := createUser(username)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	remote := userData.Remote
+
+	args := &kloud.TerraformBootstrapRequest{
+		PublicKeys: []string{userData.CredentialPublicKey},
+	}
+
+	resp, err := remote.Tell("bootstrap", args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Printf("resp = %+v\n", resp)
 }
 
 func TestTerraformPlan(t *testing.T) {

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -178,7 +178,14 @@ func TestTerraformBootstrap(t *testing.T) {
 
 	resp, err := remote.Tell("bootstrap", args)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
+	}
+	fmt.Printf("resp = %+v\n", resp)
+
+	args.Destroy = true
+	resp, err = remote.Tell("bootstrap", args)
+	if err != nil {
+		t.Error(err)
 	}
 
 	fmt.Printf("resp = %+v\n", resp)

--- a/go/src/koding/kites/kloud/terraformer/terraformer.go
+++ b/go/src/koding/kites/kloud/terraformer/terraformer.go
@@ -72,8 +72,18 @@ func (t *Terraformer) Apply(req *terraformer.TerraformRequest) (*terraform.State
 	return state, nil
 }
 
-func (t *Terraformer) Destroy() error {
-	return nil
+func (t *Terraformer) Destroy(req *terraformer.TerraformRequest) (*terraform.State, error) {
+	resp, err := t.Client.Tell("destroy", req)
+	if err != nil {
+		return nil, err
+	}
+
+	var state *terraform.State
+	if err := resp.Unmarshal(&state); err != nil {
+		return nil, err
+	}
+
+	return state, nil
 }
 
 // Ping checks if the given terraformer response with "pong" to the "ping" we send.


### PR DESCRIPTION
- A new `bootstrap` method is added to Kloud
- This new `bootstrap` method prepares the users provider environment so it's compatible with the Koding UI. This means for example it'll try to open certain ports or will upload certain ssh keys so we can connect to `klient` or ssh into the machine for debugging. We only support `aws` for now. In the future we are going to support other providers too.
- The contentId is saved as `groupname-publickey`. Publickeys are unique for each credential, so it makes sense to use them.
- Groupname is hardoced as `koding`. This will be changed once we start to receive the group name. 
- The final output is saved so kloud's `apply` can use and reference to it, example from a `jCredentialDatas` document:

![image](https://cloud.githubusercontent.com/assets/438920/7526325/483c73d6-f519-11e4-8a9d-a02b57d6123d.png)
