### PR TITLE
kloud/authenticate: add new method to validate credentials

### DIFF
--- a/go/src/koding/db/mongodb/modelhelper/credentials.go
+++ b/go/src/koding/db/mongodb/modelhelper/credentials.go
@@ -41,3 +41,9 @@ func UpdateCredentialData(publicKey string, data bson.M) error {
 		return c.Update(bson.M{"publicKey": publicKey}, data)
 	})
 }
+
+func UpdateCredential(publicKey string, data bson.M) error {
+	return Mongo.Run(CredentialsColl, func(c *mgo.Collection) error {
+		return c.Update(bson.M{"publicKey": publicKey}, data)
+	})
+}

--- a/go/src/koding/kites/kloud/kloud/authenticate.go
+++ b/go/src/koding/kites/kloud/kloud/authenticate.go
@@ -2,10 +2,75 @@ package kloud
 
 import (
 	"errors"
+	"fmt"
+	"koding/kites/kloud/contexthelper/session"
 
+	"golang.org/x/net/context"
+
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/koding/kite"
 )
 
+type AuthenticateRequest struct {
+	// PublicKeys contains publicKeys to be authenticated
+	PublicKeys []string `json:"publicKeys"`
+}
+
 func (k *Kloud) Authenticate(r *kite.Request) (interface{}, error) {
-	return nil, errors.New("not implemented yet")
+	if r.Args == nil {
+		return nil, NewError(ErrNoArguments)
+	}
+
+	var args *TerraformBootstrapRequest
+	if err := r.Args.One().Unmarshal(&args); err != nil {
+		return nil, err
+	}
+
+	if len(args.PublicKeys) == 0 {
+		return nil, errors.New("publicKeys are not passed")
+	}
+
+	ctx := k.ContextCreator(context.Background())
+	sess, ok := session.FromContext(ctx)
+	if !ok {
+		return nil, errors.New("session context is not passed")
+	}
+
+	creds, err := fetchCredentials(r.Username, sess.DB, args.PublicKeys)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, cred := range creds.Creds {
+		// We are going to support more providers in the future, for now only allow aws
+		if cred.Provider != "aws" {
+			return nil, fmt.Errorf("Bootstrap is only supported for 'aws' provider. Got: '%s'", cred.Provider)
+		}
+
+		accessKey := cred.Data["access_key"]
+		secretKey := cred.Data["secret_key"]
+		authRegion := "us-east-1"
+
+		svc := ec2.New(&aws.Config{
+			Credentials: aws.Creds(accessKey, secretKey, ""),
+			Region:      authRegion,
+		})
+
+		// We do request to fetch and describe all supported regions. This
+		// doesn't create any resources but validates the request itself before
+		// we can make a request. Also because of having dryrun enabled, we'll
+		// get no response (less network io). An erroro of tpe `DryRunOperation`
+		// means a successfull request.
+		_, err := svc.DescribeRegions(&ec2.DescribeRegionsInput{DryRun: aws.Boolean(true)})
+		if err != nil {
+			if awsError := aws.Error(err); awsError != nil {
+				if awsError.Code != "DryRunOperation" {
+					return nil, err // not authenticated
+				}
+			}
+		}
+	}
+
+	return true, nil
 }

--- a/go/src/koding/kites/kloud/kloud/authenticate.go
+++ b/go/src/koding/kites/kloud/kloud/authenticate.go
@@ -59,8 +59,7 @@ func (k *Kloud) Authenticate(r *kite.Request) (interface{}, error) {
 
 		// We do request to fetch and describe all supported regions. This
 		// doesn't create any resources but validates the request itself before
-		// we can make a request. Also because of having dryrun enabled, we'll
-		// get no response (less network io). An error means no validation.
+		// we can make a request. An error means no validation.
 		_, err := svc.DescribeRegions(&ec2.DescribeRegionsInput{})
 		if err != nil {
 			return nil, err // not authenticated

--- a/go/src/koding/kites/kloud/kloud/authenticate.go
+++ b/go/src/koding/kites/kloud/kloud/authenticate.go
@@ -60,15 +60,10 @@ func (k *Kloud) Authenticate(r *kite.Request) (interface{}, error) {
 		// We do request to fetch and describe all supported regions. This
 		// doesn't create any resources but validates the request itself before
 		// we can make a request. Also because of having dryrun enabled, we'll
-		// get no response (less network io). An erroro of tpe `DryRunOperation`
-		// means a successfull request.
-		_, err := svc.DescribeRegions(&ec2.DescribeRegionsInput{DryRun: aws.Boolean(true)})
+		// get no response (less network io). An error means no validation.
+		_, err := svc.DescribeRegions(&ec2.DescribeRegionsInput{})
 		if err != nil {
-			if awsError := aws.Error(err); awsError != nil {
-				if awsError.Code != "DryRunOperation" {
-					return nil, err // not authenticated
-				}
-			}
+			return nil, err // not authenticated
 		}
 	}
 

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -147,6 +147,7 @@ func init() {
 	kloudKite.HandleFunc("plan", kld.Plan)
 	kloudKite.HandleFunc("apply", kld.Apply)
 	kloudKite.HandleFunc("bootstrap", kld.Bootstrap)
+	kloudKite.HandleFunc("authenticate", kld.Authenticate)
 
 	kloudKite.HandleFunc("build", kld.Build)
 	kloudKite.HandleFunc("destroy", kld.Destroy)
@@ -163,6 +164,25 @@ func init() {
 	<-kloudKite.ServerReadyNotify()
 }
 
+func TestTerraformAuthenticate(t *testing.T) {
+	username := "testuser12"
+	userData, err := createUser(username)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	remote := userData.Remote
+
+	args := &kloud.AuthenticateRequest{
+		PublicKeys: []string{userData.CredentialPublicKey},
+	}
+
+	_, err = remote.Tell("authenticate", args)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func TestTerraformBootstrap(t *testing.T) {
 	username := "testuser11"
 	userData, err := createUser(username)
@@ -176,7 +196,7 @@ func TestTerraformBootstrap(t *testing.T) {
 		PublicKeys: []string{userData.CredentialPublicKey},
 	}
 
-	_, err := remote.Tell("bootstrap", args)
+	_, err = remote.Tell("bootstrap", args)
 	if err != nil {
 		t.Error(err)
 	}
@@ -706,8 +726,6 @@ resource "aws_instance" "example" {
 
 	// Get the caller
 	remote := kites[0]
-	fmt.Printf("remote = %+v\n", remote)
-	fmt.Printf("remote.Username = %+v\n", remote.Username)
 	if err := remote.Dial(); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
- A new `authenticate` method is added to validate credentials based on the sent publickeys
- Currently only `aws` provider is supported
- We do a validation based on fetching all regions. It doesn't create any resources.
- We use the new `aws-sdk-go` library, because it has support for the `DescribeRegions` API call (whereas the goamz packages doesn't have any)
