### PR TITLE
Kloud: bootstraping

### DIFF
--- a/go/src/koding/db/mongodb/modelhelper/credentials.go
+++ b/go/src/koding/db/mongodb/modelhelper/credentials.go
@@ -41,3 +41,9 @@ func UpdateCredentialData(publicKey string, data bson.M) error {
 		return c.Update(bson.M{"publicKey": publicKey}, data)
 	})
 }
+
+func UpdateCredential(publicKey string, data bson.M) error {
+	return Mongo.Run(CredentialsColl, func(c *mgo.Collection) error {
+		return c.Update(bson.M{"publicKey": publicKey}, data)
+	})
+}

--- a/go/src/koding/kites/kloud/kloud/apply.go
+++ b/go/src/koding/kites/kloud/kloud/apply.go
@@ -183,7 +183,7 @@ func apply(ctx context.Context, username, stackId string) error {
 				}
 
 				ev.Push(&eventer.Event{
-					Message:    "Building machines",
+					Message:    "Building stack",
 					Percentage: start,
 					Status:     machinestate.Building,
 				})
@@ -206,7 +206,7 @@ func apply(ctx context.Context, username, stackId string) error {
 	close(done)
 
 	ev.Push(&eventer.Event{
-		Message:    "Creating artficat",
+		Message:    "Creating artifact",
 		Percentage: 70,
 		Status:     machinestate.Building,
 	})

--- a/go/src/koding/kites/kloud/kloud/apply.go
+++ b/go/src/koding/kites/kloud/kloud/apply.go
@@ -152,9 +152,11 @@ func apply(ctx context.Context, username, stackId string) error {
 	}
 	defer tfKite.Close()
 
-	stack.Template, err = appendVariables(stack.Template, creds)
-	if err != nil {
-		return err
+	for _, cred := range creds.Creds {
+		stack.Template, err = appendAWSVariable(stack.Template, cred.Data["access_key"], cred.Data["secret_key"])
+		if err != nil {
+			return err
+		}
 	}
 
 	buildData, err := injectKodingData(ctx, stack.Template, username, creds)

--- a/go/src/koding/kites/kloud/kloud/authenticate.go
+++ b/go/src/koding/kites/kloud/kloud/authenticate.go
@@ -2,10 +2,75 @@ package kloud
 
 import (
 	"errors"
+	"fmt"
+	"koding/kites/kloud/contexthelper/session"
 
+	"golang.org/x/net/context"
+
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/ec2"
 	"github.com/koding/kite"
 )
 
+type AuthenticateRequest struct {
+	// PublicKeys contains publicKeys to be authenticated
+	PublicKeys []string `json:"publicKeys"`
+}
+
 func (k *Kloud) Authenticate(r *kite.Request) (interface{}, error) {
-	return nil, errors.New("not implemented yet")
+	if r.Args == nil {
+		return nil, NewError(ErrNoArguments)
+	}
+
+	var args *TerraformBootstrapRequest
+	if err := r.Args.One().Unmarshal(&args); err != nil {
+		return nil, err
+	}
+
+	if len(args.PublicKeys) == 0 {
+		return nil, errors.New("publicKeys are not passed")
+	}
+
+	ctx := k.ContextCreator(context.Background())
+	sess, ok := session.FromContext(ctx)
+	if !ok {
+		return nil, errors.New("session context is not passed")
+	}
+
+	creds, err := fetchCredentials(r.Username, sess.DB, args.PublicKeys)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, cred := range creds.Creds {
+		// We are going to support more providers in the future, for now only allow aws
+		if cred.Provider != "aws" {
+			return nil, fmt.Errorf("Bootstrap is only supported for 'aws' provider. Got: '%s'", cred.Provider)
+		}
+
+		accessKey := cred.Data["access_key"]
+		secretKey := cred.Data["secret_key"]
+		authRegion := "us-east-1"
+
+		svc := ec2.New(&aws.Config{
+			Credentials: aws.Creds(accessKey, secretKey, ""),
+			Region:      authRegion,
+		})
+
+		// We do request to fetch and describe all supported regions. This
+		// doesn't create any resources but validates the request itself before
+		// we can make a request. Also because of having dryrun enabled, we'll
+		// get no response (less network io). An erroro of tpe `DryRunOperation`
+		// means a successfull request.
+		_, err := svc.DescribeRegions(&ec2.DescribeRegionsInput{DryRun: aws.Boolean(true)})
+		if err != nil {
+			if awsError := aws.Error(err); awsError != nil {
+				if awsError.Code != "DryRunOperation" {
+					return nil, err // not authenticated
+				}
+			}
+		}
+	}
+
+	return true, nil
 }

--- a/go/src/koding/kites/kloud/kloud/authenticate.go
+++ b/go/src/koding/kites/kloud/kloud/authenticate.go
@@ -59,8 +59,7 @@ func (k *Kloud) Authenticate(r *kite.Request) (interface{}, error) {
 
 		// We do request to fetch and describe all supported regions. This
 		// doesn't create any resources but validates the request itself before
-		// we can make a request. Also because of having dryrun enabled, we'll
-		// get no response (less network io). An error means no validation.
+		// we can make a request. An error means no validation.
 		_, err := svc.DescribeRegions(&ec2.DescribeRegionsInput{})
 		if err != nil {
 			return nil, err // not authenticated

--- a/go/src/koding/kites/kloud/kloud/authenticate.go
+++ b/go/src/koding/kites/kloud/kloud/authenticate.go
@@ -60,15 +60,10 @@ func (k *Kloud) Authenticate(r *kite.Request) (interface{}, error) {
 		// We do request to fetch and describe all supported regions. This
 		// doesn't create any resources but validates the request itself before
 		// we can make a request. Also because of having dryrun enabled, we'll
-		// get no response (less network io). An erroro of tpe `DryRunOperation`
-		// means a successfull request.
-		_, err := svc.DescribeRegions(&ec2.DescribeRegionsInput{DryRun: aws.Boolean(true)})
+		// get no response (less network io). An error means no validation.
+		_, err := svc.DescribeRegions(&ec2.DescribeRegionsInput{})
 		if err != nil {
-			if awsError := aws.Error(err); awsError != nil {
-				if awsError.Code != "DryRunOperation" {
-					return nil, err // not authenticated
-				}
-			}
+			return nil, err // not authenticated
 		}
 	}
 

--- a/go/src/koding/kites/kloud/kloud/bootstrap.go
+++ b/go/src/koding/kites/kloud/kloud/bootstrap.go
@@ -80,8 +80,8 @@ func (k *Kloud) Bootstrap(r *kite.Request) (interface{}, error) {
 			return nil, err
 		}
 
-		k.Log.Debug("[%s] Final bootstrap:", cred.PublicKey)
-		k.Log.Debug(finalBootstrap)
+		// k.Log.Debug("[%s] Final bootstrap:", cred.PublicKey)
+		// k.Log.Debug(finalBootstrap)
 
 		// TODO(arslan): change this once we have group context name
 		groupName := "koding"
@@ -135,21 +135,25 @@ func (k *Kloud) Bootstrap(r *kite.Request) (interface{}, error) {
 
 func appendAWSVariable(content, accessKey, secretKey string) (string, error) {
 	var data struct {
-		Output   map[string]map[string]interface{} `json:"output"`
-		Resource map[string]map[string]interface{} `json:"resource"`
-		Provider map[string]map[string]interface{} `json:"provider"`
-		Variable map[string]map[string]interface{} `json:"variable"`
+		Output   map[string]map[string]interface{} `json:"output,omitempty"`
+		Resource map[string]map[string]interface{} `json:"resource,omitempty"`
+		Provider map[string]map[string]interface{} `json:"provider,omitempty"`
+		Variable map[string]map[string]interface{} `json:"variable,omitempty"`
 	}
 
 	if err := json.Unmarshal([]byte(content), &data); err != nil {
 		return "", err
 	}
 
-	data.Variable["aws_access_key"] = map[string]interface{}{
+	if data.Variable == nil {
+		data.Variable = make(map[string]map[string]interface{})
+	}
+
+	data.Variable["access_key"] = map[string]interface{}{
 		"default": accessKey,
 	}
 
-	data.Variable["aws_secret_key"] = map[string]interface{}{
+	data.Variable["secret_key"] = map[string]interface{}{
 		"default": secretKey,
 	}
 
@@ -164,8 +168,8 @@ func appendAWSVariable(content, accessKey, secretKey string) (string, error) {
 var awsBootstrap = `{
     "provider": {
         "aws": {
-            "access_key": "${var.aws_access_key}",
-            "secret_key": "${var.aws_secret_key}",
+            "access_key": "${var.access_key}",
+            "secret_key": "${var.secret_key}",
             "region": "${var.aws_region}"
         }
     },

--- a/go/src/koding/kites/kloud/kloud/plan.go
+++ b/go/src/koding/kites/kloud/kloud/plan.go
@@ -72,9 +72,11 @@ func (k *Kloud) Plan(r *kite.Request) (interface{}, error) {
 	}
 	defer tfKite.Close()
 
-	args.TerraformContext, err = appendVariables(args.TerraformContext, creds)
-	if err != nil {
-		return nil, err
+	for _, cred := range creds.Creds {
+		args.TerraformContext, err = appendAWSVariable(args.TerraformContext, cred.Data["access_key"], cred.Data["secret_key"])
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	plan, err := tfKite.Plan(&tf.TerraformRequest{

--- a/go/src/koding/kites/kloud/kloud/terraformutils.go
+++ b/go/src/koding/kites/kloud/kloud/terraformutils.go
@@ -190,15 +190,12 @@ func injectKodingData(ctx context.Context, hclContent, username string, creds *t
 		return nil, errors.New("session context is not passed")
 	}
 
-	fmt.Printf("hclContent = %+v\n", hclContent)
-
 	var awsOutput *AwsBootstrapOutput
 	for _, cred := range creds.Creds {
 		if cred.Provider != "aws" {
 			continue
 		}
 
-		fmt.Printf("cred.Data = %+v\n", cred.Data)
 		if err := mapstructure.Decode(cred.Data, &awsOutput); err != nil {
 			return nil, err
 		}

--- a/go/src/koding/kites/kloud/kloud/terraformutils.go
+++ b/go/src/koding/kites/kloud/kloud/terraformutils.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"koding/kites/kloud/api/amazon"
-	"koding/kites/kloud/contexthelper/publickeys"
 	"koding/kites/kloud/contexthelper/session"
 	"koding/kites/kloud/klient"
 	"koding/kites/kloud/userdata"
@@ -16,12 +14,11 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/fatih/structs"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/koding/kite/protocol"
-	"github.com/mitchellh/goamz/aws"
-	"github.com/mitchellh/goamz/ec2"
+	"github.com/mitchellh/mapstructure"
 	"github.com/nu7hatch/gouuid"
 )
 
@@ -176,7 +173,7 @@ func regionFromHCL(hclContent string) (string, error) {
 		}
 	}
 
-	if err := hcl.Decode(&data, hclContent); err != nil {
+	if err := json.Unmarshal([]byte(hclContent), &data); err != nil {
 		return "", err
 	}
 
@@ -193,93 +190,39 @@ func injectKodingData(ctx context.Context, hclContent, username string, creds *t
 		return nil, errors.New("session context is not passed")
 	}
 
-	keys, ok := publickeys.FromContext(ctx)
-	if !ok {
-		return nil, errors.New("public keys are not available")
-	}
+	fmt.Printf("hclContent = %+v\n", hclContent)
 
-	// for now we only support "aws", the logic below should be refactored once
-	// we support multiple providers
-	var accessKey, secretKey string
-	for _, c := range creds.Creds {
-		if c.Provider != "aws" {
+	var awsOutput *AwsBootstrapOutput
+	for _, cred := range creds.Creds {
+		if cred.Provider != "aws" {
 			continue
 		}
 
-		accessKey = c.Data["access_key"]
-		secretKey = c.Data["secret_key"]
-	}
-
-	region, err := regionFromHCL(hclContent)
-	if err != nil {
-		return nil, err
-	}
-
-	// inject our own public/private keys into the machine
-	amazonClient, err := amazon.New(
-		map[string]interface{}{
-			"key_pair":   keys.KeyName,
-			"publicKey":  keys.PublicKey,
-			"privateKey": keys.PrivateKey,
-		},
-		ec2.New(
-			aws.Auth{AccessKey: accessKey, SecretKey: secretKey},
-			aws.Regions[region],
-		))
-	if err != nil {
-		return nil, fmt.Errorf("kloud aws client err: %s", err)
-	}
-
-	subnets, err := amazonClient.ListSubnets()
-	if err != nil {
-		return nil, err
-	}
-
-	if len(subnets.Subnets) == 0 {
-		return nil, errors.New("no subnets are available")
-	}
-
-	var subnetId string
-	var vpcId string
-	for _, subnet := range subnets.Subnets {
-		if subnet.AvailableIpAddressCount == 0 {
-			continue
+		fmt.Printf("cred.Data = %+v\n", cred.Data)
+		if err := mapstructure.Decode(cred.Data, &awsOutput); err != nil {
+			return nil, err
 		}
-
-		subnetId = subnet.SubnetId
-		vpcId = subnet.VpcId
 	}
 
-	if subnetId == "" {
-		return nil, errors.New("subnetId is empty")
-	}
-
-	var groupName = "Koding-Kloud-SG"
-	sess.Log.Debug("Fetching or creating SG: %s, %s", groupName, vpcId)
-	group, err := amazonClient.CreateOrGetSecurityGroup(groupName, vpcId)
-	if err != nil {
-		return nil, err
-	}
-
-	sess.Log.Debug("first group = %+v\n", group)
-	sess.Log.Debug("vpcId = %+v\n", vpcId)
-	sess.Log.Debug("subnetId = %+v\n", subnetId)
-
-	// this will either create the "kloud-deployment" key or it will just
-	// return with a nil error (means success)
-	if _, err = amazonClient.DeployKey(); err != nil {
-		return nil, err
+	if structs.HasZero(awsOutput) {
+		return nil, fmt.Errorf("Bootstrap data is incomplete: %v", awsOutput)
 	}
 
 	var data struct {
 		Resource struct {
 			Aws_Instance map[string]map[string]interface{} `json:"aws_instance"`
 		} `json:"resource"`
-		Provider map[string]map[string]interface{} `json:"provider"`
-		Variable map[string]map[string]interface{} `json:"variable"`
+		Provider struct {
+			Aws struct {
+				Region    string `json:"region"`
+				AccessKey string `json:"access_key"`
+				SecretKey string `json:"secret_key"`
+			} `json:"aws"`
+		} `json:"provider"`
+		Variable map[string]map[string]interface{} `json:"variable,omitempty"`
 	}
 
-	if err := hcl.Decode(&data, hclContent); err != nil {
+	if err := json.Unmarshal([]byte(hclContent), &data); err != nil {
 		return nil, err
 	}
 
@@ -310,39 +253,12 @@ func injectKodingData(ctx context.Context, hclContent, username string, creds *t
 
 		kiteIds[resourceName] = kiteId
 		instance["user_data"] = string(userdata)
-		instance["key_name"] = keys.KeyName
-		instance["security_groups"] = []string{group.Id}
+		instance["key_name"] = awsOutput.KeyPair
 
-		// user has provided a custom subnet id, if this is the case, fetch the
-		// securitygroup from it.
-		if instance["subnet_id"] != nil {
-			subnetId, ok := instance["subnet_id"].(string)
-			if !ok {
-				return nil, fmt.Errorf("subnet Id should be a string, got: %v", instance["subnet_id"])
-			}
-
-			var subnet ec2.Subnet
-			found := false
-			for _, s := range subnets.Subnets {
-				if s.SubnetId == subnetId {
-					found = true
-					subnet = s
-				}
-			}
-
-			if !found {
-				return nil, fmt.Errorf("no subnet with id '%s' found", subnetId)
-			}
-
-			group, err := amazonClient.CreateOrGetSecurityGroup(groupName, subnet.VpcId)
-			if err != nil {
-				return nil, err
-			}
-
-			sess.Log.Debug("second group = %+v\n", group)
-			instance["security_groups"] = []string{group.Id}
-		} else {
-			instance["subnet_id"] = subnetId
+		// only ovveride if the user doesn't provider it's own subnet_id
+		if instance["subnet_id"] == nil {
+			instance["subnet_id"] = awsOutput.Subnet
+			instance["security_groups"] = []string{awsOutput.SG}
 		}
 
 		data.Resource.Aws_Instance[resourceName] = instance
@@ -356,37 +272,10 @@ func injectKodingData(ctx context.Context, hclContent, username string, creds *t
 	b := &buildData{
 		Template: string(out),
 		KiteIds:  kiteIds,
-		Region:   region,
+		Region:   data.Provider.Aws.Region,
 	}
 
 	return b, nil
-}
-
-// appendVariables appends the given key/value credentials to the hclFile (terraform) file
-func appendVariables(hclFile string, creds *terraformCredentials) (string, error) {
-	found := false
-	for _, cred := range creds.Creds {
-		// we only support aws for now
-		if cred.Provider != "aws" {
-			continue
-		}
-
-		found = true
-		for k, v := range cred.Data {
-			hclFile += "\n"
-			varTemplate := `
-variable "%s" {
-	default = "%s"
-}`
-			hclFile += fmt.Sprintf(varTemplate, k, v)
-		}
-	}
-
-	if !found {
-		return "", fmt.Errorf("no creds found for: %v", creds)
-	}
-
-	return hclFile, nil
 }
 
 func varsFromCredentials(creds *terraformCredentials) map[string]string {

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -147,6 +147,7 @@ func init() {
 	kloudKite.HandleFunc("plan", kld.Plan)
 	kloudKite.HandleFunc("apply", kld.Apply)
 	kloudKite.HandleFunc("bootstrap", kld.Bootstrap)
+	kloudKite.HandleFunc("authenticate", kld.Authenticate)
 
 	kloudKite.HandleFunc("build", kld.Build)
 	kloudKite.HandleFunc("destroy", kld.Destroy)
@@ -163,6 +164,25 @@ func init() {
 	<-kloudKite.ServerReadyNotify()
 }
 
+func TestTerraformAuthenticate(t *testing.T) {
+	username := "testuser12"
+	userData, err := createUser(username)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	remote := userData.Remote
+
+	args := &kloud.AuthenticateRequest{
+		PublicKeys: []string{userData.CredentialPublicKey},
+	}
+
+	_, err = remote.Tell("authenticate", args)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func TestTerraformBootstrap(t *testing.T) {
 	username := "testuser11"
 	userData, err := createUser(username)
@@ -176,7 +196,7 @@ func TestTerraformBootstrap(t *testing.T) {
 		PublicKeys: []string{userData.CredentialPublicKey},
 	}
 
-	_, err := remote.Tell("bootstrap", args)
+	_, err = remote.Tell("bootstrap", args)
 	if err != nil {
 		t.Error(err)
 	}
@@ -706,8 +726,6 @@ resource "aws_instance" "example" {
 
 	// Get the caller
 	remote := kites[0]
-	fmt.Printf("remote = %+v\n", remote)
-	fmt.Printf("remote.Username = %+v\n", remote.Username)
 	if err := remote.Dial(); err != nil {
 		log.Fatal(err)
 	}

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -181,6 +181,12 @@ func TestTerraformBootstrap(t *testing.T) {
 		t.Error(err)
 	}
 
+	// should be return true always if resource exists
+	_, err = remote.Tell("bootstrap", args)
+	if err != nil {
+		t.Error(err)
+	}
+
 	// now destroy them all
 	args.Destroy = true
 	_, err = remote.Tell("bootstrap", args)

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -176,7 +176,7 @@ func TestTerraformBootstrap(t *testing.T) {
 		PublicKeys: []string{userData.CredentialPublicKey},
 	}
 
-	_, err := remote.Tell("bootstrap", args)
+	_, err = remote.Tell("bootstrap", args)
 	if err != nil {
 		t.Error(err)
 	}
@@ -200,19 +200,21 @@ func TestTerraformPlan(t *testing.T) {
 	remote := userData.Remote
 
 	args := &kloud.TerraformPlanRequest{
-		TerraformContext: `
-provider "aws" {
-    access_key = "${var.access_key}"
-    secret_key = "${var.secret_key}"
-    region = "us-east-1"
-}
-
-resource "aws_instance" "example" {
-    ami = "ami-d05e75b8"
-    instance_type = "t2.micro"
-    subnet_id = "subnet-b47692ed"
-    tags {
-        Name = "KloudTerraform"
+		TerraformContext: `{
+    "provider": {
+        "aws": {
+            "access_key": "${var.access_key}",
+            "secret_key": "${var.secret_key}",
+            "region": "ap-northeast-1"
+        }
+    },
+    "resource": {
+        "aws_instance": {
+            "example": {
+                "instance_type": "t2.micro",
+                "ami": "ami-936d9d93"
+            }
+        }
     }
 }`,
 		PublicKeys: []string{userData.CredentialPublicKey},
@@ -255,6 +257,61 @@ func TestTerraformApply(t *testing.T) {
 	}
 
 	resp, err := remote.Tell("apply", args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var result kloud.ControlResult
+	err = resp.Unmarshal(&result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	eArgs := kloud.EventArgs([]kloud.EventArg{
+		kloud.EventArg{
+			EventId: userData.StackId,
+			Type:    "apply",
+		},
+	})
+
+	if err := listenEvent(eArgs, machinestate.Running, remote); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestTerraformStack(t *testing.T) {
+	t.Parallel()
+	username := "testuser13"
+	userData, err := createUser(username)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	remote := userData.Remote
+
+	args := &kloud.TerraformBootstrapRequest{
+		PublicKeys: []string{userData.CredentialPublicKey},
+	}
+
+	_, err = remote.Tell("bootstrap", args)
+	if err != nil {
+		t.Error(err)
+	}
+
+	defer func() {
+		// now destroy them all
+		args.Destroy = true
+		_, err = remote.Tell("bootstrap", args)
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	applyArgs := &kloud.TerraformApplyRequest{
+		StackId: userData.StackId,
+	}
+
+	resp, err := remote.Tell("apply", applyArgs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -654,18 +711,21 @@ func createUser(username string) (*singleUser, error) {
 		Id:          stackTemplateId,
 		Credentials: []string{credPublicKey},
 	}
-	stackTemplate.Template.Content = `
-provider "aws" {
-    access_key = "${var.access_key}"
-    secret_key = "${var.secret_key}"
-    region = "us-east-1"
-}
-
-resource "aws_instance" "example" {
-    ami = "ami-d05e75b8"
-    instance_type = "t2.micro"
-    tags {
-        Name = "KloudTerraform"
+	stackTemplate.Template.Content = `{
+    "provider": {
+        "aws": {
+            "access_key": "${var.access_key}",
+            "secret_key": "${var.secret_key}",
+            "region": "ap-northeast-1"
+        }
+    },
+    "resource": {
+        "aws_instance": {
+            "example": {
+                "instance_type": "t2.micro",
+                "ami": "ami-936d9d93"
+            }
+        }
     }
 }`
 

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -176,7 +176,7 @@ func TestTerraformBootstrap(t *testing.T) {
 		PublicKeys: []string{userData.CredentialPublicKey},
 	}
 
-	_, err := remote.Tell("bootstrap", args)
+	_, err = remote.Tell("bootstrap", args)
 	if err != nil {
 		t.Error(err)
 	}

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -313,7 +313,7 @@ func TestTerraformStack(t *testing.T) {
 
 	resp, err := remote.Tell("apply", applyArgs)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	var result kloud.ControlResult


### PR DESCRIPTION
# Authenticate
- A new `authenticate` method is added to validate credentials based on the sent publickeys
- Currently only `aws` provider is supported
- We do a validation based on fetching all regions. It doesn't create any resources.
- We use the new `aws-sdk-go` library, because it has support for the `DescribeRegions` API call (whereas the goamz packages doesn't have any)
# Bootstrap
- Use bootstrap resources instead of checking manually
# Apply
- Now multiple calls to bootstrap will not create resources, instead it will return a success. This makes the bootstrap method more stable.
## 

Contains:
https://github.com/koding/koding/pull/3688
https://github.com/koding/koding/pull/3689
https://github.com/koding/koding/pull/3690
