### PR TITLE
Mocha socket watcher

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -56,9 +56,12 @@
     "os": "component-os"
   },
   "devDependencies": {
+    "chokidar": "1.0.1",
     "coffee-script": "1.8.0",
+    "express": "4.12.3",
     "mocha": "2.2.4",
     "nightwatch": "0.5.36",
+    "socket.io": "1.3.5",
     "yargs": "3.5.4"
   }
 }

--- a/client/testrunner/lib/routehandler.coffee
+++ b/client/testrunner/lib/routehandler.coffee
@@ -1,7 +1,6 @@
-lazyrouter           = require 'app/lazyrouter'
-kd                   = require 'kd'
-KodingAppsController = require 'app/kodingappscontroller'
-
+lazyrouter            = require 'app/lazyrouter'
+kd                    = require 'kd'
+KodingAppsController  = require 'app/kodingappscontroller'
 RunnerSocketConnector = require './runnersocketconnector'
 
 addToHead = KodingAppsController.appendHeadElement.bind KodingAppsController
@@ -40,8 +39,7 @@ runTests = ->
   mochaContainer.id = 'mocha'
   document.body.appendChild mochaContainer
 
-  appendScripts =>
-
+  appendScripts ->
     window.socket = io "http://localhost:#{SOCKET_PORT}"
     runMocha mochaContainer, socket
 

--- a/client/testrunner/lib/routehandler.coffee
+++ b/client/testrunner/lib/routehandler.coffee
@@ -54,12 +54,15 @@ runMocha = (mochaContainer, socket) ->
 
   connector = new RunnerSocketConnector runner, socket
 
+  runner.on 'end', ->
+    connector.sendResult()
+    handleRunnerEnd mochaContainer, runner
+
   # the reporters relying on the 'start' event of mocha runner. but runner
   # instance is being created before the connector itself. we are simulating
   # the start event so that the reporters and other stuff can work as expected.
   connector.simulateRunnerStartEvent()
 
-  runner.on 'end', -> handleRunnerEnd mochaContainer, runner
 
   # server sends reload requests to re-run tests. simply refresh.
   socket.on 'reload', -> wait 50, -> window.location.reload()

--- a/client/testrunner/lib/routehandler.coffee
+++ b/client/testrunner/lib/routehandler.coffee
@@ -28,9 +28,9 @@ appendScripts = (callback) ->
     identifier : 'socket-io'
     url        : 'https://cdn.socket.io/socket.io-1.2.0.js'
 
-  addToHead 'style', cssOptions, ->
-    addToHead 'script', mochaOptions, ->
-      addToHead 'script', socketIoOptions, callback
+  addToHead 'style', cssOptions, kd.noop
+  addToHead 'script', mochaOptions, ->
+    addToHead 'script', socketIoOptions, callback
 
 
 runTests = ->

--- a/client/testrunner/lib/runnersocketconnector.coffee
+++ b/client/testrunner/lib/runnersocketconnector.coffee
@@ -1,4 +1,5 @@
-forwardEvents = require './util/forwardevents'
+forwardEvents        = require './util/forwardevents'
+BufferedEventEmitter = require './util/bufferedeventemitter'
 
 module.exports = class RunnerSocketConnector
 
@@ -6,6 +7,8 @@ module.exports = class RunnerSocketConnector
 
     @_runner = runner
     @_socket = socket
+
+    @_bufferedEmitter = new BufferedEventEmitter
 
     @connectRunnerToSocket()
 
@@ -17,7 +20,13 @@ module.exports = class RunnerSocketConnector
 
   forwardToSocket: (name, reducer) ->
 
-    forwardEvents @_runner, @_socket, name, reducer
+    forwardEvents @_runner, @_bufferedEmitter, name, reducer
+
+    # forward reduced events from buffer to socket without reducing again.
+    forwardEvents @_bufferedEmitter, @_socket, name
+
+
+  sendResult: -> @_socket.emit 'result', @_bufferedEmitter.toJSON()
 
 
   connectRunnerToSocket: ->

--- a/client/testrunner/lib/runnersocketconnector.coffee
+++ b/client/testrunner/lib/runnersocketconnector.coffee
@@ -1,0 +1,51 @@
+module.exports = class RunnerSocketConnector
+
+  constructor: (runner, socket) ->
+
+    @_runner = runner
+    @_socket = socket
+
+    @connectRunnerToSocket()
+
+
+  simulateRunnerStartEvent: ->
+
+    @_runner.$events.start.forEach (handler) -> handler?()
+
+
+  connectRunnerToSocket: ->
+
+    @_runner.on 'start', =>
+      @emitToSocket 'start'
+
+    @_runner.on 'suite', (suite) =>
+      @emitToSocket 'suite', suite.title
+
+    @_runner.on 'suite end', =>
+      @emitToSocket 'suite end'
+
+    @_runner.on 'pending', (test) =>
+      @emitToSocket 'pending', test.title
+
+    @_runner.on 'test end', (test) =>
+      @emitToSocket 'test end', test.title
+
+    @_runner.on 'end', =>
+      @emitToSocket 'end'
+
+    @_runner.on 'pass', (test) =>
+      { speed, title, duration } = test
+      slowResult = test.slow()
+      payload = JSON.stringify { speed, title, duration, slowResult }
+      @emitToSocket 'pass', payload
+
+    @_runner.on 'fail', (test, err) =>
+      { title } = test
+      fullTitleResult = test.fullTitle()
+      payload = JSON.stringify { title, err, fullTitleResult }
+      @emitToSocket 'fail', payload
+
+
+  emitToSocket: (args...) -> @_socket.emit args...
+
+

--- a/client/testrunner/lib/server/index.coffee
+++ b/client/testrunner/lib/server/index.coffee
@@ -1,0 +1,55 @@
+{ EventEmitter } = require 'events'
+chokidar         = require 'chokidar'
+path             = require 'path'
+
+app  = require('express')()
+http = require('http').Server(app)
+io   = require('socket.io')(http)
+
+SpecReporter       = require 'mocha/lib/reporters/spec'
+ServerSocketRunner = require './serversocketrunner'
+
+SOCKET_PORT = 1777
+COMPILED_PATH = path.resolve __dirname, '../../../../website/a/p/p'
+jsFiles = "#{COMPILED_PATH}/**/*.js"
+
+# For now it's a simple event emitter but it will evolve soon enough. Keeping
+# it seperate enables us to make stuff like `dispatcher.emit 'change'` to run
+# tests on every connected socket.
+dispatcher = new EventEmitter
+
+# start watching compiled js files, whenever something changes over there
+# dispatcher's gonna dispatch a change event.
+watcher = chokidar.watch jsFiles, {persistent: yes}
+watcher.on 'change', -> dispatcher.emit 'change'
+
+# connected socket registry.
+_sockets = {}
+
+# whenever a change event occurs send a reload event to all connected sockets
+# to re-run the tests.
+dispatcher.on 'change', ->
+  Object.keys(_sockets).forEach (id) -> _sockets[id].emit 'reload'
+
+# every socket connection will be wrapped by a `ServerSocketRunner` instance
+# then the `SpecReporter` (for now, it can be extended with some CLI options
+# later on) will use that runner instance to print the result coming from
+# socket to the terminal.
+io.on 'connection', (socket) ->
+
+  # create a runner for this connection
+  runner = new ServerSocketRunner socket
+
+  # connect socket runner to spec reporter
+  new SpecReporter runner
+
+  console.log 'connected', socket.id
+  _sockets[socket.id] = socket
+
+  socket.on 'disconnect', ->
+    console.log 'disconnected', socket.id
+    delete _sockets[socket.id]
+
+# start server & listening.
+http.listen SOCKET_PORT, -> console.log "Socket test runner started on port: #{SOCKET_PORT}"
+

--- a/client/testrunner/lib/server/serversocketrunner.coffee
+++ b/client/testrunner/lib/server/serversocketrunner.coffee
@@ -1,0 +1,42 @@
+{ EventEmitter } = require 'events'
+
+module.exports = class ServerSocketRunner extends EventEmitter
+
+  constructor: (socket) ->
+
+    @socket = socket
+    @bindSocketEvents()
+
+  bindSocketEvents: ->
+
+    @socket.on 'start', =>
+      @emit 'start'
+
+    @socket.on 'suite', (title) =>
+      @emit 'suite', { title }
+
+    @socket.on 'test end', (title) =>
+      @emit 'test end', { title }
+
+    @socket.on 'pass', (jsonified) =>
+      test = JSON.parse jsonified
+      test.slow = -> test.slowResult
+      @emit 'pass', test
+
+    @socket.on 'end', =>
+      @emit 'end'
+
+    @socket.on 'suite end', =>
+      @emit 'suite end'
+
+    @socket.on 'fail', (payload) =>
+
+      { title, err, fullTitleResult } = JSON.parse payload
+
+      test = { title }
+      test.fullTitle = -> fullTitleResult
+      test.err = err
+
+      @emit 'fail', test, err
+
+

--- a/client/testrunner/lib/server/serversocketrunner.coffee
+++ b/client/testrunner/lib/server/serversocketrunner.coffee
@@ -20,7 +20,7 @@ module.exports = class ServerSocketRunner extends EventEmitter
 
     # for 'suite', and 'test end' events
     # reporter waits for an object with a title property
-    @forwardFromSocket ['suite', 'test end'], (title) -> { title }
+    @forwardFromSocket ['suite', 'pending', 'test end'], (title) -> { title }
 
     @forwardFromSocket 'pass', (payload) ->
       test = JSON.parse payload

--- a/client/testrunner/lib/server/serversocketrunner.coffee
+++ b/client/testrunner/lib/server/serversocketrunner.coffee
@@ -5,16 +5,23 @@ module.exports = class ServerSocketRunner extends EventEmitter
 
   constructor: (socket) ->
 
+    super
+
     @socket = socket
+    @fakeSocket = new EventEmitter
     @bindSocketEvents()
 
 
   forwardFromSocket: (events, reducer) ->
 
-    forwardEvents @socket, this, events, reducer
+    forwardEvents @fakeSocket, this, events, reducer
 
 
   bindSocketEvents: ->
+
+    @socket.on 'result', (payload) =>
+      events = JSON.parse payload
+      events.map (e) => @fakeSocket.emit e...
 
     @forwardFromSocket ['start', 'end', 'suite end']
 

--- a/client/testrunner/lib/util/bufferedeventemitter.coffee
+++ b/client/testrunner/lib/util/bufferedeventemitter.coffee
@@ -1,0 +1,33 @@
+{ EventEmitter } = require 'events'
+
+module.exports = class BufferedEventEmitter extends EventEmitter
+
+  constructor: ->
+
+    super
+
+    @__eventQueue = []
+
+
+  emit: (args...) ->
+
+    @__eventQueue.push args
+
+
+  emitAll: ->
+
+    @__eventQueue.map (args) =>
+      EventEmitter::emit.apply this args
+
+    @__eventQueue = []
+
+
+  toJSON: ->
+
+    JSON.stringify @__eventQueue, (key, value) ->
+      if value?._afterEach? and value?._slow?
+        return undefined
+      return value
+
+
+

--- a/client/testrunner/lib/util/forwardevents.coffee
+++ b/client/testrunner/lib/util/forwardevents.coffee
@@ -1,0 +1,32 @@
+###*
+ * if reducer returns an array it will be passed as arguments to emit call. If
+ * you want to really emit an event that returns an array, return an object that
+ * wraps that array.
+ *
+ * @param {EventEmitter} from
+ * @param {EventEmitter} to
+ * @param {string|Array.<string>} events
+ * @param {function=} reducer
+###
+module.exports = forwardEvents = (from, to, events, reducer) ->
+
+  events = [events]  unless Array.isArray events
+
+  # default it to id function.
+  reducer ?= (event) -> [event]
+
+  events.map (event) ->
+    from.on event, (args...) ->
+      # pass handler args to reducer and get a new payload to be passed to emit
+      # call.
+      payload = reducer args...
+
+      # allow arbitrary results to be passed, cast them to array so that those
+      # can be expanded, this also gives a handy way to pass multiple
+      # parameters to emit call.
+      payload = [payload]  unless Array.isArray payload
+
+      to.emit event, payload...
+
+
+


### PR DESCRIPTION
This patch adds an http / socket.io server for getting output directly from the active `/TestRunner` clients. It also adds a simple file watcher that watches the compiled js files, and when there is a change it emits a `reload` event to all connected socket clients, which makes all the running clients to reloads itself, resulting in re-running all the tests, and then all cycle restarts, tests run on the browsers, emits all the events to server through socket, and reporter instances bound on each socket on server prints the test result on console.

P.S: with this patch we can run all tests in various different devices (ipads, iphones, macs, windows etc.) simultaneously (as long as a browser can connect to the test runner url, that device will automatically be a part of the process[*]).

[*]: This requires a simple change on client socket connection url.

Mocha Spec Reporter: https://github.com/mochajs/mocha/blob/master/lib/reporters/spec.js

/cc @szkl @sinan @gokmen @fatihacet 
