### PR TITLE
social: only confirm emails whose user status is 'unconfirmed'

### DIFF
--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -1326,6 +1326,7 @@ module.exports = class JUser extends jraphical.Module
   confirmEmail: (callback)->
 
     if (@getAt 'status') isnt 'unconfirmed'
+      console.log "ALERT: #{@getAt 'username'} is trying to confirm '#{@getAt 'status'}' email"
       return callback null
 
     @update {$set: status: 'confirmed'}, (err, res)=>

--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -1325,8 +1325,11 @@ module.exports = class JUser extends jraphical.Module
 
   confirmEmail: (callback)->
 
-    if (@getAt 'status') isnt 'unconfirmed'
-      console.log "ALERT: #{@getAt 'username'} is trying to confirm '#{@getAt 'status'}' email"
+    status = @getAt 'status'
+
+    # for some reason status is sometimes 'undefined', so check for that
+    if status? and status isnt 'unconfirmed'
+      console.log "ALERT: #{@getAt 'username'} is trying to confirm '#{status}' email"
       return callback null
 
     @update {$set: status: 'confirmed'}, (err, res)=>

--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -1324,6 +1324,10 @@ module.exports = class JUser extends jraphical.Module
 
 
   confirmEmail: (callback)->
+
+    if (@getAt 'status') isnt 'unconfirmed'
+      return callback null
+
     @update {$set: status: 'confirmed'}, (err, res)=>
       return callback err if err
       JUser.emit "EmailConfirmed", @


### PR DESCRIPTION
Couple users have figured out a way to unban themselves by triggering a confirm email and using the pin confirm their email. This pr should stop that happening.
