### PR TITLE
snapshots: Added defer to avoid trouble with IDE not being fully loaded

### DIFF
--- a/client/app/lib/providers/machinesettingssnapshotsview.coffee
+++ b/client/app/lib/providers/machinesettingssnapshotsview.coffee
@@ -183,7 +183,12 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
       modal = snapshotHelpers.showSnapshottingModal machine, container
 
       @on 'SnapshotProgress', modal.bound 'updatePercentage'
-      @createSnapshot label, (err, snapshot) =>
+      # Deferring here helps ensure that the IDE has made the proper
+      # calls that it needs, before we change the machine's state to
+      # Snapshotting.
+      #
+      # FIXME:
+      kd.utils.defer => @createSnapshot label, (err, snapshot) =>
         @off 'SnapshotProgress', modal.bound 'updatePercentage'
         if err
           kd.warn err

--- a/client/app/lib/util/openIdeByMachine.coffee
+++ b/client/app/lib/util/openIdeByMachine.coffee
@@ -49,7 +49,12 @@ module.exports = openIdeByMachine = (machine, callback) ->
         return callback new Error 'IDEApp being shown does not belong to
           requested machine'
 
-      return callback null, controller
+      # Remove the defer, once either MachineStateModal supports
+      # Snapshotting, or when the IDE properly emits a 'ready' event
+      # once it's *actually* fully ready.
+      #
+      # FIXME:
+      return kd.utils.defer -> callback null, controller
 
   # And now that we have subscribed to the event, fire the route.
   router.handleRoute "/IDE/#{machine.slug}"


### PR DESCRIPTION
The state immediate change was causing IDE to fail to load some
components. This is a workaround, before the proper solution of Snapshot
StateMachineModal changes can be made. At that time, IDE being ready
won't matter.

cc @usirin 
