### PR TITLE
Modal auto max height fix

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -25,7 +25,7 @@
     "kd-shim-jquery-sketchpad": "0.1.1",
     "kd-shim-jspath": "0.2.0",
     "kd-shim-sockjs-client": "0.3.4",
-    "kd.js": "1.1.2",
+    "kd.js": "1.1.3",
     "keycode": "2.0.0",
     "kite.js": "0.5.1",
     "kookies": "0.1.1",


### PR DESCRIPTION
this is a breaking change, will affect all modals. Now modals should be responsible from their own scrollable heights to avoid unwanted double scrollbars. By default it should not break anything but big modals may be retouched for small screens.

/cc @usirin @fatihacet @szkl @alex-ionochkin @gokmen 
