### PR TITLE
autocompile: fixed auto compile problem on linux for stylus files

### DIFF
--- a/client/builder/lib/index.coffee
+++ b/client/builder/lib/index.coffee
@@ -450,7 +450,7 @@ class Haydar extends events.EventEmitter
 
         onRaw = (e, file) ->
           return  unless file
-          if e is 'modified' or e is 'deleted'
+          if e in ['change','modified','deleted']
             console.log "updated #{dir}"
             start = Date.now()
             styl manifest, globs


### PR DESCRIPTION
after `make` , coffee files can be compiled when file is saved, but stylus files is not.
this code controls it  as 'modified' on mac machine ,but on linux: controlling as 'change' .
![screen shot 2015-05-13 at 5 02 17 am](https://cloud.githubusercontent.com/assets/4947983/7602478/bfbe9d54-f92d-11e4-8b83-70ab2f321fff.png)
