### PR TITLE
kdmodal title font fix, and adelleSans font.

### DIFF
--- a/client/app/lib/styl/commons/appfn.styl
+++ b/client/app/lib/styl/commons/appfn.styl
@@ -178,6 +178,8 @@ neueFamily           = 'Helvetica Neue', Helvetica, Arial, sans-serif
 proximaFamily        = 'Proxima Nova', 'Helvetica Neue', Helvetica, Arial
 openSansFamily       = 'Open Sans', 'Proxima Nova', 'Helvetica Neue', Helvetica, Arial
 adelleFamily         = 'adelle-sans', 'Adelle Sans', 'Helvetica Neue', Helvetica, Arial
+adelleSans           = 'adelle-sans', 'Adelle Sans', 'Helvetica Neue', Helvetica, Arial
+adelleSerif          = 'adelle', 'Adelle', 'Times New Roman', Georgia, serif
 monoFamily           = 'Monaco','Courier New','Courier','Andale Mono',monospace, sans-serif
 logoFamily           = 'Ubuntu','Proxima Nova', 'Helvetica Neue', Helvetica, Arial
 asapFamily           = 'Asap', 'Helvetica Neue', Helvetica, sans-serif
@@ -343,3 +345,4 @@ webfont2(family, file, weight=normal, hack-chrome-windows=false)
       @font-face
         font-family family
         src url(font-url(file + '.svg#'+ family)) format('svg')
+

--- a/client/app/lib/styl/resurrection.account.dropdown.styl
+++ b/client/app/lib/styl/resurrection.account.dropdown.styl
@@ -7,7 +7,7 @@ resurrection.account.dropdown.styl
 */
 }
 .avatararea-popup
-  font-family               adelleFamily
+  font-family               adelleSans
   bottom                    65px
   bg                        color, #F3F3F3
   z-index                   100

--- a/client/app/lib/styl/resurrection.commons.styl
+++ b/client/app/lib/styl/resurrection.commons.styl
@@ -963,6 +963,7 @@ button.app-settings-menu
 
     .title
       font-size         20px !important
+      font-family       adelleSerif
 
   .kdmodal-content
     margin              15px 0 0 0 !important

--- a/client/app/lib/styl/resurrection.commons.styl
+++ b/client/app/lib/styl/resurrection.commons.styl
@@ -937,7 +937,7 @@ button.app-settings-menu
   shadow                0 12px 19px rgba(0,0,0,.50)
   border                1px solid #979797
   position              fixed !important
-  font-family           adelleFamily
+  font-family           adelleSans
 
   .kdmodal-inner
     background          #fafafa

--- a/client/app/lib/styl/resurrection.commons.styl
+++ b/client/app/lib/styl/resurrection.commons.styl
@@ -963,7 +963,6 @@ button.app-settings-menu
 
     .title
       font-size         20px !important
-      font-family       adelleSerif
 
   .kdmodal-content
     margin              15px 0 0 0 !important
@@ -2128,6 +2127,9 @@ footer.main-footer
 
   &.kdmodal
     border                  none
+
+  .kdmodal-title span.title
+    font-family             adelleSerif
 
   .notification
     padding                 10px 20px

--- a/client/app/lib/styl/resurrection.sidebar.styl
+++ b/client/app/lib/styl/resurrection.sidebar.styl
@@ -135,7 +135,7 @@ sidebarTextShadow()
         z-index         1000
 
 .activity-sidebar
-  font-family         adelleFamily
+  font-family         adelleSans
   padding             1px 20px
   borderBox()
 
@@ -709,7 +709,7 @@ sidebarTextShadow()
 
   .avatar-area
     bg                color, #262626
-    font-family       adelleFamily
+    font-family       adelleSans
     padding           10px
     size              100% 100%
     borderBox()

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -1543,7 +1543,7 @@ paymentGrayLighter  = #f8f8f8
       margin-bottom     10px
       color             #4ea04c
       padding-bottom    10px
-      font-family       adelleFamily
+      font-family       adelleSans
 
     b
       font-weight       bold


### PR DESCRIPTION
Applied new adelleSans font to kdmodal title's, and replaced adelleFamily with adelleSans.

Note: This does not _remove_ the adelleFamily variable, because there is an IDE Style that still uses it, but this replaces all uses inside this repo.

cc @sinan 
