### PR TITLE
Send sourcemaps to Rollbar

### DIFF
--- a/.ebextensions/004_files_config_updaters.config
+++ b/.ebextensions/004_files_config_updaters.config
@@ -105,6 +105,19 @@ files:
 
       /var/app/current/scripts/announce-version
 
+  "/opt/elasticbeanstalk/hooks/appdeploy/post/05init.sh":
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      #!/bin/sh
+
+      EB_ENV_NAME=`cat /var/app/current/EB_ENV_NAME`
+      if [ "$EB_ENV_NAME" == "koding-prod" ]; then
+        cd /opt/koding
+        ./scripts/upload-sm-rollbar.sh
+      fi
+
   "/opt/elasticbeanstalk/hooks/appdeploy/post/99stop_all_services_if_proxy.sh":
     mode: "000755"
     owner: root

--- a/client/app/lib/setupanalytics.coffee
+++ b/client/app/lib/setupanalytics.coffee
@@ -2,68 +2,73 @@ isLoggedIn = require './util/isLoggedIn'
 kd = require 'kd'
 globals = require 'globals'
 
-module.exports = ->
-  return  unless analytics? and globals.config.logToExternal
+setupIdentify = ->
 
   kd.getSingleton('mainController').on 'AccountChanged', (account) ->
     return  unless isLoggedIn() and account
-
-    setupAnalyticsEvents()
     kd.utils.defer -> identifyUser account
 
-  setupAnalyticsEvents = -> setupPageAnalyticsEvent()
+identifyUser = (account)->
 
-  setupPageAnalyticsEvent = ->
+  {_id, meta, profile} = account
+  return  unless profile
 
-    kd.singletons.router.on 'RouteInfoHandled', (args) ->
-      {path} = args
-      return  unless path
+  remote = require('app/remote').getInstance()
+  remote.api.JUser.fetchUser (err, user)->
+    return  if err or not user
 
-      title = getFirstPartOfpath(path)
-      analytics.page(title, {title:document.title, path})
+    {firstName, lastName, nickname} = profile
+    {email, lastLoginDate, status, emailFrequency, foreignAuth, sshKeys} = user
 
-  identifyUser = (account)->
-    {_id, meta, profile} = account
-    return  unless profile
+    # only care about existence of 3rd party auth, not the values
+    providers = {}
+    if foreignAuth
+      for own provider, providerInfo of foreignAuth
+        # check if values isn't empty object
+        providers[provider] = yes  if Object.keys(providerInfo).length > 0
 
-    remote = require('app/remote').getInstance()
-    remote.api.JUser.fetchUser (err, user)->
-      return  if err or not user
+    kd.singletons.paymentController.subscriptions (err, currentSub) ->
+      plan = "error fetching plan" if err
+      args =
+        "$id"          : _id
+        "$username"    : nickname
+        "$first_name"  : firstName
+        "$last_name"   : lastName
+        "$created"     : meta?.createdAt
+        "$email"       : email
+        subscription   : currentSub
+        lastLoginDate  : lastLoginDate
+        status         : status
+        emailFrequency :
+          marketing    : emailFrequency?.marketing
+          global       : emailFrequency?.global
+        foreignAuth    : providers      if Object.keys(providers).length > 0
+        sshKeysCount   : sshKeys.length if sshKeys?.length > 0
+        userAgent      : navigator.userAgent
 
-      {firstName, lastName, nickname} = profile
-      {email, lastLoginDate, status, emailFrequency, foreignAuth, sshKeys} = user
+      analytics?.identify nickname, args
 
-      # only care about existence of 3rd party auth, not the values
-      providers = {}
-      if foreignAuth
-        for own provider, providerInfo of foreignAuth
-          # check if values isn't empty object
-          providers[provider] = yes  if Object.keys(providerInfo).length > 0
+setupPageAnalyticsEvent = ->
 
-      kd.singletons.paymentController.subscriptions (err, currentSub) ->
-        plan = "error fetching plan" if err
-        args =
-          "$id"          : _id
-          "$username"    : nickname
-          "$first_name"  : firstName
-          "$last_name"   : lastName
-          "$created"     : meta?.createdAt
-          "$email"       : email
-          subscription   : currentSub
-          lastLoginDate  : lastLoginDate
-          status         : status
-          emailFrequency :
-            marketing    : emailFrequency?.marketing
-            global       : emailFrequency?.global
-          foreignAuth    : providers      if Object.keys(providers).length > 0
-          sshKeysCount   : sshKeys.length if sshKeys?.length > 0
-          userAgent      : navigator.userAgent
+  kd.singletons.router.on 'RouteInfoHandled', (args) ->
+    {path} = args
+    return  unless path
 
-        analytics?.identify nickname, args
+    title = getFirstPartOfpath(path)
+    analytics?.page(title, {title:document.title, path})
 
-        path  = window.location.pathname
-        title = getFirstPartOfpath(path)
-        analytics?.page(title, {title:document.title, path})
+getFirstPartOfpath = (path) -> return path.split("/")[1] or path
 
-  getFirstPartOfpath = (path) -> return path.split("/")[1] or path
+setupRollbar = ->
 
+  Rollbar?.configure
+    payload: client: javascript:
+      source_map_enabled: true
+      code_version: globals.config.version
+      guess_uncaught_frames: true
+
+module.exports = ->
+
+  setupIdentify()
+  setupPageAnalyticsEvent()
+  setupRollbar()

--- a/client/builder/lib/index.coffee
+++ b/client/builder/lib/index.coffee
@@ -28,6 +28,8 @@ concat        = require 'gulp-concat'
 throttle      = require 'throttleit'
 child_process = require 'child_process'
 collapse      = require 'bundle-collapser/plugin'
+convert       = require 'convert-source-map'
+
 
 JS_OUTFILE                  = 'bundle.js'
 THIRDPARTY_OUTDIR           = 'thirdparty'
@@ -313,7 +315,9 @@ class Haydar extends events.EventEmitter
 
           if opts.extractJsSourcemaps
             s = fs.createWriteStream outfile
-            asStream(src).pipe(exorcist(opts.jsSourcemapsOutfile)).pipe(s)
+            asStream(src).pipe(exorcist(opts.jsSourcemapsOutfile)).pipe(
+              asStream(convert.removeMapFileComments(src.toString()))
+            ).pipe(s)
 
             s.once 'finish', ->
               secs = ((Date.now() - start)/1000).toFixed 2

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
     "bongo-client": "git+ssh://git@github.com:koding/bongo-client#v0.2.4",
     "broker-client": "git+ssh://git@github.com:koding/broker-client#v0.3.1",
     "component-os": "0.0.1",
+    "convert-source-map": "1.1.0",
     "dateformat": "1.0.11",
     "emojify.js": "0.9.5",
     "geopattern": "1.2.3",

--- a/go/src/koding/go-webserver/templates/loggedin.go
+++ b/go/src/koding/go-webserver/templates/loggedin.go
@@ -13,6 +13,8 @@ var LoggedInHome = `
   <body class='logged-in dark ide'>
     <!--[if IE]><script>(function(){window.location.href='/unsupported.html'})();</script><![endif]-->
 
+    {{template "analytics" }}
+
     <script>
       var _globals = {
         config: {{.Runtime}},
@@ -38,8 +40,6 @@ var LoggedInHome = `
         h=d.documentElement,t=setTimeout(function(){h.className=h.className.replace(/\bwf-loading\b/g,"")+" wf-inactive";},config.scriptTimeout),tk=d.createElement("script"),f=false,s=d.getElementsByTagName("script")[0],a;h.className+=" wf-loading";tk.src='//use.typekit.net/'+config.kitId+'.js';tk.async=true;tk.onload=tk.onreadystatechange=function(){a=this.readyState;if(f||a&&a!="complete"&&a!="loaded")return;f=true;clearTimeout(t);try{Typekit.load(config)}catch(e){}};s.parentNode.insertBefore(tk,s)
       })(document);
     </script>
-
-    {{template "analytics" }}
 
     {{if not .Impersonating }}
       <script type="text/javascript">

--- a/go/src/koding/go-webserver/templates/loggedout.go
+++ b/go/src/koding/go-webserver/templates/loggedout.go
@@ -12,6 +12,8 @@ var LoggedOutHome = `
   </head>
 
   <body class='home'>
+    {{template "analytics"}}
+
     <!--[if IE]><script>(function(){window.location.href='/unsupported.html'})();</script><![endif]-->
     <script src="/a/site.landing/js/libs.js?{{.Version}}"></script>
     <script src="/a/site.landing/js/kd.libs.js?{{.Version}}"></script>
@@ -28,7 +30,6 @@ var LoggedOutHome = `
       })(document);
     </script>
 
-    {{template "analytics"}}
     <a href='/Activity/Public' class="invisible" target='_self'>ACTIVITY</a>
   </body>
 </html>

--- a/scripts/upload-sm-rollbar.sh
+++ b/scripts/upload-sm-rollbar.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# This script uploads sourcemaps to rollbar.com. Sourcemaps
+# make it easier to debug client side errors that occur in
+# production.
+
+website=website/a/p/p
+rollbar_token=6b1f2079d843423fbc0037b59bd13486
+version=`cat VERSION`
+folderpath=$website/$version
+
+if [ ! -d $folderpath ]; then
+  echo "$folderpath dir doesn't exists"
+fi
+
+cd $folderpath
+for file in $(ls -l | grep ".js$" | awk '{print $9}')
+do
+  curl https://api.rollbar.com/api/1/sourcemap \
+    -F access_token=$rollbar_token\
+    -F version=$version \
+    -F minified_url=http://sandbox.koding.com/a/p/p/$version/$file \
+    -F source_map=@$file.map
+done
+
+rm -f *.map

--- a/scripts/upload-sm-rollbar.sh
+++ b/scripts/upload-sm-rollbar.sh
@@ -4,22 +4,23 @@
 # make it easier to debug client side errors that occur in
 # production.
 
-website=website/a/p/p
-rollbar_token=6b1f2079d843423fbc0037b59bd13486
-version=`cat VERSION`
-folderpath=$website/$version
+WEBSITE=$(dirname $0)/../website/a/p/p
+ROLLBAR_TOKEN=6b1f2079d843423fbc0037b59bd13486
+VERSION=`cat VERSION`
+FOLDERPATH=$WEBSITE/$VERSION
 
-if [ ! -d $folderpath ]; then
-  echo "$folderpath dir doesn't exists"
+if [ ! -d $FOLDERPATH ]; then
+  echo "ERROR: '$FOLDERPATH' dir doesn't exists...sourcemaps won't be uploaded to Rollbar"
+  exit 1
 fi
 
-cd $folderpath
+cd $FOLDERPATH
 for file in $(ls -l | grep ".js$" | awk '{print $9}')
 do
   curl https://api.rollbar.com/api/1/sourcemap \
-    -F access_token=$rollbar_token\
-    -F version=$version \
-    -F minified_url=http://sandbox.koding.com/a/p/p/$version/$file \
+    -F access_token=$ROLLBAR_TOKEN\
+    -F version=$VERSION \
+    -F minified_url=https://koding.com/a/p/p/$VERSION/$file \
     -F source_map=@$file.map
 done
 

--- a/workers/social/lib/social/render/loggedout/kodinghome.coffee
+++ b/workers/social/lib/social/render/loggedout/kodinghome.coffee
@@ -25,15 +25,7 @@ module.exports = (options, callback)->
       <link rel="stylesheet" href="/a/site.#{site}/css/main.css?#{KONFIG.version}" />
     </head>
     <body class='home'>
-
       <!--[if IE]><script>(function(){window.location.href='/unsupported.html'})();</script><![endif]-->
-
-      <script src="/a/site.#{site}/js/libs.js?#{KONFIG.version}"></script>
-      <script src="/a/site.#{site}/js/kd.libs.js?#{KONFIG.version}"></script>
-      <script src="/a/site.#{site}/js/kd.js?#{KONFIG.version}"></script>
-      <script>KD.userAccount=#{userAccount}</script>
-      <script>KD.campaignStats=#{campaignStats}</script>
-      <script src="/a/site.#{site}/js/main.js?#{KONFIG.version}"></script>
 
       <!-- SEGMENT.IO -->
       <script type="text/javascript">
@@ -46,6 +38,12 @@ module.exports = (options, callback)->
 
       #{addSiteScripts site}
 
+      <script src="/a/site.#{site}/js/libs.js?#{KONFIG.version}"></script>
+      <script src="/a/site.#{site}/js/kd.libs.js?#{KONFIG.version}"></script>
+      <script src="/a/site.#{site}/js/kd.js?#{KONFIG.version}"></script>
+      <script>KD.userAccount=#{userAccount}</script>
+      <script>KD.campaignStats=#{campaignStats}</script>
+      <script src="/a/site.#{site}/js/main.js?#{KONFIG.version}"></script>
     </body>
     </html>
     """


### PR DESCRIPTION
PR contains following:
- Load segment as 1st script, this way rollbar loads first and any load time errors are caught
- On production deploys, upload sourcemaps to rollbar
- Turn on sourcemap support in rollbar
- Remove sourcemap comments from bundle.js, so 404 for map files aren't shown anymore
