### PR TITLE
vmsettings: Fixed buttons that were incorrectly styled

### DIFF
--- a/client/app/lib/providers/machinesettingscommonview.coffee
+++ b/client/app/lib/providers/machinesettingscommonview.coffee
@@ -46,7 +46,7 @@ module.exports = class MachineSettingsCommonView extends KDView
 
     header.addSubView @headerAddNewButton = new KDButtonView
       title    : headerAddButtonTitle
-      cssClass : "solid green compact add-button #{addButtonCssClass}"
+      cssClass : "solid green small add-button #{addButtonCssClass}"
       loader   : loaderOnHeaderButton
       callback : @bound 'showAddView'
 
@@ -77,7 +77,7 @@ module.exports = class MachineSettingsCommonView extends KDView
     wrapper = new KDCustomHTMLView cssClass: 'buttons'
 
     wrapper.addSubView @addNewButton = new KDButtonView
-      cssClass : 'solid green compact add'
+      cssClass : 'solid green small add'
       loader   : yes
       title    : @getOptions().addButtonTitle
       callback : @bound 'handleAddNew'

--- a/client/app/lib/providers/machinesettingsspecsview.coffee
+++ b/client/app/lib/providers/machinesettingsspecsview.coffee
@@ -47,7 +47,7 @@ module.exports = class MachineSettingsSpecsView extends KDView
 
     wrapper.addSubView new KDButtonView
       title    : 'UPGRADE YOUR VM NOW'
-      cssClass : 'solid green compact more'
+      cssClass : 'solid green small more'
       callback : =>
         kd.singletons.router.handleRoute '/Pricing'
         @emit 'ModalDestroyRequested'

--- a/client/app/lib/providers/snapshotlistitem.coffee
+++ b/client/app/lib/providers/snapshotlistitem.coffee
@@ -56,7 +56,7 @@ module.exports = class SnapshotListItem extends kd.ListItemView
 
     @editRenameBtn = new kd.ButtonView
       title    : 'rename'
-      cssClass : 'solid green compact rename'
+      cssClass : 'solid green small rename'
       callback : @bound 'renameSnapshot'
 
     @editCancelBtn = new kd.View

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -2003,6 +2003,10 @@ paymentGrayLighter  = #f8f8f8
     text-align              center
     width                   530px
 
+    // the "upgrade your vm now" button
+    .kdbutton.more
+      padding                 0 16px
+
     p
       margin-bottom         12px
       font-size             14px
@@ -2097,6 +2101,9 @@ paymentGrayLighter  = #f8f8f8
       abs()
       top                   4px
       right                 0
+
+      .add
+        padding             0 16px
 
     .cancel
       font-size             12px
@@ -2356,6 +2363,7 @@ paymentGrayLighter  = #f8f8f8
 
   .rename
     margin-top              6px
+    padding                 0 16px
 
   .cancel
     font-size               12px


### PR DESCRIPTION
The VM Settings modal had a handful of buttons styled to `compact` rather than `small`. This has been corrected. _(I noticed it after Sinan had me fix the Snapshots buttons, for the same thing)_

Old:  http://take.ms/KQNlj
New: http://take.ms/i7mxS

cc @sinan 
