### PR TITLE
ComputeUtils::fetchUsage: do not take into account group information while checking the usage info.

### DIFF
--- a/workers/social/lib/social/models/computeproviders/computeutils.coffee
+++ b/workers/social/lib/social/models/computeproviders/computeutils.coffee
@@ -310,12 +310,11 @@ fetchUsage = (client, options, callback)->
 
   JMachine = require './machine'
 
-  { r: { group, user } } = client
-  { provider }           = options
+  { r: { user } } = client
+  { provider }    = options
 
   selector        = { provider }
   selector.users  = $elemMatch: id: user.getId(), sudo: yes, owner: yes
-  selector.groups = $elemMatch: id: group.getId()
 
   JMachine.some selector, limit: 30, (err, machines)->
 


### PR DESCRIPTION
Since we have multiple group support for now (with the Teams product) we need to make sure that usage  checkers will work globally, we also need to think that we may need to handle `koding` provider differently.
