### PR TITLE
Group creation fixes

### DIFF
--- a/client/app/lib/maincontroller/groupscontroller.coffee
+++ b/client/app/lib/maincontroller/groupscontroller.coffee
@@ -26,6 +26,7 @@ module.exports = class GroupsController extends KDController
     {entryPoint}      = globals.config
     @groups           = {}
     @currentGroupData = new GroupData
+    @currentGroupData.setGroup globals.currentGroup
 
     mainController.ready =>
       { slug } = entryPoint  if entryPoint?.type is 'group'

--- a/client/app/lib/notificationcontroller.coffee
+++ b/client/app/lib/notificationcontroller.coffee
@@ -1,6 +1,6 @@
 kookies            = require 'kookies'
-getGroup           = require './util/getGroup'
-whoami             = require './util/whoami'
+getGroup           = require 'app/util/getGroup'
+whoami             = require 'app/util/whoami'
 envDataProvider    = require 'app/userenvironmentdataprovider'
 kd                 = require 'kd'
 KDModalView        = kd.ModalView
@@ -53,8 +53,8 @@ module.exports = class NotificationController extends KDObject
         # event: "ChannelUpdateHappened"
 
         # filter notifications according to group slug
-        currentGroup = kd.singletons.groupsController.getCurrentGroup()
-        return  unless notification?.context is currentGroup.slug
+
+        return  unless notification?.context is getGroup().slug
 
         @emit 'NotificationHasArrived', notification
 

--- a/client/app/lib/notificationcontroller.coffee
+++ b/client/app/lib/notificationcontroller.coffee
@@ -46,6 +46,15 @@ module.exports = class NotificationController extends KDObject
       return kd.warn 'notification subscription error', err  if err
 
       @notificationChannel.on 'message', (notification)=>
+        # sample notification content
+        #
+        # contents: {Object}
+        # context: <groupName>
+        # event: "ChannelUpdateHappened"
+
+        # filter notifications according to group slug
+        currentGroup = kd.singletons.groupsController.getCurrentGroup()
+        return  unless notification?.context is currentGroup.slug
 
         @emit 'NotificationHasArrived', notification
 

--- a/client/app/lib/util/getGroup.coffee
+++ b/client/app/lib/util/getGroup.coffee
@@ -1,4 +1,4 @@
-globals = require 'globals'
+kd = require 'kd'
 
 module.exports = ->
-  globals.currentGroup
+  kd.singletons.groupsController.getCurrentGroup()

--- a/go/src/socialapi/Makefile
+++ b/go/src/socialapi/Makefile
@@ -361,9 +361,21 @@ testintegration:
 	@./main.test $(DBG) $(METRICS) -c $(CONFIG)
 	@rm ./main.test
 
+testrealtime:
+	@echo "$(OK_COLOR)--> realtime tests... $(NO_COLOR)"
+	@`which go` test -c workers/realtime/realtime/*.go
+	@./realtime.test $(DBG) $(METRICS) -c $(CONFIG)
+	@rm ./realtime.test
+
+	@echo "$(OK_COLOR)--> realtime model tests... $(NO_COLOR)"
+	@`which go` test -c workers/realtime/models/*.go
+	@./models.test $(DBG) $(METRICS) -c $(CONFIG)
+	@rm ./models.test
+
+
 testapi: testcollaboration testmailsender testmail testmodels testemailworker \
 	testmoderation testalgolia testtopicfeeed testnotification testtrollmode \
-	testpayment testteam testintegration
+	testpayment testteam testintegration testrealtime
 
 	@echo "$(OK_COLOR)==> Running Unit tests $(NO_COLOR)"
 
@@ -379,17 +391,10 @@ testapi: testcollaboration testmailsender testmail testmodels testemailworker \
 	@./permission.test $(DBG) $(METRICS) -c $(CONFIG)
 	@rm  ./permission.test
 
-
-
 	@echo "$(OK_COLOR)--> handler tests... $(NO_COLOR)"
 	@`which go` test -c workers/common/handler/*.go
 	@./handler.test $(DBG) $(METRICS) -c $(CONFIG)
 	@rm ./handler.test
-
-	@echo "$(OK_COLOR)--> realtime tests... $(NO_COLOR)"
-	@`which go` test -c workers/realtime/realtime/*.go
-	@./realtime.test $(DBG) $(METRICS) -c $(CONFIG)
-	@rm ./realtime.test
 
 	@echo "$(OK_COLOR)--> sitemap generator tests... $(NO_COLOR)"
 	@`which go` test -c workers/sitemap/sitemapgenerator/*.go
@@ -398,11 +403,6 @@ testapi: testcollaboration testmailsender testmail testmodels testemailworker \
 
 	@echo "$(OK_COLOR)--> sitemap model tests... $(NO_COLOR)"
 	@`which go` test workers/sitemap/models/*.go
-
-	@echo "$(OK_COLOR)--> realtime model tests... $(NO_COLOR)"
-	@`which go` test -c workers/realtime/models/*.go
-	@./models.test $(DBG) $(METRICS) -c $(CONFIG)
-	@rm ./models.test
 
 doc:
 	@for package in $(PACKAGES); \

--- a/go/src/socialapi/models/account.go
+++ b/go/src/socialapi/models/account.go
@@ -285,7 +285,6 @@ func (a *Account) CreateFollowingFeedChannel() (*Channel, error) {
 }
 
 func (a *Account) FetchFollowerChannelIds(q *request.Query) ([]int64, error) {
-
 	followerIds, err := a.FetchFollowerIds(q)
 	if err != nil {
 		return nil, err

--- a/go/src/socialapi/models/channel.go
+++ b/go/src/socialapi/models/channel.go
@@ -872,7 +872,6 @@ func (c *Channel) getAccountId() (int64, error) {
 	}
 
 	return cn.CreatorId, nil
-
 }
 
 // FetchParticipant simply fetch the participants from the channel

--- a/go/src/socialapi/models/channelmessage.go
+++ b/go/src/socialapi/models/channelmessage.go
@@ -447,7 +447,6 @@ func (c *ChannelMessage) isInChannel(query *request.Query, channelName string) (
 // dependencies of a given message. This includes interactions, optionally
 // replies, and channel message lists.
 func (c *ChannelMessage) DeleteMessageAndDependencies(deleteReplies bool) error {
-
 	// fetch interactions
 	i := NewInteraction()
 	i.MessageId = c.Id
@@ -498,7 +497,6 @@ func (c *ChannelMessage) AddReply(reply *ChannelMessage) (*MessageReply, error) 
 	}
 
 	return mr, nil
-
 }
 
 //  DeleteReplies deletes all the replies of a given ChannelMessage, one level deep

--- a/go/src/socialapi/models/channelmessagelist.go
+++ b/go/src/socialapi/models/channelmessagelist.go
@@ -56,13 +56,13 @@ func (c *ChannelMessageList) UnreadCount(cp *ChannelParticipant) (int, error) {
 
 	query := "channel_id = ? and added_at > ?"
 
-	var metaBits MetaBits
 	if isExempt {
 		query += " and meta_bits >= ?"
 	} else {
 		query += " and meta_bits = ?"
 	}
 
+	var metaBits MetaBits
 	return bongo.B.Count(c,
 		query,
 		cp.ChannelId,
@@ -111,8 +111,6 @@ func (c *ChannelMessageList) populateUnreadCount(messageList []*ChannelMessageCo
 }
 
 func (c *ChannelMessageList) getMessages(q *request.Query) ([]*ChannelMessageContainer, error) {
-	var messages []int64
-
 	if c.ChannelId == 0 {
 		return nil, ErrChannelIdIsNotSet
 	}
@@ -133,6 +131,7 @@ func (c *ChannelMessageList) getMessages(q *request.Query) ([]*ChannelMessageCon
 		bongoQuery = bongoQuery.Where("added_at < ?", q.From)
 	}
 
+	var messages []int64
 	if err := bongo.CheckErr(
 		bongoQuery.Pluck(query.Pluck, &messages),
 	); err != nil {
@@ -327,7 +326,6 @@ func (c *ChannelMessageList) isExempt() (bool, error) {
 	cm.Id = c.MessageId
 
 	return cm.isExempt()
-
 }
 
 // Count counts messages in the channel

--- a/go/src/socialapi/models/channelparticipant.go
+++ b/go/src/socialapi/models/channelparticipant.go
@@ -419,7 +419,6 @@ func (c *ChannelParticipant) FetchParticipantCount() (int, error) {
 
 // Tests are done.
 func (c *ChannelParticipant) IsParticipant(accountId int64) (bool, error) {
-
 	if accountId == 0 {
 		return false, nil
 	}

--- a/go/src/socialapi/models/messagereply.go
+++ b/go/src/socialapi/models/messagereply.go
@@ -108,8 +108,6 @@ func (m *MessageReply) ListAll() ([]ChannelMessage, error) {
 }
 
 func (m *MessageReply) fetchMessages(query *request.Query) ([]ChannelMessage, error) {
-	var replies []int64
-
 	if m.MessageId == 0 {
 		return nil, ErrMessageIdIsNotSet
 	}
@@ -130,6 +128,7 @@ func (m *MessageReply) fetchMessages(query *request.Query) ([]ChannelMessage, er
 		bongoQuery = bongoQuery.Where("created_at < ?", query.From)
 	}
 
+	var replies []int64
 	if err := bongo.CheckErr(
 		bongoQuery.Pluck(q.Pluck, &replies),
 	); err != nil {
@@ -156,13 +155,13 @@ func (m *MessageReply) UnreadCount(messageId int64, addedAt time.Time, showExemp
 
 	query := "message_id = ? and created_at > ?"
 
-	var metaBits MetaBits
 	if !showExempt {
 		query += " and meta_bits = ?"
 	} else {
 		query += " and meta_bits >= ?"
 	}
 
+	var metaBits MetaBits
 	return bongo.B.Count(
 		m,
 		query,

--- a/go/src/socialapi/workers/algoliaconnector/api/algoliakeygen.go
+++ b/go/src/socialapi/workers/algoliaconnector/api/algoliakeygen.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/url"
 	"socialapi/models"
-	"socialapi/request"
 	"socialapi/workers/common/response"
 )
 
@@ -14,12 +13,14 @@ type Response struct {
 }
 
 func (h *Handler) GenerateKey(u *url.URL, header http.Header, _ interface{}, context *models.Context) (int, http.Header, interface{}, error) {
-
 	var accountId int64
-	if context.Client != nil && context.Client.Account != nil {
+
+	if context.IsLoggedIn() {
 		accountId = context.Client.Account.Id
 	}
-	c, err := fetchContextChannel(context)
+
+	c := models.NewChannel()
+	err := c.FetchPublicChannel(context.GroupName)
 	if err != nil {
 		return response.NewBadRequest(err)
 	}
@@ -29,29 +30,15 @@ func (h *Handler) GenerateKey(u *url.URL, header http.Header, _ interface{}, con
 		return response.NewBadRequest(err)
 	}
 
-	r := &Response{ApiKey: apiKey}
-
-	return response.NewOK(r)
+	return response.NewOK(&Response{ApiKey: apiKey})
 }
 
-func fetchContextChannel(context *models.Context) (models.Channel, error) {
-	c := models.NewChannel()
-	q := request.NewQuery()
-	q.GroupName = context.GroupName
-	q.Name = "public"
-	q.Type = models.Channel_TYPE_GROUP
-
-	return c.ByName(q)
-}
-
-func (h *Handler) generateApiKey(c models.Channel, accountId int64) (string, error) {
-
+func (h *Handler) generateApiKey(c *models.Channel, accountId int64) (string, error) {
 	tagFilter := generateTagFilters(c, accountId)
-
 	return h.client.GenerateSecuredApiKey(h.apiKey, tagFilter)
 }
 
-func generateTagFilters(c models.Channel, accountId int64) string {
+func generateTagFilters(c *models.Channel, accountId int64) string {
 	return fmt.Sprintf("(%d,%s)", c.Id, generateUserToken(accountId))
 }
 

--- a/go/src/socialapi/workers/cmd/realtime/gatekeeper/main.go
+++ b/go/src/socialapi/workers/cmd/realtime/gatekeeper/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"koding/db/mongodb/modelhelper"
 	"socialapi/config"
 	"socialapi/workers/common/mux"
 	api "socialapi/workers/realtime/gatekeeper"
@@ -20,6 +21,8 @@ func main() {
 	}
 
 	appConfig := config.MustRead(r.Conf.Path)
+	modelhelper.Initialize(appConfig.Mongo)
+	defer modelhelper.Close()
 
 	// create a realtime service provider instance.
 	pubnub := models.NewPubNub(appConfig.GateKeeper.Pubnub, r.Log)

--- a/go/src/socialapi/workers/common/mux/mux.go
+++ b/go/src/socialapi/workers/common/mux/mux.go
@@ -112,8 +112,7 @@ func (m *Mux) Listen() {
 	// 	stdlog.New(os.Stderr, "metrics ", stdlog.Lmicroseconds),
 	// )
 
-	var handler http.Handler
-	handler = tigertonic.WithContext(m.nsMux, models.Context{})
+	handler := http.Handler(tigertonic.WithContext(m.nsMux, models.Context{}))
 	if m.config.Debug {
 		h := tigertonic.Logged(handler, nil)
 		h.Logger = NewTigerTonicLogger(m.log)

--- a/go/src/socialapi/workers/common/response/response.go
+++ b/go/src/socialapi/workers/common/response/response.go
@@ -21,7 +21,7 @@ var (
 // http response properties
 func NewBadRequest(err error) (int, http.Header, interface{}, error) {
 	l := runner.MustGetLogger()
-	l.SetCallDepth(1) // get previous error line
+	l.SetCallDepth(2) // get previous error line
 
 	return NewBadRequestWithLogger(l, err)
 }

--- a/go/src/socialapi/workers/email/emailmodels/channelsummary.go
+++ b/go/src/socialapi/workers/email/emailmodels/channelsummary.go
@@ -127,10 +127,10 @@ func (cs *ChannelSummary) RenderImage() (string, error) {
 	}
 
 	var nickname string
-	var err error
 
 	// do not use any images for group conversations
 	if !cs.IsGroupChannel {
+		var err error
 		nickname, err = getAccountNickname(cs.Participants[0].AccountId)
 		if err != nil {
 			return "", err
@@ -144,7 +144,6 @@ func (cs *ChannelSummary) RenderImage() (string, error) {
 }
 
 func (cs *ChannelSummary) renderGravatar(nickname string) (string, error) {
-
 	account, err := modelhelper.GetAccount(nickname)
 	if err != nil {
 		return "", err

--- a/go/src/socialapi/workers/moderation/topic/messages.go
+++ b/go/src/socialapi/workers/moderation/topic/messages.go
@@ -18,9 +18,6 @@ import (
 // channel, it has InitialChannelId, we should replace it with the parent's
 // channel id
 func (c *Controller) moveMessages(cl *models.ChannelLink) error {
-
-	var errors []error
-
 	rootChannel, err := models.Cache.Channel.ById(cl.RootId)
 	if err != nil {
 		c.log.Critical("requested root channel doesnt exist. ChannelId: %d", cl.RootId)
@@ -44,8 +41,8 @@ func (c *Controller) moveMessages(cl *models.ChannelLink) error {
 	}
 
 	m := models.ChannelMessageList{}
+	var errors []error
 	for {
-
 		var messageLists []models.ChannelMessageList
 
 		// fetch all records, even deleted ones, because we are not gonna need

--- a/go/src/socialapi/workers/notification/models/notification.go
+++ b/go/src/socialapi/workers/notification/models/notification.go
@@ -104,8 +104,6 @@ func (n *Notification) List(q *request.Query) (*NotificationResponse, error) {
 }
 
 func (n *Notification) fetchByAccountId(q *request.Query) ([]Notification, error) {
-	var notifications []Notification
-
 	if q.GroupChannelId == 0 {
 		return nil, ErrGroupChannelIdNotSet
 	}
@@ -114,6 +112,7 @@ func (n *Notification) fetchByAccountId(q *request.Query) ([]Notification, error
 		return nil, ErrAccountIdNotSet
 	}
 
+	var notifications []Notification
 	err := bongo.B.DB.Table(n.BongoName()).
 		Where(
 		"NOT (activated_at IS NULL OR activated_at <= '0001-01-02')"+

--- a/go/src/socialapi/workers/payment/paymentwebhook/webhookmodels/paypal.go
+++ b/go/src/socialapi/workers/payment/paymentwebhook/webhookmodels/paypal.go
@@ -14,8 +14,6 @@ type PaypalTime struct {
 }
 
 func (pt *PaypalTime) UnmarshalJSON(b []byte) error {
-	var err error
-
 	str := strings.Replace(fmt.Sprintf("%s", b), `"`, "", -1)
 
 	// paypal send `N/A` when time is nil
@@ -23,6 +21,7 @@ func (pt *PaypalTime) UnmarshalJSON(b []byte) error {
 		return nil
 	}
 
+	var err error
 	pt.Time, err = time.Parse(PaypalTimeLayout, str)
 
 	return err

--- a/go/src/socialapi/workers/popularpost/popularpost.go
+++ b/go/src/socialapi/workers/popularpost/popularpost.go
@@ -66,7 +66,7 @@ func (f *Controller) handleInteraction(inc float64, i *models.Interaction) error
 	}
 
 	if !isEligibleForPopularPost(c, cm) {
-		f.log.Error(fmt.Sprintf("Not eligible Interaction Id:%d", i.Id))
+		f.log.Debug(fmt.Sprintf("Not eligible Interaction Id:%d", i.Id))
 		return nil
 	}
 

--- a/go/src/socialapi/workers/realtime/dispatcher/dispatcher.go
+++ b/go/src/socialapi/workers/realtime/dispatcher/dispatcher.go
@@ -89,7 +89,7 @@ func (c *Controller) UpdateMessage(um *models.UpdateInstanceMessage) error {
 // NotifyUser sends user notifications to related channel
 func (c *Controller) NotifyUser(nm *models.NotificationMessage) error {
 	if nm.Account.Nick == "" {
-		c.logger.Error("Nickname is not set")
+		c.logger.Error("Nick is not set")
 		return nil
 	}
 

--- a/go/src/socialapi/workers/realtime/dispatcher/dispatcher.go
+++ b/go/src/socialapi/workers/realtime/dispatcher/dispatcher.go
@@ -2,6 +2,7 @@ package dispatcher
 
 import (
 	"fmt"
+	socialapimodels "socialapi/models"
 	"socialapi/workers/realtime/models"
 	"time"
 
@@ -87,7 +88,7 @@ func (c *Controller) UpdateMessage(um *models.UpdateInstanceMessage) error {
 
 // NotifyUser sends user notifications to related channel
 func (c *Controller) NotifyUser(nm *models.NotificationMessage) error {
-	if nm.Account.Nickname == "" {
+	if nm.Account.Nick == "" {
 		c.logger.Error("Nickname is not set")
 		return nil
 	}
@@ -105,7 +106,7 @@ func (c *Controller) RevokeChannelAccess(rca *models.RevokeChannelAccess) error 
 
 	for _, token := range rca.Tokens {
 		a := &models.Authenticate{
-			Account: &models.Account{Token: token},
+			Account: &socialapimodels.Account{Token: token},
 		}
 		if err := c.Pubnub.RevokeAccess(a, pmc); err != nil {
 			return err

--- a/go/src/socialapi/workers/realtime/gatekeeper/gatekeeper.go
+++ b/go/src/socialapi/workers/realtime/gatekeeper/gatekeeper.go
@@ -130,32 +130,3 @@ func checkParticipation(u *url.URL, header http.Header, cr *models.Channel) (*mo
 
 	return &cpr, nil
 }
-
-func getAccountInfo(u *url.URL, header http.Header) (*models.Account, error) {
-	cookie := header.Get("Cookie")
-	request := &handler.Request{
-		Type:     "GET",
-		Endpoint: "/api/social/account",
-		Cookie:   cookie,
-	}
-
-	// TODO update this requester
-	resp, err := handler.MakeRequest(request)
-	if err != nil {
-		return nil, err
-	}
-
-	// Need a better response
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf(resp.Status)
-	}
-
-	var a models.Account
-	err = json.NewDecoder(resp.Body).Decode(&a)
-	resp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-
-	return &a, nil
-}

--- a/go/src/socialapi/workers/realtime/gatekeeper/gatekeeper.go
+++ b/go/src/socialapi/workers/realtime/gatekeeper/gatekeeper.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	socialapimodels "socialapi/models"
 	"socialapi/workers/common/handler"
 	"socialapi/workers/common/response"
 	"socialapi/workers/realtime/models"
@@ -103,9 +104,9 @@ func checkParticipation(u *url.URL, header http.Header, cr *models.Channel) (*mo
 		Type:     "GET",
 		Endpoint: "/api/social/channel/checkparticipation",
 		Params: map[string]string{
-			"name":  cr.Name,
-			"group": cr.Group,
-			"type":  cr.Type,
+			"name":      cr.Name,
+			"groupName": cr.Group,
+			"type":      cr.Type,
 		},
 		Cookie: cookie,
 	}

--- a/go/src/socialapi/workers/realtime/gatekeeper/gatekeeper.go
+++ b/go/src/socialapi/workers/realtime/gatekeeper/gatekeeper.go
@@ -55,7 +55,7 @@ func (h *Handler) SubscribeChannel(u *url.URL, header http.Header, req *models.C
 
 // SubscribeNotification grants notification channel access for user. User information is
 // fetched from session
-func (h *Handler) SubscribeNotification(u *url.URL, header http.Header, temp *models.Account, context *socialapimodels.Context) (int, http.Header, interface{}, error) {
+func (h *Handler) SubscribeNotification(u *url.URL, header http.Header, temp *socialapimodels.Account, context *socialapimodels.Context) (int, http.Header, interface{}, error) {
 	if !context.IsLoggedIn() {
 		return response.NewBadRequest(socialapimodels.ErrNotLoggedIn)
 	}
@@ -68,7 +68,7 @@ func (h *Handler) SubscribeNotification(u *url.URL, header http.Header, temp *mo
 	a.Account = account
 
 	// TODO need async requests. Re-try in case of an error
-	err = h.pubnub.Authenticate(a)
+	err := h.pubnub.Authenticate(a)
 	if err != nil {
 		return response.NewBadRequest(err)
 	}
@@ -76,7 +76,7 @@ func (h *Handler) SubscribeNotification(u *url.URL, header http.Header, temp *mo
 	return responseWithCookie(temp, account.Token)
 }
 
-func (h *Handler) GetToken(u *url.URL, header http.Header, req *models.Account, context *socialapimodels.Context) (int, http.Header, interface{}, error) {
+func (h *Handler) GetToken(u *url.URL, header http.Header, req *socialapimodels.Account, context *socialapimodels.Context) (int, http.Header, interface{}, error) {
 	if !context.IsLoggedIn() {
 		return response.NewBadRequest(socialapimodels.ErrNotLoggedIn)
 	}

--- a/go/src/socialapi/workers/realtime/gatekeeper/handlers.go
+++ b/go/src/socialapi/workers/realtime/gatekeeper/handlers.go
@@ -6,9 +6,8 @@ import (
 )
 
 func (h *Handler) AddHandlers(m *mux.Mux) {
-
 	// channel subscription
-	m.AddSessionlessHandler(
+	m.AddHandler(
 		handler.Request{
 			Handler:  h.SubscribeChannel,
 			Name:     "channel-subscribe",
@@ -17,7 +16,7 @@ func (h *Handler) AddHandlers(m *mux.Mux) {
 		},
 	)
 
-	m.AddSessionlessHandler(
+	m.AddHandler(
 		handler.Request{
 			Handler:  h.SubscribeNotification,
 			Name:     "notification-subscribe",
@@ -26,7 +25,7 @@ func (h *Handler) AddHandlers(m *mux.Mux) {
 		},
 	)
 
-	m.AddSessionlessHandler(
+	m.AddHandler(
 		handler.Request{
 			Handler:  h.GetToken,
 			Name:     "get-token",

--- a/go/src/socialapi/workers/realtime/models/broker.go
+++ b/go/src/socialapi/workers/realtime/models/broker.go
@@ -115,7 +115,7 @@ func (b *Broker) NotifyUser(nm *NotificationMessage) error {
 
 	return channel.Publish(
 		"notification",
-		nm.Account.Nickname, // this is routing key
+		nm.Account.Nick, // this is routing key
 		false,
 		false,
 		amqp.Publishing{Body: byteNotification},

--- a/go/src/socialapi/workers/realtime/models/channel.go
+++ b/go/src/socialapi/workers/realtime/models/channel.go
@@ -3,6 +3,7 @@ package models
 import (
 	"fmt"
 	"socialapi/config"
+	socialapimodels "socialapi/models"
 )
 
 type Channel struct {
@@ -45,16 +46,18 @@ func (pmc *PrivateMessageChannel) GrantAccess(p *PubNub, a *Authenticate) error 
 ////////// NotificationChannel //////////
 
 type NotificationChannel struct {
-	Account *Account
+	Account *socialapimodels.Account
 }
 
-func NewNotificationChannel(a *Account) *NotificationChannel {
-	return &NotificationChannel{a}
+func NewNotificationChannel(a *socialapimodels.Account) *NotificationChannel {
+	return &NotificationChannel{
+		Account: a,
+	}
 }
 
 func (nc *NotificationChannel) PrepareName() string {
 	env := config.MustGet().Environment
-	return fmt.Sprintf("notification-%s-%s", env, nc.Account.Nickname)
+	return fmt.Sprintf("notification-%s-%s", env, nc.Account.Nick)
 }
 
 func (nc *NotificationChannel) GrantAccess(p *PubNub, a *Authenticate) error {

--- a/go/src/socialapi/workers/realtime/models/channel_test.go
+++ b/go/src/socialapi/workers/realtime/models/channel_test.go
@@ -3,6 +3,7 @@ package models
 import (
 	"fmt"
 	"socialapi/config"
+	"socialapi/models"
 	"testing"
 
 	"github.com/koding/runner"
@@ -21,11 +22,11 @@ func TestChannelPrepareName(t *testing.T) {
 
 	Convey("While creating PubNub channels", t, func() {
 		Convey("Notification channel name format must be as 'notification'-[env]-[nickname]", func() {
-			a := &Account{}
-			a.Nickname = "hello"
+			a := &models.Account{}
+			a.Nick = "hello"
 			nc := NewNotificationChannel(a)
 			name := nc.PrepareName()
-			expectedName := fmt.Sprintf("notification-%s-%s", appConfig.Environment, a.Nickname)
+			expectedName := fmt.Sprintf("notification-%s-%s", appConfig.Environment, a.Nick)
 			So(name, ShouldEqual, expectedName)
 		})
 		Convey("Message update and channel name format must be as 'channel'-[token]", func() {

--- a/go/src/socialapi/workers/realtime/models/pubnub.go
+++ b/go/src/socialapi/workers/realtime/models/pubnub.go
@@ -3,6 +3,7 @@ package models
 import (
 	"fmt"
 	"socialapi/config"
+	socialapimodels "socialapi/models"
 	"strconv"
 	"sync"
 	"time"
@@ -83,7 +84,10 @@ func (p *PubNub) grantServerAccess(c ChannelInterface) error {
 	}
 
 	a := &Authenticate{
-		Account: &Account{Id: ServerId, Token: p.token},
+		Account: &socialapimodels.Account{
+			Id:    ServerId,
+			Token: p.token,
+		},
 		Channel: c,
 	}
 
@@ -190,7 +194,7 @@ func (p *PubNub) GrantPublicAccess(c ChannelInterface) error {
 	}
 
 	a := &Authenticate{}
-	a.Account = &Account{Token: ""}
+	a.Account = &socialapimodels.Account{Token: ""}
 
 	if err := p.GrantAccess(a, c); err != nil {
 		return err

--- a/go/src/socialapi/workers/realtime/models/request.go
+++ b/go/src/socialapi/workers/realtime/models/request.go
@@ -1,5 +1,7 @@
 package models
 
+import socialapimodels "socialapi/models"
+
 // Channel request is used for channel authentication/
 type ChannelRequest struct {
 	Id    int64  `json:"id"`
@@ -20,10 +22,10 @@ type UpdateInstanceMessage struct {
 }
 
 type NotificationMessage struct {
-	Account   *Account            `json:"account"`
-	Body      NotificationContent `json:"body"`
-	EventName string              `json:"eventName"`
-	EventId   string              `json:"eventId"`
+	Account   *socialapimodels.Account `json:"account"`
+	Body      NotificationContent      `json:"body"`
+	EventName string                   `json:"eventName"`
+	EventId   string                   `json:"eventId"`
 }
 
 type Message struct {
@@ -34,7 +36,7 @@ type Message struct {
 }
 
 type Authenticate struct {
-	Account *Account
+	Account *socialapimodels.Account
 	Channel ChannelInterface
 }
 
@@ -46,15 +48,9 @@ type NotificationContent struct {
 }
 
 type CheckParticipationResponse struct {
-	Channel      *Channel `json:"channel"`
-	Account      *Account `json:"account"`
-	AccountToken string   `json:"accountToken"`
-}
-
-type Account struct {
-	Id       int64  `json:"id,string"`
-	Nickname string `json:"nick"`
-	Token    string `json:"token"`
+	Channel      *Channel                 `json:"channel"`
+	Account      *socialapimodels.Account `json:"account"`
+	AccountToken string                   `json:"accountToken"`
 }
 
 type RevokeChannelAccess struct {

--- a/go/src/socialapi/workers/realtime/realtime/realtime.go
+++ b/go/src/socialapi/workers/realtime/realtime/realtime.go
@@ -622,7 +622,13 @@ func (f *Controller) NotifyUser(notification *notificationmodels.Notification) e
 	}
 	content.ActorId = actor.OldId
 
-	return f.sendNotification(notification.AccountId, "koding", NotificationEventName, content)
+	c, err := models.Cache.Channel.ById(notification.ContextChannelId)
+	if err != nil {
+		f.log.New("channelId", notification.ContextChannelId).Error("Couldnt fetch from cache")
+		return nil
+	}
+
+	return f.sendNotification(notification.AccountId, c.GroupName, NotificationEventName, content)
 }
 
 func (f *Controller) sendInstanceEvent(cm *models.ChannelMessage, body interface{}, eventName string) error {

--- a/servers/lib/server/client.coffee
+++ b/servers/lib/server/client.coffee
@@ -73,7 +73,7 @@ generateFakeClient = (options, callback) ->
       return callback null, fakeClient, session
 
 prepareFakeClient = (fakeClient, options) ->
-  {groupName, session, username, account} = options
+  {groupName, session, username, account, sessionToken} = options
 
   {JAccount}      = bongo.models
 
@@ -83,6 +83,8 @@ prepareFakeClient = (fakeClient, options) ->
     account.type    = 'unregistered'
 
   fakeClient.sessionToken = session.clientId
+
+  fakeClient.sessionToken = sessionToken if sessionToken
 
   # set username into context
   fakeClient.context or= {}

--- a/servers/lib/server/client.coffee
+++ b/servers/lib/server/client.coffee
@@ -82,9 +82,7 @@ prepareFakeClient = (fakeClient, options) ->
     account.profile = nickname: username
     account.type    = 'unregistered'
 
-  fakeClient.sessionToken = session.clientId
-
-  fakeClient.sessionToken = sessionToken if sessionToken
+  fakeClient.sessionToken = sessionToken ? session.clientId
 
   # set username into context
   fakeClient.context or= {}

--- a/servers/lib/server/handlers/createteam.coffee
+++ b/servers/lib/server/handlers/createteam.coffee
@@ -8,7 +8,7 @@ module.exports = (req, res, next) ->
   { companyName, slug, redirect } = body
 
   redirect ?= '/'
-  context   = { group: 'koding' }
+  context   = { group: slug }
   clientId  = getClientId req, res
 
   # tmp: copy/paste from ./register.coffee - SY
@@ -45,7 +45,9 @@ module.exports = (req, res, next) ->
 
       # res.cookie 'clientId', result.newToken, path : '/'
 
-      owner = result.account
+      # set session token for later usage down the line
+      client.sessionToken = result.newToken
+      owner               = result.account
 
       JGroup.create client,
         title           : companyName

--- a/servers/lib/server/handlers/impersonate.coffee
+++ b/servers/lib/server/handlers/impersonate.coffee
@@ -16,7 +16,11 @@ module.exports = (req, res) ->
       unless account.can 'administer accounts'
         return res.status(403).end()
 
-      JSession.createNewSession nickname, (err, session) ->
+      JSession.createNewSession {
+        nickname  : nickname
+        # set parent group name into kookie
+        groupName : result.groupName or "koding"
+      }, (err, session) ->
         return res.status(400).send err.message  if err
 
         JSession.remove {clientId}, (err) ->

--- a/workers/social/lib/social/models/group/index.coffee
+++ b/workers/social/lib/social/models/group/index.coffee
@@ -468,7 +468,7 @@ module.exports = class JGroup extends Module
             else
               console.log 'roles are added'
               queue.next()
-        -> group.createSocialApiChannels (err)->
+        -> group.createSocialApiChannels client, (err)->
             if err then console.error err
             console.log 'created socialApiId ids'
             queue.next()
@@ -1328,7 +1328,7 @@ module.exports = class JGroup extends Module
         @fetchDefaultPermissionSet callback
 
 
-  createSocialApiChannels: (callback) ->
+  createSocialApiChannels: (client, callback) ->
 
     if @socialApiChannelId and @socialApiAnnouncementChannelId
       return callback null, {@socialApiChannelId, @socialApiAnnouncementChannelId}
@@ -1346,10 +1346,10 @@ module.exports = class JGroup extends Module
           creatorId: socialApiId
           privacyConstant: privacy
 
-        @createGroupChannel options, (err, groupChannelId) =>
+        @createGroupChannel client, options, (err, groupChannelId) =>
           return callback err if err?
 
-          @createAnnouncementChannel options, (err, announcementChannelId) =>
+          @createAnnouncementChannel client, options, (err, announcementChannelId) =>
             return callback err if err?
 
             return callback null, {
@@ -1360,21 +1360,22 @@ module.exports = class JGroup extends Module
             }
 
 
-  createGroupChannel:(options, callback)->
+  createGroupChannel:(client, options, callback)->
     options.name = "public"
     options.varName = "socialApiChannelId"
     options.typeConstant = "group"
 
-    return @createSocialAPIChannel options, callback
+    return @createSocialAPIChannel client, options, callback
 
-  createAnnouncementChannel:(options, callback)->
+  createAnnouncementChannel:(client, options, callback)->
     options.name = if @slug is "koding" then "changelog" else @slug
     options.varName = "socialApiAnnouncementChannelId"
     options.typeConstant = "announcement"
 
-    return @createSocialAPIChannel options, callback
+    return @createSocialAPIChannel client, options, callback
 
-  createSocialAPIChannel:(options, callback)->
+
+  createSocialAPIChannel:(client, options, callback)->
     {varName, name, typeConstant, creatorId, privacyConstant} = options
 
     return callback null, @[varName]  if @[varName]
@@ -1386,12 +1387,12 @@ module.exports = class JGroup extends Module
       typeConstant    : typeConstant
       privacyConstant : privacyConstant
 
-    {createChannel} = require '../socialapi/requests'
-    createChannel defaultChannel, (err, channel)=>
+    {doRequest} = require '../socialapi/helper'
+    doRequest "createChannel", client, defaultChannel, (err, channel)=>
       return callback err if err
 
       op = $set:{}
-      op.$set[varName] = channel.id
+      op.$set[varName] = channel.channel.id
 
       @update op, (err)->
         return callback err if err

--- a/workers/social/lib/social/models/group/index.coffee
+++ b/workers/social/lib/social/models/group/index.coffee
@@ -1331,7 +1331,10 @@ module.exports = class JGroup extends Module
   createSocialApiChannels: (client, callback) ->
 
     if @socialApiChannelId and @socialApiAnnouncementChannelId
-      return callback null, {@socialApiChannelId, @socialApiAnnouncementChannelId}
+      return callback null, {
+        @socialApiChannelId,
+        @socialApiAnnouncementChannelId
+      }
 
     @fetchOwner (err, owner)=>
       return callback err if err?
@@ -1343,8 +1346,8 @@ module.exports = class JGroup extends Module
         privacy = if @slug is "koding" then "public" else "private"
 
         options =
-          creatorId: socialApiId
-          privacyConstant: privacy
+          creatorId       : socialApiId
+          privacyConstant : privacy
 
         @createGroupChannel client, options, (err, groupChannelId) =>
           return callback err if err?
@@ -1354,9 +1357,9 @@ module.exports = class JGroup extends Module
 
             return callback null, {
               # channel id for #public - used as group channel
-              socialApiChannelId: groupChannelId,
+              socialApiChannelId             : groupChannelId,
               # channel id for #koding - used for announcements
-              socialApiAnnouncementChannelId:announcementChannelId
+              socialApiAnnouncementChannelId : announcementChannelId
             }
 
 

--- a/workers/social/lib/social/models/session.coffee
+++ b/workers/social/lib/social/models/session.coffee
@@ -72,11 +72,11 @@ module.exports = class JSession extends Model
         else callback null, { session, account }
 
 
-  @createNewSession = (username, callback) ->
+  @createNewSession = (data, callback) ->
 
-    clientId = createId()
+    data.clientId = createId()
 
-    session = new JSession { clientId, username }
+    session = new JSession data
     session.save (err) ->
       return callback err  if err
       return callback null, session

--- a/workers/social/lib/social/models/socialapi/helper.coffee
+++ b/workers/social/lib/social/models/socialapi/helper.coffee
@@ -40,7 +40,7 @@ ensureGroupChannel = (client, callback)->
   fetchGroup client, (err, group)->
     return callback err  if err
     return callback { message: "Group not found" } unless group
-    group.createSocialApiChannels (err, result)->
+    group.createSocialApiChannels client, (err, result)->
       return callback err  if err
       callback null, result.socialApiChannelId
 


### PR DESCRIPTION
This PR introduces 
- new separate task for realtime workers
- some socialapi style fixes
- algolia keygen generates keys with group context
- fix NewBadRequest CallDepth for logging
- gatekeeper works with group context
- session creation requires group name
- update session with group name while converting users
- filter notification according to group
