### PR TITLE
Add missing line start/end key combos [fixes #93882536]

### DIFF
--- a/client/app/lib/defaultshortcuts/editor.json
+++ b/client/app/lib/defaultshortcuts/editor.json
@@ -688,7 +688,7 @@
     "description": "Swap Characters",
     "binding": [
       [
-        "ctrl+t"
+        "ctrl+alt+shift+t"
       ],
       [
         "ctrl+t"

--- a/client/app/lib/defaultshortcuts/editorhidden.json
+++ b/client/app/lib/defaultshortcuts/editorhidden.json
@@ -81,6 +81,7 @@
       "name": "gotolineend",
       "binding": [
         [
+          "alt+right",
           "end"
         ],
         [

--- a/client/app/lib/defaultshortcuts/editorhidden.json
+++ b/client/app/lib/defaultshortcuts/editorhidden.json
@@ -73,6 +73,7 @@
           "home"
         ],
         [
+          "command+left",
           "home"
         ]
       ]

--- a/client/app/lib/defaultshortcuts/editorhidden.json
+++ b/client/app/lib/defaultshortcuts/editorhidden.json
@@ -69,6 +69,7 @@
       "name": "gotolinestart",
       "binding": [
         [
+          "alt+left",
           "home"
         ],
         [

--- a/client/app/lib/defaultshortcuts/editorhidden.json
+++ b/client/app/lib/defaultshortcuts/editorhidden.json
@@ -86,6 +86,7 @@
           "end"
         ],
         [
+          "command+right",
           "end"
         ]
       ]


### PR DESCRIPTION
[Cmd+Left and Cmd+Right aren't working in the editor](https://www.pivotaltracker.com/story/show/93882536)
