### PR TITLE
Set Ctrl+Alt+Shift+T as transpose letters key combo on win [fixes #94170416]

### DIFF
--- a/client/app/lib/defaultshortcuts/editor.json
+++ b/client/app/lib/defaultshortcuts/editor.json
@@ -688,7 +688,7 @@
     "description": "Swap Characters",
     "binding": [
       [
-        "ctrl+t"
+        "ctrl+alt+shift+t"
       ],
       [
         "ctrl+t"


### PR DESCRIPTION
[Ctrl+T does not work on Windows](https://www.pivotaltracker.com/story/show/94170416)
