### PR TITLE
Fix for modal text is bold, it should not be [fixes #94452948]

### DIFF
--- a/client/app/lib/styl/computeproviders.styl
+++ b/client/app/lib/styl/computeproviders.styl
@@ -254,7 +254,6 @@ computeproviders.styl
 
       .message
         font-size         14px
-        font-weight       bold
         margin-top        10px
         line-height       20px
         color             #373737


### PR DESCRIPTION
![Before](https://cloud.githubusercontent.com/assets/1278794/7672105/06ca869e-fcef-11e4-8265-4f474caa591c.png)

The story: https://www.pivotaltracker.com/story/show/94452948

Remove the bold from the above modal.

cc. @sinan @usirin 
