### PR TITLE
Fix for "Title fonts on the payments overlays are different than the usual one" [fixes #94388446]

### DIFF
--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -973,7 +973,7 @@ paymentGrayLighter  = #f8f8f8
       text-align        center
 
       span.title
-        font-weight     600
+        font-weight     normal
         color           paymentGreen
         line-height     34px
         margin          0 0 6px

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -994,7 +994,7 @@ paymentGrayLighter  = #f8f8f8
       .plan-price
         color           paymentGreen
         display         inline
-        font-weight     600
+        font-weight     normal
 
         span
           color         paymentGrayDark


### PR DESCRIPTION
![case 1](http://i.imgur.com/S4T2ptK.png)
![case 2](http://i.imgur.com/JIaCd2J.png)

Removed the bold from the modal title and from the price. Checked computed styles and they are the same as elsewhere on KD, now.

The story: https://www.pivotaltracker.com/story/show/94388446

cc. @sinan @usirin 
