### PR TITLE
snapshots: Labels are now automatically made unique [fixes #94481688]

### DIFF
--- a/client/app/lib/providers/machinesettingssnapshotsview.coffee
+++ b/client/app/lib/providers/machinesettingssnapshotsview.coffee
@@ -166,6 +166,10 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
       return MachineSettingsSnapshotsView.notify \
         'Name length must be larger than zero'
 
+    # Get the unique label, based on our currently loaded Snapshots
+    labels = (i.getData().label for i in @listController.getItemsOrdered())
+    label  = snapshotHelpers.getUniqueLabel label, labels
+
     # Get the IDE view.
     openIdeByMachine machine, (err, ideController) =>
       if err

--- a/client/app/lib/providers/snapshothelpers.coffee
+++ b/client/app/lib/providers/snapshothelpers.coffee
@@ -28,7 +28,7 @@ fetchNewestSnapshot = (machineId, callback = kd.noop) ->
  * label is not unique, it is returned in the format of "label index".
  *
  * @params {String} label - The source label.
- * @params {String[]} labels - The labels to avoid.
+ * @params {Array.<String>} labels - The labels to avoid.
  * @returns {String} label - A formatted label, not in the labels list.
 ###
 getUniqueLabel = (label, labels = []) ->

--- a/client/app/lib/providers/snapshothelpers.coffee
+++ b/client/app/lib/providers/snapshothelpers.coffee
@@ -24,6 +24,25 @@ fetchNewestSnapshot = (machineId, callback = kd.noop) ->
 
 
 ###*
+ * Based on the given list of labels, return a unique label. If the
+ * label is not unique, it is returned in the format of "label index".
+ *
+ * @params {String} label - The source label.
+ * @params {String[]} labels - The labels to avoid.
+ * @returns {String} label - A formatted label, not in the labels list.
+###
+getUniqueLabel = (label, labels = []) ->
+
+  # If label is already unique, return it.
+  return label  if labels.indexOf(label) is -1
+
+  index = 1
+  index++ while labels.indexOf("#{label} #{index}") isnt -1
+  return "#{label} #{index}"
+
+
+
+###*
  * Create a new vm from the given snapshotId, going directly to reinit
  * for hobbyist's, and showing the new machine modal for all other
  * users.
@@ -83,6 +102,7 @@ showSnapshottingModal = (machine, container) ->
 
 module.exports = {
   fetchNewestSnapshot
+  getUniqueLabel
   newVmFromSnapshot
   showSnapshottingModal
 }

--- a/client/app/lib/providers/snapshothelpers.coffee
+++ b/client/app/lib/providers/snapshothelpers.coffee
@@ -36,9 +36,10 @@ getUniqueLabel = (label, labels = []) ->
   # If label is already unique, return it.
   return label  if labels.indexOf(label) is -1
 
-  index = 1
-  index++ while labels.indexOf("#{label} #{index}") isnt -1
-  return "#{label} #{index}"
+  count = 1
+  while labels.indexOf("#{label} #{count}") isnt -1
+    count++
+  return "#{label} #{count}"
 
 
 


### PR DESCRIPTION
Eg, if `foo` is used by that label already exists, then `foo 1` is
used instead. Then `foo 2`, and so on.

cc @usirin 
