### PR TITLE
Timeout stalling test runs

### DIFF
--- a/client/test/run.sh
+++ b/client/test/run.sh
@@ -38,3 +38,11 @@ run() {
 }
 
 run $1 $2
+
+CODE=$?
+
+if [ $CODE -ne 0 ]; then
+  mv users.json users-$1-$2.json
+fi
+
+exit $CODE

--- a/client/test/run.sh
+++ b/client/test/run.sh
@@ -2,8 +2,6 @@
 
 cd $(dirname $0)
 
-MAX_TRY_COUNT=3
-
 NIGHTWATCH_BIN="../node_modules/.bin/nightwatch"
 NIGHTWATCH_OPTIONS="$NIGHTWATCH_OPTIONS --config ../.nightwatch.json"
 NIGHTWATCH_CMD="$NIGHTWATCH_BIN $NIGHTWATCH_OPTIONS"
@@ -24,17 +22,7 @@ run() {
             echo "skipping $i"
           else
             echo "running $i test suite"
-            command="$NIGHTWATCH_CMD --group $i"
-
-            counter=0
-            until $command
-            do
-              counter=$((counter + 1))
-              if [ $counter -eq $MAX_TRY_COUNT ]
-              then
-                exit 1
-              fi
-            done
+            $NIGHTWATCH_CMD --group $i
           fi
       fi
     done
@@ -42,20 +30,10 @@ run() {
     echo "running single test suite: $SUITE $SUBSUITE"
 
     if [ -z "$SUBSUITE" ]; then
-      command="$NIGHTWATCH_CMD --group ./$BUILD_DIR/$SUITE"
+      $NIGHTWATCH_CMD --group ./$BUILD_DIR/$SUITE
     else
-      command="$NIGHTWATCH_CMD --group ./$BUILD_DIR/$SUITE/$SUBSUITE.js"
+      $NIGHTWATCH_CMD --group ./$BUILD_DIR/$SUITE/$SUBSUITE.js
     fi
-
-    counter=0
-    until $command
-    do
-      counter=$((counter + 1))
-      if [ $counter -eq $MAX_TRY_COUNT ]
-      then
-        exit 1
-      fi
-    done
   fi
 }
 

--- a/scripts/test-instance/run-test
+++ b/scripts/test-instance/run-test
@@ -29,4 +29,6 @@ ssh -o 'StrictHostKeyChecking no' \
 
 PID=$!
 
+trap 'kill -TERM $PID' TERM
+
 wait $PID # Wait until child process is exited

--- a/scripts/test-instance/run-test
+++ b/scripts/test-instance/run-test
@@ -32,3 +32,7 @@ PID=$!
 trap 'kill -TERM $PID' TERM
 
 wait $PID # Wait until child process is exited
+
+trap - TERM INT
+
+wait $PID # In case an interrupt signal is received

--- a/scripts/test-instance/run-test
+++ b/scripts/test-instance/run-test
@@ -25,4 +25,8 @@ OPTIONS=$*
 ssh -o 'StrictHostKeyChecking no' \
     -i $KODING_DEPLOYMENT_KEY \
     ubuntu@$HOST \
-    "sudo /opt/koding/client/test/run.sh $OPTIONS"
+    "sudo /opt/koding/client/test/run.sh $OPTIONS" &
+
+PID=$!
+
+wait $PID # Wait until child process is exited

--- a/scripts/wercker/monitor-test.coffee
+++ b/scripts/wercker/monitor-test.coffee
@@ -1,0 +1,53 @@
+_ = require 'underscore'
+
+TIMEOUT  = 3 * 60 * 1000
+INTERVAL = 1 * 60 * 1000
+
+childs   = {}
+monitors = {}
+
+
+monitor = (child) ->
+
+  now = Date.now()
+
+  timestamp = childs[child.pid]
+  expired   = (now - timestamp) > TIMEOUT
+
+  return  unless expired
+
+  child.kill 'SIGTERM'
+
+
+remove = (child) ->
+
+  id = child.pid
+  childs[id] = null
+  clearInterval monitors[id]
+  monitors[id] = null
+
+
+add = (child) ->
+
+  childs[child.pid] = Date.now()
+
+  child.stdout.on 'data', do (child) ->
+    return _.debounce ->
+      childs[child.pid] = Date.now()
+    , 10000
+
+  child.on 'exit', do (child) ->
+    return (code, signal) ->
+      remove child
+
+  interval = setInterval do (child) ->
+
+    return ->
+      monitor child
+
+  , INTERVAL
+
+  monitors[child.pid] = interval
+
+
+module.exports = add

--- a/scripts/wercker/run-tests
+++ b/scripts/wercker/run-tests
@@ -6,6 +6,8 @@ child_process = require 'child_process'
 
 async = require 'async'
 
+RETRY_COUNT = 3
+
 unless filename = process.argv[2]
   console.error 'error: data file is not specified'
   process.exit 1
@@ -56,52 +58,53 @@ logWithtime = (message) ->
 runTestScript = path.join __dirname, '../test-instance/run-test'
 
 
-exec = (args, callback) ->
+runTest = (job, next) ->
 
-  child_process.execFile runTestScript, args, (error, stdout, stderr) ->
-
-    if error
-      console.error "error: #{JSON.stringify error}"
-      console.error JSON.stringify stderr
-      callback code: error.code, message: stdout
-      return
-
-    callback()
-
-
-runTest = ({instance, test}, callback) ->
+  {instance, test} = job
 
   args = [instance.publicIpAddress, test]
 
-  exec args, callback
+  child_process.execFile runTestScript, args, (error, stdout, stderr) ->
+
+    job.lap ?= 0
+    job.end = Date.now() - start
+
+    if error and ++job.lap is RETRY_COUNT
+      error.job    = job
+      error.stdout = stdout
+      error.stderr = stderr
+      next error
+    else if error
+      runTest job, next
+    else
+      next()
 
 
 startTest = (setId, instance, test, next) ->
 
   begin = Date.now() - start
-
-  lap = {test, begin}
-  stopwatch[setId].push lap
-
-  runTest {instance, test}, do (lap) ->
-    return (error) ->
-
-      lap.end = Date.now() - start
-
-      if error
-        console.error "Failed at Set:#{setId} #{test}"
-
-      next error
+  stopwatch[setId].push job = {test, instance, begin}
+  runTest job, next
 
 
 finishSet = (id, instance, callback, error) ->
 
-  console.log "Finished Set: #{id}"
+  if error
+    {job, code, signal, stdout, stderr} = error
+    {test, lap} = job
+    console.log ""
+    console.log "Set:#{id} is failed at #{test} (#{lap})"
+    console.log "Exit code: #{code} signal: #{signal}"
+    console.log ""
+    console.log "Stderr\n#{stderr}"
+    console.log "Stdout\n#{stdout}"
+  else
+    console.log "Finished Set:#{id}"
 
   logWithtime "Set:#{id} on #{instance.instanceId} #{instance.publicIpAddress}"
 
-  for lap in stopwatch[id]
-    {test, begin, end} = lap
+  for job in stopwatch[id]
+    {test, begin, end} = job
     duration = (end - begin) / 1000
     log "#{duration}\t#{test}"
 

--- a/scripts/wercker/run-tests
+++ b/scripts/wercker/run-tests
@@ -56,9 +56,7 @@ logWithtime = (message) ->
 runTestScript = path.join __dirname, '../test-instance/run-test'
 
 
-runTest = ({instance, test}, callback) ->
-
-  args = [instance.publicIpAddress, test]
+exec = (args, callback) ->
 
   child_process.execFile runTestScript, args, (error, stdout, stderr) ->
 
@@ -69,6 +67,13 @@ runTest = ({instance, test}, callback) ->
       return
 
     callback()
+
+
+runTest = ({instance, test}, callback) ->
+
+  args = [instance.publicIpAddress, test]
+
+  exec args, callback
 
 
 startTest = (setId, instance, test, next) ->

--- a/scripts/wercker/run-tests
+++ b/scripts/wercker/run-tests
@@ -6,6 +6,8 @@ child_process = require 'child_process'
 
 async = require 'async'
 
+monitor = require './monitor-test'
+
 RETRY_COUNT = 3
 
 unless filename = process.argv[2]
@@ -64,7 +66,7 @@ runTest = (job, next) ->
 
   args = [instance.publicIpAddress, test]
 
-  child_process.execFile runTestScript, args, (error, stdout, stderr) ->
+  child = child_process.execFile runTestScript, args, (error, stdout, stderr) ->
 
     job.lap ?= 0
     job.end = Date.now() - start
@@ -78,6 +80,8 @@ runTest = (job, next) ->
       runTest job, next
     else
       next()
+
+  monitor child
 
 
 startTest = (setId, instance, test, next) ->


### PR DESCRIPTION
This patch introduces test process monitor.  If a process does not print any output for a determined time then that test run will be considered as stalled.  This will help build process on stucked or unresponsive test runs.  Initial timeout duration is 3 minutes.
