### PR TITLE
Fixes "'Verify now' link is aligned incorrectly on the Account Settings modal" [fixes #91087932]

### DIFF
--- a/client/app/lib/styl/resurrection.commons.styl
+++ b/client/app/lib/styl/resurrection.commons.styl
@@ -1095,7 +1095,7 @@ button.app-settings-menu
 
 a.action-link.verify-email
   color             #888
-  margin            250px
+  margin            239px
   line-height       50px
   text-decoration   none
   span


### PR DESCRIPTION
Before:
![wjv8vcc](https://cloud.githubusercontent.com/assets/1278794/7721903/3c73cdf4-fee4-11e4-8cb3-2c7dc60a7fc8.png)

After:
![hvzcwte](https://cloud.githubusercontent.com/assets/1278794/7721902/3c6e3f42-fee4-11e4-9cd5-208d4069483e.png)

The story: https://www.pivotaltracker.com/story/show/91087932

cc. @sinan @usirin 
