### PR TITLE
account: do not show error when user cancels password confiramation [fixes #84997138]

### DIFF
--- a/client/app/lib/commonviews/verifypasswordmodal.coffee
+++ b/client/app/lib/commonviews/verifypasswordmodal.coffee
@@ -13,9 +13,6 @@ module.exports = class VerifyPasswordModal extends KDModalViewWithForms
       overlayClick                : no
       width                       : 605
       height                      : "auto"
-      cancel                      : =>
-        callback null
-        @destroy()
       tabs                        :
         navigable                 : yes
         forms                     :

--- a/client/app/lib/commonviews/verifypinmodal.coffee
+++ b/client/app/lib/commonviews/verifypinmodal.coffee
@@ -12,9 +12,6 @@ module.exports = class VerifyPINModal extends KDModalViewWithForms
       overlayClick                : no
       width                       : 605
       height                      : "auto"
-      cancel                      : =>
-        callback null
-        @destroy()
       tabs                        :
         navigable                 : yes
         forms                     :


### PR DESCRIPTION
@gokmen, can you review this fix? It's for [this bug](https://www.pivotaltracker.com/story/show/84997138) in Pivotal. 
I think it makes sense to stop saving data when user cancels password confirmation. Wrong error message was shown before this fix because after user had cancelled password confirmation, the code tried to perform the next check to confirm the password but password was not actually entered. 
The same problem occurred for pin confirmation. I fixed it too
