### PR TITLE
nginx: fix for content-rotator proxy [fixes #93639622]

### DIFF
--- a/config/main.dev.coffee
+++ b/config/main.dev.coffee
@@ -826,7 +826,7 @@ Configuration = (options={}) ->
         node scripts/create-default-workspace
 
         # Run all the worker daemons in KONFIG.workers
-        #{("worker_daemon_"+key+"\n" for key,val of KONFIG.workers).join(" ")}
+        #{("worker_daemon_"+key+"\n" for key,val of KONFIG.workers when val.supervisord).join(" ")}
 
         # Check backend option, if it's then bypass client build
         if [ "$1" == "backend" ] ; then

--- a/config/main.dev.coffee
+++ b/config/main.dev.coffee
@@ -482,8 +482,9 @@ Configuration = (options={}) ->
       nginx             :
         locations       : [
           {
-            location    : "/-/content-rotator/(.*)"
-            proxyPass   : "#{KONFIG.contentRotatorUrl}/$1"
+            location    : "~ /-/content-rotator/(.*)"
+            proxyPass   : "#{KONFIG.contentRotatorUrl}/content-rotator/$1"
+            extraParams : [ "resolver 8.8.8.8;" ]
           }
         ]
 

--- a/config/main.prod.coffee
+++ b/config/main.prod.coffee
@@ -559,8 +559,9 @@ Configuration = (options={}) ->
       nginx             :
         locations       : [
           {
-            location    : "/-/content-rotator/(.*)"
-            proxyPass   : "#{KONFIG.contentRotatorUrl}/$1"
+            location    : "~ /-/content-rotator/(.*)"
+            proxyPass   : "#{KONFIG.contentRotatorUrl}/content-rotator/$1"
+            extraParams : [ "resolver 8.8.8.8;" ]
           }
         ]
 

--- a/config/main.sandbox.coffee
+++ b/config/main.sandbox.coffee
@@ -567,8 +567,9 @@ Configuration = (options={}) ->
       nginx             :
         locations       : [
           {
-            location    : "/-/content-rotator/(.*)"
-            proxyPass   : "#{KONFIG.contentRotatorUrl}/$1"
+            location    : "~ /-/content-rotator/(.*)"
+            proxyPass   : "#{KONFIG.contentRotatorUrl}/content-rotator/$1"
+            extraParams : [ "resolver 8.8.8.8;" ]
           }
         ]
 

--- a/deployment/nginx.coffee
+++ b/deployment/nginx.coffee
@@ -44,6 +44,7 @@ createWebLocation = ({name, locationConf}) ->
         proxy_connect_timeout 1;
         #{if internalOnly then allowInternal else ''}
         #{if auth then basicAuth else ''}
+        #{extraParamsStr}
       }
   \n"""
 


### PR DESCRIPTION
@cihangir, can you please review these changes? They are intended to repair not working content-rotator proxy and fix 3 main things:
- `location` should start with `~` since it's a regexp
- `proxyPass` should include `content-rotator` segment, i.e. `#{KONFIG.contentRotatorUrl}/content-rotator/$1`
- I had to add `resolver 8.8.8.8;` in location instructions since otherwise nginx threw error `no resolver defined to resolve koding.github.io`. I assume this is because `proxyPass` is built dynamically. It works fine with resolver. We also used that resolver for prerender.io requests
