### PR TITLE
Fixes "'Verify now' link is aligned incorrectly on the Account Settings modal" [fixes #91087932]

### DIFF
--- a/client/app/lib/styl/resurrection.commons.styl
+++ b/client/app/lib/styl/resurrection.commons.styl
@@ -1098,7 +1098,7 @@ button.app-settings-menu
 
 a.action-link.verify-email
   color             #888
-  margin            239px
+  margin            235px
   line-height       50px
   text-decoration   none
   span


### PR DESCRIPTION
The end result

![screenshot at 20-57-00](https://cloud.githubusercontent.com/assets/1278794/7776658/2a006b0e-00c5-11e5-8adf-af90f437f21b.png)

Issue initially fixed and merged but had to reapply another fix due to incorrect fonts on my local env.

Original PR: https://github.com/koding/koding/pull/3831

The story: https://www.pivotaltracker.com/story/show/91087932

cc. @usirin @sinan 
