### PR TITLE
Fixes "Progress bar displayed under VM name is too close to the text." [fixes #95233076]

### DIFF
--- a/client/app/lib/styl/resurrection.sidebar.styl
+++ b/client/app/lib/styl/resurrection.sidebar.styl
@@ -358,7 +358,7 @@ sidebarTextShadow()
           background  none
           border      none
           abs         0 0 0px 0px
-          rounded     0 0 3px 3px
+          rounded     1px
           .bar
             background  #4BA148
             border      none

--- a/client/app/lib/styl/resurrection.sidebar.styl
+++ b/client/app/lib/styl/resurrection.sidebar.styl
@@ -988,7 +988,7 @@ h3.sidebar-title
         size        100% 3px
         background  none
         border      none
-        abs         0 0 0px 0px
+        abs         0 0 -4px 0px
         rounded     0 0 3px 3px
         .bar
           background  #4BA148

--- a/client/app/lib/styl/resurrection.sidebar.styl
+++ b/client/app/lib/styl/resurrection.sidebar.styl
@@ -989,7 +989,7 @@ h3.sidebar-title
         background  none
         border      none
         abs         0 0 -4px 0px
-        rounded     0 0 3px 3px
+        rounded     1px
         .bar
           background  #4BA148
           border      none


### PR DESCRIPTION
Before
![screenshot at 22-27-30](https://cloud.githubusercontent.com/assets/1278794/7778257/4eca12de-00d2-11e5-93a3-c47a18547186.png)

After
![screenshot at 22-27-50](https://cloud.githubusercontent.com/assets/1278794/7778256/4eb63322-00d2-11e5-9aba-a2aef2a0bae8.png)

Due to the fonts issue I had yesterday, the spacing was all wrong.

The story: https://www.pivotaltracker.com/story/show/95233076

cc. @sinan @usirin 
