### PR TITLE
topics search: fix for typo in method name [fixes #86883866]

### DIFF
--- a/client/activity/lib/sidebar/topicsearchmodal.coffee
+++ b/client/activity/lib/sidebar/topicsearchmodal.coffee
@@ -14,7 +14,7 @@ module.exports = class TopicSearchModal extends SidebarSearchModal
     options.emptySearchText or= 'Sorry, your search did not have any results'
     options.endpoints        ?=
       fetch                   : kd.singletons.socialapi.channel.list
-      search                  : kd.singletons.socialapi.channel.searchTopicyous
+      search                  : kd.singletons.socialapi.channel.searchTopics
 
     super options, data
 


### PR DESCRIPTION
@gokmen, can you take a look at this fix? It looks like there is a typo in method name for topic search and that's why it doesn't work now. commit: https://github.com/alex-ionochkin/koding/commit/1bddb1048064158df0ae0b591a737b666173517a
