### PR TITLE
Remove redundant go to line beginning/end shortcuts [fixes #95067542]

### DIFF
--- a/client/app/lib/defaultshortcuts/editorhidden.json
+++ b/client/app/lib/defaultshortcuts/editorhidden.json
@@ -69,12 +69,10 @@
       "name": "gotolinestart",
       "binding": [
         [
-          "alt+left",
           "home"
         ],
         [
-          "command+left",
-          "home"
+          "command+left"
         ]
       ]
     },
@@ -82,12 +80,10 @@
       "name": "gotolineend",
       "binding": [
         [
-          "alt+right",
           "end"
         ],
         [
-          "command+right",
-          "end"
+          "command+right"
         ]
       ]
     }


### PR DESCRIPTION
[Home/End don't work within the editor](https://www.pivotaltracker.com/story/show/95067542)
