### PR TITLE
Add command prefix to scroll view shortcuts on mac [fixes #95038212]

### DIFF
--- a/client/app/lib/defaultshortcuts/editor.json
+++ b/client/app/lib/defaultshortcuts/editor.json
@@ -727,7 +727,7 @@
         "ctrl+up"
       ],
       [
-        "ctrl+up"
+        "ctrl+command+up"
       ]
     ]
   },
@@ -739,7 +739,7 @@
         "ctrl+down"
       ],
       [
-        "ctrl+down"
+        "ctrl+command+down"
       ]
     ]
   },


### PR DESCRIPTION
[Ctrl+Up/Down don't work on Mac](https://www.pivotaltracker.com/story/show/95038212)
