### PR TITLE
Replace option with shift as key binding prefix [fixes #95041862]

### DIFF
--- a/client/app/lib/defaultshortcuts/editor.json
+++ b/client/app/lib/defaultshortcuts/editor.json
@@ -499,7 +499,7 @@
         "ctrl+shift+/"
       ],
       [
-        "shift+command+/"
+        "alt+command+/"
       ]
     ]
   },


### PR DESCRIPTION
[Cmd+Shift+/ doesn't work on Mac](https://www.pivotaltracker.com/story/show/95041862)
