### PR TITLE
Builder react support

### DIFF
--- a/client/builder/lib/index.coffee
+++ b/client/builder/lib/index.coffee
@@ -8,6 +8,7 @@ JSONStream    = require 'JSONStream'
 through       = require 'through2'
 coffeeify     = require 'coffeeify'
 pistachioify  = require 'pistachioify'
+reactify      = require 'coffee-reactify'
 uglifyify     = require 'uglifyify'
 xtend         = require 'xtend'
 async         = require 'async'
@@ -230,7 +231,11 @@ class Haydar extends events.EventEmitter
         style      : "#{opts.baseurl}/#{manifest.name}.css"
       }
 
-    transforms = [ coffeeify, pistachioify ]
+    # we are only using this transform to output from cjsx to coffee
+    # the rest will be handled by coffeescript compiler itself.
+    _reactify = [ reactify, { coffeeout: yes } ]
+
+    transforms = [ _reactify, coffeeify, pistachioify ]
 
     if opts.minifyJs
       transforms.push [ uglifyify, {

--- a/client/package.json
+++ b/client/package.json
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "chokidar": "1.0.1",
+    "coffee-reactify": "3.0.0",
     "coffee-script": "1.8.0",
     "express": "4.12.3",
     "mocha": "2.2.4",

--- a/client/package.json
+++ b/client/package.json
@@ -36,6 +36,7 @@
     "ndpane": "0.1.2",
     "node-uuid": "1.4.2",
     "raf": "2.0.4",
+    "react": "0.13.3",
     "record-shortcuts": "0.1.4",
     "shortcuts": "0.5.7",
     "sinkrow": "git+ssh://git@github.com:koding/sinkrow#v0.1.2",


### PR DESCRIPTION
This PR:
- adds 2 package to client package.json: `coffee-reactify` and `React`
- enables coffee-`jsx` on builder.

Main reason of this pr to make `koding` codebase ready for writing `React` components for future.

/cc @koding/kd 
