### PR TITLE
Fixes "Activity: Selected page aren't marked in the pagination control on the /Activity/Public page" [fixes #85273310]

### DIFF
--- a/client/activity/lib/styl/activity.styl
+++ b/client/activity/lib/styl/activity.styl
@@ -815,6 +815,9 @@ nav.crawler-pagination
     noTextDeco()
     fl()
 
+  .activePage
+    background            #1aaf5d
+    color                 #ffffff
 
 // Group Members //
 body.group.members

--- a/servers/lib/crawler/staticpages/feed.coffee
+++ b/servers/lib/crawler/staticpages/feed.coffee
@@ -167,7 +167,7 @@ getPagination = (options)->
     pagination += getNoHrefLink " ... "
 
   [start..end].map (pageNumber)->
-    pagination += getSinglePageLink pageNumber, null, options.route
+    pagination += getSinglePageLink pageNumber, null, options.route, options.currentPage
 
   if end < numberOfPages
     pagination += getNoHrefLink " ... "
@@ -180,8 +180,13 @@ getPagination = (options)->
 getNoHrefLink = (linkText)->
   "<a href='#'>#{linkText}  </a>"
 
-getSinglePageLink = (pageNumber, linkText=pageNumber, route)->
-  link = "<a href='#{uri.address}/#{route}?page=#{pageNumber}'>#{linkText}  </a>"
+getSinglePageLink = (pageNumber, linkText=pageNumber, route, currentPage)->
+  currentPageClass = ""
+
+  if currentPage is pageNumber
+    currentPageClass = "class='activePage'"
+
+  link = "<a href='#{uri.address}/#{route}?page=#{pageNumber}' #{currentPageClass}>#{linkText}  </a>"
   return link
 
 appendDecoratedTopic = (tag, queue)->


### PR DESCRIPTION
Before
![screenshot at 22-43-20](https://cloud.githubusercontent.com/assets/1278794/7821626/c5c3ec60-03f8-11e5-846d-51652982a1f2.png)

After
![screenshot at 22-43-52](https://cloud.githubusercontent.com/assets/1278794/7821625/c5aa003e-03f8-11e5-871e-c82542dfd56a.png)

The story: https://www.pivotaltracker.com/story/show/85273310

Notes:
In the feed.coffe file I didn't want to add an options array to the `getSinglePageLink` method because that would increase the overall code and would be redundant just a parameter since it's called in multiple places and I only need 1 param in 1 place.
in the styl file - we can modify the look, but imo it looks good now (like in the photo above with the green and white).

cc. @sinan @usirin 
