### PR TITLE
Create showcase app [completes #95484946]

### DIFF
--- a/client/showcase/bant.json
+++ b/client/showcase/bant.json
@@ -1,0 +1,10 @@
+{
+  "name": "showcase",
+  "main": "./lib/index.coffee",
+  "styles": [
+    "./lib/styl"
+  ],
+  "routes": {
+    "/Showcase": "ShowcaseIndex"
+  }
+}

--- a/client/showcase/lib/appview.coffee
+++ b/client/showcase/lib/appview.coffee
@@ -1,0 +1,11 @@
+kd = require 'kd'
+
+module.exports = class ShowcaseAppView extends kd.CustomHTMLView
+
+  constructor: (options = {}, data) ->
+
+    options.cssClass = 'ShowcaseApp'
+
+    super options, data
+
+

--- a/client/showcase/lib/index.coffee
+++ b/client/showcase/lib/index.coffee
@@ -1,0 +1,17 @@
+kd = require 'kd'
+AppController = require 'app/appcontroller'
+ShowcaseAppView = require './appview'
+
+require('./routehandler')()
+
+module.exports = class ShowcaseAppController extends AppController
+
+  @options = { name: 'Showcase' }
+
+  constructor: (options, data) ->
+
+    options.appInfo = { title: 'Showcase' }
+    options.view = new ShowcaseAppView
+
+    super options, data
+

--- a/client/showcase/lib/routehandler.coffee
+++ b/client/showcase/lib/routehandler.coffee
@@ -1,0 +1,14 @@
+lazyrouter = require 'app/lazyrouter'
+kd = require 'kd'
+
+
+module.exports = -> lazyrouter.bind 'showcase', (type, info, state, path, ctx) ->
+
+  handlers = require './routehandlers'
+
+  handle = (name) -> handlers["handle#{name}"](info, ctx, path, state)
+
+  handle type
+
+
+

--- a/client/showcase/lib/routehandlers.coffee
+++ b/client/showcase/lib/routehandlers.coffee
@@ -1,0 +1,13 @@
+kd = require 'kd'
+
+module.exports = ShowcaseRouteHandlers =
+
+  # /Showcase
+  handleShowcaseIndex: ->
+
+    openShowcase -> console.log 'hello'
+
+
+openShowcase = (callback) ->
+  {appManager, mainController} = kd.singletons
+  mainController.ready -> appManager.open 'Showcase', callback


### PR DESCRIPTION
tl;dr: This app can be used as a playground for our new/redesigned views to be designed before using them in the applications. Design (style, test, make it work) them here, implement the logic in application where you are using these.

A place for stateless (dummy) views/components to live. Will try to write more about this later, but at a glance:
### What is Showcase app?

`Showcase` app provides a place that all the views/components can be written, styled, and finalized before they are being used by the main parts of the web application and getting into another smart (container) views/components.

/cc @koding/kd 
