### PR TITLE
Fix page up/down function key identifier [fixes #94668980]

### DIFF
--- a/client/app/lib/defaultshortcuts/editor.json
+++ b/client/app/lib/defaultshortcuts/editor.json
@@ -748,10 +748,10 @@
     "description": "Pageup",
     "binding": [
       [
-        "alt+page up"
+        "alt+pageup"
       ],
       [
-        "alt+page up"
+        "alt+pageup"
       ]
     ]
   },
@@ -760,10 +760,10 @@
     "description": "Pagedown",
     "binding": [
       [
-        "alt+page down"
+        "alt+pagedown"
       ],
       [
-        "alt+page down"
+        "alt+pagedown"
       ]
     ]
   }


### PR DESCRIPTION
[Alt+Pageup/Pagedown don't work on windows](https://www.pivotaltracker.com/story/show/94668980)
