### PR TITLE
Add support for dynamically rendering components [completes #95581956]

### DIFF
--- a/client/showcase/bant.json
+++ b/client/showcase/bant.json
@@ -5,6 +5,7 @@
     "./lib/styl"
   ],
   "routes": {
-    "/Showcase": "ShowcaseIndex"
+    "/Showcase": "ShowcaseIndex",
+    "/Showcase/:collection/:component": "ShowComponent"
   }
 }

--- a/client/showcase/lib/appcomponent.coffee
+++ b/client/showcase/lib/appcomponent.coffee
@@ -1,0 +1,45 @@
+React = require 'react'
+kd = require 'kd'
+
+module.exports = class ShowcaseAppComponent extends React.Component
+
+  constructor: (props) ->
+
+    super props
+
+    @state = { component: <h3>{'HelloWorld'}</h3> }
+
+    @showComponent = @showComponent.bind this
+
+
+  componentDidMount: ->
+
+    # register to dispatcher, show the emitted component when
+    # `ShowComponent` event is dispatched.
+    @props.dispatcher.on 'ShowComponent', @showComponent
+
+
+  componentWillUnmount: ->
+
+    @props.dispatcher.off 'ShowComponent', @showComponent
+
+
+  ###
+   * Set component to the state, this will trigger the rerender.
+  ###
+  showComponent: (component) -> @setState { component }
+
+
+  ###*
+   * Custom getter for component. If you want to do funny stuff with the given
+   * component this is the place.
+   *
+   * @return {React.Component} _component
+  ###
+  getComponent: -> <span>{@state.component}</span>
+
+
+  render: ->
+    <div>{@getComponent()}</div>
+
+

--- a/client/showcase/lib/appview.coffee
+++ b/client/showcase/lib/appview.coffee
@@ -20,6 +20,16 @@ module.exports = class ShowcaseAppView extends kd.CustomHTMLView
 
 
   ###*
+   * Takes a React Component and dispatches it after initializing it.
+   *
+   * @param {React.Component} component
+  ###
+  showReactComponent: (component) ->
+
+    @_dispatcher.emit 'ShowComponent', React.createElement component
+
+
+  ###*
    * Initial render, render AppComponent, pass the dispatcher to it;
    * then append it into this view's dom element.
   ###

--- a/client/showcase/lib/appview.coffee
+++ b/client/showcase/lib/appview.coffee
@@ -1,5 +1,10 @@
-kd = require 'kd'
+kd           = require 'kd'
+React        = require 'react'
+AppComponent = require './appcomponent'
 
+###*
+ * Bridge between KD and React. Finally. ~Umut
+###
 module.exports = class ShowcaseAppView extends kd.CustomHTMLView
 
   constructor: (options = {}, data) ->
@@ -7,5 +12,22 @@ module.exports = class ShowcaseAppView extends kd.CustomHTMLView
     options.cssClass = 'ShowcaseApp'
 
     super options, data
+
+    # Since this class is not a React component and we are using this
+    # dispatcher to send events to the Top level React component, so that it
+    # can set its own state, and pass the props to its children.
+    @_dispatcher = new kd.Object
+
+
+  ###*
+   * Initial render, render AppComponent, pass the dispatcher to it;
+   * then append it into this view's dom element.
+  ###
+  viewAppended: ->
+
+    React.render(
+      React.createElement AppComponent, { dispatcher: @_dispatcher }
+      @getElement()
+    )
 
 

--- a/client/showcase/lib/appview.coffee
+++ b/client/showcase/lib/appview.coffee
@@ -30,6 +30,13 @@ module.exports = class ShowcaseAppView extends kd.CustomHTMLView
 
 
   ###*
+   * To be implemented...
+  ###
+  showKDView: (component) ->
+    console.error 'ShowcaseAppView::showKDView: not yet implemented'
+
+
+  ###*
    * Initial render, render AppComponent, pass the dispatcher to it;
    * then append it into this view's dom element.
   ###

--- a/client/showcase/lib/components/common/example.coffee
+++ b/client/showcase/lib/components/common/example.coffee
@@ -1,0 +1,6 @@
+React = require 'react'
+
+module.exports = class ExampleComponent extends React.Component
+
+  render: ->
+    <div className="ExampleComponent">Hello World!</div>

--- a/client/showcase/lib/index.coffee
+++ b/client/showcase/lib/index.coffee
@@ -2,6 +2,8 @@ kd = require 'kd'
 AppController = require 'app/appcontroller'
 ShowcaseAppView = require './appview'
 
+ComponentRegistry = require './registry'
+
 require('./routehandler')()
 
 module.exports = class ShowcaseAppController extends AppController
@@ -14,4 +16,29 @@ module.exports = class ShowcaseAppController extends AppController
     options.view = new ShowcaseAppView
 
     super options, data
+
+
+  ###*
+   * Get given record from registry and pass it to view so that it can be
+   * rendered on the page.
+   *
+   * @param {string} collection
+   * @param {string} componentName
+  ###
+  showCollectionComponent: (collection, componentName) ->
+
+    # allow components to be reached case-insensitively.
+    collection = collection.toLowerCase()
+    componentName = componentName.toLowerCase()
+
+    return  unless record = ComponentRegistry.get collection, componentName
+
+    { type, component } = record
+
+    switch type
+      when 'react'
+        @getView().showReactComponent component
+      when 'kd'
+        @getView().showKDView component
+
 

--- a/client/showcase/lib/registry.coffee
+++ b/client/showcase/lib/registry.coffee
@@ -1,0 +1,18 @@
+###*
+ * Since browserify doesn't let us require modules dynamically with variables,
+ * components should be exported here. Until we find a better solution, if you
+ * want your component to be reachable via `/Showcase` route you will have to
+ * register it here.
+###
+module.exports = ComponentRegistry =
+  common:
+    example:
+      component : require './components/common/example'
+      type      : 'react'
+
+  get: (collection, component) ->
+
+    _component = this[collection]?[component]
+
+    return _component or null
+

--- a/client/showcase/lib/routehandlers.coffee
+++ b/client/showcase/lib/routehandlers.coffee
@@ -5,7 +5,14 @@ module.exports = ShowcaseRouteHandlers =
   # /Showcase
   handleShowcaseIndex: ->
 
-    openShowcase -> console.log 'hello'
+    openShowcase (showcase) ->
+
+  # /Showcase/:collection/:component
+  handleShowComponent: ({ params: { collection, component } })->
+
+    openShowcase (showcase) ->
+
+      showcase.showCollectionComponent collection, component
 
 
 openShowcase = (callback) ->


### PR DESCRIPTION
This PR adds support for dynamically rendering a component/view through `/Showcase`.

Simply when `/Showcase/:collection/:component` route is hit, it will find the component in specified collection from `ComponentRegistry`.

`/Showcase/activity/listitem` will try to render the `listitem` component in `activity` collection of `ComponentRegistry`: [link](https://github.com/koding/koding/pull/3916/files#diff-4e7a2ee5fb64acd4860940f85287c607R8)

There is only support for `React` at this moment. `KD` component support shouldn't be very hard to implement, but can be deferred to some other time for now.

/cc @koding/kd 
