### PR TITLE
add support for chat system messages

### DIFF
--- a/client/activity/lib/views/messagepane.coffee
+++ b/client/activity/lib/views/messagepane.coffee
@@ -37,7 +37,7 @@ module.exports = class MessagePane extends KDTabPaneView
       self          : 0
       body          : 0
 
-    { itemClass, lastToFirst, wrapper, channelId
+    { itemClass, lastToFirst, wrapper, channelId, channelType,
       scrollView, noItemFoundWidget, startWithLazyLoader
     } = @getOptions()
 
@@ -46,7 +46,7 @@ module.exports = class MessagePane extends KDTabPaneView
     @listController = new ActivityListController {
       type          : typeConstant
       viewOptions   :
-        itemOptions : {channelId}
+        itemOptions : {channelId, channelType}
       wrapper
       itemClass
       lastToFirst

--- a/client/activity/lib/views/privatemessage/privatemessagelistitemview.coffee
+++ b/client/activity/lib/views/privatemessage/privatemessagelistitemview.coffee
@@ -34,44 +34,59 @@ module.exports = class PrivateMessageListItemView extends ActivityListItemView
       type        : 'privatemessage'
 
 
-  prepareDefaultBody: (type, addedBy) ->
-    body = "has #{type} the chat"
+  prepareDefaultBody: (options = {}) ->
+
+    { addedBy, paneType, initialParticipants, action } = options
+
+    # when it contains initial participants it contains all the accounts
+    # initially added to the conversation
+    if initialParticipants
+      body = "has started the #{paneType}"
+
+      return body  if initialParticipants.length is 0
+
+      body = "#{body} and invited "
+      body = "#{body} @#{participant}," for participant in initialParticipants
+
+      return body.slice 0, body.length - 1
+
+    body = "has #{action} the #{paneType}"
 
     # append who added the user
-    body = "#{body} from an invitation by @#{addedBy}" if addedBy
+    body = "#{body} from an invitation by @#{addedBy}"  if addedBy
 
     return body
 
 
   prepareActivityMessage: ->
 
-    {typeConstant, payload} = @getData()
-    {addedBy, initialParticipants, activityType} = payload if payload
-    typeConstant = activityType  if typeConstant is 'activity'
+    { typeConstant, payload } = @getData()
+
+    { channelType } = @getOptions()
+
+    {addedBy, initialParticipants, systemType} = payload if payload
+    typeConstant = systemType  if typeConstant is 'system'
+
+    paneType = if channelType is 'privatemessage' then 'conversation' else 'session'
+
+    options = { addedBy, paneType, initialParticipants }
 
     # get default join/leave message body
     switch typeConstant
       when 'join'
-        body = @prepareDefaultBody 'joined', addedBy  unless initialParticipants
+        options.action = 'joined'
+        body = @prepareDefaultBody options
       when 'leave'
-        body = @prepareDefaultBody 'left', addedBy
+        options.action = 'left'
+        body = @prepareDefaultBody options
       when 'invite'
-        body = "invited to the session"
+        body = "was invited to the #{paneType}"
       when 'reject'
-        body = "has rejected the invitation"
+        body = "has rejected the invite for this #{paneType}"
+      when 'kick'
+        body = "has been removed from this #{paneType}"
       else
         body = @getData().body
-
-
-    # when it contains initial participants it contains all the accounts
-    # initially added to the conversation
-    if initialParticipants
-      if initialParticipants.length is 0
-        body = "started this conversation"
-      else
-        body = "started the conversation and invited "
-        body = "#{body} @#{participant}," for participant in initialParticipants
-        body = body.slice 0, body.length - 1
 
     return body
 
@@ -80,11 +95,11 @@ module.exports = class PrivateMessageListItemView extends ActivityListItemView
 
     {repliesCount, payload, typeConstant} = @getData()
 
-    if typeConstant in ['join', 'leave', 'activity']
+    if typeConstant in ['join', 'leave', 'system']
       @getData().body = @prepareActivityMessage()
       @setClass 'join-leave'
 
-    if payload?['system-message'] or payload?['activityType']
+    if payload?['system-message'] or payload?['system']
       @setClass 'join-leave'
 
     @showParentPost()  if repliesCount < 3

--- a/client/activity/lib/views/privatemessage/privatemessagepane.coffee
+++ b/client/activity/lib/views/privatemessage/privatemessagepane.coffee
@@ -29,6 +29,7 @@ module.exports = class PrivateMessagePane extends MessagePane
     options.noItemFoundWidget   = no
     options.startWithLazyLoader = no
     options.itemClass         or= PrivateMessageListItemView
+    options.channelType       or= 'privatemessage'
 
     options.initialParticipantStatus = 'active'
 

--- a/client/activity/lib/views/privatemessage/privatemessagepane.coffee
+++ b/client/activity/lib/views/privatemessage/privatemessagepane.coffee
@@ -30,6 +30,8 @@ module.exports = class PrivateMessagePane extends MessagePane
     options.startWithLazyLoader = no
     options.itemClass         or= PrivateMessageListItemView
 
+    options.initialParticipantStatus = 'active'
+
     super options, data
 
     @createPreviousLink()
@@ -424,8 +426,9 @@ module.exports = class PrivateMessagePane extends MessagePane
     @autoComplete.on 'ItemListChanged', (count) =>
       participant  = @autoComplete.getSelectedItemData()[count - 1]
       options      =
-        channelId  : @getData().getId()
-        accountIds : [participant.socialApiId]
+        channelId         : @getData().getId()
+        accountIds        : [participant.socialApiId]
+        participantStatus : @getOptions().initialParticipantStatus
 
       {channel} = kd.singleton 'socialapi'
       channel.addParticipants options, (err, result) =>

--- a/client/app/lib/activity/sidebar/activitysidebar.coffee
+++ b/client/app/lib/activity/sidebar/activitysidebar.coffee
@@ -122,7 +122,10 @@ module.exports = class ActivitySidebar extends KDCustomHTMLView
     { channel, channelMessage, unreadCount } = update
 
     if isChannelCollaborative(channel) and channelMessage.payload
-      if channelMessage.payload['system-message'] in ['start', 'stop']
+      { activityType } = channelMessage.payload
+      activityType or= channelMessage.payload['system-message']
+
+      if activityType in ['start', 'stop']
         @fetchEnvironmentData =>
           @setWorkspaceUnreadCount channel, unreadCount
 

--- a/client/app/lib/activity/sidebar/activitysidebar.coffee
+++ b/client/app/lib/activity/sidebar/activitysidebar.coffee
@@ -122,10 +122,10 @@ module.exports = class ActivitySidebar extends KDCustomHTMLView
     { channel, channelMessage, unreadCount } = update
 
     if isChannelCollaborative(channel) and channelMessage.payload
-      { activityType } = channelMessage.payload
-      activityType or= channelMessage.payload['system-message']
+      { systemType } = channelMessage.payload
+      systemType or= channelMessage.payload['system-message']
 
-      if activityType in ['start', 'stop']
+      if systemType in ['start', 'stop']
         @fetchEnvironmentData =>
           @setWorkspaceUnreadCount channel, unreadCount
 

--- a/client/app/lib/socialapicontroller.coffee
+++ b/client/app/lib/socialapicontroller.coffee
@@ -684,6 +684,14 @@ module.exports = class SocialApiController extends KDController
       validateOptionsWith : ['channelId']
       successFn           : leaveChannel
 
+    acceptInvite          : channelRequesterFn
+      fnName              : 'acceptInvite'
+      validateOptionsWith : ['channelId']
+
+    rejectInvite          : channelRequesterFn
+      fnName              : 'rejectInvite'
+      validateOptionsWith : ['channelId']
+
     kickParticipants     : channelRequesterFn
       fnName             : 'leave'
       validateOptionsWith: ['channelId', 'accountIds']

--- a/config/main.dev.coffee
+++ b/config/main.dev.coffee
@@ -822,6 +822,7 @@ Configuration = (options={}) ->
         env PGPASSWORD=#{postgres.password} psql -tA -h #{postgres.host} #{postgres.dbname} -U #{postgres.username} -c "ALTER TYPE \"api\".\"channel_type_constant_enum\" ADD VALUE IF NOT EXISTS 'linkedtopic';"
         env PGPASSWORD=#{postgres.password} psql -tA -h #{postgres.host} #{postgres.dbname} -U #{postgres.username} -c "ALTER TYPE \"api\".\"channel_type_constant_enum\" ADD VALUE IF NOT EXISTS 'bot';"
         env PGPASSWORD=#{postgres.password} psql -tA -h #{postgres.host} #{postgres.dbname} -U #{postgres.username} -c "ALTER TYPE \"api\".\"channel_message_type_constant_enum\" ADD VALUE IF NOT EXISTS 'bot';"
+        env PGPASSWORD=#{postgres.password} psql -tA -h #{postgres.host} #{postgres.dbname} -U #{postgres.username} -c "ALTER TYPE \"api\".\"channel_message_type_constant_enum\" ADD VALUE IF NOT EXISTS 'activity';"
       }
 
       function run () {

--- a/config/main.dev.coffee
+++ b/config/main.dev.coffee
@@ -822,7 +822,7 @@ Configuration = (options={}) ->
         env PGPASSWORD=#{postgres.password} psql -tA -h #{postgres.host} #{postgres.dbname} -U #{postgres.username} -c "ALTER TYPE \"api\".\"channel_type_constant_enum\" ADD VALUE IF NOT EXISTS 'linkedtopic';"
         env PGPASSWORD=#{postgres.password} psql -tA -h #{postgres.host} #{postgres.dbname} -U #{postgres.username} -c "ALTER TYPE \"api\".\"channel_type_constant_enum\" ADD VALUE IF NOT EXISTS 'bot';"
         env PGPASSWORD=#{postgres.password} psql -tA -h #{postgres.host} #{postgres.dbname} -U #{postgres.username} -c "ALTER TYPE \"api\".\"channel_message_type_constant_enum\" ADD VALUE IF NOT EXISTS 'bot';"
-        env PGPASSWORD=#{postgres.password} psql -tA -h #{postgres.host} #{postgres.dbname} -U #{postgres.username} -c "ALTER TYPE \"api\".\"channel_message_type_constant_enum\" ADD VALUE IF NOT EXISTS 'activity';"
+        env PGPASSWORD=#{postgres.password} psql -tA -h #{postgres.host} #{postgres.dbname} -U #{postgres.username} -c "ALTER TYPE \"api\".\"channel_message_type_constant_enum\" ADD VALUE IF NOT EXISTS 'system';"
       }
 
       function run () {

--- a/go/src/socialapi/db/sql/definition/004-table.sql
+++ b/go/src/socialapi/db/sql/definition/004-table.sql
@@ -83,7 +83,7 @@ CREATE TYPE "api"."channel_message_type_constant_enum" AS ENUM (
     'leave',
     'privatemessage',
     'bot',
-    'activity'
+    'system'
 );
 
 ALTER TYPE "api"."channel_message_type_constant_enum" OWNER TO "social";

--- a/go/src/socialapi/db/sql/definition/004-table.sql
+++ b/go/src/socialapi/db/sql/definition/004-table.sql
@@ -82,7 +82,8 @@ CREATE TYPE "api"."channel_message_type_constant_enum" AS ENUM (
     'join',
     'leave',
     'privatemessage',
-    'bot'
+    'bot',
+    'activity'
 );
 
 ALTER TYPE "api"."channel_message_type_constant_enum" OWNER TO "social";

--- a/go/src/socialapi/db/sql/migrations/0013_add-channelmessage-activity-type.down.sql
+++ b/go/src/socialapi/db/sql/migrations/0013_add-channelmessage-activity-type.down.sql
@@ -1,0 +1,5 @@
+
+-- postgres doesnt support removing a type from ENUM
+-- ALTER TYPE "api"."channel_message_type_constant_enum" ADD VALUE IF NOT EXISTS "activity"
+-- stub
+Select 1 from pg_tables;

--- a/go/src/socialapi/db/sql/migrations/0013_add-channelmessage-activity-type.up.sql
+++ b/go/src/socialapi/db/sql/migrations/0013_add-channelmessage-activity-type.up.sql
@@ -1,0 +1,7 @@
+--
+-- We need "activity" type constant for channel message table, for storing user
+-- activities
+--
+-- ALTER TYPE "api"."channel_message_type_constant_enum" ADD VALUE IF NOT EXISTS 'activity';
+-- this is just a stub
+Select 1 from pg_tables;

--- a/go/src/socialapi/models/channelmessage.go
+++ b/go/src/socialapi/models/channelmessage.go
@@ -69,7 +69,7 @@ const (
 	ChannelMessage_TYPE_LEAVE           = "leave"
 	ChannelMessage_TYPE_PRIVATE_MESSAGE = "privatemessage"
 	ChannelMessage_TYPE_BOT             = "bot"
-	ChannelMessage_TYPE_ACTIVITY        = "activity"
+	ChannelMessage_TYPE_SYSTEM          = "system"
 
 	ChannelMessagePayloadKeyLocation = "location"
 )

--- a/go/src/socialapi/models/channelmessage.go
+++ b/go/src/socialapi/models/channelmessage.go
@@ -69,6 +69,7 @@ const (
 	ChannelMessage_TYPE_LEAVE           = "leave"
 	ChannelMessage_TYPE_PRIVATE_MESSAGE = "privatemessage"
 	ChannelMessage_TYPE_BOT             = "bot"
+	ChannelMessage_TYPE_ACTIVITY        = "activity"
 
 	ChannelMessagePayloadKeyLocation = "location"
 )

--- a/go/src/socialapi/models/channelmessage_bongo.go
+++ b/go/src/socialapi/models/channelmessage_bongo.go
@@ -142,11 +142,7 @@ func (c *ChannelMessage) validateSystemMessage() error {
 		return nil
 	}
 
-	if c.Payload == nil {
-		return ErrSystemTypeIsNotSet
-	}
-
-	if _, ok := c.Payload["systemType"]; !ok {
+	if val := c.GetPayload("systemType"); val == nil {
 		return ErrSystemTypeIsNotSet
 	}
 

--- a/go/src/socialapi/models/channelmessage_bongo.go
+++ b/go/src/socialapi/models/channelmessage_bongo.go
@@ -67,7 +67,8 @@ func (c *ChannelMessage) Update() error {
 	}
 
 	if cm.TypeConstant == ChannelMessage_TYPE_JOIN ||
-		cm.TypeConstant == ChannelMessage_TYPE_LEAVE {
+		cm.TypeConstant == ChannelMessage_TYPE_LEAVE ||
+		cm.TypeConstant == ChannelMessage_TYPE_ACTIVITY {
 		return ErrChannelMessageUpdatedNotAllowed
 	}
 
@@ -91,6 +92,10 @@ func (c *ChannelMessage) Update() error {
 // tests are added for this function
 func (c *ChannelMessage) Create() error {
 	if err := bodyLenCheck(c.Body); err != nil {
+		return err
+	}
+
+	if err := c.validateActivityMessage(); err != nil {
 		return err
 	}
 
@@ -129,4 +134,21 @@ func (c *ChannelMessage) CountWithQuery(q *bongo.Query) (int, error) {
 
 func (c *ChannelMessage) Delete() error {
 	return bongo.B.DB.Unscoped().Delete(c).Error
+}
+
+func (c *ChannelMessage) validateActivityMessage() error {
+
+	if c.TypeConstant != ChannelMessage_TYPE_ACTIVITY {
+		return nil
+	}
+
+	if c.Payload == nil {
+		return ErrActivityTypeIsNotSet
+	}
+
+	if _, ok := c.Payload["activityType"]; !ok {
+		return ErrActivityTypeIsNotSet
+	}
+
+	return nil
 }

--- a/go/src/socialapi/models/channelmessage_bongo.go
+++ b/go/src/socialapi/models/channelmessage_bongo.go
@@ -68,7 +68,7 @@ func (c *ChannelMessage) Update() error {
 
 	if cm.TypeConstant == ChannelMessage_TYPE_JOIN ||
 		cm.TypeConstant == ChannelMessage_TYPE_LEAVE ||
-		cm.TypeConstant == ChannelMessage_TYPE_ACTIVITY {
+		cm.TypeConstant == ChannelMessage_TYPE_SYSTEM {
 		return ErrChannelMessageUpdatedNotAllowed
 	}
 
@@ -95,7 +95,7 @@ func (c *ChannelMessage) Create() error {
 		return err
 	}
 
-	if err := c.validateActivityMessage(); err != nil {
+	if err := c.validateSystemMessage(); err != nil {
 		return err
 	}
 
@@ -136,18 +136,18 @@ func (c *ChannelMessage) Delete() error {
 	return bongo.B.DB.Unscoped().Delete(c).Error
 }
 
-func (c *ChannelMessage) validateActivityMessage() error {
+func (c *ChannelMessage) validateSystemMessage() error {
 
-	if c.TypeConstant != ChannelMessage_TYPE_ACTIVITY {
+	if c.TypeConstant != ChannelMessage_TYPE_SYSTEM {
 		return nil
 	}
 
 	if c.Payload == nil {
-		return ErrActivityTypeIsNotSet
+		return ErrSystemTypeIsNotSet
 	}
 
-	if _, ok := c.Payload["activityType"]; !ok {
-		return ErrActivityTypeIsNotSet
+	if _, ok := c.Payload["systemType"]; !ok {
+		return ErrSystemTypeIsNotSet
 	}
 
 	return nil

--- a/go/src/socialapi/models/channelmessage_test.go
+++ b/go/src/socialapi/models/channelmessage_test.go
@@ -94,11 +94,11 @@ func TestChannelMessageCreate(t *testing.T) {
 		Convey("type constant can be activity", func() {
 			cm := createMessageWithTest()
 
-			cm.TypeConstant = ChannelMessage_TYPE_ACTIVITY
+			cm.TypeConstant = ChannelMessage_TYPE_SYSTEM
 
-			So(cm.Create(), ShouldEqual, ErrActivityTypeIsNotSet)
+			So(cm.Create(), ShouldEqual, ErrSystemTypeIsNotSet)
 
-			cm.SetPayload("activityType", "invite")
+			cm.SetPayload("systemType", "invite")
 
 			So(cm.Create(), ShouldBeNil)
 
@@ -106,7 +106,7 @@ func TestChannelMessageCreate(t *testing.T) {
 			err := icm.ById(cm.Id)
 			So(err, ShouldBeNil)
 			So(icm.Id, ShouldEqual, cm.Id)
-			So(icm.TypeConstant, ShouldEqual, ChannelMessage_TYPE_ACTIVITY)
+			So(icm.TypeConstant, ShouldEqual, ChannelMessage_TYPE_SYSTEM)
 		})
 
 		Convey("type constant can be privatemessage", func() {

--- a/go/src/socialapi/models/channelmessage_test.go
+++ b/go/src/socialapi/models/channelmessage_test.go
@@ -91,6 +91,24 @@ func TestChannelMessageCreate(t *testing.T) {
 			So(icm.TypeConstant, ShouldEqual, ChannelMessage_TYPE_LEAVE)
 		})
 
+		Convey("type constant can be activity", func() {
+			cm := createMessageWithTest()
+
+			cm.TypeConstant = ChannelMessage_TYPE_ACTIVITY
+
+			So(cm.Create(), ShouldEqual, ErrActivityTypeIsNotSet)
+
+			cm.SetPayload("activityType", "invite")
+
+			So(cm.Create(), ShouldBeNil)
+
+			icm := NewChannelMessage()
+			err := icm.ById(cm.Id)
+			So(err, ShouldBeNil)
+			So(icm.Id, ShouldEqual, cm.Id)
+			So(icm.TypeConstant, ShouldEqual, ChannelMessage_TYPE_ACTIVITY)
+		})
+
 		Convey("type constant can be privatemessage", func() {
 			cm := createMessageWithTest()
 			// remove type Constant

--- a/go/src/socialapi/models/channelparticipant.go
+++ b/go/src/socialapi/models/channelparticipant.go
@@ -468,6 +468,10 @@ func (c *ChannelParticipant) checkAccountStatus(accountId int64) (bool, error) {
 		return false, ErrChannelIdIsNotSet
 	}
 
+	if c.StatusConstant == "" {
+		c.StatusConstant = ChannelParticipant_STATUS_ACTIVE
+	}
+
 	selector := map[string]interface{}{
 		"channel_id":      c.ChannelId,
 		"account_id":      accountId,

--- a/go/src/socialapi/models/channelparticipant_test.go
+++ b/go/src/socialapi/models/channelparticipant_test.go
@@ -70,14 +70,14 @@ func TestChannelParticipantBeforeUpdate(t *testing.T) {
 	})
 }
 
-func TestChannelParticipantIsParticipant(t *testing.T) {
+func TestChannelParticipantCheckAccountStatus(t *testing.T) {
 	r := runner.New("test")
 	if err := r.Init(); err != nil {
 		t.Fatalf("couldnt start bongo %s", err.Error())
 	}
 	defer r.Close()
 
-	Convey("While testing is participant", t, func() {
+	Convey("While testing account status", t, func() {
 		Convey("it should have channel id", func() {
 			cp := NewChannelParticipant()
 
@@ -112,6 +112,23 @@ func TestChannelParticipantIsParticipant(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(ip, ShouldEqual, true)
 			So(cp.StatusConstant, ShouldEqual, ChannelParticipant_STATUS_ACTIVE)
+		})
+		Convey("it should return true for pending participant", func() {
+
+			c := createNewChannelWithTest()
+			So(c.Create(), ShouldBeNil)
+			acc := CreateAccountWithTest()
+			So(acc.Create(), ShouldBeNil)
+			cp := NewChannelParticipant()
+			cp.ChannelId = c.Id
+			cp.AccountId = acc.Id
+			cp.StatusConstant = ChannelParticipant_STATUS_REQUEST_PENDING
+			So(cp.Create(), ShouldBeNil)
+
+			ip, err := cp.IsInvited(acc.Id)
+			So(err, ShouldBeNil)
+			So(ip, ShouldEqual, true)
+			So(cp.StatusConstant, ShouldEqual, ChannelParticipant_STATUS_REQUEST_PENDING)
 		})
 	})
 }

--- a/go/src/socialapi/models/errors.go
+++ b/go/src/socialapi/models/errors.go
@@ -18,7 +18,7 @@ var (
 	ErrParentMessageIsNotSet   = errors.New("parent message is not set")
 	ErrParentMessageIdIsNotSet = errors.New("parent message id is not set")
 	ErrCreatorIdIsNotSet       = errors.New("creator id is not set")
-	ErrActivityTypeIsNotSet    = errors.New("activityType is not set in payload")
+	ErrSystemTypeIsNotSet      = errors.New("systemType is not set in payload")
 
 	ErrChannelIsNotSet                = errors.New("channel is not set")
 	ErrChannelIdIsNotSet              = errors.New("channel id is not set")

--- a/go/src/socialapi/models/errors.go
+++ b/go/src/socialapi/models/errors.go
@@ -18,6 +18,7 @@ var (
 	ErrParentMessageIsNotSet   = errors.New("parent message is not set")
 	ErrParentMessageIdIsNotSet = errors.New("parent message id is not set")
 	ErrCreatorIdIsNotSet       = errors.New("creator id is not set")
+	ErrActivityTypeIsNotSet    = errors.New("activityType is not set in payload")
 
 	ErrChannelIsNotSet                = errors.New("channel is not set")
 	ErrChannelIdIsNotSet              = errors.New("channel id is not set")

--- a/go/src/socialapi/models/privatechannelrequest.go
+++ b/go/src/socialapi/models/privatechannelrequest.go
@@ -14,6 +14,7 @@ const (
 	PrivateMessageSystem_TYPE_JOIN   = "join"
 	PrivateMessageSystem_TYPE_LEAVE  = "leave"
 	PrivateMessageSystem_TYPE_REJECT = "reject"
+	PrivateMessageSystem_TYPE_KICK   = "kick"
 )
 
 type PrivateChannelRequest struct {
@@ -29,21 +30,9 @@ type PrivateChannelRequest struct {
 	TypeConstant    string `json:"type"`
 }
 
-func (p *PrivateChannelRequest) SetSystemTypeByParticipant(participant *ChannelParticipant) {
+func (p *PrivateChannelRequest) SetSystemMessageType(systemType string) {
 	if p.Payload == nil {
 		p.Payload = gorm.Hstore{}
-	}
-
-	var systemType string
-	switch participant.StatusConstant {
-	case ChannelParticipant_STATUS_ACTIVE:
-		systemType = PrivateMessageSystem_TYPE_JOIN
-	case ChannelParticipant_STATUS_REQUEST_PENDING:
-		systemType = PrivateMessageSystem_TYPE_INVITE
-	case ChannelParticipant_STATUS_LEFT:
-		systemType = PrivateMessageSystem_TYPE_LEAVE
-	case ChannelParticipant_STATUS_BLOCKED:
-		systemType = PrivateMessageSystem_TYPE_REJECT
 	}
 
 	if systemType != "" {

--- a/go/src/socialapi/rest/channelparticipant.go
+++ b/go/src/socialapi/rest/channelparticipant.go
@@ -85,6 +85,27 @@ func UnblockChannelParticipant(channelId, requesterId int64, accountIds ...int64
 	)
 }
 
+func InviteChannelParticipant(channelId, requesterId int64, accountIds ...int64) (*models.ChannelParticipant, error) {
+	url := fmt.Sprintf("/channel/%d/participants/add?accountId=%d", channelId, requesterId)
+
+	res := make([]*models.ChannelParticipant, 0)
+	for _, accountId := range accountIds {
+		c := models.NewChannelParticipant()
+		c.AccountId = accountId
+		c.StatusConstant = models.ChannelParticipant_STATUS_REQUEST_PENDING
+		res = append(res, c)
+	}
+
+	cps, err := sendModel("POST", url, &res)
+	if err != nil {
+		return nil, err
+	}
+
+	a := *(cps.(*[]*models.ChannelParticipant))
+
+	return a[0], nil
+}
+
 func channelParticipantOp(url string, channelId, requesterId int64, accountIds ...int64) (*models.ChannelParticipant, error) {
 
 	res := make([]*models.ChannelParticipant, 0)

--- a/go/src/socialapi/rest/channelparticipant.go
+++ b/go/src/socialapi/rest/channelparticipant.go
@@ -85,6 +85,22 @@ func UnblockChannelParticipant(channelId, requesterId int64, accountIds ...int64
 	)
 }
 
+func AcceptInvitation(channelId int64, token string) error {
+	url := fmt.Sprintf("/channel/%d/invitation/accept", channelId)
+	cp := models.NewChannelParticipant()
+	_, err := marshallAndSendRequestWithAuth("POST", url, cp, token)
+
+	return err
+}
+
+func RejectInvitation(channelId int64, token string) error {
+	url := fmt.Sprintf("/channel/%d/invitation/reject", channelId)
+	cp := models.NewChannelParticipant()
+	_, err := marshallAndSendRequestWithAuth("POST", url, cp, token)
+
+	return err
+}
+
 func InviteChannelParticipant(channelId, requesterId int64, accountIds ...int64) (*models.ChannelParticipant, error) {
 	url := fmt.Sprintf("/channel/%d/participants/add?accountId=%d", channelId, requesterId)
 

--- a/go/src/socialapi/tests/channel_participant_test.go
+++ b/go/src/socialapi/tests/channel_participant_test.go
@@ -166,6 +166,17 @@ func TestChannelParticipantOperations(t *testing.T) {
 					_, err = rest.DeleteChannelParticipant(channelContainer.Channel.Id, secondAccount.Id, thirdAccount.Id)
 					So(err, ShouldNotBeNil)
 				})
+
+			})
+			Convey("First user should be able to invite second user", func() {
+				_, err = rest.InviteChannelParticipant(channelContainer.Channel.Id, ownerAccount.Id, secondAccount.Id)
+				So(err, ShouldBeNil)
+				participants, err := rest.ListChannelParticipants(channelContainer.Channel.Id, ownerAccount.Id)
+				So(err, ShouldBeNil)
+				So(participants, ShouldNotBeNil)
+				// it is four because first user is "devrim" here
+				So(len(participants), ShouldEqual, 2)
+
 			})
 
 			// TODO Until we find a better way for handling async stuff, this test is skipped. Instead of sleep, we should use some

--- a/go/src/socialapi/tests/channel_participant_test.go
+++ b/go/src/socialapi/tests/channel_participant_test.go
@@ -177,6 +177,33 @@ func TestChannelParticipantOperations(t *testing.T) {
 				// it is four because first user is "devrim" here
 				So(len(participants), ShouldEqual, 2)
 
+				Convey("Second user should be able to reject invitation", func() {
+					ses, err := models.FetchOrCreateSession(secondAccount.Nick, groupName)
+					So(err, ShouldBeNil)
+					So(ses, ShouldNotBeNil)
+
+					err = rest.RejectInvitation(channelContainer.Channel.Id, ses.ClientId)
+					So(err, ShouldBeNil)
+
+					participants, err := rest.ListChannelParticipants(channelContainer.Channel.Id, ownerAccount.Id)
+					So(err, ShouldBeNil)
+					So(participants, ShouldNotBeNil)
+					So(len(participants), ShouldEqual, 2)
+				})
+
+				Convey("Second user should be able to accept invitation", func() {
+					ses, err := models.FetchOrCreateSession(secondAccount.Nick, groupName)
+					So(err, ShouldBeNil)
+					So(ses, ShouldNotBeNil)
+
+					err = rest.AcceptInvitation(channelContainer.Channel.Id, ses.ClientId)
+					So(err, ShouldBeNil)
+
+					participants, err := rest.ListChannelParticipants(channelContainer.Channel.Id, ownerAccount.Id)
+					So(err, ShouldBeNil)
+					So(participants, ShouldNotBeNil)
+					So(len(participants), ShouldEqual, 3)
+				})
 			})
 
 			// TODO Until we find a better way for handling async stuff, this test is skipped. Instead of sleep, we should use some

--- a/go/src/socialapi/tests/collaboration_channel_test.go
+++ b/go/src/socialapi/tests/collaboration_channel_test.go
@@ -332,11 +332,15 @@ func TestCollaborationChannels(t *testing.T) {
 			So(len(history.MessageList), ShouldEqual, 3)
 
 			So(history.MessageList[0].Message, ShouldNotBeNil)
-			So(history.MessageList[0].Message.TypeConstant, ShouldEqual, models.ChannelMessage_TYPE_JOIN)
+			So(history.MessageList[0].Message.TypeConstant, ShouldEqual, models.ChannelMessage_TYPE_ACTIVITY)
 			So(history.MessageList[0].Message.Payload, ShouldNotBeNil)
 			addedBy, ok := history.MessageList[0].Message.Payload["addedBy"]
 			So(ok, ShouldBeTrue)
 			So(*addedBy, ShouldEqual, account.OldId)
+
+			activityType, ok := history.MessageList[0].Message.Payload["activityType"]
+			So(ok, ShouldBeTrue)
+			So(*activityType, ShouldEqual, models.PrivateMessageActivity_TYPE_JOIN)
 
 			// try to add same participant
 			_, err = rest.AddChannelParticipant(cc.Channel.Id, account.Id, recipient.Id)
@@ -427,10 +431,14 @@ func TestCollaborationChannels(t *testing.T) {
 			So(len(history.MessageList), ShouldEqual, 2)
 
 			joinMessage := history.MessageList[1].Message
-			So(joinMessage.TypeConstant, ShouldEqual, models.ChannelMessage_TYPE_JOIN)
+			So(joinMessage.TypeConstant, ShouldEqual, models.ChannelMessage_TYPE_ACTIVITY)
 			So(joinMessage.Payload, ShouldNotBeNil)
 			initialParticipants, ok := joinMessage.Payload["initialParticipants"]
 			So(ok, ShouldBeTrue)
+
+			activityType, ok := history.MessageList[1].Message.Payload["activityType"]
+			So(ok, ShouldBeTrue)
+			So(*activityType, ShouldEqual, models.PrivateMessageActivity_TYPE_JOIN)
 
 			participants := make([]string, 0)
 			err = json.Unmarshal([]byte(*initialParticipants), &participants)

--- a/go/src/socialapi/tests/collaboration_channel_test.go
+++ b/go/src/socialapi/tests/collaboration_channel_test.go
@@ -332,15 +332,15 @@ func TestCollaborationChannels(t *testing.T) {
 			So(len(history.MessageList), ShouldEqual, 3)
 
 			So(history.MessageList[0].Message, ShouldNotBeNil)
-			So(history.MessageList[0].Message.TypeConstant, ShouldEqual, models.ChannelMessage_TYPE_ACTIVITY)
+			So(history.MessageList[0].Message.TypeConstant, ShouldEqual, models.ChannelMessage_TYPE_SYSTEM)
 			So(history.MessageList[0].Message.Payload, ShouldNotBeNil)
 			addedBy, ok := history.MessageList[0].Message.Payload["addedBy"]
 			So(ok, ShouldBeTrue)
 			So(*addedBy, ShouldEqual, account.OldId)
 
-			activityType, ok := history.MessageList[0].Message.Payload["activityType"]
+			systemType, ok := history.MessageList[0].Message.Payload["systemType"]
 			So(ok, ShouldBeTrue)
-			So(*activityType, ShouldEqual, models.PrivateMessageActivity_TYPE_JOIN)
+			So(*systemType, ShouldEqual, models.PrivateMessageSystem_TYPE_JOIN)
 
 			// try to add same participant
 			_, err = rest.AddChannelParticipant(cc.Channel.Id, account.Id, recipient.Id)
@@ -431,14 +431,14 @@ func TestCollaborationChannels(t *testing.T) {
 			So(len(history.MessageList), ShouldEqual, 2)
 
 			joinMessage := history.MessageList[1].Message
-			So(joinMessage.TypeConstant, ShouldEqual, models.ChannelMessage_TYPE_ACTIVITY)
+			So(joinMessage.TypeConstant, ShouldEqual, models.ChannelMessage_TYPE_SYSTEM)
 			So(joinMessage.Payload, ShouldNotBeNil)
 			initialParticipants, ok := joinMessage.Payload["initialParticipants"]
 			So(ok, ShouldBeTrue)
 
-			activityType, ok := history.MessageList[1].Message.Payload["activityType"]
+			systemType, ok := history.MessageList[1].Message.Payload["systemType"]
 			So(ok, ShouldBeTrue)
-			So(*activityType, ShouldEqual, models.PrivateMessageActivity_TYPE_JOIN)
+			So(*systemType, ShouldEqual, models.PrivateMessageSystem_TYPE_JOIN)
 
 			participants := make([]string, 0)
 			err = json.Unmarshal([]byte(*initialParticipants), &participants)

--- a/go/src/socialapi/tests/collaboration_channel_test.go
+++ b/go/src/socialapi/tests/collaboration_channel_test.go
@@ -80,19 +80,6 @@ func TestCollaborationChannels(t *testing.T) {
 
 		})
 
-		Convey("if body is nil, should fail to create PM", func() {
-			pmr := models.PrivateChannelRequest{}
-			pmr.AccountId = account.Id
-			pmr.Body = ""
-			pmr.GroupName = groupName
-			pmr.Recipients = []string{}
-			pmr.TypeConstant = models.Channel_TYPE_COLLABORATION
-
-			cmc, err := rest.SendPrivateChannelRequest(pmr)
-			So(err, ShouldNotBeNil)
-			So(cmc, ShouldBeNil)
-		})
-
 		Convey("if group name is nil, should not fail to create collaboration channel", func() {
 			pmr := models.PrivateChannelRequest{}
 			pmr.AccountId = account.Id

--- a/go/src/socialapi/tests/private_channel_test.go
+++ b/go/src/socialapi/tests/private_channel_test.go
@@ -321,15 +321,15 @@ func TestPrivateMesssages(t *testing.T) {
 			So(len(history.MessageList), ShouldEqual, 3)
 
 			So(history.MessageList[0].Message, ShouldNotBeNil)
-			So(history.MessageList[0].Message.TypeConstant, ShouldEqual, models.ChannelMessage_TYPE_ACTIVITY)
+			So(history.MessageList[0].Message.TypeConstant, ShouldEqual, models.ChannelMessage_TYPE_SYSTEM)
 			So(history.MessageList[0].Message.Payload, ShouldNotBeNil)
 			addedBy, ok := history.MessageList[0].Message.Payload["addedBy"]
 			So(ok, ShouldBeTrue)
 			So(*addedBy, ShouldEqual, account.OldId)
 
-			activityType, ok := history.MessageList[0].Message.Payload["activityType"]
+			systemType, ok := history.MessageList[0].Message.Payload["systemType"]
 			So(ok, ShouldBeTrue)
-			So(*activityType, ShouldEqual, models.PrivateMessageActivity_TYPE_JOIN)
+			So(*systemType, ShouldEqual, models.PrivateMessageSystem_TYPE_JOIN)
 
 			// try to add same participant
 			_, err = rest.AddChannelParticipant(cc.Channel.Id, account.Id, recipient.Id)
@@ -418,14 +418,14 @@ func TestPrivateMesssages(t *testing.T) {
 			So(len(history.MessageList), ShouldEqual, 2)
 
 			joinMessage := history.MessageList[1].Message
-			So(joinMessage.TypeConstant, ShouldEqual, models.ChannelMessage_TYPE_ACTIVITY)
+			So(joinMessage.TypeConstant, ShouldEqual, models.ChannelMessage_TYPE_SYSTEM)
 			So(joinMessage.Payload, ShouldNotBeNil)
 			initialParticipants, ok := joinMessage.Payload["initialParticipants"]
 			So(ok, ShouldBeTrue)
 
-			activityType, ok := history.MessageList[1].Message.Payload["activityType"]
+			systemType, ok := history.MessageList[1].Message.Payload["systemType"]
 			So(ok, ShouldBeTrue)
-			So(*activityType, ShouldEqual, models.PrivateMessageActivity_TYPE_JOIN)
+			So(*systemType, ShouldEqual, models.PrivateMessageSystem_TYPE_JOIN)
 
 			participants := make([]string, 0)
 			err = json.Unmarshal([]byte(*initialParticipants), &participants)

--- a/go/src/socialapi/tests/private_channel_test.go
+++ b/go/src/socialapi/tests/private_channel_test.go
@@ -100,16 +100,6 @@ func TestPrivateMesssages(t *testing.T) {
 			So(cmc, ShouldNotBeNil)
 
 		})
-		Convey("if body is nil, should fail to create PM", func() {
-			pmr := models.PrivateChannelRequest{}
-			pmr.AccountId = account.Id
-			pmr.Body = ""
-			pmr.GroupName = groupName
-			pmr.Recipients = []string{}
-			cmc, err := rest.SendPrivateChannelRequest(pmr)
-			So(err, ShouldNotBeNil)
-			So(cmc, ShouldBeNil)
-		})
 		Convey("if group name is nil, should not fail to create PM", func() {
 			pmr := models.PrivateChannelRequest{}
 			pmr.AccountId = account.Id

--- a/go/src/socialapi/tests/private_channel_test.go
+++ b/go/src/socialapi/tests/private_channel_test.go
@@ -321,11 +321,15 @@ func TestPrivateMesssages(t *testing.T) {
 			So(len(history.MessageList), ShouldEqual, 3)
 
 			So(history.MessageList[0].Message, ShouldNotBeNil)
-			So(history.MessageList[0].Message.TypeConstant, ShouldEqual, models.ChannelMessage_TYPE_JOIN)
+			So(history.MessageList[0].Message.TypeConstant, ShouldEqual, models.ChannelMessage_TYPE_ACTIVITY)
 			So(history.MessageList[0].Message.Payload, ShouldNotBeNil)
 			addedBy, ok := history.MessageList[0].Message.Payload["addedBy"]
 			So(ok, ShouldBeTrue)
 			So(*addedBy, ShouldEqual, account.OldId)
+
+			activityType, ok := history.MessageList[0].Message.Payload["activityType"]
+			So(ok, ShouldBeTrue)
+			So(*activityType, ShouldEqual, models.PrivateMessageActivity_TYPE_JOIN)
 
 			// try to add same participant
 			_, err = rest.AddChannelParticipant(cc.Channel.Id, account.Id, recipient.Id)
@@ -414,10 +418,14 @@ func TestPrivateMesssages(t *testing.T) {
 			So(len(history.MessageList), ShouldEqual, 2)
 
 			joinMessage := history.MessageList[1].Message
-			So(joinMessage.TypeConstant, ShouldEqual, models.ChannelMessage_TYPE_JOIN)
+			So(joinMessage.TypeConstant, ShouldEqual, models.ChannelMessage_TYPE_ACTIVITY)
 			So(joinMessage.Payload, ShouldNotBeNil)
 			initialParticipants, ok := joinMessage.Payload["initialParticipants"]
 			So(ok, ShouldBeTrue)
+
+			activityType, ok := history.MessageList[1].Message.Payload["activityType"]
+			So(ok, ShouldBeTrue)
+			So(*activityType, ShouldEqual, models.PrivateMessageActivity_TYPE_JOIN)
 
 			participants := make([]string, 0)
 			err = json.Unmarshal([]byte(*initialParticipants), &participants)

--- a/go/src/socialapi/workers/api/handlers/handlers.go
+++ b/go/src/socialapi/workers/api/handlers/handlers.go
@@ -316,6 +316,26 @@ func AddHandlers(m *mux.Mux) {
 		},
 	)
 
+	m.AddHandler(
+		handler.Request{
+			Handler:  participant.AcceptInvite,
+			Name:     "participant-invitation-accept",
+			Type:     handler.PostRequest,
+			Endpoint: "/channel/{id}/invitation/accept",
+			Securer:  models.ParticipantSecurer,
+		},
+	)
+
+	m.AddHandler(
+		handler.Request{
+			Handler:  participant.RejectInvite,
+			Name:     "participant-invitation-reject",
+			Type:     handler.PostRequest,
+			Endpoint: "/channel/{id}/invitation/reject",
+			Securer:  models.ParticipantSecurer,
+		},
+	)
+
 	// list messages of the channel
 	// exempt contents are filtered
 	// caching enabled

--- a/go/src/socialapi/workers/api/modules/channel/channel.go
+++ b/go/src/socialapi/workers/api/modules/channel/channel.go
@@ -178,13 +178,22 @@ func handleChannelResponse(c models.Channel, q *request.Query) (int, http.Header
 	}
 
 	if !canOpen {
-		return response.NewAccessDenied(
-			fmt.Errorf(
-				"account (%d) tried to retrieve the unattended channel (%d)",
-				q.AccountId,
-				c.Id,
-			),
-		)
+		cp := models.NewChannelParticipant()
+		cp.ChannelId = c.Id
+		isInvited, err := cp.IsInvited(q.AccountId)
+		if err != nil {
+			return response.NewBadRequest(err)
+		}
+
+		if !isInvited {
+			return response.NewAccessDenied(
+				fmt.Errorf(
+					"account (%d) tried to retrieve the unattended channel (%d)",
+					q.AccountId,
+					c.Id,
+				),
+			)
+		}
 	}
 
 	cc := models.NewChannelContainer()

--- a/go/src/socialapi/workers/api/modules/participant/participant.go
+++ b/go/src/socialapi/workers/api/modules/participant/participant.go
@@ -461,7 +461,7 @@ func addJoinActivity(channelId int64, participant *models.ChannelParticipant, ad
 	}
 
 	pmr := &models.PrivateChannelRequest{AccountId: participant.AccountId}
-	pmr.SetActivityTypeByParticipant(participant)
+	pmr.SetSystemTypeByParticipant(participant)
 	if participant.StatusConstant == models.ChannelParticipant_STATUS_REQUEST_PENDING {
 		addedBy = 0
 	}
@@ -480,7 +480,7 @@ func addLeaveActivity(channelId int64, participant *models.ChannelParticipant) e
 	}
 
 	pmr := &models.PrivateChannelRequest{AccountId: participant.AccountId}
-	pmr.SetActivityTypeByParticipant(participant)
+	pmr.SetSystemTypeByParticipant(participant)
 
 	return pmr.AddLeaveActivity(c)
 }

--- a/go/src/socialapi/workers/api/modules/participant/participant.go
+++ b/go/src/socialapi/workers/api/modules/participant/participant.go
@@ -77,6 +77,10 @@ func AddMulti(u *url.URL, h http.Header, participants []*models.ChannelParticipa
 		}
 
 		participant.AccountId = participants[i].AccountId
+		//We can add users with requestpending status
+		if participants[i].StatusConstant != "" {
+			participant.StatusConstant = participants[i].StatusConstant
+		}
 
 		if err := participant.Create(); err != nil {
 			return response.NewBadRequest(err)

--- a/workers/social/lib/social/models/socialapi/channel.coffee
+++ b/workers/social/lib/social/models/socialapi/channel.coffee
@@ -36,6 +36,10 @@ module.exports = class SocialChannel extends Base
           (signature Object, Function)
         leave                :
           (signature Object, Function)
+        acceptInvite         :
+          (signature Object, Function)
+        rejectInvite         :
+          (signature Object, Function)
         fetchPopularTopics   :
           (signature Object, Function)
         fetchPopularPosts    :
@@ -208,6 +212,22 @@ module.exports = class SocialChannel extends Base
     data.accountIds = [ delegate.socialApiId ]  unless data.accountIds
 
     doRequest 'removeParticipants', client, data, callback
+
+  @acceptInvite = secure (client, data, callback) ->
+    return callback message: "channel id is required for accepting an invitation"  unless data.channelId
+
+    { delegate } = client.connection
+    data.accountId = delegate.socialApiId
+
+    doRequest 'acceptInvite', client, data, callback
+
+  @rejectInvite = secure (client, data, callback) ->
+    return callback message: "channel id is required for rejecting an invitation"  unless data.channelId
+
+    { delegate } = client.connection
+    data.accountId = delegate.socialApiId
+
+    doRequest 'rejectInvite', client, data, callback
 
   # glancePinnedPost - updates user's lastSeenDate for pinned posts
   @glancePinnedPost = secureRequest

--- a/workers/social/lib/social/models/socialapi/message.coffee
+++ b/workers/social/lib/social/models/socialapi/message.coffee
@@ -152,8 +152,6 @@ module.exports = class SocialMessage extends Base
     validate      : ['id']
 
   initPrivateMessageHelper = (client, data, callback)->
-    unless data.body
-      return callback message: "Message body should be set"
 
     if not data.recipients or data.recipients.length < 1
       return callback message: "You should have at least one recipient"

--- a/workers/social/lib/social/models/socialapi/requests.coffee
+++ b/workers/social/lib/social/models/socialapi/requests.coffee
@@ -257,7 +257,7 @@ fetchFollowedChannelCount = (data, callback)->
   get url, data, callback
 
 initPrivateMessage = (data, callback)->
-  if not data.body or not data.recipients or data.recipients.length < 1
+  if not data.recipients or data.recipients.length < 1
     return callback { message: "Request is not valid"}
 
   url = "#{socialProxyUrl}/privatechannel/init"

--- a/workers/social/lib/social/models/socialapi/requests.coffee
+++ b/workers/social/lib/social/models/socialapi/requests.coffee
@@ -198,32 +198,25 @@ removeParticipants = (data, callback)->
     return callback err if err?
     return callback { message: 'Channel not found' } unless channel?.channel
 
-    doChannelParticipantOperation data, url, (err, leftUsers)->
-      return callback err if err
-      cycleChannelHelper {leftUsers, channel}, callback
+    doChannelParticipantOperation data, url, callback
 
-# TODO when we remove broker we will no longer need this
-cycleChannelHelper = ({leftUsers, channel}, callback)->
-  return callback { message: "user could not leave the channel" } unless leftUsers?.length
+acceptInvite = (data, callback)->
 
-  isUserRemoved = (leftUsers)->
-    return yes  for user in leftUsers when user.statusConstant is 'left'
+  unless data.channelId or data.accountId
+    return callback { message: "Request is not valid" }
 
-    return no
+  url = "/channel/#{data.channelId}/invitation/accept"
 
-  return callback { message: "user could not leave the channel" } unless isUserRemoved leftUsers
+  post url, data, callback
 
-  callback null, leftUsers
+rejectInvite = (data, callback)->
 
-  {channel} = channel
-  options =
-    groupSlug     : channel.groupName
-    apiChannelType: channel.typeConstant
-    apiChannelName: channel.name
-  SocialChannel = require './channel'
-  SocialChannel.cycleChannel options, (err)->
-    console.warn err  if err?
+  unless data.channelId or data.accountId
+    return callback { message: "Request is not valid" }
 
+  url = "/channel/#{data.channelId}/invitation/reject"
+
+  post url, data, callback
 
 doChannelParticipantOperation = (data, url, callback)->
   return callback { message: "Request is not valid" } unless data.channelId
@@ -234,8 +227,10 @@ doChannelParticipantOperation = (data, url, callback)->
     return callback { message: "Request is not valid" } if not data.accountId
     data.accountIds = [data.accountId]
 
+  { participantStatus: statusConstant } = data
+
   # make the object according to channel participant data
-  req = ({accountId} for accountId in data.accountIds)
+  req = ({accountId, statusConstant} for accountId in data.accountIds)
 
   url = "#{url}?accountId=#{data.accountId}"
   post url, req, callback
@@ -500,6 +495,8 @@ module.exports = {
   listParticipants
   addParticipants
   removeParticipants
+  acceptInvite
+  rejectInvite
   fetchPinnedMessages
   pinMessage
   unpinMessage

--- a/workers/social/lib/social/models/socialapi/requests.coffee
+++ b/workers/social/lib/social/models/socialapi/requests.coffee
@@ -205,7 +205,7 @@ acceptInvite = (data, callback)->
   unless data.channelId or data.accountId
     return callback { message: "Request is not valid" }
 
-  url = "/channel/#{data.channelId}/invitation/accept"
+  url = "#{socialProxyUrl}/channel/#{data.channelId}/invitation/accept"
 
   post url, data, callback
 
@@ -214,7 +214,7 @@ rejectInvite = (data, callback)->
   unless data.channelId or data.accountId
     return callback { message: "Request is not valid" }
 
-  url = "/channel/#{data.channelId}/invitation/reject"
+  url = "#{socialProxyUrl}/channel/#{data.channelId}/invitation/reject"
 
   post url, data, callback
 


### PR DESCRIPTION
With this PR:
- Introduced a new message type as: Activity
- Removed old Join/Leave typed messages and collected all under this new message type
- Added a new middle state for channel participants as: RequestPending
- When a new user is invited to a collaboration session, they are first added with this status.
- Invite/Accept/Reject/Kick messages are added
- It is now possible to create a channel without sending initial message

**Invite**
![Image](https://cldup.com/IIb1kPvHoz.png)

**Accept**
![Image](https://cldup.com/hMpBNJixfD.png)

**Reject**
![Image](https://cldup.com/zKLY0gCbqk.png)
