### PR TITLE
tunnel: improvements from the public repo

### DIFF
--- a/go/src/github.com/koding/tunnel/.travis.yml
+++ b/go/src/github.com/koding/tunnel/.travis.yml
@@ -1,0 +1,4 @@
+language: go
+go: 
+  - 1.4
+  - tip

--- a/go/src/github.com/koding/tunnel/LICENSE
+++ b/go/src/github.com/koding/tunnel/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2015 The Koding Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of Koding Inc. nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/go/src/github.com/koding/tunnel/README.md
+++ b/go/src/github.com/koding/tunnel/README.md
@@ -1,0 +1,90 @@
+# Tunnel [![GoDoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](http://godoc.org/github.com/koding/tunnel) [![Build Status](http://img.shields.io/travis/koding/tunnel.svg?style=flat-square)](https://travis-ci.org/koding/tunnel)
+
+Tunnel is a server/client package that enables to proxy public connections to
+your local machine over a tunnel connection from the local machine to the
+public server. What this means is, you can share your localhost even if it
+doesn't have a Public IP or if it's not reachable from outside. 
+
+It uses the excellent [yamux](https://github.com/hashicorp/yamux) package to
+multiplex connections between server and client.
+
+The project is under active development, please vendor it if you want to use it.
+
+# Usage
+
+The tunnel package consists of two parts. The `server` and the `client`. 
+
+Server is the public facing part. It's type that satisfies the `http.Handler`.
+So it's easily pluggable into existing servers. 
+
+
+Let assume that you setup your DNS service so all `*.example.com` domains route
+to your server at the public IP `203.0.113.0`. Let us first create the server
+part:
+
+```go
+package main
+
+import (
+	"net/http"
+
+	"github.com/koding/tunnel"
+)
+
+func main() {
+	server, _ := tunnel.NewServer(nil)
+	server.AddHost("sub.example.com", "1234")
+	http.ListenAndServe(":80", server)
+}
+```
+
+Once you create the `server`, you just plug it into your server. The only
+detail here is to map a virtualhost to a secret token. The secret token is the
+only part that needs to be known for the client side.
+
+Let us now create the client side part:
+
+```go
+package main
+
+import "github.com/koding/tunnel"
+
+func main() {
+	cfg := &tunnel.ClientConfig{
+		Identifier: "1234",
+		ServerAddr: "203.0.113.0",
+	}
+
+	client, err := tunnel.NewClient(cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	client.Start()
+}
+```
+
+The `Start()` method is by default blocking. As you see you, we just passed the
+server address and the secret token. 
+
+Now whenever someone hit `sub.example.com`, the request will be proxied to the
+machine where client is running and hit the local server running `127.0.0.1:80`
+(assuming there is one). If someone hits `sub.example.com:3000` (assume your
+server is running at this port), it'll be routed to `127.0.0.1:3000`
+
+That's it. 
+
+There are many options that can be changed, such as a static local address for
+your client. Have alook at the
+[documentation](http://godoc.org/github.com/koding/tunnel)
+
+
+# Protocol
+
+The server/client protocol is written in the [spec.md](spec.md) file. Please
+have a look for more detail.
+
+
+## License
+
+The BSD 3-Clause License - see LICENSE for more details

--- a/go/src/github.com/koding/tunnel/client.go
+++ b/go/src/github.com/koding/tunnel/client.go
@@ -22,12 +22,8 @@ type Client struct {
 	// underlying yamux session
 	session *yamux.Session
 
-	// serverAddr is the address of the tunnel-server
-	serverAddr string
-
-	// localAddr is the address of a local server that will be tunneled to the
-	// public. Currently only one server is supported.
-	localAddr string
+	// config holds the ClientConfig
+	config *ClientConfig
 
 	// yamuxConfig is passed to new yamux.Session's
 	yamuxConfig *yamux.Config
@@ -35,23 +31,28 @@ type Client struct {
 
 	// redialBackoff is used to reconnect in exponential backoff intervals
 	redialBackoff backoff.BackOff
-
-	// identifier can be used to fetch identifier before a Start() is initiated.
-	FetchIdentifier func() (string, error)
 }
 
 // ClientConfig defines the configuration for the Client
 type ClientConfig struct {
-	// ServerAddr defines the TCP address of the tunnel server to be connected
+	// Identifier is the secret token that needs to be passed to the server.
+	// Required if FetchIdentifier is not set
+	Identifier string
+
+	// FetchIdentifier can be used to fetch identifier. Required if Identifier
+	// is not set.
+	FetchIdentifier func() (string, error)
+
+	// ServerAddr defines the TCP address of the tunnel server to be connected. This is required.
 	ServerAddr string
 
 	// LocalAddr defines the TCP address of the local server. This is optional
 	// if you want to specify a single TCP address. Otherwise the client will
 	// always proxy to 127.0.0.1:incomingPort, where incomingPort is the
-	// tunnelserver's public exposed Port
+	// tunnelserver's public exposed Port.
 	LocalAddr string
 
-	// Debug enables debug mode, enable only if you want to debug the server
+	// Debug enables debug mode, enable only if you want to debug the server.
 	Debug bool
 
 	// Log defines the logger. If nil a default logging.Logger is used.
@@ -62,54 +63,75 @@ type ClientConfig struct {
 	YamuxConfig *yamux.Config
 }
 
+// verify is used to verify the ClientConfig
+func (c *ClientConfig) verify() error {
+	if c.ServerAddr == "" {
+		return errors.New("config.ServerAddr must be set")
+	}
+
+	if c.Identifier == "" && c.FetchIdentifier == nil {
+		return errors.New("neither config.Identifier nor config.FetchIdentifier is set")
+	}
+
+	if c.YamuxConfig != nil {
+		if err := yamux.VerifyConfig(c.YamuxConfig); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // NewClient creates a new tunnel that is established between the serverAddr
 // and localAddr. It exits if it can't create a new control connection to the
 // server. If localAddr is empty client will always try to proxy to a local
 // port.
-func NewClient(cfg *ClientConfig) *Client {
+func NewClient(cfg *ClientConfig) (*Client, error) {
 	yamuxConfig := yamux.DefaultConfig()
 	if cfg.YamuxConfig != nil {
-		if err := yamux.VerifyConfig(cfg.YamuxConfig); err != nil {
-			fmt.Fprintf(os.Stderr, err.Error())
-			os.Exit(1)
-		}
-
 		yamuxConfig = cfg.YamuxConfig
 	}
 
-	log := newLogger("streamtunnel-server", cfg.Debug)
+	log := newLogger("tunnel-client", cfg.Debug)
 	if cfg.Log != nil {
 		log = cfg.Log
+	}
+
+	if err := cfg.verify(); err != nil {
+		return nil, err
 	}
 
 	forever := backoff.NewExponentialBackOff()
 	forever.MaxElapsedTime = 365 * 24 * time.Hour // 1 year
 
 	client := &Client{
-		serverAddr:    cfg.ServerAddr,
-		localAddr:     cfg.LocalAddr,
+		config:        cfg,
 		log:           log,
 		yamuxConfig:   yamuxConfig,
 		redialBackoff: forever,
 	}
 
-	return client
+	return client, nil
 }
 
-// Start starts the client and connects to the server with the identifier that
-// was fetched with client.FetchIdentifier(). It support reconnectig with
-// exponential backoff intervals.
+// Start starts the client and connects to the server with the identifier.
+// client.FetchIdentifier() will be used if it's not nil. It's supports
+// reconnecting with exponential backoff intervals when the connection to the
+// server disconnects.
 func (c *Client) Start() {
-	if c.FetchIdentifier == nil {
-		fmt.Fprintf(os.Stderr, "FetchIdentifier() function is not set.")
-		os.Exit(1)
+	id := func() (string, error) {
+		if c.config.FetchIdentifier != nil {
+			return c.config.FetchIdentifier()
+		}
+
+		return c.config.Identifier, nil
 	}
 
 	c.redialBackoff.Reset()
 	for {
 		time.Sleep(c.redialBackoff.NextBackOff())
 
-		identifier, err := c.FetchIdentifier()
+		identifier, err := id()
 		if err != nil {
 			c.log.Critical("client fetch identifier err: %s", err.Error())
 			continue
@@ -121,33 +143,21 @@ func (c *Client) Start() {
 	}
 }
 
-// Start starts the client and connects to the server with the given identifier
-// that It support reconnectig with exponential backoff intervals.
-func (c *Client) StartWithIdentifier(identifier string) {
-	c.redialBackoff.Reset()
-	for {
-		time.Sleep(c.redialBackoff.NextBackOff())
-		if err := c.connect(identifier); err != nil {
-			c.log.Critical("client connect err: %s", err.Error())
-		}
-	}
-}
-
 func (c *Client) connect(identifier string) error {
-	c.log.Debug("Trying to connect to '%s' with identifier '%s'", c.serverAddr, identifier)
-	conn, err := net.Dial("tcp", c.serverAddr)
+	c.log.Debug("Trying to connect to '%s' with identifier '%s'", c.config.ServerAddr, identifier)
+	conn, err := net.Dial("tcp", c.config.ServerAddr)
 	if err != nil {
 		return err
 	}
 
-	remoteAddr := fmt.Sprintf("http://%s%s", conn.RemoteAddr(), ControlPath)
+	remoteAddr := fmt.Sprintf("http://%s%s", conn.RemoteAddr(), controlPath)
 	c.log.Debug("CONNECT to '%s'", remoteAddr)
 	req, err := http.NewRequest("CONNECT", remoteAddr, nil)
 	if err != nil {
 		return fmt.Errorf("CONNECT %s", err)
 	}
 
-	req.Header.Set(XKTunnelIdentifier, identifier)
+	req.Header.Set(xKTunnelIdentifier, identifier)
 	c.log.Debug("Writing request to TCP: %+v", req)
 	if err := req.Write(conn); err != nil {
 		return err
@@ -160,7 +170,7 @@ func (c *Client) connect(identifier string) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 && resp.Status != Connected {
+	if resp.StatusCode != 200 && resp.Status != connected {
 		out, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return err
@@ -217,7 +227,7 @@ func (c *Client) connect(identifier string) error {
 
 func (c *Client) listenControl(ct *control) error {
 	for {
-		var msg ControlMsg
+		var msg controlMsg
 		err := ct.dec.Decode(&msg)
 		if err != nil {
 			c.session.GoAway()
@@ -228,7 +238,7 @@ func (c *Client) listenControl(ct *control) error {
 		c.log.Debug("controlMsg: %+v", msg)
 
 		switch msg.Action {
-		case RequestClientSession:
+		case requestClientSession:
 			go func() {
 				if err := c.proxy(msg.LocalPort); err != nil {
 					fmt.Fprintf(os.Stderr, "proxy err: '%s'\n", err)
@@ -249,8 +259,8 @@ func (c *Client) proxy(port string) error {
 	}
 
 	localAddr := "127.0.0.1:" + port
-	if c.localAddr != "" {
-		localAddr = c.localAddr
+	if c.config.LocalAddr != "" {
+		localAddr = c.config.LocalAddr
 	}
 
 	local, err := newLocalDial(localAddr)

--- a/go/src/github.com/koding/tunnel/protocol.go
+++ b/go/src/github.com/koding/tunnel/protocol.go
@@ -1,32 +1,33 @@
 package tunnel
 
-var Connected = "200 Connected to Tunnel"
-
 const (
+	connected = "200 Connected to Tunnel"
+
 	// control messages
 	ctHandshakeRequest  = "controlHandshake"
 	ctHandshakeResponse = "controlOk"
 
-	ControlPath = "/_controlPath/"
+	// http.Handler path for control connection
+	controlPath = "/_controlPath/"
 
 	// Custom Tunnel specific header
-	XKTunnelIdentifier = "X-KTunnel-Identifier"
+	xKTunnelIdentifier = "X-KTunnel-Identifier"
 )
 
-type Action int
+type action int
 
 const (
-	RequestClientSession Action = iota + 1
+	requestClientSession action = iota + 1
 )
 
-type TransportProtocol int
+type transportProtocol int
 
 const (
-	HTTPTransport TransportProtocol = iota + 1
+	httpTransport transportProtocol = iota + 1
 )
 
-type ControlMsg struct {
-	Action    Action            `json:"action"`
-	Protocol  TransportProtocol `json:"transportProtocol"`
+type controlMsg struct {
+	Action    action            `json:"action"`
+	Protocol  transportProtocol `json:"transportProtocol"`
 	LocalPort string            `json:"localPort"`
 }

--- a/go/src/github.com/koding/tunnel/spec.md
+++ b/go/src/github.com/koding/tunnel/spec.md
@@ -1,4 +1,4 @@
-# Network protocol
+# Specification
 
 # Naming conventions
 

--- a/go/src/github.com/koding/tunnel/tunnel_test.go
+++ b/go/src/github.com/koding/tunnel/tunnel_test.go
@@ -18,7 +18,7 @@ var (
 
 func TestTunnel(t *testing.T) {
 	// setup tunnelserver
-	server := NewServer(&ServerConfig{
+	server, _ := NewServer(&ServerConfig{
 		Debug: true,
 	})
 	server.AddHost(serverAddr, identifier)
@@ -33,12 +33,13 @@ func TestTunnel(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// setup tunnelclient
-	client := NewClient(&ClientConfig{
+	client, _ := NewClient(&ClientConfig{
+		Identifier: identifier,
 		ServerAddr: serverAddr,
 		LocalAddr:  localAddr,
 		Debug:      true,
 	})
-	go client.StartWithIdentifier(identifier)
+	go client.Start()
 
 	// start local server to be tunneled
 	go http.ListenAndServe(localAddr, echo())

--- a/go/src/koding/kites/tunnelclient/tunnelclient.go
+++ b/go/src/koding/kites/tunnelclient/tunnelclient.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"os"
 	"strings"
 
 	"github.com/koding/kite"
@@ -35,9 +37,7 @@ func main() {
 	}
 
 	conf.ServerAddr = addPort(conf.ServerAddr, "80")
-
-	client := tunnel.NewClient(conf)
-	client.FetchIdentifier = func() (string, error) {
+	conf.FetchIdentifier = func() (string, error) {
 		result, err := callRegister(tunnelserver)
 		if err != nil {
 			return "", err
@@ -46,6 +46,13 @@ func main() {
 		k.Log.Info("Our tunnel public host is: '%s'", result.VirtualHost)
 		return result.Identifier, nil
 	}
+
+	client, err := tunnel.NewClient(conf)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+
 	client.Start()
 }
 

--- a/go/src/koding/kites/tunnelserver/tunnelserver.go
+++ b/go/src/koding/kites/tunnelserver/tunnelserver.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"koding/kites/common"
 	"koding/kites/kloud/pkg/dnsclient"
+	"os"
 
 	"github.com/koding/kite"
 	"github.com/koding/logging"
@@ -48,10 +49,16 @@ func main() {
 		SecretKey: t.SecretKey,
 	}
 
-	t.Dns = dnsclient.NewRoute53Client(t.HostedZone, auth)
-	t.Server = tunnel.NewServer(&tunnel.ServerConfig{
+	var err error
+	t.Server, err = tunnel.NewServer(&tunnel.ServerConfig{
 		Debug: t.Debug,
 	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+
+	t.Dns = dnsclient.NewRoute53Client(t.HostedZone, auth)
 	t.Log = common.NewLogger("tunnelkite", t.Debug)
 
 	k := kite.New("tunnelserver", "0.0.1")


### PR DESCRIPTION
Contains changes from: https://github.com/koding/tunnel
- Unexport types and variables that are not needed for the API
  consumer
- Return errors from `NewServer()` and `NewClient()` instead of calling
  os.Exit() internally
- Make identifier passing to client side more idiomatic
- Add `ClientConfig.Verify()` method to verify the client config
- Add a documentation, readme and license.
- Add .public travis integration

Current GoDoc layout:

![image](https://cloud.githubusercontent.com/assets/438920/7865869/5baa1e80-0574-11e5-9849-45476755d12b.png)
