### PR TITLE
Fixes "Referral URL shouldn't be a link" [fixes #95221884]

### DIFF
--- a/client/account/lib/styl/account.styl
+++ b/client/account/lib/styl/account.styl
@@ -452,6 +452,9 @@ app.settings.styl
       color                 #888
       noTextDeco()
 
+    .link
+      color                 #888
+
     .subtitle
       color                 #888
 

--- a/client/account/lib/views/referral/referralcustomviews.coffee
+++ b/client/account/lib/views/referral/referralcustomviews.coffee
@@ -85,13 +85,13 @@ module.exports = class ReferralCustomViews extends CustomViews
         text_invite   : 'Your personal invite link:'
         view          : 
           partial     : getReferralUrl nick()
-          cssClass    : "text link"
+          cssClass    : 'text link'
           click       : ->
             referralUrl = @getElement()
             @utils.selectText referralUrl
             @setTooltip
               title     : "#{superKey} + C to copy"
-              placement : "above"
+              placement : 'above'
               sticky    : yes
             @tooltip.show()
             @tooltip.once 'ReceivedClickElsewhere', @tooltip.bound 'destroy'

--- a/client/account/lib/views/referral/referralcustomviews.coffee
+++ b/client/account/lib/views/referral/referralcustomviews.coffee
@@ -83,14 +83,18 @@ module.exports = class ReferralCustomViews extends CustomViews
         view          : 
           partial     : getReferralUrl nick()
           cssClass    : "text link"
-          domId       : "referral-item"
+          tooltip     :
+            title     : "CTRL (⌘) + C to copy"
+            placement : "above"
+            offset    : 0
+            delayIn   : 300
+            html      : yes
+            animate   : yes
+            selector  : null
+            partial   : "i"
           click       : ->
-            text = document.getElementById "referral-item"
-            selection = window.getSelection()
-            range = document.createRange()
-            range.selectNodeContents text
-            selection.removeAllRanges()
-            selection.addRange range
+            text = @getElement()
+            @utils.selectText text
 
       return container
 

--- a/client/account/lib/views/referral/referralcustomviews.coffee
+++ b/client/account/lib/views/referral/referralcustomviews.coffee
@@ -80,9 +80,7 @@ module.exports = class ReferralCustomViews extends CustomViews
         socialIcons   :
           providers   : ['facebook', 'linkedin', 'twitter', 'google', 'mail']
         text_invite   : 'Your personal invite link:'
-        link          :
-          href        : getReferralUrl nick()
-          target      : '_blank'
+        text_link     : getReferralUrl nick()
 
       return container
 

--- a/client/account/lib/views/referral/referralcustomviews.coffee
+++ b/client/account/lib/views/referral/referralcustomviews.coffee
@@ -74,9 +74,7 @@ module.exports = class ReferralCustomViews extends CustomViews
     shareBox: ({title, subtitle}) =>
 
       container = @views.container 'share-box'
-      
-      tooltipVisible = no
-      
+
       kmt = globals.keymapType
       firstKeyChar = if kmt.charAt(0).toUpperCase() is 'W' then 'ctrl' else '&#8984'
       secondKeyChar = '&#x0043'
@@ -90,18 +88,16 @@ module.exports = class ReferralCustomViews extends CustomViews
         view          : 
           partial     : getReferralUrl nick()
           cssClass    : "text link"
-          mouseenter  : ->
-            if tooltipVisible not yes then @tooltip.destroy()
-          mouseleave  : ->
-            if tooltipVisible not yes then @tooltip.destroy()
           click       : ->
             referralUrl = @getElement()
             @utils.selectText referralUrl
             @setTooltip
               title     : "#{firstKeyChar.toUpperCase()} + #{secondKeyChar} to copy"
               placement : "above"
+              sticky    : yes
             @tooltip.show()
-            tooltipVisible = yes
+            @tooltip.once 'ReceivedClickElsewhere', =>
+              @tooltip.destroy()
 
       return container
 

--- a/client/account/lib/views/referral/referralcustomviews.coffee
+++ b/client/account/lib/views/referral/referralcustomviews.coffee
@@ -77,7 +77,6 @@ module.exports = class ReferralCustomViews extends CustomViews
 
       kmt = globals.keymapType
       firstKeyChar = if kmt.charAt(0).toUpperCase() is 'W' then 'ctrl' else '&#8984'
-      secondKeyChar = '&#x0043'
 
       @addTo container,
         text_title    : title
@@ -92,7 +91,7 @@ module.exports = class ReferralCustomViews extends CustomViews
             referralUrl = @getElement()
             @utils.selectText referralUrl
             @setTooltip
-              title     : "#{firstKeyChar.toUpperCase()} + #{secondKeyChar} to copy"
+              title     : "#{firstKeyChar.toUpperCase()} + C to copy"
               placement : "above"
               sticky    : yes
             @tooltip.show()

--- a/client/account/lib/views/referral/referralcustomviews.coffee
+++ b/client/account/lib/views/referral/referralcustomviews.coffee
@@ -74,7 +74,9 @@ module.exports = class ReferralCustomViews extends CustomViews
     shareBox: ({title, subtitle}) =>
 
       container = @views.container 'share-box'
-
+      
+      tooltipVisible = no
+      
       kmt = globals.keymapType
       firstKeyChar = if kmt.charAt(0).toUpperCase() is 'W' then 'ctrl' else '&#8984'
       secondKeyChar = '&#x0043'
@@ -88,14 +90,18 @@ module.exports = class ReferralCustomViews extends CustomViews
         view          : 
           partial     : getReferralUrl nick()
           cssClass    : "text link"
-          tooltip     :
-            title     : "#{firstKeyChar.toUpperCase()} + #{secondKeyChar} to copy"
-            placement : "above"
+          mouseenter  : ->
+            if tooltipVisible not yes then @tooltip.destroy()
+          mouseleave  : ->
+            if tooltipVisible not yes then @tooltip.destroy()
           click       : ->
             referralUrl = @getElement()
             @utils.selectText referralUrl
+            @setTooltip
+              title     : "#{firstKeyChar.toUpperCase()} + #{secondKeyChar} to copy"
+              placement : "above"
             @tooltip.show()
-            
+            tooltipVisible = yes
 
       return container
 

--- a/client/account/lib/views/referral/referralcustomviews.coffee
+++ b/client/account/lib/views/referral/referralcustomviews.coffee
@@ -1,4 +1,5 @@
 kd             = require 'kd'
+globals        = require 'globals'
 nick           = require 'app/util/nick'
 getReferralUrl = require 'app/util/getReferralUrl'
 CustomViews    = require 'app/commonviews/customviews'
@@ -74,6 +75,10 @@ module.exports = class ReferralCustomViews extends CustomViews
 
       container = @views.container 'share-box'
 
+      kmt = globals.keymapType
+      firstKeyChar = if kmt.charAt(0).toUpperCase() is 'W' then 'ctrl' else '&#8984'
+      secondKeyChar = '&#x0043'
+
       @addTo container,
         text_title    : title
         text_subtitle : subtitle
@@ -84,17 +89,13 @@ module.exports = class ReferralCustomViews extends CustomViews
           partial     : getReferralUrl nick()
           cssClass    : "text link"
           tooltip     :
-            title     : "CTRL (⌘) + C to copy"
+            title     : "#{firstKeyChar.toUpperCase()} + #{secondKeyChar} to copy"
             placement : "above"
-            offset    : 0
-            delayIn   : 300
-            html      : yes
-            animate   : yes
-            selector  : null
-            partial   : "i"
           click       : ->
-            text = @getElement()
-            @utils.selectText text
+            referralUrl = @getElement()
+            @utils.selectText referralUrl
+            @tooltip.show()
+            
 
       return container
 

--- a/client/account/lib/views/referral/referralcustomviews.coffee
+++ b/client/account/lib/views/referral/referralcustomviews.coffee
@@ -80,7 +80,17 @@ module.exports = class ReferralCustomViews extends CustomViews
         socialIcons   :
           providers   : ['facebook', 'linkedin', 'twitter', 'google', 'mail']
         text_invite   : 'Your personal invite link:'
-        text_link     : getReferralUrl nick()
+        view          : 
+          partial     : getReferralUrl nick()
+          cssClass    : "text link"
+          domId       : "referral-item"
+          click       : ->
+            text = document.getElementById "referral-item"
+            selection = window.getSelection()
+            range = document.createRange()
+            range.selectNodeContents text
+            selection.removeAllRanges()
+            selection.addRange range
 
       return container
 

--- a/client/account/lib/views/referral/referralcustomviews.coffee
+++ b/client/account/lib/views/referral/referralcustomviews.coffee
@@ -75,8 +75,7 @@ module.exports = class ReferralCustomViews extends CustomViews
 
       container = @views.container 'share-box'
 
-      kmt = globals.keymapType
-      firstKeyChar = if kmt.charAt(0).toUpperCase() is 'W' then 'ctrl' else '&#8984'
+      superKey = if globals.os is 'mac' then '⌘' else 'CTRL'
 
       @addTo container,
         text_title    : title
@@ -91,12 +90,11 @@ module.exports = class ReferralCustomViews extends CustomViews
             referralUrl = @getElement()
             @utils.selectText referralUrl
             @setTooltip
-              title     : "#{firstKeyChar.toUpperCase()} + C to copy"
+              title     : "#{superKey} + C to copy"
               placement : "above"
               sticky    : yes
             @tooltip.show()
-            @tooltip.once 'ReceivedClickElsewhere', =>
-              @tooltip.destroy()
+            @tooltip.once 'ReceivedClickElsewhere', @tooltip.bound 'destroy'
 
       return container
 


### PR DESCRIPTION
Visually the end result is exactly as the current, one on production.
![screenshot at 23-24-19](https://cloud.githubusercontent.com/assets/1278794/7870267/ddca6688-0590-11e5-9ea5-a12e329925aa.png)

The functionality has changed though. No more link.
![screencast 2015-05-28 23-21-09](https://cloud.githubusercontent.com/assets/1278794/7870268/dde53d6e-0590-11e5-9e5b-927fcbc23cfa.gif)

The story: https://www.pivotaltracker.com/story/show/95221884

Notes: I could have implemented an automated copy to clipboard once the users clicks on the url but that would have been an issue imo, if the user had something in his/hers clipboard that wasn't meant to be lost at that time. Also, tested this on Safari, Firefox and Chrome.

cc. @sinan @usirin 
