### PR TITLE
Limited permissions view for groups.

### DIFF
--- a/client/admin/lib/views/permissionsform.coffee
+++ b/client/admin/lib/views/permissionsform.coffee
@@ -143,7 +143,6 @@ module.exports = class PermissionsForm extends KDFormViewWithFields
 
   optionizePermissions = (roles, set) ->
 
-    isKoding          = isKoding()
     permissionOptions = {}
 
     # set.permissionsByModule is giving all the possible permissions
@@ -154,7 +153,7 @@ module.exports = class PermissionsForm extends KDFormViewWithFields
       headerTitle    = "header #{module.toLowerCase()}"
       headerCssClass = 'permissions-module text'
 
-      if not isKoding and not limitedPermissions[module]
+      if not isKoding() and not limitedPermissions[module]
         headerCssClass += ' hidden'
 
       permissionOptions[headerTitle] =
@@ -165,7 +164,7 @@ module.exports = class PermissionsForm extends KDFormViewWithFields
       for permission in permissions
         cssClass = 'text'
 
-        if not isKoding
+        unless isKoding()
           if limitedPermissions[module]
             if limitedPermissions[module].indexOf(permission) is -1
               cssClass += ' hidden'

--- a/client/admin/lib/views/permissionsform.coffee
+++ b/client/admin/lib/views/permissionsform.coffee
@@ -1,14 +1,19 @@
-kd = require 'kd'
-KDButtonView = kd.ButtonView
+kd                   = require 'kd'
+KDView               = kd.View
+isKoding             = require 'app/util/isKoding'
+showError            = require 'app/util/showError'
+KDInputView          = kd.InputView
+KDLabelView          = kd.LabelView
+KDModalView          = kd.ModalView
+KDSelectBox          = kd.SelectBox
+KDButtonView         = kd.ButtonView
+PermissionSwitch     = require './permissionswitch'
+KDNotificationView   = kd.NotificationView
 KDFormViewWithFields = kd.FormViewWithFields
-KDInputView = kd.InputView
-KDLabelView = kd.LabelView
-KDModalView = kd.ModalView
-KDNotificationView = kd.NotificationView
-KDSelectBox = kd.SelectBox
-KDView = kd.View
-PermissionSwitch = require './permissionswitch'
-showError = require 'app/util/showError'
+limitedPermissions   =
+  JGroup             : [ 'send invitations', 'send private message', 'browse content by tag', 'edit tags' ]
+  ComputeProvider    : [ 'sudoer', 'create machines', 'update machines' ]
+  JStackTemplate     : [ 'create stack template', 'update stack template' ]
 
 
 module.exports = class PermissionsForm extends KDFormViewWithFields
@@ -29,6 +34,7 @@ module.exports = class PermissionsForm extends KDFormViewWithFields
         title         : 'Add'
         style         : 'solid medium green'
         callback      : @bound 'showNewRoleModal'
+        cssClass      : if isKoding() then '' else 'hidden'
 
     options.fields or= optionizePermissions.call this, @roles, @permissionSet
     super options,data
@@ -137,6 +143,7 @@ module.exports = class PermissionsForm extends KDFormViewWithFields
 
   optionizePermissions = (roles, set) ->
 
+    isKoding          = isKoding()
     permissionOptions = {}
 
     # set.permissionsByModule is giving all the possible permissions
@@ -144,21 +151,37 @@ module.exports = class PermissionsForm extends KDFormViewWithFields
     # var permissions is permission under collection (module)
     # like "edit comments" for JComment
     for own module, permissions of set.permissionsByModule
-      permissionOptions['header '+module.toLowerCase()] =
+      headerTitle    = "header #{module.toLowerCase()}"
+      headerCssClass = 'permissions-module text'
+
+      if not isKoding and not limitedPermissions[module]
+        headerCssClass += ' hidden'
+
+      permissionOptions[headerTitle] =
         itemClass       : KDView
         partial         : readableText module
-        cssClass        : 'permissions-module text'
+        cssClass        : headerCssClass
 
       for permission in permissions
-        permissionOptions[module+'-' + kd.utils.slugify(permission)] =
+        cssClass = 'text'
+
+        if not isKoding
+          if limitedPermissions[module]
+            if limitedPermissions[module].indexOf(permission) is -1
+              cssClass += ' hidden'
+          else
+            cssClass += ' hidden'
+
+        permissionOptions[ module + '-' + kd.utils.slugify(permission) ] =
           itemClass     : KDView
           partial       : readableText permission
-          cssClass      : 'text'
+          cssClass      : cssClass
           attributes    :
             title       : readableText permission
           nextElement :
             cascadeFormElements.call this, set, roles, module, permission, roles.length
-    permissionOptions
+
+    return permissionOptions
 
 
   createTree = (values) ->


### PR DESCRIPTION
- [x] Implement limited permissions grid.
- [ ] Apply new styling.
- [ ] Remove guest column from limited grid.
- [ ] Make permission switch more clever, when a role changed automatically change related roles.
- [ ] Add missing section titles like `ComputeProvider`.
