### PR TITLE
Admin modal permissions grid improvements 

### DIFF
--- a/client/admin/lib/styl/app.group.admin.styl
+++ b/client/admin/lib/styl/app.group.admin.styl
@@ -189,6 +189,7 @@ Admin main styles
       .permissions-view
         borderBox()
         overflow                auto
+        font-size               14px
 
         .button-field
           .kdbutton
@@ -199,22 +200,20 @@ Admin main styles
           z-index               99
           width                 714px
           position              fixed
-          padding               0
-          height                62px
-          line-height           62px
-          box-shadow            inset 0 -3px 0 #f2f2f2
-          border                none
-          background            #fff
+          color                 #787878
+          height                50px
+          line-height           50px
+          bg                    color, #FAFAFA
 
           .header-item
             text-align          center
             color               #969696
-            font-size           14px
             width               140px
+            border-bottom       1px solid #EFEFEF
             fl()
 
             &:first-child
-              margin-left       135px
+              margin-left       150px
 
         .permissions-form
           overflow              visible
@@ -229,58 +228,24 @@ Admin main styles
               display           inline-block
 
           .formline
-            borderBox()
-            padding             10px 0
+            height              50px
+            line-height         50px
             margin              0
-            border              none
+            padding             0
+            border-top         1px solid #EFEFEF
 
-            &:nth-child(2n+1):not(.permissions-module):not(.permissions-header)
-              bg color,         rgba(0,0,0,0.025)
             .input-wrapper
-              margin-bottom     0
-            .input-wrapper:first-child
-              border-left       none
               > .kdview
-                borderBox()
-                line-height     18px
-                display         inline-block
                 width           140px
-                text-align      left
-                padding         0 16px
-                overflow        hidden
-                text-overflow   ellipsis
-                white-space     nowrap
+                ellipsis()
                 fl()
 
-            input.kdinput.permission-checkbox
-              display           inline
-              width             auto
-              margin            0 73px
-              vertical-align    middle
-            .input-wrapper
-              borderBox()
-              display           inline-block
-              width             100%
-              vertical-align    top
-              > .input-wrapper
-                vertical-align  middle
-
           .permissions-module
-            color               white
-            bg                  color #323232
-            padding             0 10px !important
-            font-size           16px
+            color               #00B057
+            border              none
 
-            &:nth-child(2) // Header is first, first subgroup is 2
-              padding-top       0
-
-            .input-wrapper:first-child
-              text-align        left
-              overflow          visible
-              > .kdview
-                line-height     40px
-                overflow        visible
-                padding         0 6px!important
+            &.formline
+              margin-top        30px
 
     &.membership-policy
       .policy-view-wrapper

--- a/client/admin/lib/styl/app.group.admin.styl
+++ b/client/admin/lib/styl/app.group.admin.styl
@@ -191,6 +191,22 @@ Admin main styles
         overflow                auto
         font-size               14px
 
+        &.not-koding
+          .header .header-item
+            &:first-child
+              margin-left       294px
+
+            &:last-child
+              hidden()
+
+          .switcher
+            &:last-child
+              hidden()
+
+          .text + .switcher
+            margin-left         154px
+
+
         .button-field
           .kdbutton
             margin-right        6px

--- a/client/admin/lib/views/grouppermissionsview.coffee
+++ b/client/admin/lib/views/grouppermissionsview.coffee
@@ -1,15 +1,18 @@
-kd = require 'kd'
-KDLoaderView = kd.LoaderView
-PermissionsForm = require './permissionsform'
-showError = require 'app/util/showError'
-JView = require 'app/jview'
+kd               = require 'kd'
+JView            = require 'app/jview'
+isKoding         = require 'app/util/isKoding'
+showError        = require 'app/util/showError'
+KDLoaderView     = kd.LoaderView
+PermissionsForm  = require './permissionsform'
 KDCustomHTMLView = kd.CustomHTMLView
 
 
 module.exports = class GroupPermissionsView extends JView
 
-  constructor: (options={}, data)->
-    options.cssClass = "permissions-view"
+  constructor: (options = {}, data) ->
+
+    options.cssClass = 'permissions-view'
+
     super options, data
 
     @loader     = new KDLoaderView
@@ -22,6 +25,9 @@ module.exports = class GroupPermissionsView extends JView
         height       : 40
 
     @addPermissionsView()
+
+    @setClass 'not-koding'  unless isKoding()
+
 
   addPermissionsView: ->
     group = @getData()

--- a/client/admin/lib/views/permissionsform.coffee
+++ b/client/admin/lib/views/permissionsform.coffee
@@ -85,18 +85,27 @@ module.exports = class PermissionsForm extends KDFormViewWithFields
   readableText = (text) ->
 
     dictionary =
-      "JNewApp"        : "Apps"
-      "JGroup"         : "Groups"
-      "SocialMessage"  : "Social API"
-      "JGroupBundle"   : "Group Bundles"
-      "JProposedDomain": "Domains"
-      "JProxyFilter"   : "Proxy Filters"
-      "JInvitation"    : "Invitations"
-      "JStack"         : "Stacks"
-      "JStackTemplate" : "Stack Templates"
-      "JCredential"    : "Credentials"
+      JNewApp            : 'Apps'
+      JGroup             : 'Groups'
+      SocialMessage      : 'Social API'
+      JGroupBundle       : 'Group Bundles'
+      JProposedDomain    : 'Domains'
+      JProxyFilter       : 'Proxy Filters'
+      JInvitation        : 'Invitations'
+      JStack             : 'Stacks'
+      JStackTemplate     : 'Stack Templates'
+      JCredential        : 'Credentials'
+      ComputeProvider    : 'Compute Providers'
+      JComputeStack      : 'Compute Stacks'
+      JDomainAlias       : 'Domain Aliases'
+      JKite              : 'Kites'
+      JMachine           : 'Machines'
+      JProvisioner       : 'Provisioners'
+      JRewardCampaign    : 'Campaigns'
+      JSnapshot          : 'Snapshots'
+      SocialNotification : 'Social Notifications'
 
-    return dictionary[text] or text.charAt(0).toUpperCase()+text.slice(1)
+    return dictionary[text] or text.capitalize()
 
 
   _getCheckboxName = (module, permission, role) ->

--- a/client/admin/lib/views/permissionsform.coffee
+++ b/client/admin/lib/views/permissionsform.coffee
@@ -23,7 +23,7 @@ module.exports = class PermissionsForm extends KDFormViewWithFields
   # dependent upon a cleaner intermediate data structure in the form api.
 
 
-  constructor:(options,data)->
+  constructor: (options, data) ->
 
     @group           = data
     {@permissionSet} = options
@@ -37,8 +37,10 @@ module.exports = class PermissionsForm extends KDFormViewWithFields
         cssClass      : if isKoding() then '' else 'hidden'
 
     options.fields or= optionizePermissions.call this, @roles, @permissionSet
+
     super options,data
-    @setClass 'permissions-form col-'+@roles.length
+
+    @setClass "permissions-form col-#{@roles.length}"
 
 
   showNewRoleModal: ->
@@ -142,11 +144,13 @@ module.exports = class PermissionsForm extends KDFormViewWithFields
       callback     : => @save()
     }
 
-    if current in ['admin','owner']
+    if current in ['admin', 'owner']
       cascadeData[current].defaultValue = yes
       cascadeData[current].disabled = yes
+
     if current and remainder.length > 0
       cascadeData[current].nextElement = cascadeFormElements.call this, set, remainder, module, permission, roleCount
+
     return cascadeData
 
 


### PR DESCRIPTION
Follow up PR for https://github.com/koding/koding/pull/3929
- [x] Implement limited permissions grid.
- [x] Apply new styling.
- [x] Remove guest column from limited grid.
- [ ] Make permission switch more clever, when a role changed automatically change related roles.
- [x] Add missing section titles like `ComputeProvider`.
- [ ] Change scrollView to `CustomScrollView`
