### PR TITLE
Fixes "Expand incomplete sentences in shortcuts view" [fixes #93951102]

### DIFF
--- a/client/account/lib/styl/shortcuts.styl
+++ b/client/account/lib/styl/shortcuts.styl
@@ -118,13 +118,13 @@
         height              auto
         position            relative;
         top                 50%;
-        transform           translateY(-50%)
+        vendor              transform, translateY(-50%)
 
       .col:nth-child(2)
         height              auto
         position            relative;
         top                 50%;
-        transform           translateY(-50%)
+        vendor              transform, translateY(-50%)
 
       .col:nth-child(3)
         text-align          right !important
@@ -134,7 +134,7 @@
         height              auto
         position            relative;
         top                 50%;
-        transform           translateY(-50%)
+        vendor              transform, translateY(-50%)
 
         &:hover
           color             #01B05A

--- a/client/account/lib/styl/shortcuts.styl
+++ b/client/account/lib/styl/shortcuts.styl
@@ -121,9 +121,6 @@
         width               60%
         padding             4px 0px
 
-      .multi-line
-        height              auto
-
       .col:nth-child(3)
         text-align          right !important
         float               right
@@ -143,6 +140,9 @@
     div.row.multi-line-row
       height                50px
       padding               8px 0px 10px 0px
+
+      .col:nth-child(2)
+        height              auto
 
     div.row.collides
       .col:nth-child(3)

--- a/client/account/lib/styl/shortcuts.styl
+++ b/client/account/lib/styl/shortcuts.styl
@@ -74,7 +74,7 @@
       clear                 both
       border-bottom         1px solid #e0e0e0
       height                40px
-      padding               10px 0px
+      padding               8px 0px
       cursor                pointer
 
       &:hover
@@ -101,11 +101,11 @@
 
       .col
         display             table-column
-        width               60%
+        width               45%
         float               left
         font-size           .94em
         line-height         22px
-        padding             4px 0px 4px 0px
+        padding             4px 16px 4px 0px
         borderBox()
 
         > *
@@ -113,26 +113,25 @@
           vertical-align    middle
 
       .col:first-child
-        width               7%
+        width               8%
         text-align          center
+        padding             4px 0px 4px 10px
         height              auto
-        position            relative;
         top                 50%;
         vendor              transform, translateY(-50%)
 
       .col:nth-child(2)
+        width               60%
+        padding             0px 0px 4px 0px
         height              auto
-        position            relative;
-        top                 50%;
-        vendor              transform, translateY(-50%)
+        top                 42%;
+        vendor              transform, translateY(-30%)
 
       .col:nth-child(3)
         text-align          right !important
         float               right
         width               auto
-        padding             4px 16px 4px 0px
         height              auto
-        position            relative;
         top                 50%;
         vendor              transform, translateY(-50%)
 

--- a/client/account/lib/styl/shortcuts.styl
+++ b/client/account/lib/styl/shortcuts.styl
@@ -73,7 +73,7 @@
       width                 100% !important
       clear                 both
       border-bottom         1px solid #e0e0e0
-      height                40px
+      height                30px
       padding               8px 0px
       cursor                pointer
 
@@ -101,7 +101,7 @@
 
       .col
         display             table-column
-        width               45%
+        width               60%
         float               left
         font-size           .94em
         line-height         22px
@@ -113,27 +113,21 @@
           vertical-align    middle
 
       .col:first-child
-        width               8%
+        width               9%
         text-align          center
-        padding             4px 0px 4px 10px
-        height              auto
-        top                 50%;
-        vendor              transform, translateY(-50%)
+        padding-left        6px
 
       .col:nth-child(2)
         width               60%
-        padding             0px 0px 4px 0px
+        padding             4px 0px
+
+      .multi-line
         height              auto
-        top                 42%;
-        vendor              transform, translateY(-30%)
 
       .col:nth-child(3)
         text-align          right !important
         float               right
         width               auto
-        height              auto
-        top                 50%;
-        vendor              transform, translateY(-50%)
 
         &:hover
           color             #01B05A
@@ -145,6 +139,10 @@
 
         span:first-child
           padding-left      0
+
+    div.row.multi-line-row
+      height                50px
+      padding               8px 0px 10px 0px
 
     div.row.collides
       .col:nth-child(3)

--- a/client/account/lib/styl/shortcuts.styl
+++ b/client/account/lib/styl/shortcuts.styl
@@ -101,9 +101,9 @@
 
       .col
         display             table-column
-        width               45%
+        width               55%
         float               left
-        font-size           .94em
+        font-size           .74em
         line-height         22px
         padding             4px 16px 4px 0px
         borderBox()

--- a/client/account/lib/styl/shortcuts.styl
+++ b/client/account/lib/styl/shortcuts.styl
@@ -73,8 +73,8 @@
       width                 100% !important
       clear                 both
       border-bottom         1px solid #e0e0e0
-      height                30px
-      padding               8px 0px
+      height                40px
+      padding               10px 0px
       cursor                pointer
 
       &:hover
@@ -101,11 +101,11 @@
 
       .col
         display             table-column
-        width               55%
+        width               60%
         float               left
-        font-size           .74em
+        font-size           .94em
         line-height         22px
-        padding             4px 16px 4px 0px
+        padding             4px 0px 4px 0px
         borderBox()
 
         > *
@@ -113,14 +113,28 @@
           vertical-align    middle
 
       .col:first-child
-        width               10%
+        width               7%
         text-align          center
-        padding-left        10px
+        height              auto
+        position            relative;
+        top                 50%;
+        transform           translateY(-50%)
+
+      .col:nth-child(2)
+        height              auto
+        position            relative;
+        top                 50%;
+        transform           translateY(-50%)
 
       .col:nth-child(3)
         text-align          right !important
         float               right
         width               auto
+        padding             4px 16px 4px 0px
+        height              auto
+        position            relative;
+        top                 50%;
+        transform           translateY(-50%)
 
         &:hover
           color             #01B05A

--- a/client/account/lib/views/accounteditshortcutsrow.coffee
+++ b/client/account/lib/views/accounteditshortcutsrow.coffee
@@ -25,7 +25,7 @@ class AccountEditShortcutsRow extends kd.View
   CANCEL_CLASS_NAME = 'cancel'
 
   # The maximum description string length.
-  DESCRIPTION_TRUNC_LEN = 50
+  DESCRIPTION_TRUNC_LEN = 100
 
   # The separator pattern to truncate to.
   DESCRIPTION_TRUNC_SEP = ' '

--- a/client/account/lib/views/accounteditshortcutsrow.coffee
+++ b/client/account/lib/views/accounteditshortcutsrow.coffee
@@ -12,6 +12,9 @@ class AccountEditShortcutsRow extends kd.View
   # Class name for columns.
   COL_CLASS_NAME = 'col'
 
+  # Default class name for desc columns.
+  DESC_CLASS_NAME = 'col single-line'
+  
   # Class name to set for currently recording item.
   ENABLED_CLASS_NAME = 'enabled'
 
@@ -26,6 +29,9 @@ class AccountEditShortcutsRow extends kd.View
 
   # The maximum description string length.
   DESCRIPTION_TRUNC_LEN = 100
+  
+  # The maximum description string length for a single line.
+  SINGLE_LINE_LEN = 50
 
   # The separator pattern to truncate to.
   DESCRIPTION_TRUNC_SEP = ' '
@@ -63,9 +69,13 @@ class AccountEditShortcutsRow extends kd.View
     if @model.enabled then toggle.setClass ENABLED_CLASS_NAME
 
     descriptionText = _.escape @model.description
+    
+    if descriptionText.length > SINGLE_LINE_LEN
+      DESC_CLASS_NAME = 'col multi-line'
+      @setClass 'multi-line-row'
 
     description = new kd.View
-      cssClass : COL_CLASS_NAME
+      cssClass : DESC_CLASS_NAME
       partial  : _.trunc descriptionText, separator: DESCRIPTION_TRUNC_SEP, length: DESCRIPTION_TRUNC_LEN
 
     if descriptionText.length > DESCRIPTION_TRUNC_LEN

--- a/client/account/lib/views/accounteditshortcutsrow.coffee
+++ b/client/account/lib/views/accounteditshortcutsrow.coffee
@@ -12,9 +12,6 @@ class AccountEditShortcutsRow extends kd.View
   # Class name for columns.
   COL_CLASS_NAME = 'col'
 
-  # Default class name for desc columns.
-  DESC_CLASS_NAME = 'col single-line'
-  
   # Class name to set for currently recording item.
   ENABLED_CLASS_NAME = 'enabled'
 
@@ -71,11 +68,10 @@ class AccountEditShortcutsRow extends kd.View
     descriptionText = _.escape @model.description
     
     if descriptionText.length > SINGLE_LINE_LEN
-      DESC_CLASS_NAME = 'col multi-line'
       @setClass 'multi-line-row'
 
     description = new kd.View
-      cssClass : DESC_CLASS_NAME
+      cssClass : COL_CLASS_NAME
       partial  : _.trunc descriptionText, separator: DESCRIPTION_TRUNC_SEP, length: DESCRIPTION_TRUNC_LEN
 
     if descriptionText.length > DESCRIPTION_TRUNC_LEN

--- a/client/account/lib/views/accounteditshortcutsrow.coffee
+++ b/client/account/lib/views/accounteditshortcutsrow.coffee
@@ -25,7 +25,7 @@ class AccountEditShortcutsRow extends kd.View
   CANCEL_CLASS_NAME = 'cancel'
 
   # The maximum description string length.
-  DESCRIPTION_TRUNC_LEN = 30
+  DESCRIPTION_TRUNC_LEN = 50
 
   # The separator pattern to truncate to.
   DESCRIPTION_TRUNC_SEP = ' '


### PR DESCRIPTION
Before
![screenshot at 23-35-12](https://cloud.githubusercontent.com/assets/1278794/7946572/14d1d768-0980-11e5-906d-f21ba6d3572f.png)

After
![screenshot at 23-35-21](https://cloud.githubusercontent.com/assets/1278794/7946573/14d2b8b8-0980-11e5-9244-d53293261885.png)

The story: https://www.pivotaltracker.com/story/show/93951102

Notes:
Each desc now has a class and we know what type it is, a multi-line or a single line. If a description is over the default single line setting it will be switched to multi-line.

_design with blessings from Emre_

cc. @sinan @usirin 
