### PR TITLE
support: hide button loader when form has validation errors [fixes #95942320]

### DIFF
--- a/client/app/lib/commonviews/helpsupportmodal.coffee
+++ b/client/app/lib/commonviews/helpsupportmodal.coffee
@@ -50,6 +50,9 @@ module.exports = class HelpSupportModal extends KDModalViewWithForms
 
     @addOnboardingView()
 
+    form = @modalTabs.forms.Main
+    form.on 'FormValidationFailed', -> form.buttons.submit.hideLoader()
+
     @on "NewTicketRequested", (form)=>
 
       return if @ticketRequested


### PR DESCRIPTION
@gokmen, can you please review this fix? It's for [this bug](https://www.pivotaltracker.com/story/show/95942320)
