### PR TITLE
klienteventmanager: Added a pubsub event manager for client.Subscribe

### DIFF
--- a/client/app/lib/kite/klienteventmanager.coffee
+++ b/client/app/lib/kite/klienteventmanager.coffee
@@ -25,7 +25,7 @@ module.exports = class KlientEventManager extends kd.Object
     if @kite.isDisconnected
       throw new Error "KlientEventManager requires an active Kite connection"
 
-    @subscribe eventName, callback for eventName, callback of options
+    @subscribe eventName, callback  for eventName, callback of options
 
 
   ###*

--- a/client/app/lib/kite/klienteventmanager.coffee
+++ b/client/app/lib/kite/klienteventmanager.coffee
@@ -1,0 +1,45 @@
+kd = require 'kd'
+
+###*
+ * The KlientEventManager is a wrapper over Klient events (from
+ * `client.Subscribe`) that have repeating callbacks. It serves to
+ * provide a cleaner pubsub interface for methods of Klient
+ * that make sense using this style.
+###
+module.exports = class KlientEventManager extends kd.Object
+
+  ###*
+   * @param {Object} options - An object where the keys are event names,
+   * and the values are callbacks. As an alternative, you can simply
+   * use the `@subscribe` method.
+  ###
+  constructor: (options = {}, machine) ->
+
+    super
+
+    if not machine
+      throw new Error kd.err "KlientEventManager requires a Machine"
+
+    @kite = machine.getBaseKite()
+
+    if @kite.isDisconnected
+      throw new Error "KlientEventManager requires an active Kite connection"
+
+    @subscribe eventName, callback for eventName, callback of options
+
+
+  ###*
+   * Subscribe to the given Klient client.Subscribe eventName
+   *
+   * @param {String} eventName
+   * @param {Function()} callback - Called with whatever data the given
+   *  eventName responds with.
+  ###
+  subscribe: (eventName, callback) ->
+
+    @kite.clientSubscribe { eventName, onPublish: callback }
+
+    # Return this, to match the EventEmitter's self return.
+    return this
+
+

--- a/client/app/lib/kite/klienteventmanager.coffee
+++ b/client/app/lib/kite/klienteventmanager.coffee
@@ -17,7 +17,7 @@ module.exports = class KlientEventManager extends kd.Object
 
     super
 
-    if not machine
+    unless machine
       throw new Error kd.err "KlientEventManager requires a Machine"
 
     @kite = machine.getBaseKite()

--- a/client/app/lib/kite/klienteventmanager.coffee
+++ b/client/app/lib/kite/klienteventmanager.coffee
@@ -15,7 +15,7 @@ module.exports = class KlientEventManager extends kd.Object
   ###
   constructor: (options = {}, machine) ->
 
-    super
+    super options, machine
 
     unless machine
       throw new Error kd.err "KlientEventManager requires a Machine"


### PR DESCRIPTION
At the request of @szkl, An EventManager has been added for the new Klient `client.Subscribe` method. This will be used in the IDE, to subscribe to the `openFiles` event, along with future events.

Note: Klient itself does not have an unsub method, but that will be added in the coming days, and then added to this Class as well. This class is still needed now though, to provide UI support for the `client.Subscribe`.

cc @usirin 
