### PR TITLE
Fixes "Activity: Share popup should scroll together with the page" [fixes #85068990]

### DIFF
--- a/client/activity/lib/views/activityactionsview.coffee
+++ b/client/activity/lib/views/activityactionsview.coffee
@@ -42,16 +42,20 @@ module.exports = class ActivityActionsView extends JView
 
         {scrollX, scrollY} = global
 
-        @append sharePopup = new KDContextMenu
+        @sharePopup = new KDContextMenu
           cssClass    : "activity-share-popup"
           type        : "activity-share"
           delegate    : this
-          x           : scrollX + 140
-          y           : scrollY - 12
+          x           : @shareLink.getX() + scrollX + 25
+          y           : @shareLink.getY() + scrollY - 12
           menuMaxWidth: 400
           menuMinWidth: 192
           lazyLoad    : yes
         , customView  : new ActivitySharePopup delegate: this, url: shareUrl
+
+        pane = kd.singletons.appManager.frontApp.getView().tabs.getActivePane()
+
+        pane.scrollView.wrapper.on "scroll", @sharePopup.bound "destroy"
 
         trackEvent "Activity share, click"
 
@@ -76,7 +80,7 @@ module.exports = class ActivityActionsView extends JView
 
 
   viewAppended: ->
-
+      
     @loader.hide()
 
     super

--- a/client/activity/lib/views/activityactionsview.coffee
+++ b/client/activity/lib/views/activityactionsview.coffee
@@ -53,9 +53,9 @@ module.exports = class ActivityActionsView extends JView
           lazyLoad    : yes
         , customView  : new ActivitySharePopup delegate: this, url: shareUrl
 
-        pane = kd.singletons.appManager.frontApp.getView().tabs.getActivePane()
-
-        pane.scrollView.wrapper.on "scroll", @sharePopup.bound "destroy"
+        pane = @parent.getDelegate()
+        
+        pane.parent.parent.parent.parent.parent.scrollView.wrapper.on "scroll", @sharePopup.bound "destroy"
 
         trackEvent "Activity share, click"
 

--- a/client/activity/lib/views/activityactionsview.coffee
+++ b/client/activity/lib/views/activityactionsview.coffee
@@ -42,12 +42,12 @@ module.exports = class ActivityActionsView extends JView
 
         {scrollX, scrollY} = global
 
-        new KDContextMenu
+        @append sharePopup = new KDContextMenu
           cssClass    : "activity-share-popup"
           type        : "activity-share"
           delegate    : this
-          x           : @shareLink.getX() + scrollX + 25
-          y           : @shareLink.getY() + scrollY - 7
+          x           : scrollX + 140
+          y           : scrollY - 12
           menuMaxWidth: 400
           menuMinWidth: 192
           lazyLoad    : yes

--- a/client/activity/lib/views/activityactionsview.coffee
+++ b/client/activity/lib/views/activityactionsview.coffee
@@ -53,9 +53,9 @@ module.exports = class ActivityActionsView extends JView
           lazyLoad    : yes
         , customView  : new ActivitySharePopup delegate: this, url: shareUrl
 
-        pane = @parent.getDelegate()
+        pane = kd.singletons.appManager.frontApp.getView().tabs.getActivePane()
 
-        pane.parent.parent.parent.parent.parent.scrollView.wrapper.on "scroll", @sharePopup.bound "destroy"
+        pane.scrollView.wrapper.on 'scroll', @sharePopup.bound 'destroy'
 
         trackEvent "Activity share, click"
 

--- a/client/activity/lib/views/activityactionsview.coffee
+++ b/client/activity/lib/views/activityactionsview.coffee
@@ -55,7 +55,7 @@ module.exports = class ActivityActionsView extends JView
 
         pane = kd.singletons.appManager.frontApp.getView().tabs.getActivePane()
 
-        pane.scrollView.wrapper.on 'scroll', @sharePopup.bound 'destroy'
+        pane.scrollView.wrapper.once 'scroll', @sharePopup.bound 'destroy'
 
         trackEvent "Activity share, click"
 

--- a/client/activity/lib/views/activityactionsview.coffee
+++ b/client/activity/lib/views/activityactionsview.coffee
@@ -54,7 +54,7 @@ module.exports = class ActivityActionsView extends JView
         , customView  : new ActivitySharePopup delegate: this, url: shareUrl
 
         pane = @parent.getDelegate()
-        
+
         pane.parent.parent.parent.parent.parent.scrollView.wrapper.on "scroll", @sharePopup.bound "destroy"
 
         trackEvent "Activity share, click"

--- a/client/activity/lib/views/activityactionsview.coffee
+++ b/client/activity/lib/views/activityactionsview.coffee
@@ -80,7 +80,7 @@ module.exports = class ActivityActionsView extends JView
 
 
   viewAppended: ->
-      
+
     @loader.hide()
 
     super


### PR DESCRIPTION
Before
![screencast 2015-06-04 23-48-15](https://cloud.githubusercontent.com/assets/1278794/7994236/6e1dd426-0b14-11e5-97e4-cb7da49fc49e.gif)

After
![screencast 2015-06-04 23-49-15](https://cloud.githubusercontent.com/assets/1278794/7994237/6e39d1e4-0b14-11e5-881d-a4159a7b9e91.gif)

The story: https://www.pivotaltracker.com/story/show/85068990

Notes: The popup is now appended to the Share button parent, that was the only (and easiest way) to make it relative to that container. Until then it was appended at the bottom, outside or everything relative to the body of the page.

cc. @usirin @sinan 
