### PR TITLE
React view

### DIFF
--- a/client/app/lib/react/basecomponent.coffee
+++ b/client/app/lib/react/basecomponent.coffee
@@ -1,0 +1,22 @@
+_              = require 'lodash'
+ReactComponent = require 'react/lib/ReactComponent'
+
+# the reason we are using this instead of `kd.Object` is because kd.Object
+# extends from EventEmitter and has extra functionality that we don't need to
+# extract. This is a pure KDObject with `bound` and `lazyBound` types of
+# methods.
+{ KDObject }   = require 'kdf-core'
+
+
+module.exports = class KDReactComponent extends ReactComponent
+
+  _.extend @prototype, KDObject.prototype
+
+  constructor: (props) ->
+
+    # first call KDObject constructor.
+    KDObject.call this, props
+
+    super props
+
+

--- a/client/app/lib/react/index.coffee
+++ b/client/app/lib/react/index.coffee
@@ -1,0 +1,15 @@
+React = require 'react'
+_ = require 'lodash'
+
+KDReactComponent = require './basecomponent'
+
+# extend React object and inject our component into it.
+# from now on requires should be like below:
+#
+#   React = require 'app/react'
+KDReact = _.assign {}, React, {
+  Component: KDReactComponent
+}
+
+module.exports = KDReact
+

--- a/client/app/lib/react/reactbridge.coffee
+++ b/client/app/lib/react/reactbridge.coffee
@@ -11,19 +11,17 @@ module.exports = class ReactBridge extends React.Component
 
     @state = { component: @props.component or null }
 
-    @setComponent = @setComponent.bind this
-
 
   componentDidMount: ->
 
     # register to dispatcher, show the emitted component when
     # `ShowComponent` event is dispatched.
-    @props.dispatcher.on 'SetComponent', @setComponent
+    @props.dispatcher.on 'SetComponent', @bound 'setComponent'
 
 
   componentWillUnmount: ->
 
-    @props.dispatcher.off 'SetComponent', @setComponent
+    @props.dispatcher.off 'SetComponent'
 
 
   ###

--- a/client/app/lib/react/reactbridge.coffee
+++ b/client/app/lib/react/reactbridge.coffee
@@ -1,0 +1,47 @@
+React = require 'app/react'
+
+module.exports = class ReactBridge extends React.Component
+
+  constructor: (props) ->
+
+    unless props.dispatcher
+      throw new Error "#{@constructor.name}: requires a dispatcher."
+
+    super props
+
+    @state = { component: @props.component or null }
+
+    @setComponent = @setComponent.bind this
+
+
+  componentDidMount: ->
+
+    # register to dispatcher, show the emitted component when
+    # `ShowComponent` event is dispatched.
+    @props.dispatcher.on 'SetComponent', @setComponent
+
+
+  componentWillUnmount: ->
+
+    @props.dispatcher.off 'SetComponent', @setComponent
+
+
+  ###
+   * Set component to the state, this will trigger the rerender.
+  ###
+  setComponent: (component) -> @setState { component }
+
+
+  ###*
+   * Custom getter for component. If you want to do funny stuff with the given
+   * component this is the place.
+   *
+   * @return {React.Component} _component
+  ###
+  getComponent: -> @state.component
+
+
+  render: ->
+    <div className="js-bridgeContainer">{@getComponent()}</div>
+
+

--- a/client/app/lib/react/reactbridge.coffee
+++ b/client/app/lib/react/reactbridge.coffee
@@ -4,7 +4,7 @@ module.exports = class ReactBridge extends React.Component
 
   constructor: (props) ->
 
-    unless props.dispatcher
+    unless props?.dispatcher
       throw new Error "#{@constructor.name}: requires a dispatcher."
 
     super props

--- a/client/app/lib/react/reactview.coffee
+++ b/client/app/lib/react/reactview.coffee
@@ -1,0 +1,39 @@
+kd          = require 'kd'
+React       = require 'app/react'
+ReactBridge = require './reactbridge'
+
+
+module.exports = class ReactView extends kd.CustomHTMLView
+
+  constructor: (options, data) ->
+
+    super options, data
+
+    @_dispatcher = new kd.Object
+
+
+  renderReact: ->
+
+    console.error "#{@constructor.name}: needs to implement 'renderReact' method"
+
+
+  setComponent: (component, props) ->
+
+    @_dispatcher.emit 'SetComponent', React.createElement component, props
+
+
+  viewAppended: ->
+
+    bridgeOptions =
+      dispatcher : @_dispatcher
+      component  : @renderReact()
+
+    bridge = @options.bridge or ReactBridge
+
+    React.render(
+      React.createElement(bridge, bridgeOptions),
+      @getElement()
+    )
+
+
+

--- a/client/app/lib/react/test/basecomponent.test.coffee
+++ b/client/app/lib/react/test/basecomponent.test.coffee
@@ -1,0 +1,46 @@
+React         = require 'react/addons'
+{ expect }    = require 'chai'
+{ TestUtils } = React.addons
+
+KDReactComponent = require '../basecomponent'
+
+describe 'KDReactComponent', ->
+
+  class FooComponent extends KDReactComponent
+    render: -> <div {...@props} />
+
+  it 'works', ->
+
+    expect(<FooComponent />).to.be.ok
+
+
+  it 'has KDObject::bound abilities', ->
+
+    flag = no
+
+    class BarComponent extends KDReactComponent
+      constructor: (props) ->
+        super props
+        # this will prove that bound method works for
+        # click handlers as it should. We are gonna assign
+        # this instance variable to flag, and will test if flag has
+        # this value.
+        @instanceBoolean = yes
+
+      onClick: -> flag = @instanceBoolean
+      render: -> <div onClick={@bound 'onClick'} />
+
+    flag = no
+    onClick = (e) -> flag = yes
+
+    component = TestUtils.renderIntoDocument(
+      <BarComponent onClick={onClick} />
+    )
+
+    element = TestUtils.findRenderedDOMComponentWithTag component, 'div'
+
+    TestUtils.Simulate.click element
+
+    expect(flag).to.equal yes
+
+

--- a/client/app/lib/react/test/index.coffee
+++ b/client/app/lib/react/test/index.coffee
@@ -1,4 +1,5 @@
 describe 'KDReact', ->
   require './basecomponent.test'
+  require './reactbridge.test'
 
 

--- a/client/app/lib/react/test/index.coffee
+++ b/client/app/lib/react/test/index.coffee
@@ -1,5 +1,6 @@
 describe 'KDReact', ->
   require './basecomponent.test'
+  require './reactview.test'
   require './reactbridge.test'
 
 

--- a/client/app/lib/react/test/index.coffee
+++ b/client/app/lib/react/test/index.coffee
@@ -1,0 +1,4 @@
+describe 'KDReact', ->
+  require './basecomponent.test'
+
+

--- a/client/app/lib/react/test/reactbridge.test.coffee
+++ b/client/app/lib/react/test/reactbridge.test.coffee
@@ -1,0 +1,87 @@
+kd            = require 'kd'
+React         = require 'react/addons'
+{ expect }    = require 'chai'
+{ TestUtils } = React.addons
+
+ReactBridge = require '../reactbridge'
+
+describe 'ReactBridge', ->
+
+  it 'requires a dispatcher to work', ->
+
+    bridge = TestUtils.renderIntoDocument(
+      <ReactBridge dispatcher={new kd.Object} />
+    )
+
+    expect(bridge).to.be.ok
+
+    createBridgeWithoutDispatcher = ->
+      bridge = TestUtils.renderIntoDocument(
+        <ReactBridge />
+      )
+
+    expect(createBridgeWithoutDispatcher).to.throw /requires a dispatcher/
+
+
+  describe '#constructor', ->
+
+    it 'renders nothing if nothing is passed', ->
+
+      container = renderBridge dispatcher: new kd.Object
+
+      expect(container.getDOMNode().childElementCount).to.equal 0
+
+
+    it 'renders given component', ->
+
+      container = renderBridge
+        dispatcher: new kd.Object
+        component: <div className="foo">Hello World</div>
+
+      element = container.getDOMNode()
+
+      expect(element.childElementCount).to.equal 1
+      expect(element.textContent).to.equal 'Hello World'
+
+
+  describe 'bridge dispatcher', ->
+
+    # since this class is designed to be used by a KDReactView,
+    # it uses a dispatcher to communicate outside world.
+    # That default dispatcher for now has limited api,
+    # but a subclass of a KDBridgeComponent can implement extra
+    # functionality, since KDReactView accepts a custom KDReactBridge
+    # class through its options object.
+
+    it 'uses dispatcher to set its component any time', ->
+
+      # KDReactView will automatically create a dispatcher
+      # and will save you from this boilerplate. In fact, KDReactBridge
+      # is just an implementation detail to make arbitrary react components
+      # to work inside KD Framework.
+      mockDispatcher = new kd.Object
+
+      component = <div>Hello World</div>
+      container = renderBridge dispatcher: mockDispatcher, component: component
+
+      element = container.getDOMNode()
+
+      expect(element.textContent).to.equal 'Hello World'
+
+      component = <div>Hello Changed World</div>
+
+      mockDispatcher.emit 'SetComponent', component
+
+      expect(container.getDOMNode().textContent).to.equal 'Hello Changed World'
+
+
+
+renderBridge = (options) ->
+
+  bridge = TestUtils.renderIntoDocument(
+    <ReactBridge {...options} />
+  )
+
+  return TestUtils.findRenderedDOMComponentWithClass bridge, 'js-bridgeContainer'
+
+

--- a/client/app/lib/react/test/reactview.test.coffee
+++ b/client/app/lib/react/test/reactview.test.coffee
@@ -1,0 +1,38 @@
+kd         = require 'kd'
+{ expect } = require 'chai'
+React      = require 'react/addons'
+
+ReactView = require '../reactview'
+
+renderIntoDocument = (view) ->
+  div = document.createElement 'div'
+  div.appendChild view.getElement()
+  view.emit 'viewAppended'
+
+  return view
+
+findRenderedDOMWithClassName = (view, className) ->
+
+  view.getElement().querySelector ".#{className}"
+
+
+describe 'ReactView', ->
+
+  it 'works', ->
+
+    expect(new ReactView).to.be.ok
+
+
+  it 'renders dom element with react', ->
+
+    class FooReactView extends ReactView
+
+      renderReact: ->
+        <div className="hello-world">Hello World</div>
+
+    foo = renderIntoDocument(new FooReactView)
+
+    helloWorld = findRenderedDOMWithClassName foo, 'hello-world'
+
+    expect(helloWorld.textContent).to.equal 'Hello World'
+

--- a/client/app/test/index.coffee
+++ b/client/app/test/index.coffee
@@ -1,1 +1,2 @@
 require './statemachine.test'
+require '../lib/react/test'

--- a/client/package.json
+++ b/client/package.json
@@ -27,6 +27,7 @@
     "kd-shim-jspath": "0.2.0",
     "kd-shim-sockjs-client": "0.3.4",
     "kd.js": "1.1.6",
+    "kdf-core": "0.0.6",
     "keycode": "2.0.0",
     "kite.js": "0.5.1",
     "kookies": "0.1.1",


### PR DESCRIPTION
This PR includes base classes that can be used for integrating `React` to be able to use it with `kd`.
### ReactView

ReactView is a subclass of KDView that can be used for rendering an arbitrary react component as its DOM element.

Use this view to wrap a React element and easily `addSubView` it to a parent.

``` coffeescript
ReactView = require 'app/react/reactview'

# this require is necessary for the fact that
# JSX will be compiled into `React.createElement` calls.
React = require 'app/react'

SomeReactComponent = require 'app/components/somereactcomponent'

class ExampleView extends ReactView

  constructor: (options, data) ->

    options.cssClass = 'ExampleView'

    super options, data


  # yep JSX inside KDView.
  renderReact: ->
    <SomeReactComponent />
```

`renderReact` method allows us to inject `<AnyReactComponent />`.

Keep in mind that this class is designed to be a simple wrapper around a `ReactComponent`, so don't put unnecessary logic in here, instead use this as a simple bridge between a complicated `KDView` and a `ReactComponent`.
### KDReact

`KDReact` extends `React` for changing the base classes that are exported by `React` itself. For now we are only extending `React.Component` with `KDObject` to have best of both worlds (Mainly for `KDObject::bound`).

This requires us to require React as `React = require 'app/react'` instead of `React = require 'react'`.

The reason of extending `React` and requiring it as `React = require 'app/react'` is that the `coffee-react` compiler we are using for `JSX` compilation doesn't allow us to inject the symbols we want to convert:

``` coffee
<div>Hello World</div>
```

`coffee-react` transform will transform this to following function call:

``` coffee
React.createElement 'div', null, 'Hello World'
```

As you can see it requires a `React` variable to exist in the scope.

So if we were to use the `KDReactComponent` alone:

``` coffee
KDReactComponent = require 'app/react/basecomponent'

class FooComponent extends KDReactComponent
  render: ->
    <div>Foo</div>
```

This would throw a reference error saying that `React` is not defined.

So the reason to extend `React.Component` with `KDReactComponent` is to remove the necessity to require `React` with no visible reason (compiled results of JSX is not in the page, but for some reason I am requiring React, wtf, why isn't my code working? etc. etc.)

If we were to rewrite the example above:

``` coffee
# We have a React in our scope. Notice the require.
React = require 'app/react'

# But its component is `KDReactComponent`
class FooComponent extends React.Component
  render: ->
    <div>Foo</div>
```
