### PR TITLE
EnvironmentMachineStateModal: fix no machine modal issue [completes #96316570]

### DIFF
--- a/client/app/lib/providers/environmentsmachinestatemodal.coffee
+++ b/client/app/lib/providers/environmentsmachinestatemodal.coffee
@@ -471,7 +471,7 @@ module.exports = class EnvironmentsMachineStateModal extends BaseModalView
         </span>
       "
 
-    if customState is 'NotFound'
+    if customState is 'NotFound' and not isKoding()
       {groupsController} = kd.singletons
       customState = 'NoTemplate'  unless groupsController.currentGroupHasStack()
 


### PR DESCRIPTION
Don't know what is causing this but following line never returned `false` for me for `koding` group, and it shouldn't https://github.com/koding/koding/pull/4046/files#diff-4465a7893c9128eddbd400ad5e97a313R476 but somehow it's returning `false` it seems.
