### PR TITLE
Fixes "Fix spaces between comments" [fixes #96420914]

### DIFF
--- a/client/activity/lib/styl/activity.listitem.styl
+++ b/client/activity/lib/styl/activity.listitem.styl
@@ -461,13 +461,13 @@ activity.listitem.styl
         padding             0
         line-height         16px
         opacity             .99
+        margin-bottom       0
 
         &:after
           content           ''
           display           block
           width             100%
           clear             both
-          margin            0 0 3px 0
 
         p
           a

--- a/client/activity/lib/styl/activity.listitem.styl
+++ b/client/activity/lib/styl/activity.listitem.styl
@@ -461,7 +461,9 @@ activity.listitem.styl
         padding             0
         line-height         16px
         opacity             .99
-        margin-bottom       0
+
+        &.has-show-more
+          margin-bottom     12px
 
         &:after
           content           ''
@@ -802,7 +804,6 @@ activity.listitem.styl
     kalc                    width (100% \- 100px)
 
 .kdlistitemview .has-show-more
-  margin-bottom             12px
   overflow                  hidden
   max-height                400px
   opacity                   .99

--- a/client/app/lib/styl/markdown.styl
+++ b/client/app/lib/styl/markdown.styl
@@ -59,7 +59,7 @@ activity.markdown.styl
     padding                 0 10px
     margin                  12px 0
   p
-    padding                 0 0 8px 0
+    padding                 0 0 5px 0
     word-wrap               break-word
     img
       size                  auto auto

--- a/client/app/lib/styl/markdown.styl
+++ b/client/app/lib/styl/markdown.styl
@@ -59,7 +59,7 @@ activity.markdown.styl
     padding                 0 10px
     margin                  12px 0
   p
-    padding                 0 0 5px 0
+    padding                 0 0 8px 0
     word-wrap               break-word
     img
       size                  auto auto


### PR DESCRIPTION
Before:
![activity 2015-06-06 11-31-16](https://cloud.githubusercontent.com/assets/1278794/8042618/232e95c8-0e29-11e5-897e-0f7cec2b04e7.png)

After:
![screenshot at 21-55-47](https://cloud.githubusercontent.com/assets/1278794/8042617/232d8584-0e29-11e5-954b-91f9e9bdc4d4.png)

The story: https://www.pivotaltracker.com/story/show/96420914

Notes: Not sure if I got the correct height precisely since I couldn't find a proper Invision screen.

cc. @sinan @usirin
