### PR TITLE
onboarding: scrollable throbbers [fixes #95184274]

### DIFF
--- a/client/app/lib/onboarding/onboardingitemview.coffee
+++ b/client/app/lib/onboarding/onboardingitemview.coffee
@@ -24,7 +24,7 @@ module.exports = class OnboardingItemView extends KDView
       @targetElement?.on 'KDObjectWillBeDestroyed', @bound 'handleTargetDestroyed'
 
       if @targetElement and not @targetElement.hasClass 'hidden'
-        { placementX, placementY, offsetX, offsetY, content, tooltipPlacement, color } = @getData()
+        { placementX, placementY, offsetX, offsetY, content, tooltipPlacement, color, targetIsScrollable } = @getData()
         @throbber = new ThrobberView {
           cssClass    : kd.utils.curry color, if isModal then 'modal-throbber' else ''
           delegate    : @targetElement
@@ -34,6 +34,7 @@ module.exports = class OnboardingItemView extends KDView
           offsetX
           offsetY
           tooltipPlacement
+          targetIsScrollable
         }
         @throbber.on 'TooltipReady', =>
           @startTrackDate = new Date()

--- a/client/app/lib/onboarding/throbberview.coffee
+++ b/client/app/lib/onboarding/throbberview.coffee
@@ -46,7 +46,6 @@ module.exports = class ThrobberView extends KDView
       cssClass  : 'throbber-tooltip'
       placement : tooltipPlacement
       html      : yes
-      sticky    : yes
 
 
   setPosition: ->

--- a/client/app/lib/onboarding/throbberview.coffee
+++ b/client/app/lib/onboarding/throbberview.coffee
@@ -13,9 +13,22 @@ module.exports = class ThrobberView extends KDView
 
     super options, data
 
-    @appendToDomBody()
+    @appendToParent()
     @createElements()
     @setPosition()
+
+
+  appendToParent: ->
+
+    { targetIsScrollable } = @getOptions()
+    targetElement          = @getDelegate()
+    targetDomElement       = targetElement.getDomElement()
+
+    if targetIsScrollable
+      targetElement.addSubView this
+      targetElement.setCss 'position', 'relative'  if targetDomElement.css('position') is 'static'
+    else
+      @appendToDomBody()
 
 
   createElements: ->
@@ -38,11 +51,11 @@ module.exports = class ThrobberView extends KDView
 
   setPosition: ->
 
-    { placementX, placementY, offsetX, offsetY } = @getOptions()
+    { placementX, placementY, offsetX, offsetY, targetIsScrollable } = @getOptions()
 
     targetElement       = @getDelegate()
-    targetElementX      = targetElement.getX()
-    targetElementY      = targetElement.getY()
+    targetElementX      = if targetIsScrollable then 0 else targetElement.getX()
+    targetElementY      = if targetIsScrollable then 0 else targetElement.getY()
     targetElementWidth  = targetElement.getWidth()
     targetElementHeight = targetElement.getHeight()
 

--- a/client/dashboard/lib/views/onboarding/onboardingaddnewform.coffee
+++ b/client/dashboard/lib/views/onboarding/onboardingaddnewform.coffee
@@ -1,6 +1,7 @@
 kd = require 'kd'
 KDInputView = kd.InputView
 KDSelectBox = kd.SelectBox
+KDCheckBox = kd.CheckBox
 AddNewCustomViewForm = require '../customviews/addnewcustomviewform'
 Encoder = require 'htmlencode'
 
@@ -77,6 +78,9 @@ module.exports = class OnboardingAddNewForm extends AddNewCustomViewForm
       ]
     @tooltipPlacement.setValue data.tooltipPlacement  if data.tooltipPlacement
 
+    @targetIsScrollable = new KDCheckBox
+      defaultValue  : data.targetIsScrollable
+
     @editor.setClass "hidden"
 
     @oldData = data
@@ -95,15 +99,16 @@ module.exports = class OnboardingAddNewForm extends AddNewCustomViewForm
     offsetX = @throbberOffsetX.getValue()
     offsetY = @throbberOffsetY.getValue()
     newItem =
-      name             : @input.getValue()
-      path             : @path.getValue()
-      placementX       : @throbberPlacementX.getValue()
-      placementY       : @throbberPlacementY.getValue()
-      color            : @throbberColor.getValue()
-      offsetX          : parseInt offsetX  if offsetX.length > 0
-      offsetY          : parseInt offsetY  if offsetY.length > 0
-      content          : @tooltipText.getValue()
-      tooltipPlacement : @tooltipPlacement.getValue()
+      name               : @input.getValue()
+      path               : @path.getValue()
+      placementX         : @throbberPlacementX.getValue()
+      placementY         : @throbberPlacementY.getValue()
+      color              : @throbberColor.getValue()
+      offsetX            : parseInt offsetX  if offsetX.length > 0
+      offsetY            : parseInt offsetY  if offsetY.length > 0
+      content            : @tooltipText.getValue()
+      tooltipPlacement   : @tooltipPlacement.getValue()
+      targetIsScrollable : @targetIsScrollable.getValue()
       partial : { html: "", css: "", js: "" }
 
     isUpdate = no
@@ -136,6 +141,8 @@ module.exports = class OnboardingAddNewForm extends AddNewCustomViewForm
         {{> @tooltipText}}
         <p>Tooltip Placement</p>
         {{> @tooltipPlacement}}
+        <p>Scrollable Content</p>
+        {{> @targetIsScrollable}}
       </div>
       {{> @editor}}
       <div class="button-container">


### PR DESCRIPTION
@sinan, can you review this fix? It's for onboarding throbbers which are attached to scrollable content

Problem - http://recordit.co/AlUxVS7Omo
I added an option to onboarding admin page - `Scrollable Content` - which helps to fix that problem. It makes sense to check `Scrollable Content` for onboarding targets which can be scrolled.

Here is the screenshot of admin page:

![onboarding-edit-item](https://cloud.githubusercontent.com/assets/492219/8048319/9dd44dde-0e58-11e5-9ba0-601846825475.jpg)
