### PR TITLE
spinner: bug at the topic moderation about lazyloader[#96575880]

### DIFF
--- a/client/admin/lib/views/moderation/topicitemview.coffee
+++ b/client/admin/lib/views/moderation/topicitemview.coffee
@@ -175,9 +175,8 @@ module.exports = class TopicItemView extends KDListItemView
       
   listLeafChannels: (channels) ->
     
-    @leafChannelsListController.hideLazyLoader()
     return  unless channels?.length
-
+    @removeLabel.show()
     
     @leafSkip += channels.length
 
@@ -244,7 +243,7 @@ module.exports = class TopicItemView extends KDListItemView
         cssClass          : 'leaf-channel-list'
         itemOptions       : {}
       noItemFoundWidget   : new KDCustomHTMLView  { partial: "Doesn't have linked channel" }
-      startWithLazyLoader : yes
+      startWithLazyLoader : no
       lazyLoadThreshold   : .99
       lazyLoaderOptions   :
         spinnerOptions    :


### PR DESCRIPTION
Spinner is displayed continuously on the moderation form.
LazyLoader is spinning continuously.
http://recordit.co/YjKyOGPDlh
