### PR TITLE
Fixes "Change position of the Verify now link" [fixes #95942250]

### DIFF
--- a/client/account/lib/views/accounteditusername.coffee
+++ b/client/account/lib/views/accounteditusername.coffee
@@ -1,3 +1,4 @@
+$ = require 'jquery'
 kd = require 'kd'
 KDButtonView = kd.ButtonView
 KDCustomHTMLView = kd.CustomHTMLView
@@ -330,7 +331,11 @@ module.exports = class AccountEditUsername extends JView
               return showError err if err
               notify "We've sent you a confirmation mail.", 3500
 
-    @emailForm.fields.username.parent.prepend verifyEmail = new KDCustomHTMLView opts
+    @verifyEmail = new KDCustomHTMLView opts
+
+    header = @emailForm.fields.passwordHeader.getElement()
+
+    header.parentElement.insertBefore @verifyEmail.getElement(), header
 
   getAvatarOptions: ->
     tagName       : 'figure'

--- a/client/account/lib/views/accounteditusername.coffee
+++ b/client/account/lib/views/accounteditusername.coffee
@@ -330,8 +330,7 @@ module.exports = class AccountEditUsername extends JView
               return showError err if err
               notify "We've sent you a confirmation mail.", 3500
 
-    @addSubView @verifyEmail = new KDCustomHTMLView opts
-
+    @emailForm.fields.username.parent.prepend verifyEmail = new KDCustomHTMLView opts
 
   getAvatarOptions: ->
     tagName       : 'figure'

--- a/client/account/lib/views/accounteditusername.coffee
+++ b/client/account/lib/views/accounteditusername.coffee
@@ -332,9 +332,9 @@ module.exports = class AccountEditUsername extends JView
 
     @verifyEmail = new KDCustomHTMLView opts
 
-    header = @emailForm.fields.passwordHeader.getElement()
+    sectionHeader = @emailForm.fields.passwordHeader.getElement()
 
-    header.parentElement.insertBefore @verifyEmail.getElement(), header
+    sectionHeader.parentElement.insertBefore @verifyEmail.getElement(), sectionHeader
 
   getAvatarOptions: ->
     tagName       : 'figure'

--- a/client/account/lib/views/accounteditusername.coffee
+++ b/client/account/lib/views/accounteditusername.coffee
@@ -1,4 +1,3 @@
-$ = require 'jquery'
 kd = require 'kd'
 KDButtonView = kd.ButtonView
 KDCustomHTMLView = kd.CustomHTMLView

--- a/client/app/lib/styl/resurrection.commons.styl
+++ b/client/app/lib/styl/resurrection.commons.styl
@@ -1093,6 +1093,7 @@ button.app-settings-menu
     color         #EEE
 
 a.action-link.verify-email
+  color             #434343
   line-height       22px
   text-decoration   none
   span

--- a/client/app/lib/styl/resurrection.commons.styl
+++ b/client/app/lib/styl/resurrection.commons.styl
@@ -1094,8 +1094,7 @@ button.app-settings-menu
 
 a.action-link.verify-email
   color             #888
-  margin-left       12px
-  line-height       50px
+  line-height       22px
   text-decoration   none
   span
     color           logoBg

--- a/client/app/lib/styl/resurrection.commons.styl
+++ b/client/app/lib/styl/resurrection.commons.styl
@@ -1094,7 +1094,7 @@ button.app-settings-menu
 
 a.action-link.verify-email
   color             #888
-  margin            235px
+  margin-left       12px
   line-height       50px
   text-decoration   none
   span

--- a/client/app/lib/styl/resurrection.commons.styl
+++ b/client/app/lib/styl/resurrection.commons.styl
@@ -1093,7 +1093,6 @@ button.app-settings-menu
     color         #EEE
 
 a.action-link.verify-email
-  color             #888
   line-height       22px
   text-decoration   none
   span


### PR DESCRIPTION
Before
![screenshot at 12-43-38](https://cloud.githubusercontent.com/assets/1278794/8104318/858c4a06-1038-11e5-9190-ee9729c0ac8f.png)

After
![screenshot at 12-42-21](https://cloud.githubusercontent.com/assets/1278794/8104317/85873228-1038-11e5-82fc-0311d4f1cfbf.png)

The story: https://www.pivotaltracker.com/story/show/95942250

Notes: Dom manipulation!! I found this to be the easiest and quickest way to add that element there. Instead of rewriting the whole fields view.

cc. @usirin @sinan
