### PR TITLE
snapshots: Default snapshot region UX fix [fixes #96130760]

### DIFF
--- a/client/app/lib/providers/computehelpers.coffee
+++ b/client/app/lib/providers/computehelpers.coffee
@@ -57,10 +57,10 @@ module.exports = class ComputeHelpers
         return cc._inprogress = no
 
       { plan, plans, usage } = info
-      { snapshotId }         = options
+      { snapshotId, region } = options
 
       limits  = plans[plan]
-      options = { plan, limits, usage, snapshotId }
+      options = { plan, limits, usage, snapshotId, region }
 
       if limits.total > 1
 

--- a/client/app/lib/providers/computeplansmodalpaid.coffee
+++ b/client/app/lib/providers/computeplansmodalpaid.coffee
@@ -62,7 +62,7 @@ module.exports = class ComputePlansModalPaid extends ComputePlansModal
 
     # Set the default region passed in as an option
     if region
-      @disableRegion()
+      @regionSelector.makeDisabled()
       @regionSelector.setValue region
 
     regionContainer.addSubView @regionTextView = new KDView
@@ -91,9 +91,9 @@ module.exports = class ComputePlansModalPaid extends ComputePlansModal
         if snapshotId
           @regionSelector.setValue @snapshots[snapshotId].region
           @updateRegionText()
-          @disableRegion()
+          @regionSelector.makeDisabled()
         else
-          @enableRegion()
+          @regionSelector.makeEnabled()
 
     content.addSubView storageContainer = new KDView
       cssClass : "storage-container"
@@ -275,13 +275,5 @@ module.exports = class ComputePlansModalPaid extends ComputePlansModal
 
       @createVMButton.hideLoader()
       @destroy()
-
-
-  disableRegion: ->
-    @regionSelector.makeDisabled()
-
-
-  enableRegion: ->
-    @regionSelector.makeEnabled()
 
 

--- a/client/app/lib/providers/computeplansmodalpaid.coffee
+++ b/client/app/lib/providers/computeplansmodalpaid.coffee
@@ -26,7 +26,7 @@ module.exports = class ComputePlansModalPaid extends ComputePlansModal
 
   viewAppended:->
 
-    { usage, limits, plan } = @getOptions()
+    { usage, limits, plan, region } = @getOptions()
 
     @addSubView content = new KDView
       cssClass : 'container'
@@ -60,6 +60,11 @@ module.exports = class ComputePlansModalPaid extends ComputePlansModal
         { title: "Ireland",                        value: "eu-west-1" }
       ]
 
+    # Set the default region passed in as an option
+    if region
+      @disableRegion()
+      @regionSelector.setValue region
+
     regionContainer.addSubView @regionTextView = new KDView
 
     content.addSubView @snapshotsContainer = new KDView
@@ -72,13 +77,23 @@ module.exports = class ComputePlansModalPaid extends ComputePlansModal
     @snapshotsContainer.addSubView @snapshotsSelector = new KDSelectBox
       name          : 'snapshots'
       selectOptions : [ title: 'None', value: "" ]
-      callback      : =>
+      callback      : (snapshotId) =>
         # Update the usage text with the value of the slider
         #
         # Note that @getValues() just returns the value *option* of the
         # handles, so we're getting the value directly.
         @updateSnapshotUsageText @storageSlider.handles.first.value
         @updateCreateVMBtnEnabled @storageSlider.handles.first.value
+
+        # If the selected snapshot has a value (not empty), disable the
+        # region selector, and set it's value to the snapshot region.
+        # If it does not have a value (empty), enable the region selector.
+        if snapshotId
+          @regionSelector.setValue @snapshots[snapshotId].region
+          @updateRegionText()
+          @disableRegion()
+        else
+          @enableRegion()
 
     content.addSubView storageContainer = new KDView
       cssClass : "storage-container"
@@ -260,3 +275,13 @@ module.exports = class ComputePlansModalPaid extends ComputePlansModal
 
       @createVMButton.hideLoader()
       @destroy()
+
+
+  disableRegion: ->
+    @regionSelector.makeDisabled()
+
+
+  enableRegion: ->
+    @regionSelector.makeEnabled()
+
+

--- a/client/app/lib/providers/machinesettingssnapshotsview.coffee
+++ b/client/app/lib/providers/machinesettingssnapshotsview.coffee
@@ -31,9 +31,8 @@ module.exports = class MachineSettingsSnapshotsView extends MachineSettingsCommo
       @listController.showNoItemWidget()
 
     @listController.getListView().on 'NewVmFromSnapshot', (snapshot) =>
-      { snapshotId } = snapshot
-      machine        = @getData()
-      snapshotHelpers.newVmFromSnapshot machine, snapshotId, =>
+      machine = @getData()
+      snapshotHelpers.newVmFromSnapshot snapshot, machine, =>
         @emit 'ModalDestroyRequested'
 
 

--- a/client/app/lib/providers/snapshothelpers.coffee
+++ b/client/app/lib/providers/snapshothelpers.coffee
@@ -48,14 +48,26 @@ getUniqueLabel = (label, labels = []) ->
  * for hobbyist's, and showing the new machine modal for all other
  * users.
  *
+ * @param {Object} snapshot - An object, containing required `region` and
+ *  `snapshotId` fields.
+ * @param {String} snapshot.region - The region that the vm will be
+ *  created in.
+ * @param {String} snapshot.snapshotId - The snapshotId to create the
+ *  machine from.
  * @param {Machine} machine - The machine to reinit a snapshot onto, in
  *  the event that it's needed (hobbyists).
- * @param {String} snapshotId - The snapshotId to create the machine from
  * @param {Function()} callback - Called once the process has begin, *not*
  *  when the process is entirely done. (Eg, after plan confirmations have
  *  taken place, etc).
 ###
-newVmFromSnapshot = (machine, snapshotId, callback = kd.noop) ->
+newVmFromSnapshot = (snapshot, machine, callback = kd.noop) ->
+
+  { region, snapshotId } = snapshot
+
+  unless region
+    return kd.error "newVmFromSnapshot: snapshot.region is required"
+  unless snapshotId
+    return kd.error "newVmFromSnapshot: snapshot.snapshotId is required"
 
   computeController = kd.getSingleton 'computeController'
   paymentController = kd.getSingleton 'paymentController'
@@ -72,6 +84,7 @@ newVmFromSnapshot = (machine, snapshotId, callback = kd.noop) ->
     else
       handleNewMachineRequest
         provider   : 'koding'
+        region     : region
         snapshotId : snapshotId
         callback
 

--- a/client/app/lib/styl/computeproviders.styl
+++ b/client/app/lib/styl/computeproviders.styl
@@ -348,6 +348,9 @@ computeproviders.styl
         font-weight       bold !important
         margin-bottom     10px
 
+      .kdselectbox.disabled
+        opacity           .5
+
       .container-title
         margin-bottom     10px
 


### PR DESCRIPTION
VM Creation currently allows a user to choose a VM from one Region and a Snapshot from another. This fails because Snapshots do not currently support cross region usage. This PR fixes this UX issue, by doing a few to the Compute Paid Modal (and involved files):
1. When a snapshot is selected, the region selector is set to whatever region the snapshot was created in.
2. When a snapshot is selected, the region selector is disabled.
3. On the VM Settings Modal, when the user chooses to make a new VM from the snapshot, the Compute Modal's region is preselected.

A video of these can be seen here: http://take.ms/y3kd0

cc @usirin @sinan 
