### PR TITLE
terminal: Fixes frozen terminals after VM resize [fixes #93681298]

### DIFF
--- a/client/app/lib/terminal/webtermview.coffee
+++ b/client/app/lib/terminal/webtermview.coffee
@@ -98,14 +98,8 @@ module.exports = class WebTermView extends KDCustomScrollView
         if event.status is Stopped
           @messagePane.handleError message: "ErrNoSession"
 
-    # If the machine is resizing, it will have a status of Stopping
-    # but never Stopped. For resizing, status progress goes:
-    #
-    #   Stopping -> Pending -> Starting -> Pending -> Running
-    #
-    # As such, we need to listen specifically for the resize-
-    # event to know if this is a resizing Terminal and needs to
-    # show ErrNoSession.
+    # Listen for resize events to show an error after a resize has
+    # finished. This provides same UX as a stopped machine (above).
     computeController.on "resize-#{machineId}", (event) =>
       if event.percentage is 100
         @messagePane.handleError message: "ErrNoSession"


### PR DESCRIPTION
When a resize takes place, all existing Terminals lose their session and fail to show an error. This is because the Machine never emits Stopped during the Resize process. This commit specifically subscribes to the `resize-` event, and when it reaches 100% it shows the Terminal error. This is the same behavior as turning a vm off/on.

Video: http://take.ms/naomt

cc @usirin 
