### PR TITLE
segment: fix event name

### DIFF
--- a/workers/social/lib/social/models/datadog.coffee
+++ b/workers/social/lib/social/models/datadog.coffee
@@ -115,7 +115,7 @@ module.exports = class DataDog extends Base
       text += "\n #{ev.notify}"
 
     if ev.sendToSegment?
-      analytics.track userId: nickname, event: text, properties: data.tags
+      analytics.track userId: nickname, event: ev.text, properties: data.tags
 
     DogApi.add_event {title, text, tags}, (err, res, status)->
 


### PR DESCRIPTION
In production, event names are in the form `turn on machine LOGS: https://koding-client.s3.amazonaws.com/user/rustserverbrazuka/logs_2015-06-16T19:36:26.021Z.txt` which makes it unable to be used for event matching. Hoping this change will send just `turn on machine`.
