### PR TITLE
payment: let canceled/expired paypal users buy new subscription

### DIFF
--- a/go/src/socialapi/db/sql/definition/create-wercker.sh
+++ b/go/src/socialapi/db/sql/definition/create-wercker.sh
@@ -66,6 +66,8 @@ psql $WERCKER_POSTGRESQL_URL < $1/payment_definition/modifications/001-add-kodin
 
 psql $WERCKER_POSTGRESQL_URL < $1/payment_definition/modifications/002-add-betatester-plan.sql
 
+psql $WERCKER_POSTGRESQL_URL < $1/payment_definition/modifications/003-drop-customer-oldid-constraint.sql
+
 # create sequences
 psql $WERCKER_POSTGRESQL_URL < $1/integration_definition/002-schema.sql
 

--- a/go/src/socialapi/db/sql/definition/create.sh
+++ b/go/src/socialapi/db/sql/definition/create.sh
@@ -87,6 +87,8 @@ sudo -u postgres psql social < $1/payment_definition/modifications/001-add-kodin
 
 sudo -u postgres psql social < $1/payment_definition/modifications/002-add-betatester-plan.sql
 
+sudo -u postgres psql social < $1/payment_definition/modifications/003-drop-customer-oldid-constraint.sql
+
 # create sequences
 sudo -u postgres psql social < $1/integration_definition/002-schema.sql
 

--- a/go/src/socialapi/db/sql/migrations/0016_drop-customer-oldid-constraint.down.sql
+++ b/go/src/socialapi/db/sql/migrations/0016_drop-customer-oldid-constraint.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE payment.customer ADD CONSTRAINT "customer_old_id_key" UNIQUE ("old_id") NOT DEFERRABLE INITIALLY IMMEDIATE;

--- a/go/src/socialapi/db/sql/migrations/0016_drop-customer-oldid-constraint.up.sql
+++ b/go/src/socialapi/db/sql/migrations/0016_drop-customer-oldid-constraint.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE payment.customer DROP CONSTRAINT IF EXISTS "customer_old_id_key";

--- a/go/src/socialapi/db/sql/payment_definition/modifications/003-drop-customer-oldid-constraint.sql
+++ b/go/src/socialapi/db/sql/payment_definition/modifications/003-drop-customer-oldid-constraint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE payment.customer DROP CONSTRAINT IF EXISTS "customer_old_id_key";

--- a/go/src/socialapi/workers/payment/payment_test.go
+++ b/go/src/socialapi/workers/payment/payment_test.go
@@ -199,7 +199,7 @@ func TestSubscriptionsRequest1(t *testing.T) {
 	})
 }
 
-func TestSubscriptionsRequest2(t *testing.T) {
+func TestMultipleSubscriptionsRequest(t *testing.T) {
 	Convey("Given user has multiple subscriptions", t, func() {
 		token, accId, _ := generateFakeUserInfo()
 

--- a/go/src/socialapi/workers/payment/paymentmodels/customer.go
+++ b/go/src/socialapi/workers/payment/paymentmodels/customer.go
@@ -93,12 +93,12 @@ func (c *Customer) FindSubscriptions() ([]Subscription, error) {
 
 	s := Subscription{}
 	err := s.Some(&subscriptions, query)
-	if err != nil && err != bongo.RecordNotFound {
-		return nil, err
-	}
-
 	if err == bongo.RecordNotFound {
 		return nil, paymenterrors.ErrCustomerNotSubscribedToAnyPlans
+	}
+
+	if err != nil {
+		return nil, err
 	}
 
 	return subscriptions, nil

--- a/go/src/socialapi/workers/payment/paymentmodels/customer_bongo.go
+++ b/go/src/socialapi/workers/payment/paymentmodels/customer_bongo.go
@@ -28,6 +28,5 @@ func (c *Customer) Delete() error {
 
 func (c *Customer) ById(id int64) error {
 	selector := map[string]interface{}{"id": id}
-
 	return c.One(bongo.NewQS(selector))
 }

--- a/go/src/socialapi/workers/payment/paymentmodels/plan.go
+++ b/go/src/socialapi/workers/payment/paymentmodels/plan.go
@@ -38,9 +38,7 @@ func (p *Plan) ByProviderId(providerId, provider string) error {
 		"provider_plan_id": providerId,
 		"provider":         provider,
 	}
-	err := p.Find(selector)
-
-	return err
+	return p.Find(selector)
 }
 
 func (p *Plan) ByTitleAndInterval(title, interval string) error {
@@ -48,12 +46,9 @@ func (p *Plan) ByTitleAndInterval(title, interval string) error {
 		"title":    title,
 		"interval": interval,
 	}
-	err := p.One(bongo.NewQS(selector))
-
-	return err
+	return p.One(bongo.NewQS(selector))
 }
 
 func (p *Plan) Find(selector map[string]interface{}) error {
-	err := p.One(bongo.NewQS(selector))
-	return err
+	return p.One(bongo.NewQS(selector))
 }

--- a/go/src/socialapi/workers/payment/paymentmodels/subscription.go
+++ b/go/src/socialapi/workers/payment/paymentmodels/subscription.go
@@ -79,16 +79,12 @@ func (s *Subscription) UpdatePlan(planId int64, amountInCents uint64) error {
 	s.PlanId = planId
 	s.AmountInCents = amountInCents
 
-	err := bongo.B.Update(s)
-
-	return err
+	return bongo.B.Update(s)
 }
 
 func (s *Subscription) UpdateState(state string) error {
 	s.State = state
-	err := bongo.B.Update(s)
-
-	return err
+	return bongo.B.Update(s)
 }
 
 func (s *Subscription) Cancel() error {
@@ -107,9 +103,7 @@ func (s *Subscription) Expire() error {
 
 func (s *Subscription) UpdateTimeForDowngrade(t time.Time) error {
 	s.CanceledAt = t
-	err := bongo.B.Update(s)
-
-	return err
+	return bongo.B.Update(s)
 }
 
 func (s *Subscription) ByProviderId(providerId, provider string) error {
@@ -117,9 +111,8 @@ func (s *Subscription) ByProviderId(providerId, provider string) error {
 		"provider_subscription_id": providerId,
 		"provider":                 provider,
 	}
-	err := s.Find(selector)
 
-	return err
+	return s.Find(selector)
 }
 
 func (s *Subscription) ByCustomerIdAndState(customerId int64, state string) error {
@@ -165,9 +158,7 @@ func (s *Subscription) UpdateToExpireTime(t time.Time) error {
 	s.ExpiredAt = t
 	s.CanceledAt = t
 
-	err := bongo.B.Update(s)
-
-	return err
+	return bongo.B.Update(s)
 }
 
 func (s *Subscription) UpdateCurrentPeriods(start, end time.Time) error {

--- a/go/src/socialapi/workers/payment/paymentmodels/subscription_bongo.go
+++ b/go/src/socialapi/workers/payment/paymentmodels/subscription_bongo.go
@@ -41,14 +41,11 @@ func (s *Subscription) BeforeUpdate() error {
 
 func (s *Subscription) ById(id int64) error {
 	selector := map[string]interface{}{"id": s.Id}
-	err := s.Find(selector)
-
-	return err
+	return s.Find(selector)
 }
 
 func (s *Subscription) Find(selector map[string]interface{}) error {
-	err := s.One(bongo.NewQS(selector))
-	return err
+	return s.One(bongo.NewQS(selector))
 }
 
 func (s *Subscription) Delete() error {

--- a/go/src/socialapi/workers/payment/paymentstatus/paymentstatus.go
+++ b/go/src/socialapi/workers/payment/paymentstatus/paymentstatus.go
@@ -34,12 +34,12 @@ func Check(customer *paymentmodels.Customer, err error, plan *paymentmodels.Plan
 	}
 
 	currentSubscription, err := customer.FindActiveSubscription()
-	if err != nil && err != paymenterrors.ErrCustomerNotSubscribedToAnyPlans {
-		return Error, err
-	}
-
 	if err == paymenterrors.ErrCustomerNotSubscribedToAnyPlans {
 		return ExistingUserHasNoSub, nil
+	}
+
+	if err != nil {
+		return Error, err
 	}
 
 	oldPlan := paymentmodels.NewPlan()

--- a/go/src/socialapi/workers/payment/paymentstatus/paymentstatus.go
+++ b/go/src/socialapi/workers/payment/paymentstatus/paymentstatus.go
@@ -11,7 +11,8 @@ type Status int
 const (
 	Default                 Status = iota
 	Error                   Status = iota
-	NewSubscription         Status = iota
+	NewSub                  Status = iota
+	ExpiredSub              Status = iota
 	ExistingUserHasNoSub    Status = iota
 	AlreadySubscribedToPlan Status = iota
 	DowngradeToFreePlan     Status = iota
@@ -21,11 +22,15 @@ const (
 
 func Check(customer *paymentmodels.Customer, err error, plan *paymentmodels.Plan) (Status, error) {
 	if IsNewSubscription(customer, err) {
-		return NewSubscription, nil
+		return NewSub, nil
 	}
 
 	if IsDowngradeToFreePlan(plan) {
 		return DowngradeToFreePlan, nil
+	}
+
+	if sub, err := IsSubscribedToNotActiveSub(customer); err == nil && sub {
+		return ExpiredSub, nil
 	}
 
 	currentSubscription, err := customer.FindActiveSubscription()
@@ -38,8 +43,7 @@ func Check(customer *paymentmodels.Customer, err error, plan *paymentmodels.Plan
 	}
 
 	oldPlan := paymentmodels.NewPlan()
-	err = oldPlan.ById(currentSubscription.PlanId)
-	if err != nil {
+	if err := oldPlan.ById(currentSubscription.PlanId); err != nil {
 		return Error, err
 	}
 
@@ -73,6 +77,30 @@ func IsAlreadySubscribedToPlan(oldPlan, plan *paymentmodels.Plan) bool {
 
 func IsDowngradeToFreePlan(plan *paymentmodels.Plan) bool {
 	return plan.Title == "free"
+}
+
+// IsSubscribedToNotActiveSub returns if user has an active subscription. If an
+// user has multiple subscriptions, active subscription takes precedence.
+func IsSubscribedToNotActiveSub(customer *paymentmodels.Customer) (bool, error) {
+	subscriptions, err := customer.FindSubscriptions()
+	if err != nil && err != paymenterrors.ErrCustomerNotSubscribedToAnyPlans {
+		return false, err
+	}
+
+	if len(subscriptions) == 0 || err == paymenterrors.ErrCustomerNotSubscribedToAnyPlans {
+		return false, nil
+	}
+
+	var states = map[string]struct{}{}
+	for _, sub := range subscriptions {
+		states[sub.State] = struct{}{}
+	}
+
+	if _, ok := states[paymentmodels.SubscriptionStateActive]; ok {
+		return false, nil
+	}
+
+	return true, nil
 }
 
 func IsDowngradeToNonFreePlan(oldPlan, plan *paymentmodels.Plan) bool {

--- a/go/src/socialapi/workers/payment/paypal/paypal.go
+++ b/go/src/socialapi/workers/payment/paypal/paypal.go
@@ -33,8 +33,7 @@ func InitializeClientKey(creds config.Paypal) {
 }
 
 func Client() (*paypal.PayPalClient, error) {
-	err := isClientInitialized()
-	if err != nil {
+	if err := isClientInitialized(); err != nil {
 		return nil, err
 	}
 

--- a/go/src/socialapi/workers/payment/paypal/subscribe.go
+++ b/go/src/socialapi/workers/payment/paypal/subscribe.go
@@ -51,7 +51,7 @@ func subscribe(token, accId string, plan *paymentmodels.Plan) error {
 	}
 
 	switch status {
-	case paymentstatus.NewSubscription:
+	case paymentstatus.NewSub, paymentstatus.ExpiredSub:
 		err = handleNewSubscription(token, accId, plan)
 	case paymentstatus.ExistingUserHasNoSub:
 		err = handleExistingUser(token, accId, plan)

--- a/go/src/socialapi/workers/payment/paypal/subscribe_test.go
+++ b/go/src/socialapi/workers/payment/paypal/subscribe_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestSubscribe1(t *testing.T) {
+func TestSubscribe(t *testing.T) {
 	server := startTestServer()
 	defer server.Close()
 
@@ -32,7 +32,7 @@ func TestSubscribe1(t *testing.T) {
 	)
 }
 
-func TestSubscribe2(t *testing.T) {
+func TestReactivatedSubscription(t *testing.T) {
 	server := startTestServer()
 	defer server.Close()
 
@@ -55,38 +55,13 @@ func TestSubscribe2(t *testing.T) {
 				})
 
 				Convey("Then it should save subscription", func() {
+					customer, err := paymentmodels.NewCustomer().ByOldId(accId)
 					sub, err := customer.FindActiveSubscription()
 
 					So(err, ShouldBeNil)
 					So(sub, ShouldNotBeNil)
 				})
 			})
-		}),
-	)
-}
-
-func TestSubscribe3(t *testing.T) {
-	server := startTestServer()
-	defer server.Close()
-
-	Convey("Given customer with not active subscription", t,
-		subscribeFn(func(token, accId, email string) {
-			customer, err := paymentmodels.NewCustomer().ByOldId(accId)
-			So(err, ShouldBeNil)
-			So(customer, ShouldNotBeNil)
-
-			err = ExpireSubscription(customer.ProviderCustomerId)
-			So(err, ShouldBeNil)
-
-			err = Subscribe(token, accId)
-			So(err, ShouldBeNil)
-
-			customer, err = paymentmodels.NewCustomer().ByOldId(accId)
-			So(err, ShouldBeNil)
-
-			sub, err := customer.FindActiveSubscription()
-			So(err, ShouldBeNil)
-			So(sub, ShouldNotBeNil)
 		}),
 	)
 }

--- a/go/src/socialapi/workers/payment/paypal/subscribe_test.go
+++ b/go/src/socialapi/workers/payment/paypal/subscribe_test.go
@@ -31,3 +31,62 @@ func TestSubscribe1(t *testing.T) {
 		}),
 	)
 }
+
+func TestSubscribe2(t *testing.T) {
+	server := startTestServer()
+	defer server.Close()
+
+	Convey("Given customer with not active subscription", t,
+		subscribeFn(func(token, accId, email string) {
+			customer, err := paymentmodels.NewCustomer().ByOldId(accId)
+
+			So(err, ShouldBeNil)
+			So(customer, ShouldNotBeNil)
+
+			err = ExpireSubscription(customer.ProviderCustomerId)
+			So(err, ShouldBeNil)
+
+			Convey("When customer subscribes again", func() {
+				err = Subscribe(token, accId)
+				So(err, ShouldBeNil)
+
+				Convey("Then it should create new customer", func() {
+					So(checkCustomerIsSaved(accId), ShouldBeTrue)
+				})
+
+				Convey("Then it should save subscription", func() {
+					sub, err := customer.FindActiveSubscription()
+
+					So(err, ShouldBeNil)
+					So(sub, ShouldNotBeNil)
+				})
+			})
+		}),
+	)
+}
+
+func TestSubscribe3(t *testing.T) {
+	server := startTestServer()
+	defer server.Close()
+
+	Convey("Given customer with not active subscription", t,
+		subscribeFn(func(token, accId, email string) {
+			customer, err := paymentmodels.NewCustomer().ByOldId(accId)
+			So(err, ShouldBeNil)
+			So(customer, ShouldNotBeNil)
+
+			err = ExpireSubscription(customer.ProviderCustomerId)
+			So(err, ShouldBeNil)
+
+			err = Subscribe(token, accId)
+			So(err, ShouldBeNil)
+
+			customer, err = paymentmodels.NewCustomer().ByOldId(accId)
+			So(err, ShouldBeNil)
+
+			sub, err := customer.FindActiveSubscription()
+			So(err, ShouldBeNil)
+			So(sub, ShouldNotBeNil)
+		}),
+	)
+}

--- a/go/src/socialapi/workers/payment/paypal/subscription.go
+++ b/go/src/socialapi/workers/payment/paypal/subscription.go
@@ -56,8 +56,8 @@ func CreateSubscription(token string, plan *paymentmodels.Plan, customer *paymen
 		CurrentPeriodStart:     time.Now(),
 		AmountInCents:          plan.AmountInCents,
 	}
-	err = subModel.Create()
-	if err != nil {
+
+	if err := subModel.Create(); err != nil {
 		return err
 	}
 

--- a/go/src/socialapi/workers/payment/stripe/customer.go
+++ b/go/src/socialapi/workers/payment/stripe/customer.go
@@ -80,7 +80,5 @@ func DeleteCustomer(accId string) error {
 		return err
 	}
 
-	err = stripeCustomer.Del(customer.ProviderCustomerId)
-
-	return err
+	return stripeCustomer.Del(customer.ProviderCustomerId)
 }

--- a/go/src/socialapi/workers/payment/stripe/plan.go
+++ b/go/src/socialapi/workers/payment/stripe/plan.go
@@ -78,8 +78,7 @@ func CreatePlan(id, title, nameForStripe string, interval paymentplan.PlanInterv
 func FindPlanByTitleAndInterval(title, interval string) (*paymentmodels.Plan, error) {
 	plan := paymentmodels.NewPlan()
 
-	err := plan.ByTitleAndInterval(title, interval)
-	if err != nil {
+	if err := plan.ByTitleAndInterval(title, interval); err != nil {
 		if paymenterrors.IsPlanNotFoundErr(err) {
 			return nil, paymenterrors.ErrPlanNotFound
 		}

--- a/go/src/socialapi/workers/payment/stripe/stripe_test.go
+++ b/go/src/socialapi/workers/payment/stripe/stripe_test.go
@@ -93,11 +93,7 @@ func checkCustomerIsSaved(accId string) bool {
 
 func checkCustomerExistsInStripe(id string) bool {
 	customer, err := stripeCustomer.Get(id, nil)
-	if err != nil {
-		return false
-	}
-
-	if customer.Id != id {
+	if err != nil || customer.Id != id {
 		return false
 	}
 

--- a/go/src/socialapi/workers/payment/stripe/subscribe.go
+++ b/go/src/socialapi/workers/payment/stripe/subscribe.go
@@ -38,7 +38,7 @@ func subscribe(token, accId, email string, plan *paymentmodels.Plan) error {
 	}
 
 	switch status {
-	case paymentstatus.NewSub:
+	case paymentstatus.NewSub, paymentstatus.ExpiredSub:
 		err = handleNewSubscription(token, accId, email, plan)
 	case paymentstatus.ExistingUserHasNoSub:
 		err = handleUserNoSub(customer, token, plan)

--- a/go/src/socialapi/workers/payment/stripe/subscribe.go
+++ b/go/src/socialapi/workers/payment/stripe/subscribe.go
@@ -38,7 +38,7 @@ func subscribe(token, accId, email string, plan *paymentmodels.Plan) error {
 	}
 
 	switch status {
-	case paymentstatus.NewSubscription:
+	case paymentstatus.NewSub:
 		err = handleNewSubscription(token, accId, email, plan)
 	case paymentstatus.ExistingUserHasNoSub:
 		err = handleUserNoSub(customer, token, plan)

--- a/go/src/socialapi/workers/payment/stripe/subscription.go
+++ b/go/src/socialapi/workers/payment/stripe/subscription.go
@@ -77,9 +77,7 @@ func CancelSubscription(customer *paymentmodels.Customer, subscription *paymentm
 		Log.Error(err.Error())
 	}
 
-	err = subscription.UpdateState(paymentmodels.SubscriptionStateCanceled)
-
-	return err
+	return subscription.UpdateState(paymentmodels.SubscriptionStateCanceled)
 }
 
 func findCustomerSubscriptions(customer *paymentmodels.Customer, query *bongo.Query) ([]paymentmodels.Subscription, error) {
@@ -108,9 +106,7 @@ func CancelSubscriptionAndRemoveCC(customer *paymentmodels.Customer, currentSubs
 		return err
 	}
 
-	err = RemoveCreditCard(customer)
-
-	return err
+	return RemoveCreditCard(customer)
 }
 
 func handleUpgrade(currentSubscription *paymentmodels.Subscription, customer *paymentmodels.Customer, plan *paymentmodels.Plan) error {
@@ -138,9 +134,7 @@ func handleUpgrade(currentSubscription *paymentmodels.Subscription, customer *pa
 		}
 	}
 
-	err = currentSubscription.UpdatePlan(plan.Id, plan.AmountInCents)
-
-	return err
+	return currentSubscription.UpdatePlan(plan.Id, plan.AmountInCents)
 }
 
 // On downgrade, unlike upgrade, wait till end of the billing cycle to move to the new plan.
@@ -156,7 +150,5 @@ func handleDowngrade(currentSubscription *paymentmodels.Subscription, customer *
 		return handleStripeError(err)
 	}
 
-	err = currentSubscription.UpdatePlan(plan.Id, plan.AmountInCents)
-
-	return err
+	return currentSubscription.UpdatePlan(plan.Id, plan.AmountInCents)
 }

--- a/go/src/socialapi/workers/payment/stripe/webhook.go
+++ b/go/src/socialapi/workers/payment/stripe/webhook.go
@@ -12,8 +12,7 @@ import (
 
 func SubscriptionDeletedWebhook(req *webhookmodels.StripeSubscription) error {
 	subscription := paymentmodels.NewSubscription()
-	err := subscription.ByProviderId(req.ID, ProviderName)
-	if err != nil {
+	if err := subscription.ByProviderId(req.ID, ProviderName); err != nil {
 		return err
 	}
 
@@ -22,8 +21,7 @@ func SubscriptionDeletedWebhook(req *webhookmodels.StripeSubscription) error {
 	}
 
 	customer := paymentmodels.NewCustomer()
-	err = customer.ById(subscription.CustomerId)
-	if err != nil {
+	if err := customer.ById(subscription.CustomerId); err != nil {
 		return err
 	}
 
@@ -49,14 +47,12 @@ func InvoiceCreatedWebhook(req *webhookmodels.StripeInvoice) error {
 	}
 
 	subscription := paymentmodels.NewSubscription()
-	err := subscription.ByProviderId(id, ProviderName)
-	if err != nil {
+	if err := subscription.ByProviderId(id, ProviderName); err != nil {
 		return err
 	}
 
 	plan := paymentmodels.NewPlan()
-	plan.ByProviderId(item.Plan.ID, ProviderName)
-	if err != nil {
+	if err := plan.ByProviderId(item.Plan.ID, ProviderName); err != nil {
 		return err
 	}
 
@@ -72,7 +68,7 @@ func InvoiceCreatedWebhook(req *webhookmodels.StripeInvoice) error {
 		subscription.Id, plan.Id, time.Unix(int64(item.Period.Start), 0),
 	)
 
-	err = subscription.UpdateInvoiceCreated(
+	err := subscription.UpdateInvoiceCreated(
 		plan.AmountInCents, plan.Id,
 		int64(item.Period.Start), int64(item.Period.End),
 	)
@@ -90,8 +86,7 @@ func InvoiceCreatedWebhook(req *webhookmodels.StripeInvoice) error {
 
 func CustomerDeletedWebhook(req *webhookmodels.StripeCustomer) error {
 	customer := paymentmodels.NewCustomer()
-	err := customer.ByProviderCustomerId(req.ID)
-	if err != nil {
+	if err := customer.ByProviderCustomerId(req.ID); err != nil {
 		return err
 	}
 

--- a/go/src/socialapi/workers/payment/tests.sh
+++ b/go/src/socialapi/workers/payment/tests.sh
@@ -8,3 +8,6 @@ go test -c socialapi/workers/payment/stripe/ && ./stripe.test -c $(dirname $0)/.
 
 echo "running paypal tests"
 go test -c socialapi/workers/payment/paypal/ && ./paypal.test -c $(dirname $0)/../../config/dev.toml -test.v=true
+
+echo "running webhook tests"
+go test -c socialapi/workers/payment/paymentwebhook/ && ./paymentwebhook.test -c $(dirname $0)/../../config/dev.toml -test.v=true

--- a/go/src/socialapi/workers/payment/tests.sh
+++ b/go/src/socialapi/workers/payment/tests.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+echo "running payment tests"
+go test -c socialapi/workers/payment/ && ./payment.test -c $(dirname $0)/../../config/dev.toml -test.v=true
+
+echo "running stripe tests"
+go test -c socialapi/workers/payment/stripe/ && ./stripe.test -c $(dirname $0)/../../config/dev.toml -test.v=true
+
+echo "running paypal tests"
+go test -c socialapi/workers/payment/paypal/ && ./paypal.test -c $(dirname $0)/../../config/dev.toml -test.v=true


### PR DESCRIPTION
- Allow canceled/expired users buy new subscription.
  - Users can pick paypal or stripe for new subscription, since it's a completely new subscription
- Remove constraint that was enforcing unique jAccount#_id in customers table
  - this was required to let customers table have duplicate entries
- Added test case when user has 2 subscription and one of them is expired
- Fix formatting to make it consistent with other socialapi pkgs
