### PR TITLE
Fixes 'Add badge to all "staff" users' border color [fixes #97163088]

### DIFF
--- a/client/activity/lib/styl/activity.listitem.styl
+++ b/client/activity/lib/styl/activity.listitem.styl
@@ -309,7 +309,7 @@ activity.listitem.styl
           display           block
 
         cite.staff
-          border-color      #fafafa
+          border-color      #fbfbfb
 
       .comment-input-wrapper
         margin-left         37px
@@ -456,7 +456,7 @@ activity.listitem.styl
           display           block
 
         cite.staff
-          border-color      #fafafa
+          border-color      #fbfbfb
 
       a.profile
         font-size           12px

--- a/client/activity/lib/styl/activity.pm.styl
+++ b/client/activity/lib/styl/activity.pm.styl
@@ -260,6 +260,11 @@ headsListSelectedBgColor   = #7a7a7a
       font-weight       600
       min-width         0
 
+  .chat-heads
+    .avatarview
+      cite.staff
+        border-color    #fff
+
   .new-message-form:after
   .chat-heads:after
       content           ''
@@ -445,6 +450,9 @@ headsListSelectedBgColor   = #7a7a7a
       abs                   10px 0 0 -56px
       border                none
 
+      cite.staff
+        border-color        #fff !important
+
     .activity-content-wrapper
       background            none
       hidden()
@@ -507,6 +515,10 @@ headsListSelectedBgColor   = #7a7a7a
           rounded           2px
           margin-left       7px
           font-size         11px
+
+      .avatarview
+        cite.staff
+          border-color      #f8f8f8
 
     .meta
       .profile:after
@@ -699,7 +711,7 @@ headsListSelectedBgColor   = #7a7a7a
         padding           0
 
       cite.staff
-        border-color      #fafafa
+        border-color      #f8f8f8
 
   .ParticipantHeads-previewContainer
   .ParticipantHeads-actionsContainer

--- a/client/activity/lib/styl/activity.pm.styl
+++ b/client/activity/lib/styl/activity.pm.styl
@@ -142,10 +142,6 @@ headsListSelectedBgColor   = #7a7a7a
       padding           0 34px 0 0
       borderBox()
 
-    .avatarview
-      cite.staff
-        border-color    #fff
-
   .new-message-form
     width               100%
     height              100%
@@ -262,11 +258,6 @@ headsListSelectedBgColor   = #7a7a7a
       font-size         12px
       font-weight       600
       min-width         0
-
-  .chat-heads
-    .avatarview
-      cite.staff
-        border-color    #fff
 
   .new-message-form:after
   .chat-heads:after
@@ -640,7 +631,7 @@ headsListSelectedBgColor   = #7a7a7a
 .collaboration .kdlistview-collaboration
   .avatarview
     cite.staff
-      border-color  #f8f8f8 !important
+      border-color  #f8f8f8
 
 #kdmaincontainer.collapsed .reply-input-widget
   kalc                width, 100% \- 131px

--- a/client/activity/lib/styl/activity.pm.styl
+++ b/client/activity/lib/styl/activity.pm.styl
@@ -142,6 +142,9 @@ headsListSelectedBgColor   = #7a7a7a
       padding           0 34px 0 0
       borderBox()
 
+    .avatarview
+      cite.staff
+        border-color    #fff
 
   .new-message-form
     width               100%
@@ -450,9 +453,6 @@ headsListSelectedBgColor   = #7a7a7a
       abs                   10px 0 0 -56px
       border                none
 
-      cite.staff
-        border-color        #fff !important
-
     .activity-content-wrapper
       background            none
       hidden()
@@ -637,6 +637,7 @@ headsListSelectedBgColor   = #7a7a7a
     font-size       12px
 
 .collaboration .chat-heads
+.collaboration .kdlistview-collaboration
   .avatarview
     cite.staff
       border-color  #f8f8f8 !important

--- a/client/activity/lib/styl/activity.pm.styl
+++ b/client/activity/lib/styl/activity.pm.styl
@@ -516,10 +516,6 @@ headsListSelectedBgColor   = #7a7a7a
           margin-left       7px
           font-size         11px
 
-      .avatarview
-        cite.staff
-          border-color      #f8f8f8
-
     .meta
       .profile:after
         display             none
@@ -640,6 +636,11 @@ headsListSelectedBgColor   = #7a7a7a
   .input-view.hitenterview
     font-size       12px
 
+.collaboration .chat-heads
+  .avatarview
+    cite.staff
+      border-color  #f8f8f8 !important
+
 #kdmaincontainer.collapsed .reply-input-widget
   kalc                width, 100% \- 131px
 
@@ -709,9 +710,6 @@ headsListSelectedBgColor   = #7a7a7a
         display           block
         margin            0
         padding           0
-
-      cite.staff
-        border-color      #f8f8f8
 
   .ParticipantHeads-previewContainer
   .ParticipantHeads-actionsContainer

--- a/client/app/lib/styl/resurrection.commons.styl
+++ b/client/app/lib/styl/resurrection.commons.styl
@@ -150,7 +150,7 @@ validationRed = rgba(217, 58, 55, 0.65)
   cite.staff
     r-sprite                app 'staff-badge-16'
     abs                     0 -6px -8px 0
-    border                  2px solid #fafafa
+    border                  2px solid #fff
     rounded                 3px
 
 aside.app-sidebar

--- a/client/app/lib/styl/resurrection.commons.styl
+++ b/client/app/lib/styl/resurrection.commons.styl
@@ -150,7 +150,7 @@ validationRed = rgba(217, 58, 55, 0.65)
   cite.staff
     r-sprite                app 'staff-badge-16'
     abs                     0 -6px -8px 0
-    border                  2px solid #fff
+    border                  2px solid #fafafa
     rounded                 3px
 
 aside.app-sidebar

--- a/client/members/lib/styl/resurrection.profile.styl
+++ b/client/members/lib/styl/resurrection.profile.styl
@@ -43,6 +43,8 @@ body.profile
         r-sprite          app 'staff-badge-48'
         right             -12px
         bottom            -12px
+        border-color      #e1e1e1
+        rounded           7px
 
     h3.full-name
       display             block


### PR DESCRIPTION
![screenshot at 13-53-46](https://cloud.githubusercontent.com/assets/1278794/8230070/6878d73a-15c5-11e5-8331-8a3efbcf7013.png)
![screenshot at 13-54-30](https://cloud.githubusercontent.com/assets/1278794/8230071/687f7900-15c5-11e5-93ae-003c14c1bb0d.png)
![screenshot at 14-21-49](https://cloud.githubusercontent.com/assets/1278794/8230072/688070f8-15c5-11e5-86b5-1cc4b9b2579f.png)

The story: https://www.pivotaltracker.com/story/show/97163088

Notes: This fixes the border color for this PR https://github.com/koding/koding/pull/4139

cc. @sinan 
