### PR TITLE
Hotfix for badge border on profile page

### DIFF
--- a/client/members/lib/styl/resurrection.profile.styl
+++ b/client/members/lib/styl/resurrection.profile.styl
@@ -43,7 +43,7 @@ body.profile
         r-sprite          app 'staff-badge-48'
         right             -12px
         bottom            -12px
-        border-color      #e1e1e1
+        border            3px solid #e1e1e1
         rounded           7px
 
     h3.full-name


### PR DESCRIPTION
![screenshot at 23-59-46](https://cloud.githubusercontent.com/assets/1278794/8242150/1f80908a-1616-11e5-98de-f4f67a541466.png)

Notes: Made it the same size as the avatar's border.

cc. @sinan 
