### PR TITLE
vmwatcher: get per user limit from storage

### DIFF
--- a/config/main.dev.coffee
+++ b/config/main.dev.coffee
@@ -193,7 +193,7 @@ Configuration = (options={}) ->
 
     # -- WORKER CONFIGURATION -- #
 
-    vmwatcher                      : {port          : "6400"              , awsKey    : awsKeys.vm_vmwatcher.accessKeyId     , awsSecret : awsKeys.vm_vmwatcher.secretAccessKey , kloudSecretKey : kloud.secretKey , kloudAddr : kloud.address, connectToKlient: true, debug: false, mongo: mongo, redis: redis.url }
+    vmwatcher                      : {port          : "6400"              , awsKey    : awsKeys.vm_vmwatcher.accessKeyId     , awsSecret : awsKeys.vm_vmwatcher.secretAccessKey , kloudSecretKey : kloud.secretKey , kloudAddr : kloud.address, connectToKlient: false, debug: false, mongo: mongo, redis: redis.url }
     gowebserver                    : {port          : 6500}
     webserver                      : {port          : 8080                , useCacheHeader: no                     , kitePort          : 8860}
     authWorker                     : {login         : "#{rabbitmq.login}" , queueName : socialQueueName+'auth'     , authExchange      : "auth"                                  , authAllExchange : "authAll"                                      , port  : 9530 }
@@ -1565,6 +1565,9 @@ Configuration = (options={}) ->
       elif [ "$1" == "socialworkertests" ]; then
 
         #{projectRoot}/scripts/node-testing/mocha-runner "#{projectRoot}/workers/social/lib/social"
+
+      elif [ "$1" == "vmwatchertests" ]; then
+        go test koding/vmwatcher -test.v=true
 
       else
         echo "Unknown command: $1"

--- a/go/src/github.com/koding/redis/redis.go
+++ b/go/src/github.com/koding/redis/redis.go
@@ -316,6 +316,13 @@ func (r *RedisSession) SortedSetReverseRange(key string, rest ...interface{}) ([
 	return redis.Values(r.Do("ZREVRANGE", prefixedReq...))
 }
 
+// HashSet sets a single element at key with given field and value.
+// Returns error state of this operation
+func (r *RedisSession) HashSet(key, member string, value interface{}) error {
+	_, err := r.Do("HSET", r.AddPrefix(key), member, value)
+	return err
+}
+
 // HashMultipleSet sets multiple hashset elements stored at key with given field values.
 // Returns error state of this operation
 func (r *RedisSession) HashMultipleSet(key string, item map[string]interface{}) error {

--- a/go/src/github.com/koding/redis/redis.go
+++ b/go/src/github.com/koding/redis/redis.go
@@ -318,9 +318,8 @@ func (r *RedisSession) SortedSetReverseRange(key string, rest ...interface{}) ([
 
 // HashSet sets a single element at key with given field and value.
 // Returns error state of this operation
-func (r *RedisSession) HashSet(key, member string, value interface{}) error {
-	_, err := r.Do("HSET", r.AddPrefix(key), member, value)
-	return err
+func (r *RedisSession) HashSet(key, member string, value interface{}) (int, error) {
+	return redis.Int(r.Do("HSET", r.AddPrefix(key), member, value))
 }
 
 // HashMultipleSet sets multiple hashset elements stored at key with given field values.

--- a/go/src/github.com/koding/redis/redis_test.go
+++ b/go/src/github.com/koding/redis/redis_test.go
@@ -304,7 +304,7 @@ func TestKeys(t *testing.T) {
 }
 
 func TestHashSet(t *testing.T) {
-	err := session.HashSet("mayhem", "janice", "guitar")
+	_, err := session.HashSet("mayhem", "janice", "guitar")
 	if err != nil {
 		t.Errorf("Could create hash set: %v", err)
 		return

--- a/go/src/github.com/koding/redis/redis_test.go
+++ b/go/src/github.com/koding/redis/redis_test.go
@@ -303,6 +303,25 @@ func TestKeys(t *testing.T) {
 	session.Del("electricmayhem")
 }
 
+func TestHashSet(t *testing.T) {
+	err := session.HashSet("mayhem", "janice", "guitar")
+	if err != nil {
+		t.Errorf("Could create hash set: %v", err)
+		return
+	}
+	defer session.Del("mayhem")
+
+	reply, err := session.GetHashSetField("mayhem", "janice")
+	if err != nil {
+		t.Errorf("Could not get hash set length: %v", err)
+		return
+	}
+
+	if reply != "guitar" {
+		t.Errorf("Wrong hashset value of the element: %s", reply)
+	}
+}
+
 func TestHashMultipleSet(t *testing.T) {
 	item := map[string]interface{}{
 		"janice":  "guitar",

--- a/go/src/koding/db/mongodb/modelhelper/machine.go
+++ b/go/src/koding/db/mongodb/modelhelper/machine.go
@@ -233,6 +233,17 @@ func UpdateMachineAlwaysOn(machineId bson.ObjectId, alwaysOn bool) error {
 	return Mongo.Run(MachinesColl, query)
 }
 
+func ChangeMachineState(machineId bson.ObjectId, state string) error {
+	query := func(c *mgo.Collection) error {
+		return c.Update(
+			bson.M{"_id": machineId},
+			bson.M{"$set": bson.M{"status.state": state}},
+		)
+	}
+
+	return Mongo.Run(MachinesColl, query)
+}
+
 func CreateMachine(m *models.Machine) error {
 	query := func(c *mgo.Collection) error {
 		return c.Insert(m)

--- a/go/src/koding/db/mongodb/modelhelper/modeltesthelper/user_machines.go
+++ b/go/src/koding/db/mongodb/modelhelper/modeltesthelper/user_machines.go
@@ -15,7 +15,7 @@ func CreateUserWithMachine(username string) (*models.User, error) {
 		return nil, err
 	}
 
-	machine, err := CreateMachineForUser(user.ObjectId)
+	machine, err := CreateMachineForUser(user.ObjectId, username)
 	if err != nil {
 		return nil, err
 	}
@@ -35,9 +35,9 @@ func DeleteMachine(id bson.ObjectId) error {
 	return modelhelper.Mongo.Run(modelhelper.MachinesColl, deleteQuery)
 }
 
-func CreateMachineForUser(userId bson.ObjectId) (*models.Machine, error) {
+func CreateMachineForUser(userId bson.ObjectId, username string) (*models.Machine, error) {
 	machineUser := models.MachineUser{Id: userId, Owner: true}
-	return createMachine(machineUser)
+	return createMachine(machineUser, username)
 }
 
 func ShareMachineWithUser(machineId, userId bson.ObjectId, p bool) error {
@@ -55,11 +55,13 @@ func ShareMachineWithUser(machineId, userId bson.ObjectId, p bool) error {
 	return modelhelper.Mongo.Run(modelhelper.MachinesColl, query)
 }
 
-func createMachine(machineUser models.MachineUser) (*models.Machine, error) {
+func createMachine(machineUser models.MachineUser, username string) (*models.Machine, error) {
 	machine := &models.Machine{
-		ObjectId: bson.NewObjectId(),
-		Users:    []models.MachineUser{machineUser},
-		Uid:      randStr(10),
+		ObjectId:   bson.NewObjectId(),
+		Users:      []models.MachineUser{machineUser},
+		Uid:        randStr(10),
+		Provider:   "koding",
+		Credential: username,
 	}
 
 	insertQuery := func(c *mgo.Collection) error {

--- a/go/src/koding/vmwatcher/action.go
+++ b/go/src/koding/vmwatcher/action.go
@@ -7,7 +7,10 @@ import (
 	"time"
 )
 
-var KloudTimeout = time.Second * 2
+var (
+	KloudTimeout  = time.Second * 2
+	DefaultReason = "NetworkOut limit reached"
+)
 
 // request arguments
 type requestArgs struct {
@@ -24,7 +27,7 @@ func stopVm(machineId, username, reason string) error {
 
 	_, err := controller.Klient.TellWithTimeout("stop", KloudTimeout, &requestArgs{
 		MachineId: machineId,
-		Reason:    reason,
+		Reason:    DefaultReason,
 		Provider:  "koding",
 	})
 
@@ -39,7 +42,7 @@ func stopVm(machineId, username, reason string) error {
 }
 
 func blockUserAndDestroyVm(machineId, username, reason string) error {
-	err := modelhelper.BlockUser(username, reason, BlockDuration)
+	err := modelhelper.BlockUser(username, DefaultReason, BlockDuration)
 	if err != nil {
 		return err
 	}

--- a/go/src/koding/vmwatcher/cloudwatch_test.go
+++ b/go/src/koding/vmwatcher/cloudwatch_test.go
@@ -1,11 +1,7 @@
 package main
 
 import (
-	"fmt"
 	"koding/db/mongodb/modelhelper/modeltesthelper"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -22,37 +18,35 @@ func TestCloudwatchFree(t *testing.T) {
 		_, _, err := modeltesthelper.CreateUser(username)
 		So(err, ShouldBeNil)
 
-		defer modeltesthelper.DeleteUsersByUsername(username)
+		defer removeUser(username)
 
-		Convey("Given user", func() {
-			var networkOutMetric = metricsToSave[0]
+		var networkOutMetric = metricsToSave[0]
 
-			Convey("When user is overlimit", func() {
-				var value float64 = NetworkOutLimit * PaidPlanMultiplier * 2
+		Convey("When user is overlimit than free plan", func() {
+			var value float64 = NetworkOutLimit * PaidPlanMultiplier * 2
 
-				err := networkOutMetric.Save(username, value)
+			err := networkOutMetric.Save(username, value)
+			So(err, ShouldBeNil)
+
+			Convey("Then they can't start their machine", func() {
+				lr, err := networkOutMetric.IsUserOverLimit(username, StopLimitKey)
 				So(err, ShouldBeNil)
 
-				Convey("Then they can't start their machine", func() {
-					lr, err := networkOutMetric.IsUserOverLimit(username, StopLimitKey)
-					So(err, ShouldBeNil)
-
-					So(lr.CanStart, ShouldBeFalse)
-				})
+				So(lr.CanStart, ShouldBeFalse)
 			})
+		})
 
-			Convey("When user is underlimit", func() {
-				var value float64 = NetworkOutLimit - 100
+		Convey("When user is underlimit than free plan", func() {
+			var value float64 = NetworkOutLimit - 100
 
-				err := networkOutMetric.Save(username, value)
+			err := networkOutMetric.Save(username, value)
+			So(err, ShouldBeNil)
+
+			Convey("Then they can start their machine", func() {
+				lr, err := networkOutMetric.IsUserOverLimit(username, StopLimitKey)
 				So(err, ShouldBeNil)
 
-				Convey("Then they cna start their machine", func() {
-					lr, err := networkOutMetric.IsUserOverLimit(username, StopLimitKey)
-					So(err, ShouldBeNil)
-
-					So(lr.CanStart, ShouldBeTrue)
-				})
+				So(lr.CanStart, ShouldBeTrue)
 			})
 		})
 	})
@@ -69,50 +63,91 @@ func TestCloudwatchPaid(t *testing.T) {
 		_, _, err := modeltesthelper.CreateUser(username)
 		So(err, ShouldBeNil)
 
-		defer modeltesthelper.DeleteUsersByUsername(username)
+		defer removeUser(username)
+		var networkOutMetric = metricsToSave[0]
 
-		Convey("Given user", func() {
-			var networkOutMetric = metricsToSave[0]
+		Convey("When user is overlimit than paid plan", func() {
+			var value float64 = NetworkOutLimit * PaidPlanMultiplier * 2
 
-			Convey("When user is overlimit", func() {
-				var value float64 = NetworkOutLimit * PaidPlanMultiplier * 2
+			err := networkOutMetric.Save(username, value)
+			So(err, ShouldBeNil)
 
-				err := networkOutMetric.Save(username, value)
+			Convey("Then they can't start their machine", func() {
+				lr, err := networkOutMetric.IsUserOverLimit(username, StopLimitKey)
 				So(err, ShouldBeNil)
 
-				Convey("Then they can't start their machine", func() {
-					lr, err := networkOutMetric.IsUserOverLimit(username, StopLimitKey)
-					So(err, ShouldBeNil)
-
-					So(lr.CanStart, ShouldBeFalse)
-				})
+				So(lr.CanStart, ShouldBeFalse)
 			})
+		})
 
-			Convey("When user is underlimit", func() {
-				var value float64 = (NetworkOutLimit * PaidPlanMultiplier) - 100
+		Convey("When user is underlimit than free plan", func() {
+			var value float64 = (NetworkOutLimit * PaidPlanMultiplier) - 100
 
-				err := networkOutMetric.Save(username, value)
+			err := networkOutMetric.Save(username, value)
+			So(err, ShouldBeNil)
+
+			Convey("Then they can start their machine", func() {
+				lr, err := networkOutMetric.IsUserOverLimit(username, StopLimitKey)
 				So(err, ShouldBeNil)
 
-				Convey("Then they cna start their machine", func() {
-					lr, err := networkOutMetric.IsUserOverLimit(username, StopLimitKey)
-					So(err, ShouldBeNil)
-
-					So(lr.CanStart, ShouldBeTrue)
-				})
+				So(lr.CanStart, ShouldBeTrue)
 			})
 		})
 	})
 }
 
-func buildPaymentServer(planTitle string) (string, *httptest.Server) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, fmt.Sprintf(`{"planTitle":"%s"}`, planTitle))
+func TestCloudwatchPerUser(t *testing.T) {
+	Convey("", t, func() {
+		url, server := buildPaymentServer("free")
+		PlanUrl = url
+
+		defer server.Close()
+
+		username := "indianajones"
+		_, _, err := modeltesthelper.CreateUser(username)
+		So(err, ShouldBeNil)
+
+		defer removeUser(username)
+
+		var networkOutMetric = metricsToSave[0]
+
+		Convey("When user is overlimit than their specified limit", func() {
+			var value float64 = NetworkOutLimit
+
+			err := networkOutMetric.Save(username, value)
+			So(err, ShouldBeNil)
+
+			err = saveUserLimit(username, value-1)
+			So(err, ShouldBeNil)
+
+			Convey("Then they can't start their machine", func() {
+				lr, err := networkOutMetric.IsUserOverLimit(username, StopLimitKey)
+				So(err, ShouldBeNil)
+
+				So(lr.CanStart, ShouldBeFalse)
+			})
+		})
+
+		Convey("When user is underlimit than their specified limit", func() {
+			var value float64 = NetworkOutLimit
+
+			err := networkOutMetric.Save(username, value)
+			So(err, ShouldBeNil)
+
+			err = saveUserLimit(username, value+1)
+			So(err, ShouldBeNil)
+
+			Convey("Then they can start their machine", func() {
+				lr, err := networkOutMetric.IsUserOverLimit(username, StopLimitKey)
+				So(err, ShouldBeNil)
+
+				So(lr.CanStart, ShouldBeTrue)
+			})
+		})
 	})
+}
 
-	server := httptest.NewServer(mux)
-	url, _ := url.Parse(server.URL)
-
-	return url.String(), server
+func removeUser(username string) {
+	modeltesthelper.DeleteUsersByUsername(username)
+	storage.RemoveUserLimit(username)
 }

--- a/go/src/koding/vmwatcher/cloudwatch_test.go
+++ b/go/src/koding/vmwatcher/cloudwatch_test.go
@@ -1,56 +1,54 @@
 package main
 
 import (
+	"fmt"
+	"koding/db/mongodb/modelhelper/modeltesthelper"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestCloudwatch(t *testing.T) {
-	// Convey("Given a vm", t, func() {
-	//   machine, err := insertRunningMachine()
-	//   So(err, ShouldBeNil)
+func TestCloudwatchFree(t *testing.T) {
+	Convey("", t, func() {
+		url, server := buildPaymentServer("free")
+		PlanUrl = url
 
-	//   Convey("Then it should save cloudwatch data", func() {
-	//     c := Cloudwatch{Name: NetworkOut}
-	//     err := c.GetAndSaveData(machine.Credential)
+		defer server.Close()
 
-	//     So(err, ShouldBeNil)
-	//   })
+		username := "indianajones"
+		_, _, err := modeltesthelper.CreateUser(username)
+		So(err, ShouldBeNil)
 
-	//   Reset(func() {
-	//     removeMachine(machine)
-	//   })
-	// })
+		defer modeltesthelper.DeleteUsersByUsername(username)
 
-	Convey("Given user", t, func() {
-		var networkOutMetric, username = metricsToSave[0], "indianajones"
+		Convey("Given user", func() {
+			var networkOutMetric = metricsToSave[0]
 
-		Convey("When user is overlimit", func() {
-			Convey("Then it should save value", func() {
+			Convey("When user is overlimit", func() {
 				var value float64 = NetworkOutLimit * PaidPlanMultiplier * 2
 
 				err := networkOutMetric.Save(username, value)
 				So(err, ShouldBeNil)
 
-				Convey("Then it return if user is overlimit", func() {
-					lr, err := networkOutMetric.IsUserOverLimit(username)
+				Convey("Then they can't start their machine", func() {
+					lr, err := networkOutMetric.IsUserOverLimit(username, StopLimitKey)
 					So(err, ShouldBeNil)
 
 					So(lr.CanStart, ShouldBeFalse)
 				})
 			})
-		})
 
-		Convey("When user is underlimit", func() {
-			Convey("Then it should save value", func() {
+			Convey("When user is underlimit", func() {
 				var value float64 = NetworkOutLimit - 100
 
 				err := networkOutMetric.Save(username, value)
 				So(err, ShouldBeNil)
 
-				Convey("Then it return if user is overlimit", func() {
-					lr, err := networkOutMetric.IsUserOverLimit(username)
+				Convey("Then they cna start their machine", func() {
+					lr, err := networkOutMetric.IsUserOverLimit(username, StopLimitKey)
 					So(err, ShouldBeNil)
 
 					So(lr.CanStart, ShouldBeTrue)
@@ -58,4 +56,63 @@ func TestCloudwatch(t *testing.T) {
 			})
 		})
 	})
+}
+
+func TestCloudwatchPaid(t *testing.T) {
+	Convey("", t, func() {
+		url, server := buildPaymentServer("hobbyist")
+		PlanUrl = url
+
+		defer server.Close()
+
+		username := "indianajones"
+		_, _, err := modeltesthelper.CreateUser(username)
+		So(err, ShouldBeNil)
+
+		defer modeltesthelper.DeleteUsersByUsername(username)
+
+		Convey("Given user", func() {
+			var networkOutMetric = metricsToSave[0]
+
+			Convey("When user is overlimit", func() {
+				var value float64 = NetworkOutLimit * PaidPlanMultiplier * 2
+
+				err := networkOutMetric.Save(username, value)
+				So(err, ShouldBeNil)
+
+				Convey("Then they can't start their machine", func() {
+					lr, err := networkOutMetric.IsUserOverLimit(username, StopLimitKey)
+					So(err, ShouldBeNil)
+
+					So(lr.CanStart, ShouldBeFalse)
+				})
+			})
+
+			Convey("When user is underlimit", func() {
+				var value float64 = (NetworkOutLimit * PaidPlanMultiplier) - 100
+
+				err := networkOutMetric.Save(username, value)
+				So(err, ShouldBeNil)
+
+				Convey("Then they cna start their machine", func() {
+					lr, err := networkOutMetric.IsUserOverLimit(username, StopLimitKey)
+					So(err, ShouldBeNil)
+
+					So(lr.CanStart, ShouldBeTrue)
+				})
+			})
+		})
+	})
+}
+
+func buildPaymentServer(planTitle string) (string, *httptest.Server) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, fmt.Sprintf(`{"planTitle":"%s"}`, planTitle))
+	})
+
+	server := httptest.NewServer(mux)
+	url, _ := url.Parse(server.URL)
+
+	return url.String(), server
 }

--- a/go/src/koding/vmwatcher/peruser.go
+++ b/go/src/koding/vmwatcher/peruser.go
@@ -1,0 +1,9 @@
+package main
+
+func getUserLimit(username string) (float64, error) {
+	return storage.GetUserLimit(username)
+}
+
+func saveUserLimit(username string, limit float64) error {
+	return storage.SaveUserLimit(username, limit)
+}

--- a/go/src/koding/vmwatcher/queue_test.go
+++ b/go/src/koding/vmwatcher/queue_test.go
@@ -1,19 +1,14 @@
 package main
 
 import (
-	"koding/db/models"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestQueueUsernamesForMetricsGet(t *testing.T) {
-	var machine *models.Machine
-
 	Convey("Given running machine", t, func() {
-		var err error
-
-		machine, err = insertRunningMachine()
+		machine, err := insertRunningMachine()
 		So(err, ShouldBeNil)
 
 		Convey("Then it should queue & pop the machine", func() {
@@ -21,6 +16,7 @@ func TestQueueUsernamesForMetricsGet(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			queuedMachines, err := popMachinesForMetricGet(NetworkOut)
+
 			So(err, ShouldBeNil)
 			So(len(queuedMachines), ShouldEqual, 1)
 
@@ -28,23 +24,19 @@ func TestQueueUsernamesForMetricsGet(t *testing.T) {
 		})
 
 		Reset(func() {
-			removeUserMachine(testUsername)
+			removeUserMachine(machine.Credential)
 		})
 	})
 }
 
 func TestQueueOverLimitUsers(t *testing.T) {
-	var machine *models.Machine
-
 	Convey("Given users that are overlimit", t, func() {
-		var err error
-
-		machine, err = insertRunningMachine()
+		machine, err := insertRunningMachine()
 		So(err, ShouldBeNil)
 
 		Convey("Then it should queue machine for stopping", func() {
 			networkOutMetric := metricsToSave[0]
-			err := storage.SaveScore(networkOutMetric.GetName(), testUsername, NetworkOutLimit*5)
+			err := storage.SaveScore(networkOutMetric.GetName(), machine.Credential, NetworkOutLimit*5)
 			So(err, ShouldBeNil)
 
 			queueOverlimitUsers()
@@ -59,7 +51,7 @@ func TestQueueOverLimitUsers(t *testing.T) {
 		})
 
 		Reset(func() {
-			removeUserMachine(testUsername)
+			removeUserMachine(machine.Credential)
 		})
 	})
 }

--- a/go/src/koding/vmwatcher/vmwatcher_test.go
+++ b/go/src/koding/vmwatcher/vmwatcher_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"fmt"
 	"koding/db/models"
 	"koding/db/mongodb/modelhelper"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"labix.org/v2/mgo"
@@ -135,4 +139,16 @@ func removeUserMachine(username string) {
 	}
 
 	modelhelper.Mongo.Run(modelhelper.MachinesColl, query)
+}
+
+func buildPaymentServer(planTitle string) (string, *httptest.Server) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, fmt.Sprintf(`{"planTitle":"%s"}`, planTitle))
+	})
+
+	server := httptest.NewServer(mux)
+	url, _ := url.Parse(server.URL)
+
+	return url.String(), server
 }

--- a/go/src/koding/vmwatcher/vmwatcher_test.go
+++ b/go/src/koding/vmwatcher/vmwatcher_test.go
@@ -134,5 +134,5 @@ func removeUserMachine(username string) {
 		return c.Remove(bson.M{"credential": username})
 	}
 
-	modelhelper.Mongo.Run(modelhelper.MachineColl, query)
+	modelhelper.Mongo.Run(modelhelper.MachinesColl, query)
 }

--- a/wercker.yml
+++ b/wercker.yml
@@ -143,7 +143,7 @@ build:
     - script:
         name: test vmwatcher
         code: |
-          go test koding/vmwatcher
+          ./run vmwatchertests
     # - script:
     #     name: test koding kites
     #     code: |

--- a/wercker.yml
+++ b/wercker.yml
@@ -141,7 +141,7 @@ build:
         code: |
           go test ./go/src/koding/db/mongodb/modelhelper/*go
     - script:
-        name: test vmwatcehr
+        name: test vmwatcher
         code: |
           go test koding/vmwatcher
     # - script:

--- a/wercker.yml
+++ b/wercker.yml
@@ -140,6 +140,10 @@ build:
         name: test koding mongo models
         code: |
           go test ./go/src/koding/db/mongodb/modelhelper/*go
+    - script:
+        name: test vmwatcehr
+        code: |
+          go test koding/vmwatcher
     # - script:
     #     name: test koding kites
     #     code: |


### PR DESCRIPTION
- Get per user limit from storage, ie Redis
  - Some users have legitimate reason for going above allowed GB limit of 7 for free and 14 for paid. The only choice before was to exempt them completely from checking. This pr lets us to specify per user limit.
- Run vmwatcher tests with each build (I must've forgotten to add them to wercker before)
  - vmwatcher relies on config, so the tests are run using `./run` which has the app specific env vars set already.
- Fix failing tests. Tests broke due to changes in way machines are saved/fetched, which the tests depeneded up. I wasn't aware of this till now since tests weren't run in CI. Lesson learnt!
