### PR TITLE
Fixes "Sidebar VM spacing is incorrect" [fixes #97161344]

### DIFF
--- a/client/app/lib/styl/resurrection.sidebar.styl
+++ b/client/app/lib/styl/resurrection.sidebar.styl
@@ -425,6 +425,7 @@ sidebarTextShadow()
       &:last-child
         .listview-wrapper
           margin-bottom 0px
+
       .listview-wrapper
         margin-bottom   8px
 

--- a/client/app/lib/styl/resurrection.sidebar.styl
+++ b/client/app/lib/styl/resurrection.sidebar.styl
@@ -421,8 +421,12 @@ sidebarTextShadow()
       right           36px
       abs()
 
-    .listview-wrapper
-      margin-bottom   8px
+    .sidebar-machine-box
+      &:last-child
+        .listview-wrapper
+          margin-bottom 0px
+      .listview-wrapper
+        margin-bottom   8px
 
     .kdlistview
       overflow        visible

--- a/client/app/lib/styl/resurrection.sidebar.styl
+++ b/client/app/lib/styl/resurrection.sidebar.styl
@@ -421,6 +421,9 @@ sidebarTextShadow()
       right           36px
       abs()
 
+    .listview-wrapper
+      margin-bottom   8px
+
     .kdlistview
       overflow        visible
 


### PR DESCRIPTION
Before
![screenshot at 23-05-40](https://cloud.githubusercontent.com/assets/1278794/8262006/bb20d86c-16d7-11e5-9cb2-2abd6324bc74.png)

After
![screenshot at 23-04-25](https://cloud.githubusercontent.com/assets/1278794/8262005/bb010244-16d7-11e5-9e6c-b465f148fcd1.png)

The story: https://www.pivotaltracker.com/story/show/97161344

Notes: After screen - first arrow and second arrow are the same height (according to my measuring tools). Nr. 1 and nr. 2 have kept the same height.

cc. @sinan @usirin
