### PR TITLE
ReactView

### DIFF
--- a/client/app/lib/react/reactview.coffee
+++ b/client/app/lib/react/reactview.coffee
@@ -1,0 +1,21 @@
+kd    = require 'kd'
+React = require 'kd-react'
+
+module.exports = class ReactView extends kd.CustomHTMLView
+
+  renderReact: ->
+
+    console.error "#{@constructor.name}: needs to implement 'renderReact' method"
+
+    return null
+
+
+  viewAppended: ->
+
+    React.render(
+      @renderReact()
+      @getElement()
+    )
+
+
+

--- a/client/app/lib/react/test/index.coffee
+++ b/client/app/lib/react/test/index.coffee
@@ -1,0 +1,4 @@
+describe 'KDReact', ->
+  require './reactview.test'
+
+

--- a/client/app/lib/react/test/reactview.test.coffee
+++ b/client/app/lib/react/test/reactview.test.coffee
@@ -1,0 +1,38 @@
+kd         = require 'kd'
+{ expect } = require 'chai'
+React      = require 'react/addons'
+
+ReactView = require '../reactview'
+
+renderIntoDocument = (view) ->
+  div = document.createElement 'div'
+  div.appendChild view.getElement()
+  view.emit 'viewAppended'
+
+  return view
+
+findRenderedDOMWithClassName = (view, className) ->
+
+  view.getElement().querySelector ".#{className}"
+
+
+describe 'ReactView', ->
+
+  it 'works', ->
+
+    expect(new ReactView).to.be.ok
+
+
+  it 'renders dom element with react', ->
+
+    class FooReactView extends ReactView
+
+      renderReact: ->
+        <div className="hello-world">Hello World</div>
+
+    foo = renderIntoDocument(new FooReactView)
+
+    helloWorld = findRenderedDOMWithClassName foo, 'hello-world'
+
+    expect(helloWorld.textContent).to.equal 'Hello World'
+

--- a/client/app/test/index.coffee
+++ b/client/app/test/index.coffee
@@ -1,1 +1,2 @@
 require './statemachine.test'
+require '../lib/react/test'

--- a/client/package.json
+++ b/client/package.json
@@ -56,7 +56,8 @@
     "algoliasearch": "kd-shim-algoliasearch",
     "underscore": "lodash",
     "sockjs-client": "kd-shim-sockjs-client",
-    "os": "component-os"
+    "os": "component-os",
+    "kd-react": "@koding/kd-react"
   },
   "devDependencies": {
     "chokidar": "1.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "bluebird": "2.8.2",
     "bongo-client": "git+ssh://git@github.com:koding/bongo-client#v0.2.5",
     "broker-client": "git+ssh://git@github.com:koding/broker-client#v0.3.1",
+    "kd-react": "git+ssh://git@github.com:koding/kd-react#0.1.2",
     "component-os": "0.0.1",
     "convert-source-map": "1.1.0",
     "dateformat": "1.0.11",


### PR DESCRIPTION
This PR includes base classes that can be used for integrating `React` to be able to use it with `kd`.
### ReactView

ReactView is a subclass of KDView that can be used for rendering an arbitrary react component as its DOM element.

Use this view to wrap a React element and easily `addSubView` it to a parent.

``` coffeescript
ReactView = require 'app/react/reactview'

# this require is necessary for the fact that
# JSX will be compiled into `React.createElement` calls.
React = require 'app/react'

SomeReactComponent = require 'app/components/somereactcomponent'

class ExampleView extends ReactView

  constructor: (options, data) ->

    options.cssClass = 'ExampleView'

    super options, data


  # yep JSX inside KDView.
  renderReact: ->
    <SomeReactComponent />
```

`renderReact` method allows us to inject `<AnyReactComponent />`.

Keep in mind that this class is designed to be a simple wrapper around a `ReactComponent`, so don't put unnecessary logic in here, instead use this as a simple bridge between a complicated `KDView` and a `ReactComponent`.
### KDReact

`KDReact` extends `React` for changing the base classes that are exported by `React` itself. For now we are only extending `React.Component` with `KDObject` to have best of both worlds (Mainly for `KDObject::bound`).

This requires us to require React as `React = require 'kd-react'` instead of `React = require 'react'`.

The reason of extending `React` and requiring it as `React = require 'kd-react'` is that the `coffee-react` compiler we are using for `JSX` compilation doesn't allow us to inject the symbols we want to convert:

``` coffee
<div>Hello World</div>
```

`coffee-react` transform will transform this to following function call:

``` coffee
React.createElement 'div', null, 'Hello World'
```

As you can see it requires a `React` variable to exist in the scope.

So

``` coffee
KDReactComponent = require 'kd-react/src/component'

class FooComponent extends KDReactComponent
  render: ->
    <div>Foo</div>
```

This would throw a reference error saying that `React` is not defined.

So the reason to extend `React.Component` with `KDReactComponent` is to remove the necessity to require `React` with no visible reason (compiled results of JSX is not in the page, but for some reason I am requiring React, wtf, why isn't my code working? etc. etc.)

If we were to rewrite the example above:

``` coffee
# We have a React in our scope. Notice the require.
React = require 'kd-react'

# But its component is `KDReactComponent`
class FooComponent extends React.Component
  render: ->
    <div>Foo</div>
```
