### PR TITLE
integration: update fetch channel integration response

### DIFF
--- a/go/src/socialapi/workers/integration/webhook/api/webhook.go
+++ b/go/src/socialapi/workers/integration/webhook/api/webhook.go
@@ -218,7 +218,19 @@ func (h *Handler) GetChannelIntegration(u *url.URL, header http.Header, _ interf
 		return response.NewBadRequest(ErrInvalidGroup)
 	}
 
-	return response.NewOK(response.NewSuccessResponse(ci))
+	cic := webhook.NewChannelIntegrationContainer(ci)
+	cic.ChannelIntegration = ci
+	if err := cic.Populate(); err != nil {
+		return response.NewBadRequest(err)
+	}
+
+	i, err := webhook.Cache.Integration.ById(ci.IntegrationId)
+	if err != nil {
+		return response.NewBadRequest(err)
+	}
+	cic.Integration = i
+
+	return response.NewOK(response.NewSuccessResponse(cic))
 }
 
 func (h *Handler) UpdateChannelIntegration(u *url.URL, header http.Header, i *webhook.ChannelIntegration, ctx *models.Context) (int, http.Header, interface{}, error) {

--- a/go/src/socialapi/workers/integration/webhook/api/webhook_test.go
+++ b/go/src/socialapi/workers/integration/webhook/api/webhook_test.go
@@ -582,11 +582,11 @@ func TestWebhookGetChannelIntegration(t *testing.T) {
 				sr, srOk := res.(*response.SuccessResponse)
 				So(srOk, ShouldBeTrue)
 
-				newCi, ok := sr.Data.(*webhook.ChannelIntegration)
+				newCi, ok := sr.Data.(*webhook.ChannelIntegrationContainer)
 				So(ok, ShouldBeTrue)
 
 				So(newCi, ShouldNotBeNil)
-				So(newCi.Id, ShouldEqual, ci.Id)
+				So(newCi.ChannelIntegration.Id, ShouldEqual, ci.Id)
 			})
 
 		})

--- a/go/src/socialapi/workers/integration/webhook/channelintegrationcontainer.go
+++ b/go/src/socialapi/workers/integration/webhook/channelintegrationcontainer.go
@@ -1,0 +1,33 @@
+package webhook
+
+import "socialapi/models"
+
+type ChannelIntegrationContainer struct {
+	ChannelIntegration *ChannelIntegration `json:"channelIntegration"`
+	AccountOldId       string              `json:"accountOldId"`
+	Integration        *Integration        `json:"integration,omitempty"`
+	Channel            *models.Channel     `json:"channel"`
+}
+
+func NewChannelIntegrationContainer(ci *ChannelIntegration) *ChannelIntegrationContainer {
+	return &ChannelIntegrationContainer{
+		ChannelIntegration: ci,
+	}
+}
+
+func (cic *ChannelIntegrationContainer) Populate() error {
+	ci := cic.ChannelIntegration
+	c, err := models.Cache.Channel.ById(ci.ChannelId)
+	if err != nil {
+		return err
+	}
+	cic.Channel = c
+
+	acc, err := models.Cache.Account.ById(ci.CreatorId)
+	if err != nil {
+		return err
+	}
+	cic.AccountOldId = acc.OldId
+
+	return nil
+}

--- a/go/src/socialapi/workers/integration/webhook/channelintegrationcontainer.go
+++ b/go/src/socialapi/workers/integration/webhook/channelintegrationcontainer.go
@@ -16,6 +16,10 @@ func NewChannelIntegrationContainer(ci *ChannelIntegration) *ChannelIntegrationC
 }
 
 func (cic *ChannelIntegrationContainer) Populate() error {
+	if cic.ChannelIntegration == nil {
+		return ErrChannelIntegrationNotFound
+	}
+
 	ci := cic.ChannelIntegration
 	c, err := models.Cache.Channel.ById(ci.ChannelId)
 	if err != nil {

--- a/go/src/socialapi/workers/integration/webhook/integrationcontainer.go
+++ b/go/src/socialapi/workers/integration/webhook/integrationcontainer.go
@@ -1,17 +1,17 @@
 package webhook
 
 type IntegrationContainer struct {
-	Integration         *Integration         `json:"integration"`
-	ChannelIntegrations []ChannelIntegration `json:"channelIntegrations"`
+	Integration         *Integration                  `json:"integration"`
+	ChannelIntegrations []ChannelIntegrationContainer `json:"channelIntegrations"`
 }
 
 func NewIntegrationContainer() *IntegrationContainer {
 	return &IntegrationContainer{
-		ChannelIntegrations: make([]ChannelIntegration, 0),
+		ChannelIntegrations: make([]ChannelIntegrationContainer, 0),
 	}
 }
 
-func (ic *IntegrationContainer) PushChannelIntegration(ci ChannelIntegration) {
+func (ic *IntegrationContainer) Push(ci ChannelIntegrationContainer) {
 	ic.ChannelIntegrations = append(ic.ChannelIntegrations, ci)
 }
 
@@ -21,7 +21,7 @@ func NewIntegrationContainers() *IntegrationContainers {
 	return &IntegrationContainers{}
 }
 
-func (ics *IntegrationContainers) PushIntegrationContainer(i IntegrationContainer) {
+func (ics *IntegrationContainers) Push(i IntegrationContainer) {
 	*ics = append(*ics, i)
 }
 
@@ -41,7 +41,12 @@ func (ics *IntegrationContainers) Populate(groupName string) error {
 			integration = NewIntegrationContainer()
 			containers[channelIntegration.IntegrationId] = integration
 		}
-		integration.PushChannelIntegration(channelIntegration)
+		cic := NewChannelIntegrationContainer(&channelIntegration)
+		if err := cic.Populate(); err != nil {
+			return err
+		}
+
+		integration.Push(*cic)
 	}
 
 	// fetch related integrations
@@ -58,7 +63,7 @@ func (ics *IntegrationContainers) Populate(groupName string) error {
 	for _, integration := range ints {
 		ic := containers[integration.Id]
 		ic.Integration = &integration
-		ics.PushIntegrationContainer(*ic)
+		ics.Push(*ic)
 	}
 
 	return nil

--- a/go/src/socialapi/workers/integration/webhook/integrationcontainer_test.go
+++ b/go/src/socialapi/workers/integration/webhook/integrationcontainer_test.go
@@ -37,7 +37,7 @@ func TestIntegrationContainersPopulate(t *testing.T) {
 			So(testInt.Name, ShouldEqual, integration.Name)
 			So(len((*ics)[0].ChannelIntegrations), ShouldEqual, 1)
 			testCi := (*ics)[0].ChannelIntegrations[0]
-			So(testCi.Id, ShouldEqual, ci.Id)
+			So(testCi.ChannelIntegration.Id, ShouldEqual, ci.Id)
 
 			// test for 2 channel integrations created from 1 integration
 			ci.Id = 0


### PR DESCRIPTION
In this PR: 
- When channel integration is fetched, instead of returning only the `ChannelIntegration` data, we are also returning `AccountOldId`, `Integration`, and `Channel` data within `ChannelIntegrationContainer`
