### PR TITLE
analytics: add wrapper for Segment calls, send env

### DIFF
--- a/client/app/lib/setupanalytics.coffee
+++ b/client/app/lib/setupanalytics.coffee
@@ -1,6 +1,6 @@
+kd          = require 'kd'
+globals     = require 'globals'
 isLoggedIn = require './util/isLoggedIn'
-kd = require 'kd'
-globals = require 'globals'
 
 setupIdentify = ->
 
@@ -43,6 +43,7 @@ identifyUser = (account)->
         foreignAuth    : providers      if Object.keys(providers).length > 0
         sshKeysCount   : sshKeys.length if sshKeys?.length > 0
         userAgent      : navigator.userAgent
+        env            : globals.config.environment
 
       analytics?.identify nickname, args
 
@@ -61,9 +62,9 @@ setupRollbar = ->
 
   Rollbar?.configure
     payload: client: javascript:
-      source_map_enabled: true
-      code_version: globals.config.version
+      source_map_enabled:    true
       guess_uncaught_frames: true
+      code_version:          globals.config.version
 
 module.exports = ->
 

--- a/go/src/socialapi/workers/cmd/email/emailsender/main.go
+++ b/go/src/socialapi/workers/cmd/email/emailsender/main.go
@@ -26,7 +26,7 @@ func main() {
 	defer modelhelper.Close()
 
 	exporter := eventexporter.NewSegmentIOExporter(appConfig.Segment, QueueLength)
-	constructor := emailsender.New(exporter, r.Log)
+	constructor := emailsender.New(exporter, r.Log, appConfig.Config)
 	r.ShutdownHandler = constructor.Close
 
 	r.SetContext(constructor)

--- a/go/src/socialapi/workers/email/emailsender/emailsender.go
+++ b/go/src/socialapi/workers/email/emailsender/emailsender.go
@@ -7,6 +7,7 @@ import (
 	"github.com/koding/bongo"
 	"github.com/koding/eventexporter"
 	"github.com/koding/logging"
+	"github.com/koding/runner"
 	"github.com/streadway/amqp"
 )
 
@@ -17,13 +18,17 @@ type Controller struct {
 	log             logging.Logger
 	emailer         eventexporter.Exporter
 	forcedRecipient string
+	env             string
+	host            string
 }
 
 // New Creates a new controller for mail worker
-func New(exporter eventexporter.Exporter, log logging.Logger) *Controller {
+func New(exporter eventexporter.Exporter, log logging.Logger, conf runner.Config) *Controller {
 	return &Controller{
 		emailer: exporter,
 		log:     log,
+		env:     conf.Environment,
+		host:    conf.Hostname,
 	}
 }
 
@@ -51,6 +56,10 @@ func (c *Controller) Process(m *Mail) error {
 
 	user.Username = m.Properties.Username
 	m.SetOption("subject", m.Subject)
+
+	// set default properties
+	m.SetOption("env", c.env)
+	m.SetOption("host", c.host)
 
 	escapedBody := template.HTMLEscapeString(m.HTML)
 	event := &eventexporter.Event{

--- a/go/src/socialapi/workers/email/emailsender/emailsender_test.go
+++ b/go/src/socialapi/workers/email/emailsender/emailsender_test.go
@@ -33,7 +33,9 @@ func TestBongoName(t *testing.T) {
 func TestNew(t *testing.T) {
 	r := startRunner()
 	defer r.Close()
-
+        
+        appConfig := config.MustRead(r.Conf.Path)
+        
 	Convey("Given an exporter client", t, func() {
 		Convey("Then it should call it", func() {
 			mail := &Mail{
@@ -45,7 +47,7 @@ func TestNew(t *testing.T) {
 			}
 
 			exporter := eventexporter.NewFakeExporter()
-			c := New(exporter, r.Log)
+			c := New(exporter, r.Log, appConfig.Config)
 
 			err := c.Process(mail)
 			So(err, ShouldBeNil)

--- a/go/src/socialapi/workers/email/emailsender/emailsender_test.go
+++ b/go/src/socialapi/workers/email/emailsender/emailsender_test.go
@@ -2,6 +2,7 @@ package emailsender
 
 import (
 	"testing"
+	"socialapi/config"
 
 	"github.com/koding/eventexporter"
 	"github.com/koding/runner"

--- a/go/src/socialapi/workers/email/emailsender/mail_bongo.go
+++ b/go/src/socialapi/workers/email/emailsender/mail_bongo.go
@@ -61,5 +61,5 @@ func (m *Mail) SetOption(key string, value interface{}) {
 		m.Properties.Options = NewPropertiesOptions()
 	}
 
-	m.Properties.Options["subject"] = m.Subject
+	m.Properties.Options[key] = value
 }

--- a/servers/lib/server/handlers/confirm.coffee
+++ b/servers/lib/server/handlers/confirm.coffee
@@ -2,9 +2,7 @@
 KONFIG    = require('koding-config-manager').load("main.#{argv.c}")
 {secret}  = KONFIG.jwt
 
-Analytics = require('analytics-node')
-analytics = new Analytics(KONFIG.segment)
-
+Analytics = require '../../../../workers/social/lib/social/models/analytics.coffee'
 Jwt       = require 'jsonwebtoken'
 
 module.exports = (req, res, next) ->
@@ -39,4 +37,4 @@ module.exports = (req, res, next) ->
           res.cookie 'clientId', session.clientId, path: '/'
           res.redirect redirect_uri or '/'
 
-          analytics.track userId: username, event: 'confirmed & logged in using token'
+          Analytics.track username, 'confirmed & logged in using token'

--- a/workers/social/lib/social/models/analytics.coffee
+++ b/workers/social/lib/social/models/analytics.coffee
@@ -17,6 +17,6 @@ module.exports = class Analytics
 
   @addDefaults = (opts) ->
     opts["env"]      = KONFIG.environment
-    opts["hostname"] = KONFIG.publicHostname
+    opts["hostname"] = KONFIG.hostname
 
     opts

--- a/workers/social/lib/social/models/analytics.coffee
+++ b/workers/social/lib/social/models/analytics.coffee
@@ -1,0 +1,22 @@
+{argv}    = require 'optimist'
+KONFIG    = require('koding-config-manager').load("main.#{argv.c}")
+Analytics = require('analytics-node')
+analytics = new Analytics(KONFIG.segment)
+
+module.exports = class Analytics
+
+  @track = (userId, event, properties={}) ->
+    properties = @addDefaults properties
+    analytics.track {userId, event, properties}
+
+
+  @identify = (userId, traits={}) ->
+    traits = @addDefaults traits
+    analytics.identify {userId, traits}
+
+
+  @addDefaults = (opts) ->
+    opts["env"]      = KONFIG.environment
+    opts["hostname"] = KONFIG.publicHostname
+
+    opts

--- a/workers/social/lib/social/models/datadog.coffee
+++ b/workers/social/lib/social/models/datadog.coffee
@@ -4,9 +4,6 @@ KodingError = require '../error'
 {argv} = require 'optimist'
 KONFIG = require('koding-config-manager').load("main.#{argv.c}")
 
-Analytics   = require('analytics-node')
-analytics   = new Analytics(KONFIG.segment)
-
 module.exports = class DataDog extends Base
 
   dogapi = require 'dogapi'
@@ -115,7 +112,8 @@ module.exports = class DataDog extends Base
       text += "\n #{ev.notify}"
 
     if ev.sendToSegment?
-      analytics.track userId: nickname, event: ev.text, properties: data.tags
+      Analytics  = require './analytics'
+      Analytics.track nickname, ev.text, data.tags
 
     DogApi.add_event {title, text, tags}, (err, res, status)->
 

--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -6,9 +6,6 @@ Flaggable   = require '../../traits/flaggable'
 KodingError = require '../../error'
 { extend, uniq }  = require 'underscore'
 
-Analytics   = require('analytics-node')
-analytics   = new Analytics(KONFIG.segment)
-
 module.exports = class JUser extends jraphical.Module
   {secure, signature, daisy, dash} = require 'bongo'
 
@@ -22,6 +19,7 @@ module.exports = class JUser extends jraphical.Module
   JPaymentSubscription = require '../payment/subscription'
   ComputeProvider      = require '../computeproviders/computeprovider'
   Email                = require '../email'
+  Analytics            = require '../analytics'
 
   { v4: createId } = require 'node-uuid'
   {Relationship}   = jraphical
@@ -733,7 +731,7 @@ module.exports = class JUser extends jraphical.Module
               JUser.clearOauthFromSession session, ->
                 callback null, { account, replacementToken, returnUrl: session.returnUrl }
 
-                analytics.track userId: username, event: 'logged in'
+                Analytics.track username, 'logged in'
 
 
   @logout = secure (client, callback)->
@@ -1299,8 +1297,8 @@ module.exports = class JUser extends jraphical.Module
         # uses 'HS256' as default for signing
         token = jwt.sign { username }, secret, { expiresInMinutes: confirmExpiresInMinutes }
 
-        analytics.identify userId: username, traits: { jwtToken: token, host: publicHostname }
-        analytics.track userId: username, event: 'registered'
+        Analytics.identify username, { jwtToken: token }
+        Analytics.track username, 'registered'
     ]
 
     daisy queue
@@ -1503,7 +1501,7 @@ module.exports = class JUser extends jraphical.Module
 
       callback null
 
-      analytics.track userId: username, event: 'confirmed email'
+      Analytics.track username, 'confirmed email'
 
 
   block:(blockedUntil, callback)->

--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -1297,7 +1297,7 @@ module.exports = class JUser extends jraphical.Module
         # uses 'HS256' as default for signing
         token = jwt.sign { username }, secret, { expiresInMinutes: confirmExpiresInMinutes }
 
-        Analytics.identify username, { jwtToken: token }
+        Analytics.identify username, { jwtToken: token, email: email }
         Analytics.track username, 'registered'
     ]
 


### PR DESCRIPTION
- Create `Analytics` class to act as wrapper for Segment calls
  - This is different than `Email` wrapper since these events don't necessary result in emails
  - In the future I might remove `Email` abstraction/worker completely
- Send env with all events, identify calls to prevent sending campaign emails to dev accounts which happened on saturday
