### PR TITLE
integration: regenerate token request wrapper

### DIFF
--- a/client/app/lib/socialapicontroller.coffee
+++ b/client/app/lib/socialapicontroller.coffee
@@ -873,4 +873,14 @@ module.exports = class SocialApiController extends KDController
 
         return callback null, response.data
 
+    regenerateToken : (options, callback) ->
+
+      doXhrRequest
+        endPoint : "/api/integration/channelintegration/token"
+        type     : 'POST'
+        data     : options
+      , (err, response) ->
+        return callback err  if err
+
+        return callback null, response.data
 

--- a/go/src/socialapi/workers/integration/webhook/api/webhook.go
+++ b/go/src/socialapi/workers/integration/webhook/api/webhook.go
@@ -166,7 +166,7 @@ func (h *Handler) RegenerateToken(u *url.URL, header http.Header, i *webhook.Cha
 		return response.NewBadRequest(err)
 	}
 
-	if i.GroupName != ctx.GroupName {
+	if ci.GroupName != ctx.GroupName {
 		return response.NewBadRequest(ErrInvalidGroup)
 	}
 

--- a/go/src/socialapi/workers/integration/webhook/api/webhook_test.go
+++ b/go/src/socialapi/workers/integration/webhook/api/webhook_test.go
@@ -502,10 +502,12 @@ func TestWebhookRegenerateToken(t *testing.T) {
 				c.Client = &models.Client{Account: acc}
 				c.GroupName = models.RandomGroupName()
 
+				testCi := webhook.NewChannelIntegration()
+				testCi.Id = ci.Id
 				s, _, _, err := h.RegenerateToken(
 					mocking.URL(m, "POST", "/channelintegration/token"),
 					mocking.Header(nil),
-					ci,
+					testCi,
 					c,
 				)
 				So(err.Error(), ShouldEqual, ErrInvalidGroup.Error())
@@ -518,10 +520,12 @@ func TestWebhookRegenerateToken(t *testing.T) {
 				c.Client = &models.Client{Account: acc}
 				c.GroupName = groupName
 
+				testCi := webhook.NewChannelIntegration()
+				testCi.Id = ci.Id
 				s, _, res, err := h.RegenerateToken(
 					mocking.URL(m, "POST", "/channelintegration/create"),
 					mocking.Header(nil),
-					ci,
+					testCi,
 					c,
 				)
 


### PR DESCRIPTION
In this PR:
- RegenerateToken wrapper is added to socialapicontroller
- Fixed a bug in regenerateToken handler in integration worker
