### PR TITLE
update mattes/migrate package

### DIFF
--- a/go/src/github.com/mattes/migrate/README.md
+++ b/go/src/github.com/mattes/migrate/README.md
@@ -23,7 +23,7 @@ __Features__
 
  * [PostgreSQL](https://github.com/mattes/migrate/tree/master/driver/postgres)
  * [Cassandra](https://github.com/mattes/migrate/tree/master/driver/cassandra)
- * SQLite ([planned](https://github.com/mattes/migrate/issues/2))
+ * [SQLite](https://github.com/mattes/migrate/tree/master/driver/sqlite3)
  * [MySQL](https://github.com/mattes/migrate/tree/master/driver/mysql) ([experimental](https://github.com/mattes/migrate/issues/1#issuecomment-58728186))
  * Bash (planned)
 
@@ -65,6 +65,8 @@ migrate -url driver://url -path ./migrations migrate -2
 migrate -url driver://url -path ./migrations migrate -n
 
 # go to specific migration
+migrate -url driver://url -path ./migrations goto 1
+migrate -url driver://url -path ./migrations goto 10
 migrate -url driver://url -path ./migrations goto v
 ```
 
@@ -114,5 +116,6 @@ that the filename extension depends on the driver.
  * https://github.com/tanel/dbmigrate
  * https://github.com/BurntSushi/migration
  * https://github.com/DavidHuie/gomigrate
+ * https://github.com/rubenv/sql-migrate
 
 

--- a/go/src/github.com/mattes/migrate/migrate/migrate.go
+++ b/go/src/github.com/mattes/migrate/migrate/migrate.go
@@ -27,7 +27,7 @@ func Up(pipe chan interface{}, url, migrationsPath string) {
 
 	applyMigrationFiles, err := files.ToLastFrom(version)
 	if err != nil {
-		if err2 := d.Close(); err != nil {
+		if err2 := d.Close(); err2 != nil {
 			pipe <- err2
 		}
 		go pipep.Close(pipe, err)
@@ -42,14 +42,14 @@ func Up(pipe chan interface{}, url, migrationsPath string) {
 				break
 			}
 		}
-		if err2 := d.Close(); err != nil {
-			pipe <- err2
+		if err := d.Close(); err != nil {
+			pipe <- err
 		}
 		go pipep.Close(pipe, nil)
 		return
 	} else {
-		if err2 := d.Close(); err != nil {
-			pipe <- err2
+		if err := d.Close(); err != nil {
+			pipe <- err
 		}
 		go pipep.Close(pipe, nil)
 		return
@@ -74,7 +74,7 @@ func Down(pipe chan interface{}, url, migrationsPath string) {
 
 	applyMigrationFiles, err := files.ToFirstFrom(version)
 	if err != nil {
-		if err2 := d.Close(); err != nil {
+		if err2 := d.Close(); err2 != nil {
 			pipe <- err2
 		}
 		go pipep.Close(pipe, err)
@@ -89,13 +89,13 @@ func Down(pipe chan interface{}, url, migrationsPath string) {
 				break
 			}
 		}
-		if err2 := d.Close(); err != nil {
+		if err2 := d.Close(); err2 != nil {
 			pipe <- err2
 		}
 		go pipep.Close(pipe, nil)
 		return
 	} else {
-		if err2 := d.Close(); err != nil {
+		if err2 := d.Close(); err2 != nil {
 			pipe <- err2
 		}
 		go pipep.Close(pipe, nil)
@@ -161,7 +161,7 @@ func Migrate(pipe chan interface{}, url, migrationsPath string, relativeN int) {
 
 	applyMigrationFiles, err := files.From(version, relativeN)
 	if err != nil {
-		if err2 := d.Close(); err != nil {
+		if err2 := d.Close(); err2 != nil {
 			pipe <- err2
 		}
 		go pipep.Close(pipe, err)
@@ -176,13 +176,13 @@ func Migrate(pipe chan interface{}, url, migrationsPath string, relativeN int) {
 				break
 			}
 		}
-		if err2 := d.Close(); err != nil {
+		if err2 := d.Close(); err2 != nil {
 			pipe <- err2
 		}
 		go pipep.Close(pipe, nil)
 		return
 	}
-	if err2 := d.Close(); err != nil {
+	if err2 := d.Close(); err2 != nil {
 		pipe <- err2
 	}
 	go pipep.Close(pipe, nil)


### PR DESCRIPTION
I have updated mattes/migrate package, and now when an error occurs while applying the migration scripts, it is exiting with `os.Exit(1)`

Ironically we can see how the build is really failing here: https://app.wercker.com/#buildstep/5588b8e77089f6684e03e2d6

Yes it shows us the update really works, but before fixing current migration script errors we should not merge it. 
