### PR TITLE
Fixes "add more space when >1 names appear in tooltips" [fixes #97748552]

### DIFF
--- a/client/activity/lib/styl/activity.pm.styl
+++ b/client/activity/lib/styl/activity.pm.styl
@@ -640,6 +640,7 @@ headsListSelectedBgColor   = #7a7a7a
 .reply-like-tooltip
   p
     text-align              left
+    line-height             15px
 
 .chat-heads
   height              40px


### PR DESCRIPTION
Before
![k8r1kjd](https://cloud.githubusercontent.com/assets/1278794/8342056/26d6502a-1ad2-11e5-8a2f-73d6534b9a5d.png)

After
![screenshot at 23-27-02](https://cloud.githubusercontent.com/assets/1278794/8342057/26d7c69e-1ad2-11e5-84aa-06cb0a1cff74.png)

The story: https://www.pivotaltracker.com/story/show/97748552

Notes: Fixed line height for tooltips on activity feed.

cc. @sinan
