### PR TITLE
klient: terminal tab renaming [#87220296]

### DIFF
--- a/client/app/lib/kite/kites/klient.coffee
+++ b/client/app/lib/kite/kites/klient.coffee
@@ -29,6 +29,7 @@ module.exports = class KodingKite_KlientKite extends require('../kodingkite')
     webtermKillSessions: 'webterm.killSessions'
     webtermGetSessions : 'webterm.getSessions'
     webtermPing        : 'webterm.ping'
+    webtermRename      : 'webterm.rename'
 
     klientShare        : 'klient.share'
     klientUnshare      : 'klient.unshare'


### PR DESCRIPTION
@gokmen, this is a change to support `webterm.rename` klient method. It's used in https://github.com/koding/IDE/pull/396
