### PR TITLE
oauth: fix facebook signup

### DIFF
--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -715,6 +715,7 @@ module.exports = class JUser extends jraphical.Module
 
             if session.foreignAuth
               { foreignAuth } = user
+              foreignAuth or= {}
               foreignAuth = extend foreignAuth, session.foreignAuth
               options.foreignAuth = foreignAuth
 


### PR DESCRIPTION
I was not able to test it on my local, but according to papertrail, error is caused by this line:

``` bash
prod-54.172.107.16 webserver.log:   there was an uncaught exception [TypeError: Cannot set property 'facebook' of undefined]
prod-54.172.107.16 webserver.log:  TypeError: Cannot set property 'facebook' of undefined
prod-54.172.107.16 webserver.log:    at /var/app/current/node_modules/underscore/underscore.js:822:21
prod-54.172.107.16 webserver.log:    at Array.forEach (native)
prod-54.172.107.16 webserver.log:    at _.each._.forEach (/var/app/current/node_modules/underscore/underscore.js:79:11)
prod-54.172.107.16 webserver.log:    at _.extend (/var/app/current/node_modules/underscore/underscore.js:819:5)
prod-54.172.107.16 webserver.log:    at /var/app/current/workers/social/lib/social/models/user/index.coffee:718:29
prod-54.172.107.16 webserver.log:    at /var/app/current/node_modules_koding/bongo/lib/model/index.coffee:879:11
prod-54.172.107.16 webserver.log:    at /var/app/current/node_modules/mongodb/lib/mongodb/collection/core.js:706:7
prod-54.172.107.16 webserver.log:    at /var/app/current/node_modules/mongodb/lib/mongodb/collection/core.js:631:7
prod-54.172.107.16 webserver.log:    at Server.Base._callHandler (/var/app/current/node_modules/mongodb/lib/mongodb/connection/base.js:448:41)
prod-54.172.107.16 webserver.log:    at /var/app/current/node_modules/mongodb/lib/mongodb/connection/server.js:481:18
prod-54.172.107.16 webserver.log:    at [object Object].MongoReply.parseBody (/var/app/current/node_modules/mongodb/lib/mongodb/responses/mongo_reply.js:68:5)
prod-54.172.107.16 webserver.log:    at [object Object].<anonymous> (/var/app/current/node_modules/mongodb/lib/mongodb/connection/server.js:439:20)
prod-54.172.107.16 webserver.log:    at [object Object].emit (events.js:95:17)
prod-54.172.107.16 webserver.log:    at [object Object].<anonymous> (/var/app/current/node_modules/mongodb/lib/mongodb/connection/connection_pool.js:201:13)
prod-54.172.107.16 webserver.log:    at [object Object].emit (events.js:98:17)
prod-54.172.107.16 webserver.log:    at Socket.<anonymous> (/var/app/current/node_modules/mongodb/lib/mongodb/connection/connection.js:439:22)
prod-54.172.107.16 webserver.log:    at Socket.emit (events.js:95:17)
prod-54.172.107.16 webserver.log:    at Socket.<anonymous> (_stream_readable.js:765:14)
prod-54.172.107.16 webserver.log:    at Socket.emit (events.js:92:17)
prod-54.172.107.16 webserver.log:    at emitReadable_ (_stream_readable.js:427:10)
prod-54.172.107.16 webserver.log:    at emitReadable (_stream_readable.js:423:5)
prod-54.172.107.16 webserver.log:    at readableAddChunk (_stream_readable.js:166:9)
prod-54.172.107.16 webserver.log:    at Socket.Readable.push (_stream_readable.js:128:10)
prod-54.172.107.16 webserver.log:    at TCP.onread (net.js:529:21)
```
