### PR TITLE
analytics: force flush after identify call

### DIFF
--- a/workers/social/lib/social/models/analytics.coffee
+++ b/workers/social/lib/social/models/analytics.coffee
@@ -14,6 +14,10 @@ module.exports = class Analytics
     traits = @addDefaults traits
     analytics.identify {userId, traits}
 
+    # force flush so identify call doesn't sit in queue, while events
+    # from Go/other systems are being sent
+    analytics.flush (err, batch)-> console.error err  if err
+
 
   @addDefaults = (opts) ->
     opts["env"]      = KONFIG.environment


### PR DESCRIPTION
This should make it faster for users to get their first confirm emails.
