### PR TITLE
Payments checks snapshots during for Downgrade [fixes #98332308]

### DIFF
--- a/client/app/lib/payment/paymentdowngradewithdeletionmodal.coffee
+++ b/client/app/lib/payment/paymentdowngradewithdeletionmodal.coffee
@@ -25,7 +25,7 @@ module.exports = class PaymentDowngradeWithDeletionModal extends PaymentBaseModa
 
     return """
       You are currently using more resources than <strong>#{planTitle.capitalize()}</strong> plan allows.
-      Downgrading will <strong>delete your existing VM(s) and all the data inside them</strong> and give you
+      Downgrading will <strong>delete your existing VM(s), Snapshots, and all the data inside them</strong> and give you
       new default VM. <strong>This action cannot be undone!</strong>
       <br /><br />
       Are you sure you want to continue?

--- a/client/app/lib/payment/paymentdowngradewithdeletionmodal.coffee
+++ b/client/app/lib/payment/paymentdowngradewithdeletionmodal.coffee
@@ -24,7 +24,7 @@ module.exports = class PaymentDowngradeWithDeletionModal extends PaymentBaseModa
     { state: { planTitle } } = @getOptions()
 
     return """
-      You are currently using more resources than <strong>#{planTitle.capitalize()}</strong> plan allows.
+      You are currently using more resources than the <strong>#{planTitle.capitalize()}</strong> plan allows.
       Downgrading will <strong>delete your existing VM(s), Snapshots, and all the data inside them</strong> and give you
       new default VM. <strong>This action cannot be undone!</strong>
       <br /><br />

--- a/client/app/lib/payment/paymentworkflow.coffee
+++ b/client/app/lib/payment/paymentworkflow.coffee
@@ -303,4 +303,4 @@ module.exports = class PaymentWorkflow extends KDController
           @modal.emit 'PaymentSucceeded'
 
     @modal.emit 'DestroyingMachinesStarted'
-    ComputeHelpers.destroyExistingResources callback, yes
+    ComputeHelpers.destroyExistingResources yes, callback

--- a/client/app/lib/payment/paymentworkflow.coffee
+++ b/client/app/lib/payment/paymentworkflow.coffee
@@ -303,4 +303,4 @@ module.exports = class PaymentWorkflow extends KDController
           @modal.emit 'PaymentSucceeded'
 
     @modal.emit 'DestroyingMachinesStarted'
-    ComputeHelpers.destroyExistingMachines callback, yes
+    ComputeHelpers.destroyExistingResources callback, yes

--- a/client/app/lib/providers/computehelpers.coffee
+++ b/client/app/lib/providers/computehelpers.coffee
@@ -26,6 +26,10 @@ module.exports = class ComputeHelpers
    * @returns {Promise}
   ###
   @destroyExistingResources = (callback = kd.noop, waitForCompleteDeletion = no) ->
+    # destroyPromises is a list of all the promises returned by the destroy
+    # functions that @destroyExistingResources will call. The name of this
+    # list (and it's existence) match the other destroy functions, for
+    # consistency.
     destroyPromises = []
 
     # Creating a promise here, because @destroyExistingMachines does

--- a/client/app/lib/providers/computehelpers.coffee
+++ b/client/app/lib/providers/computehelpers.coffee
@@ -25,7 +25,7 @@ module.exports = class ComputeHelpers
    *  destroyed.
    * @returns {Promise}
   ###
-  @destroyExistingResources = (callback = kd.noop, waitForCompleteDeletion = no) ->
+  @destroyExistingResources = (waitForCompleteDeletion = no, callback = kd.noop) ->
     # destroyPromises is a list of all the promises returned by the destroy
     # functions that @destroyExistingResources will call. The name of this
     # list (and it's existence) match the other destroy functions, for
@@ -38,12 +38,10 @@ module.exports = class ComputeHelpers
       machineCallback = (err) ->
         return reject err  if err
         resolve()
-      ComputeHelpers.destroyExistingMachines machineCallback,
-        waitForCompleteDeletion
+      ComputeHelpers.destroyExistingMachines waitForCompleteDeletion, machineCallback
 
     # Add the destroy Snapshots promise
-    destroyPromises.push ComputeHelpers.destroyExistingSnapshots null,
-      waitForCompleteDeletion
+    destroyPromises.push ComputeHelpers.destroyExistingSnapshots waitForCompleteDeletion
 
     result = Promise
       .all destroyPromises
@@ -53,7 +51,7 @@ module.exports = class ComputeHelpers
     return result
 
 
-  @destroyExistingMachines = (callback = kd.noop, waitForCompleteDeletion = no) ->
+  @destroyExistingMachines = (waitForCompleteDeletion = no, callback = kd.noop) ->
 
     { computeController } = kd.singletons
 
@@ -88,7 +86,7 @@ module.exports = class ComputeHelpers
    *  used on the Promise.
    * @returns {Promise}
   ###
-  @destroyExistingSnapshots = (callback = kd.noop, waitForCompleteDeletion = no) ->
+  @destroyExistingSnapshots = (waitForCompleteDeletion = no, callback = kd.noop) ->
 
     { computeController } = kd.singletons
     { JSnapshot }         = remote.api

--- a/client/app/lib/providers/computehelpers.coffee
+++ b/client/app/lib/providers/computehelpers.coffee
@@ -45,8 +45,8 @@ module.exports = class ComputeHelpers
 
     result = Promise
       .all destroyPromises
-      .then        -> callback null  if callback
-      .catch (err) -> callback err   if callback
+      .then        -> callback? null
+      .catch (err) -> callback? err
     result.timeout globals.COMPUTECONTROLLER_TIMEOUT  unless waitForCompleteDeletion
     return result
 
@@ -105,8 +105,8 @@ module.exports = class ComputeHelpers
         return kloud.deleteSnapshot { machineId, snapshotId }
 
     # Callback if needed, and return the resulting promise.
-    result.then        -> callback null  if callback
-    result.catch (err) -> callback err   if callback
+    result.then        -> callback? null
+    result.catch (err) -> callback? err
     result.timeout globals.COMPUTECONTROLLER_TIMEOUT  unless waitForCompleteDeletion
     return result
 

--- a/client/app/lib/providers/computehelpers.coffee
+++ b/client/app/lib/providers/computehelpers.coffee
@@ -98,11 +98,9 @@ module.exports = class ComputeHelpers
 
     # call deleteSnapshot for all snapshots, and return a promise
     result = result.then (snapshots = []) ->
-      destroyPromises = []
-      snapshots.forEach (snapshot) ->
+      return Promise.all snapshots.map (snapshot) ->
         { machineId, snapshotId } = snapshot
-        destroyPromises.push kloud.deleteSnapshot { machineId, snapshotId }
-      return Promise.all destroyPromises
+        return kloud.deleteSnapshot { machineId, snapshotId }
 
     # Callback if needed, and return the resulting promise.
     result.then        -> callback null  if callback

--- a/client/app/lib/providers/computehelpers.coffee
+++ b/client/app/lib/providers/computehelpers.coffee
@@ -95,7 +95,7 @@ module.exports = class ComputeHelpers
 
     # Fetch snapshots
     result = new Promise (resolve, reject) ->
-      JSnapshot.some {}, {}, (err, snapshots) ->
+      JSnapshot.some {}, { limit: 20 }, (err, snapshots) ->
         if err
         then reject err
         else resolve snapshots

--- a/client/app/lib/providers/computehelpers.coffee
+++ b/client/app/lib/providers/computehelpers.coffee
@@ -44,11 +44,10 @@ module.exports = class ComputeHelpers
     # Add the destroy Snapshots promise
     destroyPromises.push ComputeHelpers.destroyExistingSnapshots waitForCompleteDeletion
 
-    result = Promise
-      .all destroyPromises
+    result = Promise.all destroyPromises
+    result.timeout globals.COMPUTECONTROLLER_TIMEOUT  unless waitForCompleteDeletion
       .then        -> callback? null
       .catch (err) -> callback? err
-    result.timeout globals.COMPUTECONTROLLER_TIMEOUT  unless waitForCompleteDeletion
     return result
 
 
@@ -107,9 +106,9 @@ module.exports = class ComputeHelpers
         return kloud.deleteSnapshot { machineId, snapshotId }
 
     # Callback if needed, and return the resulting promise.
-    result.then        -> callback? null
-    result.catch (err) -> callback? err
     result.timeout globals.COMPUTECONTROLLER_TIMEOUT  unless waitForCompleteDeletion
+      .then        -> callback? null
+      .catch (err) -> callback? err
     return result
 
 

--- a/client/app/lib/providers/computehelpers.coffee
+++ b/client/app/lib/providers/computehelpers.coffee
@@ -46,8 +46,8 @@ module.exports = class ComputeHelpers
 
     result = Promise.all destroyPromises
     result.timeout globals.COMPUTECONTROLLER_TIMEOUT  unless waitForCompleteDeletion
-      .then        -> callback? null
-      .catch (err) -> callback? err
+    result.then        -> callback? null
+    result.catch (err) -> callback? err
     return result
 
 
@@ -107,8 +107,8 @@ module.exports = class ComputeHelpers
 
     # Callback if needed, and return the resulting promise.
     result.timeout globals.COMPUTECONTROLLER_TIMEOUT  unless waitForCompleteDeletion
-      .then        -> callback? null
-      .catch (err) -> callback? err
+    result.then        -> callback? null
+    result.catch (err) -> callback? err
     return result
 
 

--- a/client/app/lib/providers/computehelpers.coffee
+++ b/client/app/lib/providers/computehelpers.coffee
@@ -25,7 +25,7 @@ module.exports = class ComputeHelpers
    *  destroyed.
    * @returns {Promise}
   ###
-  @destroyExistingResources = (callback = kd.noop, waitForCompleteDeletion = no)->
+  @destroyExistingResources = (callback = kd.noop, waitForCompleteDeletion = no) ->
     destroyPromises = []
 
     # Creating a promise here, because @destroyExistingMachines does
@@ -49,7 +49,7 @@ module.exports = class ComputeHelpers
     return result
 
 
-  @destroyExistingMachines = (callback = kd.noop, waitForCompleteDeletion = no)->
+  @destroyExistingMachines = (callback = kd.noop, waitForCompleteDeletion = no) ->
 
     { computeController } = kd.singletons
 

--- a/client/app/lib/providers/computehelpers.coffee
+++ b/client/app/lib/providers/computehelpers.coffee
@@ -36,8 +36,9 @@ module.exports = class ComputeHelpers
     # not return a promise.
     destroyPromises.push new Promise (resolve, reject) ->
       machineCallback = (err) ->
-        return reject err  if err
-        resolve()
+        if err
+        then reject err
+        else resolve()
       ComputeHelpers.destroyExistingMachines waitForCompleteDeletion, machineCallback
 
     # Add the destroy Snapshots promise
@@ -95,8 +96,9 @@ module.exports = class ComputeHelpers
     # Fetch snapshots
     result = new Promise (resolve, reject) ->
       JSnapshot.some {}, {}, (err, snapshots) ->
-        return reject err  if err
-        resolve snapshots
+        if err
+        then reject err
+        else resolve snapshots
 
     # call deleteSnapshot for all snapshots, and return a promise
     result = result.then (snapshots = []) ->

--- a/client/app/lib/providers/environmentsmachinestatemodal.coffee
+++ b/client/app/lib/providers/environmentsmachinestatemodal.coffee
@@ -329,9 +329,8 @@ module.exports = class EnvironmentsMachineStateModal extends BaseModalView
         if destroyVMs
 
           @showBusy "Deleting your VM(s)..."
-          ComputeHelpers.destroyExistingMachines (err)=>
+          ComputeHelpers.destroyExistingMachines yes, (err)=>
             @buildExpiredView subscription, "downgrade"
-          , yes
 
         else
 

--- a/client/app/lib/providers/environmentsmachinestatemodal.coffee
+++ b/client/app/lib/providers/environmentsmachinestatemodal.coffee
@@ -329,7 +329,7 @@ module.exports = class EnvironmentsMachineStateModal extends BaseModalView
         if destroyVMs
 
           @showBusy "Deleting your VM(s)..."
-          ComputeHelpers.destroyExistingMachines yes, (err)=>
+          ComputeHelpers.destroyExistingResources yes, (err)=>
             @buildExpiredView subscription, "downgrade"
 
         else

--- a/workers/social/lib/social/models/computeproviders/computeutils.coffee
+++ b/workers/social/lib/social/models/computeproviders/computeutils.coffee
@@ -342,15 +342,12 @@ fetchUsage = (client, options, callback)->
   JMachine  = require './machine'
   JSnapshot = require './snapshot'
 
-  { r: { user } } = client
+  { r: { user, account } } = client
   { provider }    = options
-  # Need to get the delegate, to get the jAccount
-  # originId, which is apparently what snapshots uses.
-  { connection: { delegate } } = client
 
   selector         = { provider }
   selector.users   = $elemMatch: id: user.getId(), sudo: yes, owner: yes
-  snapshotSelector = { originId: delegate.getId() }
+  snapshotSelector = { originId: account.getId() }
 
   JSnapshot.some snapshotSelector, {}, (err, snapshots = [])->
     return callback err  if err?

--- a/workers/social/lib/social/models/computeproviders/computeutils.coffee
+++ b/workers/social/lib/social/models/computeproviders/computeutils.coffee
@@ -12,6 +12,10 @@ PROVIDERS =
 
 PLANS          = require './plans'
 
+# When adding up the storage usage totals, the DEFAULT_STORAGE_USAGE is
+# the default value to add, if no storage is defined.
+DEFAULT_STORAGE_USAGE = 3
+
 reviveProvisioners = (client, provisioners, callback, revive = no)->
 
   if not revive or not provisioners or provisioners.length is 0
@@ -362,7 +366,7 @@ fetchUsage = (client, options, callback)->
 
       machines.forEach (machine)->
         alwaysOn++  if machine.meta?.alwaysOn
-        storage += machine.meta?.storage_size ? 3
+        storage += machine.meta?.storage_size ? DEFAULT_STORAGE_USAGE
 
       callback null, { total, alwaysOn, storage, snapshots }
 

--- a/workers/social/lib/social/models/computeproviders/plans.coffee
+++ b/workers/social/lib/social/models/computeproviders/plans.coffee
@@ -6,39 +6,46 @@ module.exports       = clone
     storage          : 3
     allowedInstances : ['t2.micro']
     managed          : 1
+    snapshots        : 0
   hobbyist           :
     total            : 1
     alwaysOn         : 1
     storage          : 10
     allowedInstances : ['t2.micro']
     managed          : 2
+    snapshots        : 1
   developer          :
     total            : 3
     alwaysOn         : 1
     storage          : 25
     allowedInstances : ['t2.micro']
     managed          : 3
+    snapshots        : 3
   professional       :
     total            : 5
     alwaysOn         : 2
     storage          : 50
     allowedInstances : ['t2.micro']
     managed          : 5
+    snapshots        : 5
   super              :
     total            : 10
     alwaysOn         : 5
     storage          : 100
     allowedInstances : ['t2.micro']
     managed          : 10
+    snapshots        : 10
   koding             :
     total            : 20
     alwaysOn         : 20
     storage          : 200
     allowedInstances : ['t2.micro', 't2.small', 't2.medium']
     managed          : 20
+    snapshots        : 20
   betatester         :
     total            : 1
     alwaysOn         : 1
     storage          : 3
     allowedInstances : ['t2.micro']
     managed          : 0
+    snapshots        : 0

--- a/workers/social/lib/social/models/payment.coffee
+++ b/workers/social/lib/social/models/payment.coffee
@@ -153,6 +153,8 @@ module.exports = class Payment extends Base
         "GB storage"
       when "total"
         "total vms"
+      when "snapshots"
+        "total snapshots"
 
   canChangePlan = (client, planTitle, callback)->
     fetchPlan client, planTitle, (err, plan)->
@@ -161,7 +163,7 @@ module.exports = class Payment extends Base
       fetchUsage client, (err, usage)->
         return callback err  if err
 
-        for name in ["alwaysOn", "storage", "total"]
+        for name in ["alwaysOn", "storage", "total", "snapshots"]
           if usage[name] > plan[name]
             return callback {
               "message"   : "Sorry, your request to downgrade can't be processed because you are currently using more resources than the plan you are trying to downgrade to allows."


### PR DESCRIPTION
This PR submits two changes:
1. Downgrades from paid to free now automatically remove all snapshots.
2. Downgrades from paid to paid will also check for snapshot usage, and display the difference as needed _(same UX for storage/alwaysOn/totalMachines)_.

Example paid to paid downgrade modal: http://take.ms/t4T6P
Example paid to free downgrade modal: http://take.ms/34Gg7

cc @usirin 
