### PR TITLE
Fixes "Hide staff badge for avatars smaller then 30px"

### DIFF
--- a/client/app/lib/commonviews/avatarviews/avatarview.coffee
+++ b/client/app/lib/commonviews/avatarviews/avatarview.coffee
@@ -126,6 +126,8 @@ module.exports = class AvatarView extends LinkView
     else ""
 
     @cite.setClass flags
+    
+    if width and height < 30 then @cite.hide()
 
     kd.getSingleton("groupsController").ready =>
       {slug} = kd.getSingleton("groupsController").getCurrentGroup()

--- a/client/app/lib/commonviews/avatarviews/avatarview.coffee
+++ b/client/app/lib/commonviews/avatarviews/avatarview.coffee
@@ -126,7 +126,7 @@ module.exports = class AvatarView extends LinkView
     else ""
 
     @cite.setClass flags
-    
+
     if width and height < 30 then @cite.hide()
 
     kd.getSingleton("groupsController").ready =>

--- a/client/app/lib/styl/resurrection.commons.styl
+++ b/client/app/lib/styl/resurrection.commons.styl
@@ -1982,6 +1982,7 @@ footer.main-footer
         rounded         3px
         abs             -1px 0 0 -1px
 
+
 // autocomplete base styling
 
 .kdautocomplete.listview-wrapper.private-message


### PR DESCRIPTION
**The story:** No story

**Notes:** Based on this https://github.com/koding/IDE/pull/401#issuecomment-118112004 We have some places where the avatar size is exactly 30, so that's why I only made it smaller then 30 and not smaller and equal to 30. I believe we need the badge in those places.

eg. here
![screenshot at 15-55-53](https://cloud.githubusercontent.com/assets/1278794/8499474/07408458-219c-11e5-8b87-0ccc579d856f.png)

cc. @sinan 
