### PR TITLE
Fixes "Hide staff badge for avatars smaller then 30px" [fixes #98578722]

### DIFF
--- a/client/app/lib/commonviews/avatarviews/avatarview.coffee
+++ b/client/app/lib/commonviews/avatarviews/avatarview.coffee
@@ -127,7 +127,7 @@ module.exports = class AvatarView extends LinkView
     else ""
 
     @cite.setClass flags
-    
+
     @cite.hide() if width and height < minAvatarSize
 
     kd.getSingleton("groupsController").ready =>

--- a/client/app/lib/commonviews/avatarviews/avatarview.coffee
+++ b/client/app/lib/commonviews/avatarviews/avatarview.coffee
@@ -110,8 +110,9 @@ module.exports = class AvatarView extends LinkView
     height          = width unless height
     avatarURI       = @getGravatarUri()
 
-    width  = width * @dpr
-    height = height * @dpr
+    width         = width * @dpr
+    height        = height * @dpr
+    minAvatarSize = 30 * @dpr 
 
     if profile.avatar?.match regexps.webProtocolRegExp
       resizedAvatar = proxifyUrl profile.avatar, {crop: yes, width, height}
@@ -126,6 +127,8 @@ module.exports = class AvatarView extends LinkView
     else ""
 
     @cite.setClass flags
+    
+    @cite.hide() if width and height < minAvatarSize
 
     kd.getSingleton("groupsController").ready =>
       {slug} = kd.getSingleton("groupsController").getCurrentGroup()

--- a/client/app/lib/commonviews/avatarviews/avatarview.coffee
+++ b/client/app/lib/commonviews/avatarviews/avatarview.coffee
@@ -128,7 +128,7 @@ module.exports = class AvatarView extends LinkView
 
     @cite.setClass flags
 
-    @cite.hide() if width and height < minAvatarSize
+    @cite.hide() if height < minAvatarSize
 
     kd.getSingleton("groupsController").ready =>
       {slug} = kd.getSingleton("groupsController").getCurrentGroup()


### PR DESCRIPTION
**The story:** https://www.pivotaltracker.com/story/show/98578722

**Notes:** Reimplementation (previous PR was borked).

Based on this https://github.com/koding/IDE/pull/401#issuecomment-118112004 We have some places where the avatar size is exactly 30, so that's why I only made it smaller then 30 and not smaller and equal to 30. I believe we need the badge in those places.

eg. here
![screenshot at 15-55-53](https://cloud.githubusercontent.com/assets/1278794/8499474/07408458-219c-11e5-8b87-0ccc579d856f.png)

cc. @sinan
