### PR TITLE
deploy: copy credential repo regardless of config

### DIFF
--- a/scripts/copy-prod-creds.sh
+++ b/scripts/copy-prod-creds.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
 
-if [ "$CONFIG" == "prod" ]; then
-  git clone git@github.com:koding/credential.git
-  cp credential/config/main.prod.coffee config/
-fi
+git clone git@github.com:koding/credential.git
+cp credential/config/main.prod.coffee config/


### PR DESCRIPTION
this fixes bug where validation of config/main.prod.coffee wasn't happening during build time...we delete main.prod.coffee if config isn't "prod" on build and deploy steps, so no leak no sandbox servers
