### PR TITLE
This PR fixes the stack build operation issues on teams

### DIFF
--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -263,7 +263,8 @@ module.exports = class ComputeController extends KDController
 
   findStackFromMachineId: (machineId)->
     for stack in @stacks
-      return stack  if machineId in stack.machines
+      for machine in stack.machines
+        return stack  if machine._id is machineId
 
   findMachineFromQueryString: (queryString)->
 

--- a/go/src/koding/db/models/machine.go
+++ b/go/src/koding/db/models/machine.go
@@ -51,7 +51,7 @@ type Machine struct {
 	Meta          interface{}          `bson:"meta" json:"meta"`
 	Assignee      MachineAssignee      `bson:"assignee" json:"assignee"`
 	UserDeleted   bool                 `bson:"userDeleted" json:"userDeleted"`
-	GeneratedFrom MachineGeneratedFrom `bson:"generatedFrom" json:"generatedFrom"`
+	GeneratedFrom MachineGeneratedFrom `bson:"generatedFrom,omitempty" json:"generatedFrom,omitempty"`
 }
 
 // Owner returns the owner of a machine

--- a/go/src/koding/db/models/machine.go
+++ b/go/src/koding/db/models/machine.go
@@ -28,24 +28,30 @@ type MachineAssignee struct {
 	InProgress bool      `bson:"inProgress" json:"inProgress"`
 }
 
+type MachineGeneratedFrom struct {
+	TemplateId bson.ObjectId `bson:"templateId" json:"templateId"`
+	Revision   string        `bson:"revision" json:"revision"`
+}
+
 type Machine struct {
-	ObjectId    bson.ObjectId   `bson:"_id" json:"_id"`
-	Uid         string          `bson:"uid" json:"uid"`
-	QueryString string          `bson:"queryString" json:"queryString"`
-	IpAddress   string          `bson:"ipAddress" json:"ipAddress"`
-	Domain      string          `bson:"domain" json:"domain"`
-	Provider    string          `bson:"provider" json:"provider"`
-	Label       string          `bson:"label" json:"label"`
-	Slug        string          `bson:"slug" json:"slug"`
-	Provisoners []bson.ObjectId `bson:"provisoners" json:"provisoners"`
-	Credential  string          `bson:"credential" json:"credential"`
-	Users       []MachineUser   `bson:"users" json:"users"`
-	Groups      []MachineGroup  `bson:"groups" json:"groups"`
-	CreatedAt   time.Time       `bson:"createdAt" json:"createdAt" `
-	Status      MachineStatus   `bson:"status" json:"status"`
-	Meta        interface{}     `bson:"meta" json:"meta"`
-	Assignee    MachineAssignee `bson:"assignee" json:"assignee"`
-	UserDeleted bool            `bson:"userDeleted" json:"userDeleted"`
+	ObjectId      bson.ObjectId        `bson:"_id" json:"_id"`
+	Uid           string               `bson:"uid" json:"uid"`
+	QueryString   string               `bson:"queryString" json:"queryString"`
+	IpAddress     string               `bson:"ipAddress" json:"ipAddress"`
+	Domain        string               `bson:"domain" json:"domain"`
+	Provider      string               `bson:"provider" json:"provider"`
+	Label         string               `bson:"label" json:"label"`
+	Slug          string               `bson:"slug" json:"slug"`
+	Provisoners   []bson.ObjectId      `bson:"provisoners" json:"provisoners"`
+	Credential    string               `bson:"credential" json:"credential"`
+	Users         []MachineUser        `bson:"users" json:"users"`
+	Groups        []MachineGroup       `bson:"groups" json:"groups"`
+	CreatedAt     time.Time            `bson:"createdAt" json:"createdAt" `
+	Status        MachineStatus        `bson:"status" json:"status"`
+	Meta          interface{}          `bson:"meta" json:"meta"`
+	Assignee      MachineAssignee      `bson:"assignee" json:"assignee"`
+	UserDeleted   bool                 `bson:"userDeleted" json:"userDeleted"`
+	GeneratedFrom MachineGeneratedFrom `bson:"generatedFrom" json:"generatedFrom"`
 }
 
 // Owner returns the owner of a machine


### PR DESCRIPTION
Since we were using the outdated schema on the go-webserver's Machine model (aka `JMachine`) it was swallowing outdated fields (like `generatedFrom`) so client side was ending up with corrupted `JMachine` which was causing the use `build` method instead `buildStack` for stack building. And on the other hand there was another issue with the `ComputeController.findStackFromMachineId` helper, which is fixed as well.
