### PR TITLE
Socialapi: do not add users to PM channels

### DIFF
--- a/go/src/socialapi/models/privatechannelrequest.go
+++ b/go/src/socialapi/models/privatechannelrequest.go
@@ -65,16 +65,11 @@ func (p *PrivateChannelRequest) Create() (*ChannelContainer, error) {
 		return nil, err
 	}
 
-	// add participants to tha channel
+	// add participants to the channel
 	for _, participantId := range participantIds {
-		// added accounts should be a member of parent channel
-		isParticipant, err := groupChannel.IsParticipant(participantId)
-		if err != nil {
+		// users should be in regarding group channel
+		if err := checkForGroupParticipation(groupChannel, participantId); err != nil {
 			return nil, err
-		}
-
-		if !isParticipant {
-			return nil, ErrCannotOpenChannel
 		}
 
 		cp, err := c.AddParticipant(participantId)
@@ -96,6 +91,24 @@ func (p *PrivateChannelRequest) Create() (*ChannelContainer, error) {
 	}
 
 	return p.buildInitContainer(c, participantIds)
+}
+
+func checkForGroupParticipation(groupChannel *Channel, participantId int64) error {
+	// everyone is a member of koding group
+	if groupChannel.GroupName == Channel_KODING_NAME {
+		return nil
+	}
+
+	isParticipant, err := groupChannel.IsParticipant(participantId)
+	if err != nil {
+		return nil
+	}
+
+	if !isParticipant {
+		return ErrCannotOpenChannel
+	}
+
+	return nil
 }
 
 func (p *PrivateChannelRequest) buildInitContainer(c *Channel, participantIds []int64) (*ChannelContainer, error) {

--- a/go/src/socialapi/models/privatechannelrequest.go
+++ b/go/src/socialapi/models/privatechannelrequest.go
@@ -60,8 +60,23 @@ func (p *PrivateChannelRequest) Create() (*ChannelContainer, error) {
 		return nil, err
 	}
 
+	groupChannel, err := Cache.Channel.ByGroupName(c.GroupName)
+	if err != nil {
+		return nil, err
+	}
+
 	// add participants to tha channel
 	for _, participantId := range participantIds {
+		// added accounts should be a member of parent channel
+		isParticipant, err := groupChannel.IsParticipant(participantId)
+		if err != nil {
+			return nil, err
+		}
+
+		if !isParticipant {
+			return nil, ErrCannotOpenChannel
+		}
+
 		cp, err := c.AddParticipant(participantId)
 		if err != nil {
 			continue

--- a/go/src/socialapi/tests/channel_participant_test.go
+++ b/go/src/socialapi/tests/channel_participant_test.go
@@ -56,9 +56,34 @@ func TestChannelParticipantOperations(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(forthAccount, ShouldNotBeNil)
 
-			CreatePrivateChannelUser("devrim")
+			devrim, err := models.CreateAccountInBothDbsWithNick("devrim")
+			So(err, ShouldBeNil)
+			So(devrim, ShouldNotBeNil)
 
-			groupName := "testgroup" + strconv.FormatInt(rand.Int63(), 10)
+			groupName := models.RandomGroupName()
+
+			ses, err := models.FetchOrCreateSession(ownerAccount.Nick, groupName)
+			So(err, ShouldBeNil)
+			So(ses, ShouldNotBeNil)
+
+			groupChannel, err := rest.CreateChannelByGroupNameAndType(
+				ownerAccount.Id,
+				groupName,
+				models.Channel_TYPE_GROUP,
+				ses.ClientId,
+			)
+			tests.ResultedWithNoErrorCheck(groupChannel, err)
+			_, err = groupChannel.AddParticipant(secondAccount.Id)
+			So(err, ShouldBeNil)
+
+			_, err = groupChannel.AddParticipant(thirdAccount.Id)
+			So(err, ShouldBeNil)
+
+			_, err = groupChannel.AddParticipant(forthAccount.Id)
+			So(err, ShouldBeNil)
+
+			_, err = groupChannel.AddParticipant(devrim.Id)
+			So(err, ShouldBeNil)
 
 			pmr := models.PrivateChannelRequest{}
 

--- a/go/src/socialapi/tests/channel_participant_test.go
+++ b/go/src/socialapi/tests/channel_participant_test.go
@@ -2,11 +2,10 @@ package main
 
 import (
 	"koding/db/mongodb/modelhelper"
-	"math/rand"
 	"socialapi/config"
 	"socialapi/models"
 	"socialapi/rest"
-	"strconv"
+	"socialapi/workers/common/tests"
 	"strings"
 	"testing"
 	"time"

--- a/go/src/socialapi/tests/collaboration_channel_test.go
+++ b/go/src/socialapi/tests/collaboration_channel_test.go
@@ -93,11 +93,26 @@ func TestCollaborationChannels(t *testing.T) {
 		})
 
 		Convey("if group name is nil, should not fail to create collaboration channel", func() {
+			ses, err := models.FetchOrCreateSession(sinan.Nick, "koding")
+			So(err, ShouldBeNil)
+			So(ses, ShouldNotBeNil)
+
+			groupChannel, err := rest.CreateChannelByGroupNameAndType(
+				sinan.Id,
+				"koding",
+				models.Channel_TYPE_GROUP,
+				ses.ClientId,
+			)
+			tests.ResultedWithNoErrorCheck(groupChannel, err)
+			groupChannel.AddParticipant(devrim.Id)  // ignore error
+			groupChannel.AddParticipant(account.Id) // ignore error
+			groupChannel.AddParticipant(sinan.Id)   // ignore error
+
 			pmr := models.PrivateChannelRequest{}
 			pmr.AccountId = account.Id
-			pmr.Body = "this is a body for private message @chris @devrim @sinan"
+			pmr.Body = "this is a body for private message @devrim @sinan"
 			pmr.GroupName = ""
-			pmr.Recipients = []string{"chris", "devrim", "sinan"}
+			pmr.Recipients = []string{"devrim", "sinan"}
 			pmr.TypeConstant = models.Channel_TYPE_COLLABORATION
 
 			cmc, err := rest.SendPrivateChannelRequest(pmr)
@@ -153,9 +168,9 @@ func TestCollaborationChannels(t *testing.T) {
 		Convey("send response should have participant status data", func() {
 			pmr := models.PrivateChannelRequest{}
 			pmr.AccountId = account.Id
-			pmr.Body = "this is a body for private message @chris @devrim @sinan"
+			pmr.Body = "this is a body for private message @devrim @sinan"
 			pmr.GroupName = groupName
-			pmr.Recipients = []string{"chris", "devrim", "sinan"}
+			pmr.Recipients = []string{"devrim", "sinan"}
 			pmr.TypeConstant = models.Channel_TYPE_COLLABORATION
 
 			cmc, err := rest.SendPrivateChannelRequest(pmr)
@@ -181,9 +196,9 @@ func TestCollaborationChannels(t *testing.T) {
 		Convey("send response should have participant preview", func() {
 			pmr := models.PrivateChannelRequest{}
 			pmr.AccountId = account.Id
-			pmr.Body = "this is @chris a body for @devrim private message"
+			pmr.Body = "this is @sinan a body for @devrim private message"
 			pmr.GroupName = groupName
-			pmr.Recipients = []string{"chris", "devrim"}
+			pmr.Recipients = []string{"sinan", "devrim"}
 			pmr.TypeConstant = models.Channel_TYPE_COLLABORATION
 
 			cmc, err := rest.SendPrivateChannelRequest(pmr)
@@ -193,12 +208,12 @@ func TestCollaborationChannels(t *testing.T) {
 		})
 
 		Convey("send response should have last Message", func() {
-			body := "hi @devrim this is a body for private message also for @chris"
+			body := "hi @devrim this is a body for private message also for @sinan"
 			pmr := models.PrivateChannelRequest{}
 			pmr.AccountId = account.Id
 			pmr.Body = body
 			pmr.GroupName = groupName
-			pmr.Recipients = []string{"chris", "devrim"}
+			pmr.Recipients = []string{"sinan", "devrim"}
 			pmr.TypeConstant = models.Channel_TYPE_COLLABORATION
 
 			cmc, err := rest.SendPrivateChannelRequest(pmr)
@@ -208,16 +223,16 @@ func TestCollaborationChannels(t *testing.T) {
 		})
 
 		Convey("channel messages should be listed by all recipients", func() {
-			// use a different group name
-			// in order not to interfere with another request
-			groupName := "testgroup" + strconv.FormatInt(rand.Int63(), 10)
+			// // use a different group name
+			// // in order not to interfere with another request
+			// groupName := "testgroup" + strconv.FormatInt(rand.Int63(), 10)
 
-			body := "hi @devrim this is a body for private message also for @chris"
+			body := "hi @devrim this is a body for private message also for @sinan"
 			pmr := models.PrivateChannelRequest{}
 			pmr.AccountId = account.Id
 			pmr.Body = body
 			pmr.GroupName = groupName
-			pmr.Recipients = []string{"chris", "devrim"}
+			pmr.Recipients = []string{"sinan", "devrim"}
 			pmr.TypeConstant = models.Channel_TYPE_COLLABORATION
 
 			cmc, err := rest.SendPrivateChannelRequest(pmr)
@@ -246,13 +261,11 @@ func TestCollaborationChannels(t *testing.T) {
 		})
 
 		Convey("user should be able to search collaboration channels via purpose field", func() {
-			groupName := "testgroup" + strconv.FormatInt(rand.Int63(), 10)
-
 			pmr := models.PrivateChannelRequest{}
 			pmr.AccountId = account.Id
 			pmr.Body = "search collaboration channel"
 			pmr.GroupName = groupName
-			pmr.Recipients = []string{"chris", "devrim"}
+			pmr.Recipients = []string{"sinan", "devrim"}
 			pmr.Purpose = "test me up"
 			pmr.TypeConstant = models.Channel_TYPE_COLLABORATION
 
@@ -284,23 +297,42 @@ func TestCollaborationChannels(t *testing.T) {
 		})
 
 		Convey("user join activity should be listed by recipients", func() {
-			groupName := "testgroup" + strconv.FormatInt(rand.Int63(), 10)
+			groupName := models.RandomGroupName()
+
+			// cretae admin user
+			account, err := models.CreateAccountInBothDbs()
+			tests.ResultedWithNoErrorCheck(account, err)
+			// fetch admin's session
+			ses, err := models.FetchOrCreateSession(account.Nick, groupName)
+			So(err, ShouldBeNil)
+			So(ses, ShouldNotBeNil)
+
+			groupChannel, err := rest.CreateChannelByGroupNameAndType(
+				account.Id,
+				groupName,
+				models.Channel_TYPE_GROUP,
+				ses.ClientId,
+			)
+			tests.ResultedWithNoErrorCheck(groupChannel, err)
+
+			_, err = groupChannel.AddParticipant(devrim.Id)
+			So(err, ShouldBeNil)
+			_, err = groupChannel.AddParticipant(sinan.Id)
+			So(err, ShouldBeNil)
+			_, err = groupChannel.AddParticipant(recipient.Id)
+			So(err, ShouldBeNil)
 
 			pmr := models.PrivateChannelRequest{}
 			pmr.AccountId = account.Id
 			pmr.Body = "test collaboration channel participants"
 			pmr.GroupName = groupName
-			pmr.Recipients = []string{"chris", "devrim"}
+			pmr.Recipients = []string{"sinan", "devrim"}
 			pmr.TypeConstant = models.Channel_TYPE_COLLABORATION
 
 			cc, err := rest.SendPrivateChannelRequest(pmr)
 
 			So(err, ShouldBeNil)
 			So(cc, ShouldNotBeNil)
-
-			ses, err := models.FetchOrCreateSession(account.Nick, groupName)
-			So(err, ShouldBeNil)
-			So(ses, ShouldNotBeNil)
 
 			history, err := rest.GetHistory(
 				cc.Channel.Id,
@@ -335,7 +367,7 @@ func TestCollaborationChannels(t *testing.T) {
 			So(history.MessageList[0].Message.Payload, ShouldNotBeNil)
 			addedBy, ok := history.MessageList[0].Message.Payload["addedBy"]
 			So(ok, ShouldBeTrue)
-			So(*addedBy, ShouldEqual, account.OldId)
+			So(*addedBy, ShouldEqual, account.Nick)
 
 			systemType, ok := history.MessageList[0].Message.Payload["systemType"]
 			So(ok, ShouldBeTrue)
@@ -360,13 +392,11 @@ func TestCollaborationChannels(t *testing.T) {
 		})
 
 		Convey("user should not be able to edit join messages", func() {
-			groupName := "testgroup" + strconv.FormatInt(rand.Int63(), 10)
-
 			pmr := models.PrivateChannelRequest{}
 			pmr.AccountId = account.Id
 			pmr.Body = "test collaboration channel participants again"
 			pmr.GroupName = groupName
-			pmr.Recipients = []string{"chris"}
+			pmr.Recipients = []string{"devrim"}
 			pmr.TypeConstant = models.Channel_TYPE_COLLABORATION
 
 			cc, err := rest.SendPrivateChannelRequest(pmr)
@@ -400,13 +430,11 @@ func TestCollaborationChannels(t *testing.T) {
 		})
 
 		Convey("first chat message should include initial participants", func() {
-			groupName := "testgroup" + strconv.FormatInt(rand.Int63(), 10)
-
 			pmr := models.PrivateChannelRequest{}
 			pmr.AccountId = account.Id
 			pmr.Body = "test initial participation message"
 			pmr.GroupName = groupName
-			pmr.Recipients = []string{"chris", "devrim"}
+			pmr.Recipients = []string{"sinan", "devrim"}
 			pmr.TypeConstant = models.Channel_TYPE_COLLABORATION
 
 			cc, err := rest.SendPrivateChannelRequest(pmr)
@@ -443,7 +471,7 @@ func TestCollaborationChannels(t *testing.T) {
 			err = json.Unmarshal([]byte(*initialParticipants), &participants)
 			So(err, ShouldBeNil)
 			So(len(participants), ShouldEqual, 2)
-			So(participants, ShouldContain, "chris")
+			So(participants, ShouldContain, "devrim")
 			// So(*addedBy, ShouldEqual, account.OldId)
 
 		})

--- a/go/src/socialapi/tests/private_channel_test.go
+++ b/go/src/socialapi/tests/private_channel_test.go
@@ -197,10 +197,6 @@ func TestPrivateMesssages(t *testing.T) {
 		})
 
 		Convey("private message should be listed by all recipients", func() {
-			// use a different group name
-			// in order not to interfere with another request
-			// groupName := "testgroup" + strconv.FormatInt(rand.Int63(), 10)
-
 			body := "hi @devrim this is a body for private message also for @sinan"
 			pmr := models.PrivateChannelRequest{}
 			pmr.AccountId = account.Id

--- a/go/src/socialapi/tests/private_channel_test.go
+++ b/go/src/socialapi/tests/private_channel_test.go
@@ -52,6 +52,7 @@ func TestPrivateMesssages(t *testing.T) {
 			ses.ClientId,
 		)
 		tests.ResultedWithNoErrorCheck(groupChannel, err)
+
 		recipient := models.NewAccount()
 		recipient.OldId = AccountOldId2.Hex()
 		recipient, err = rest.CreateAccount(recipient)

--- a/go/src/socialapi/tests/private_channel_test.go
+++ b/go/src/socialapi/tests/private_channel_test.go
@@ -2,43 +2,18 @@ package main
 
 import (
 	"encoding/json"
-	mongomodels "koding/db/models"
 	"koding/db/mongodb/modelhelper"
-	"math/rand"
 	"socialapi/config"
 	"socialapi/models"
 	"socialapi/request"
 	"socialapi/rest"
-	"strconv"
+	"socialapi/workers/common/tests"
 	"testing"
 
 	"github.com/koding/runner"
-	"labix.org/v2/mgo/bson"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
-
-func CreatePrivateChannelUser(nickname string) {
-	_, err := modelhelper.GetAccount(nickname)
-	if err == nil {
-		return
-	}
-
-	if err != modelhelper.ErrNotFound {
-		panic(err)
-	}
-
-	acc := new(mongomodels.Account)
-	acc.Id = bson.NewObjectId()
-	acc.Profile.Nickname = nickname
-
-	modelhelper.CreateAccount(acc)
-
-	a := models.NewAccount()
-	a.Nick = nickname
-	a.OldId = acc.Id.Hex()
-	a.Create()
-}
 
 func TestPrivateMesssages(t *testing.T) {
 	r := runner.New("test")
@@ -51,17 +26,32 @@ func TestPrivateMesssages(t *testing.T) {
 	modelhelper.Initialize(appConfig.Mongo)
 	defer modelhelper.Close()
 
-	CreatePrivateChannelUser("devrim")
-	CreatePrivateChannelUser("sinan")
-	CreatePrivateChannelUser("chris")
-
 	Convey("while testing private channels", t, func() {
-		account := models.NewAccount()
-		account.OldId = AccountOldId.Hex()
-		account, err := rest.CreateAccount(account)
-		So(err, ShouldBeNil)
-		So(account, ShouldNotBeNil)
 
+		devrim, err := models.CreateAccountInBothDbsWithNick("devrim")
+		So(err, ShouldBeNil)
+		So(devrim, ShouldNotBeNil)
+		sinan, err := models.CreateAccountInBothDbsWithNick("sinan")
+		So(err, ShouldBeNil)
+		So(sinan, ShouldNotBeNil)
+
+		groupName := models.RandomGroupName()
+
+		// cretae admin user
+		account, err := models.CreateAccountInBothDbs()
+		tests.ResultedWithNoErrorCheck(account, err)
+		// fetch admin's session
+		ses, err := models.FetchOrCreateSession(account.Nick, groupName)
+		So(err, ShouldBeNil)
+		So(ses, ShouldNotBeNil)
+
+		groupChannel, err := rest.CreateChannelByGroupNameAndType(
+			account.Id,
+			groupName,
+			models.Channel_TYPE_GROUP,
+			ses.ClientId,
+		)
+		tests.ResultedWithNoErrorCheck(groupChannel, err)
 		recipient := models.NewAccount()
 		recipient.OldId = AccountOldId2.Hex()
 		recipient, err = rest.CreateAccount(recipient)
@@ -74,14 +64,28 @@ func TestPrivateMesssages(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(recipient2, ShouldNotBeNil)
 
-		groupName := "testgroup" + strconv.FormatInt(rand.Int63(), 10)
+		Convey("participants should be a member of parent group", func() {
+			pmr := models.PrivateChannelRequest{}
+			pmr.AccountId = account.Id
+			pmr.Body = "this is a body message for private message @devrim @sinan"
+			pmr.GroupName = groupName
+			pmr.Recipients = []string{"devrim", "sinan"}
+			_, err := rest.SendPrivateChannelRequest(pmr)
+			So(err, ShouldNotBeNil)
+		})
+
+		_, err = groupChannel.AddParticipant(sinan.Id)
+		So(err, ShouldBeNil)
+
+		_, err = groupChannel.AddParticipant(devrim.Id)
+		So(err, ShouldBeNil)
 
 		Convey("one can send private message to one person", func() {
 			pmr := models.PrivateChannelRequest{}
 			pmr.AccountId = account.Id
-			pmr.Body = "this is a body message for private message @chris @devrim @sinan"
+			pmr.Body = "this is a body message for private message @devrim @sinan"
 			pmr.GroupName = groupName
-			pmr.Recipients = []string{"chris", "devrim", "sinan"}
+			pmr.Recipients = []string{"devrim", "sinan"}
 			cmc, err := rest.SendPrivateChannelRequest(pmr)
 			So(err, ShouldBeNil)
 			So(cmc, ShouldNotBeNil)
@@ -99,17 +103,6 @@ func TestPrivateMesssages(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(cmc, ShouldNotBeNil)
 
-		})
-		Convey("if group name is nil, should not fail to create PM", func() {
-			pmr := models.PrivateChannelRequest{}
-			pmr.AccountId = account.Id
-			pmr.Body = "this is a body for private message @chris @devrim @sinan"
-			pmr.GroupName = ""
-			pmr.Recipients = []string{"chris", "devrim", "sinan"}
-
-			cmc, err := rest.SendPrivateChannelRequest(pmr)
-			So(err, ShouldBeNil)
-			So(cmc, ShouldNotBeNil)
 		})
 
 		Convey("if sender is not defined should fail to create PM", func() {
@@ -155,9 +148,9 @@ func TestPrivateMesssages(t *testing.T) {
 		Convey("private message response should have participant status data", func() {
 			pmr := models.PrivateChannelRequest{}
 			pmr.AccountId = account.Id
-			pmr.Body = "this is a body for private message @chris @devrim @sinan"
+			pmr.Body = "this is a body for private message @devrim @sinan"
 			pmr.GroupName = groupName
-			pmr.Recipients = []string{"chris", "devrim", "sinan"}
+			pmr.Recipients = []string{"devrim", "sinan"}
 
 			cmc, err := rest.SendPrivateChannelRequest(pmr)
 			So(err, ShouldBeNil)
@@ -180,9 +173,9 @@ func TestPrivateMesssages(t *testing.T) {
 		Convey("private message response should have participant preview", func() {
 			pmr := models.PrivateChannelRequest{}
 			pmr.AccountId = account.Id
-			pmr.Body = "this is @chris a body for @devrim private message"
+			pmr.Body = "this is @sinan a body for @devrim private message"
 			pmr.GroupName = groupName
-			pmr.Recipients = []string{"chris", "devrim"}
+			pmr.Recipients = []string{"sinan", "devrim"}
 			cmc, err := rest.SendPrivateChannelRequest(pmr)
 			So(err, ShouldBeNil)
 			So(cmc, ShouldNotBeNil)
@@ -190,12 +183,12 @@ func TestPrivateMesssages(t *testing.T) {
 		})
 
 		Convey("private message response should have last Message", func() {
-			body := "hi @devrim this is a body for private message also for @chris"
+			body := "hi @devrim this is a body for private message also for @sinan"
 			pmr := models.PrivateChannelRequest{}
 			pmr.AccountId = account.Id
 			pmr.Body = body
 			pmr.GroupName = groupName
-			pmr.Recipients = []string{"chris", "devrim"}
+			pmr.Recipients = []string{"sinan", "devrim"}
 			cmc, err := rest.SendPrivateChannelRequest(pmr)
 			So(err, ShouldBeNil)
 			So(cmc, ShouldNotBeNil)
@@ -205,14 +198,14 @@ func TestPrivateMesssages(t *testing.T) {
 		Convey("private message should be listed by all recipients", func() {
 			// use a different group name
 			// in order not to interfere with another request
-			groupName := "testgroup" + strconv.FormatInt(rand.Int63(), 10)
+			// groupName := "testgroup" + strconv.FormatInt(rand.Int63(), 10)
 
-			body := "hi @devrim this is a body for private message also for @chris"
+			body := "hi @devrim this is a body for private message also for @sinan"
 			pmr := models.PrivateChannelRequest{}
 			pmr.AccountId = account.Id
 			pmr.Body = body
 			pmr.GroupName = groupName
-			pmr.Recipients = []string{"chris", "devrim"}
+			pmr.Recipients = []string{"sinan", "devrim"}
 			cmc, err := rest.SendPrivateChannelRequest(pmr)
 			So(err, ShouldBeNil)
 			So(cmc, ShouldNotBeNil)
@@ -233,13 +226,11 @@ func TestPrivateMesssages(t *testing.T) {
 		})
 
 		Convey("user should be able to search private messages via purpose field", func() {
-			groupName := "testgroup" + strconv.FormatInt(rand.Int63(), 10)
-
 			pmr := models.PrivateChannelRequest{}
 			pmr.AccountId = account.Id
 			pmr.Body = "search private messages"
 			pmr.GroupName = groupName
-			pmr.Recipients = []string{"chris", "devrim"}
+			pmr.Recipients = []string{"sinan", "devrim"}
 			pmr.Purpose = "test me up"
 
 			cmc, err := rest.SendPrivateChannelRequest(pmr)
@@ -265,22 +256,41 @@ func TestPrivateMesssages(t *testing.T) {
 		})
 
 		Convey("user join activity should be listed by recipients", func() {
-			groupName := "testgroup" + strconv.FormatInt(rand.Int63(), 10)
+			groupName := models.RandomGroupName()
+
+			// cretae admin user
+			account, err := models.CreateAccountInBothDbs()
+			tests.ResultedWithNoErrorCheck(account, err)
+			// fetch admin's session
+			ses, err := models.FetchOrCreateSession(account.Nick, groupName)
+			So(err, ShouldBeNil)
+			So(ses, ShouldNotBeNil)
+
+			groupChannel, err := rest.CreateChannelByGroupNameAndType(
+				account.Id,
+				groupName,
+				models.Channel_TYPE_GROUP,
+				ses.ClientId,
+			)
+			tests.ResultedWithNoErrorCheck(groupChannel, err)
+
+			_, err = groupChannel.AddParticipant(devrim.Id)
+			So(err, ShouldBeNil)
+			_, err = groupChannel.AddParticipant(sinan.Id)
+			So(err, ShouldBeNil)
+			_, err = groupChannel.AddParticipant(recipient.Id)
+			So(err, ShouldBeNil)
 
 			pmr := models.PrivateChannelRequest{}
 			pmr.AccountId = account.Id
 			pmr.Body = "test private message participants"
 			pmr.GroupName = groupName
-			pmr.Recipients = []string{"chris", "devrim"}
+			pmr.Recipients = []string{"sinan", "devrim"}
 
 			cc, err := rest.SendPrivateChannelRequest(pmr)
 
 			So(err, ShouldBeNil)
 			So(cc, ShouldNotBeNil)
-
-			ses, err := models.FetchOrCreateSession(account.Nick, groupName)
-			So(err, ShouldBeNil)
-			So(ses, ShouldNotBeNil)
 
 			history, err := rest.GetHistory(
 				cc.Channel.Id,
@@ -315,7 +325,7 @@ func TestPrivateMesssages(t *testing.T) {
 			So(history.MessageList[0].Message.Payload, ShouldNotBeNil)
 			addedBy, ok := history.MessageList[0].Message.Payload["addedBy"]
 			So(ok, ShouldBeTrue)
-			So(*addedBy, ShouldEqual, account.OldId)
+			So(*addedBy, ShouldEqual, account.Nick)
 
 			systemType, ok := history.MessageList[0].Message.Payload["systemType"]
 			So(ok, ShouldBeTrue)
@@ -340,13 +350,11 @@ func TestPrivateMesssages(t *testing.T) {
 		})
 
 		Convey("user should not be able to edit join messages", func() {
-			groupName := "testgroup" + strconv.FormatInt(rand.Int63(), 10)
-
 			pmr := models.PrivateChannelRequest{}
 			pmr.AccountId = account.Id
 			pmr.Body = "test private message participants again"
 			pmr.GroupName = groupName
-			pmr.Recipients = []string{"chris"}
+			pmr.Recipients = []string{"devrim"}
 
 			cc, err := rest.SendPrivateChannelRequest(pmr)
 			So(err, ShouldBeNil)
@@ -379,13 +387,11 @@ func TestPrivateMesssages(t *testing.T) {
 		})
 
 		Convey("first chat message should include initial participants", func() {
-			groupName := "testgroup" + strconv.FormatInt(rand.Int63(), 10)
-
 			pmr := models.PrivateChannelRequest{}
 			pmr.AccountId = account.Id
 			pmr.Body = "test initial participation message"
 			pmr.GroupName = groupName
-			pmr.Recipients = []string{"chris", "devrim"}
+			pmr.Recipients = []string{"sinan", "devrim"}
 
 			cc, err := rest.SendPrivateChannelRequest(pmr)
 			So(err, ShouldBeNil)
@@ -421,7 +427,7 @@ func TestPrivateMesssages(t *testing.T) {
 			err = json.Unmarshal([]byte(*initialParticipants), &participants)
 			So(err, ShouldBeNil)
 			So(len(participants), ShouldEqual, 2)
-			So(participants, ShouldContain, "chris")
+			So(participants, ShouldContain, "devrim")
 			// So(*addedBy, ShouldEqual, account.OldId)
 
 		})

--- a/go/src/socialapi/workers/trollmode/trollmode_test.go
+++ b/go/src/socialapi/workers/trollmode/trollmode_test.go
@@ -86,6 +86,19 @@ func TestMarkedAsTroll(t *testing.T) {
 		)
 		tests.ResultedWithNoErrorCheck(groupChannel, err)
 
+		sinan := models.NewAccount()
+		err = sinan.ByNick("sinan")
+		So(err, ShouldBeNil)
+
+		_, err = groupChannel.AddParticipant(sinan.Id)
+		So(err, ShouldBeNil)
+
+		_, err = groupChannel.AddParticipant(trollUser.Id)
+		So(err, ShouldBeNil)
+
+		_, err = groupChannel.AddParticipant(normalUser.Id)
+		So(err, ShouldBeNil)
+
 		controller := NewController(r.Log)
 
 		Convey("err should be nil", func() {

--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -1046,7 +1046,7 @@ module.exports = class JUser extends jraphical.Module
     if not firstName or firstName is "" then firstName = username
     if not lastName then lastName = ""
 
-    # only unreigstered accounts can be "converted"
+    # only unregistered accounts can be "converted"
     if account.type is "registered"
       return callback new KodingError "This account is already registered."
 


### PR DESCRIPTION
if they are not a member of parent group channel
