### PR TITLE
kloud: add user-data support for stacks

### DIFF
--- a/go/src/koding/kites/kloud/kloud/apply.go
+++ b/go/src/koding/kites/kloud/kloud/apply.go
@@ -263,6 +263,9 @@ func apply(ctx context.Context, username, stackId string) error {
 		}
 	}
 
+	sess.Log.Debug("Stack template before injecting Koding data:")
+	sess.Log.Debug(stack.Template)
+
 	buildData, err := injectKodingData(ctx, stack.Template, username, creds)
 	if err != nil {
 		return err
@@ -295,8 +298,9 @@ func apply(ctx context.Context, username, stackId string) error {
 		}
 	}()
 
-	sess.Log.Debug("Calling terraform.apply method with context:")
+	sess.Log.Debug("Final stack template. Calling terraform.apply method:")
 	sess.Log.Debug(stack.Template)
+
 	state, err := tfKite.Apply(&tf.TerraformRequest{
 		Content:   stack.Template,
 		ContentID: username + "-" + stackId,

--- a/go/src/koding/kites/kloud/kloud/terraformutils.go
+++ b/go/src/koding/kites/kloud/kloud/terraformutils.go
@@ -216,13 +216,21 @@ func injectKodingData(ctx context.Context, content, username string, creds *terr
 		}
 
 		kiteId := kiteUUID.String()
-
-		userdata, err := sess.Userdata.Create(&userdata.CloudInitConfig{
+		userCfg := &userdata.CloudInitConfig{
 			Username: username,
 			Groups:   []string{"sudo"},
 			Hostname: username, // no typo here. hostname = username
 			KiteId:   kiteId,
-		})
+		}
+
+		// prepend custom script if available
+		if c, ok := instance["user_data"]; ok {
+			if customCMD, ok := c.(string); ok {
+				userCfg.CustomCMD = customCMD
+			}
+		}
+
+		userdata, err := sess.Userdata.Create(userCfg)
 		if err != nil {
 			return nil, err
 		}

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -105,7 +105,8 @@ var (
             "example": {
 				"count": %d,
                 "instance_type": "t2.micro",
-                "ami": "ami-936d9d93"
+                "ami": "ami-936d9d93",
+                "user_data": "sudo apt-get install sl -y"
             }
         }
     }

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -106,7 +106,7 @@ var (
 				"count": %d,
                 "instance_type": "t2.micro",
                 "ami": "ami-936d9d93",
-                "user_data": "sudo apt-get install sl -y"
+                "user_data": "sudo apt-get install sl -y\ntouch /tmp/arslan.txt"
             }
         }
     }
@@ -379,6 +379,9 @@ func TestTerraformStack(t *testing.T) {
 	if err := listenEvent(eArgs, machinestate.Running, remote); err != nil {
 		t.Error(err)
 	}
+
+	fmt.Printf("\n=== Test is stopped for 5 minutes, now is your time to debug FATIH! ===\n\n")
+	time.Sleep(time.Minute * 5)
 
 	destroyArgs := &kloud.TerraformApplyRequest{
 		StackId: userData.StackId,

--- a/go/src/koding/kites/kloud/userdata/userdata.go
+++ b/go/src/koding/kites/kloud/userdata/userdata.go
@@ -82,7 +82,14 @@ var (
 				return ""
 			}
 
-			return fmt.Sprintf("  - '%s'\n", strings.TrimSpace(cmd))
+			lines := strings.Split(cmd, "\n")
+			fmt.Printf("lines = %+v\n", lines)
+			c := "  - |\n"
+			for _, line := range lines {
+				c += fmt.Sprintf("    %s\n", line)
+			}
+			fmt.Printf("c = %+v\n", c)
+			return c
 		},
 	}
 

--- a/go/src/koding/kites/kloud/userdata/userdata.go
+++ b/go/src/koding/kites/kloud/userdata/userdata.go
@@ -47,6 +47,12 @@ type CloudInitConfig struct {
 	// can't be accessed from the instance
 	DisableEC2MetaData bool
 
+	// CustomCMD is appended to the user_data if given to be executed. It
+	// will be passed as a plain string to the `runcmd` directive, so what this
+	// means it the whole content wil be saves to a file by cloud-init and then
+	// executed with `sh`
+	CustomCMD string
+
 	// KodingSetup setups koding specific changes, such as Apache config,
 	// custom bashrc, custom directories... These files are only available in
 	// the KodingAMI
@@ -71,6 +77,13 @@ var (
 			return c
 		},
 		"join": strings.Join,
+		"custom_cmd": func(cmd string) string {
+			if cmd == "" {
+				return ""
+			}
+
+			return fmt.Sprintf("  - '%s'\n", strings.TrimSpace(cmd))
+		},
 	}
 
 	cloudInitTemplate = template.Must(template.New("cloudinit").Funcs(funcMap).Parse(cloudInit))
@@ -182,6 +195,7 @@ runcmd:
   - service apache2 restart
 {{end}}
 
+{{ custom_cmd .CustomCMD }}
 
 final_message: "All done!"
 `


### PR DESCRIPTION
This PR enables us to pass a custom script via the `user_data` field. An example template would be:

```
{
    "provider": {
        "aws": {
            "access_key": "${var.access_key}",
            "secret_key": "${var.secret_key}",
            "region": "${var.region}"
        }
    },
    "resource": {
        "aws_instance": {
            "example": {
                "count": %d,
                "instance_type": "t2.micro",
                "ami": "ami-936d9d93",
                "user_data": "sudo apt-get install sl -y\ntouch /tmp/arslan.txt"
            }
        }
    }
}
```
