### PR TITLE
apply: use default AMI as fallback if empty image is passed

### DIFF
--- a/go/src/koding/kites/kloud/kloud/apply.go
+++ b/go/src/koding/kites/kloud/kloud/apply.go
@@ -183,6 +183,12 @@ func destroy(ctx context.Context, username, stackId string) error {
 		}
 	}
 
+	buildData, err := injectKodingData(ctx, stack.Template, username, creds)
+	if err != nil {
+		return err
+	}
+	stack.Template = buildData.Template
+
 	sess.Log.Debug("Calling terraform.destroy method with context:")
 	sess.Log.Debug(stack.Template)
 	_, err = tfKite.Destroy(&tf.TerraformRequest{

--- a/go/src/koding/kites/kloud/kloud/bootstrap.go
+++ b/go/src/koding/kites/kloud/kloud/bootstrap.go
@@ -26,6 +26,7 @@ type AwsBootstrapOutput struct {
 	SG        string `json:"sg" mapstructure:"sg"`
 	Subnet    string `json:"subnet" mapstructure:"subnet"`
 	VPC       string `json:"vpc" mapstructure:"vpc"`
+	AMI       string `json:"ami" mapstructure:"ami"`
 }
 
 type TerraformBootstrapRequest struct {
@@ -133,6 +134,7 @@ func (k *Kloud) Bootstrap(r *kite.Request) (interface{}, error) {
 				"meta.sg":         awsOutput.SG,
 				"meta.subnet":     awsOutput.Subnet,
 				"meta.vpc":        awsOutput.VPC,
+				"meta.ami":        awsOutput.AMI,
 			},
 		}); err != nil {
 			return nil, err
@@ -195,6 +197,9 @@ var awsBootstrap = `{
         },
         "sg": {
             "value": "${aws_security_group.allow_all.id}"
+        },
+        "ami": {
+            "value": "${lookup(var.aws_amis, var.region)}"
         },
         "key_pair": {
             "value": "${aws_key_pair.koding_key_pair.key_name}"
@@ -298,6 +303,19 @@ var awsBootstrap = `{
                 "us-east-1": "us-east-1b",
                 "us-west-1": "us-west-1b",
                 "us-west-2": "us-west-2b"
+            }
+        },
+        "aws_amis": {
+            "default": {
+                "ap-northeast-1": "ami-9e5cff9e",
+                "ap-southeast-1": "ami-ec7879be",
+                "ap-southeast-2": "ami-2fce8b15",
+                "eu-central-1": "ami-60f9c27d",
+                "eu-west-1": "ami-7c4b0a0b",
+                "sa-east-1": "ami-cd9518d0",
+                "us-east-1": "ami-cf35f3a4",
+                "us-west-1": "ami-b33dccf7",
+                "us-west-2": "ami-8d5b5dbd"
             }
         }
     }

--- a/go/src/koding/kites/kloud/kloud/terraformutils.go
+++ b/go/src/koding/kites/kloud/kloud/terraformutils.go
@@ -231,9 +231,13 @@ func injectKodingData(ctx context.Context, content, username string, creds *terr
 		instance["user_data"] = string(userdata)
 		instance["key_name"] = awsOutput.KeyPair
 
-		// if nothing is provide use default Ubuntu AMI's
-		if instance["ami"] == nil {
+		// if nothing is provided or the ami is empty use default Ubuntu AMI's
+		if a, ok := instance["ami"]; !ok {
 			instance["ami"] = awsOutput.AMI
+		} else {
+			if ami, ok := a.(string); ok && ami == "" {
+				instance["ami"] = awsOutput.AMI
+			}
 		}
 
 		// only ovveride if the user doesn't provider it's own subnet_id

--- a/go/src/koding/kites/kloud/kloud/terraformutils.go
+++ b/go/src/koding/kites/kloud/kloud/terraformutils.go
@@ -231,6 +231,11 @@ func injectKodingData(ctx context.Context, content, username string, creds *terr
 		instance["user_data"] = string(userdata)
 		instance["key_name"] = awsOutput.KeyPair
 
+		// if nothing is provide use default Ubuntu AMI's
+		if instance["ami"] == nil {
+			instance["ami"] = awsOutput.AMI
+		}
+
 		// only ovveride if the user doesn't provider it's own subnet_id
 		if instance["subnet_id"] == nil {
 			instance["subnet_id"] = awsOutput.Subnet

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -104,8 +104,7 @@ var (
         "aws_instance": {
             "example": {
 				"count": %d,
-                "instance_type": "t2.micro",
-                "ami": "ami-9e5cff9e"
+                "instance_type": "t2.micro"
             }
         }
     }

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -105,7 +105,7 @@ var (
             "example": {
 				"count": %d,
                 "instance_type": "t2.micro",
-                "ami": "ami-936d9d93"
+                "ami": "ami-9e5cff9e"
             }
         }
     }

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -104,7 +104,6 @@ var (
         "aws_instance": {
             "example": {
 				"count": %d,
-				"ami": "",
                 "instance_type": "t2.micro"
             }
         }

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -104,6 +104,7 @@ var (
         "aws_instance": {
             "example": {
 				"count": %d,
+				"ami": "",
                 "instance_type": "t2.micro"
             }
         }


### PR DESCRIPTION
This adds two new features:
1. Now bootstrapping does add a new `ami` field to `jCredentialDatas` meta
   field"
   ![image](https://cloud.githubusercontent.com/assets/438920/8646193/5c04eb7a-2956-11e5-8129-726235e8756a.png)
   After calling the bootstrap, the client side can use this new
    information to populate the default example script if wished. Example pseudo code:
   
   ```
     {  
         "provider":{  
             "aws":{  
                 "access_key":"${var.access_key}",
                 "secret_key":"${var.secret_key}",
                 "region":"${var.region}"
             }
         },
         "resource":{  
             "aws_instance":{  
                 "example":{  
                     "ami":"#{FetchFromCredentialDatas.meta.ami}",
                     "instance_type":"t2.micro"
                 }
             }
         }
     }
   ```
2. If the user doesn't pass anything (no `ami` field in template), then Kloud
   automatically puts the AMI itself. This prevents not building the stack and
   improves the overall experience.
