### PR TITLE
managed: Added heartbeatKites helper function

### DIFF
--- a/client/app/lib/kite/kites/klient.coffee
+++ b/client/app/lib/kite/kites/klient.coffee
@@ -31,6 +31,7 @@ module.exports = class KodingKite_KlientKite extends require('../kodingkite')
     webtermPing        : 'webterm.ping'
     webtermRename      : 'webterm.rename'
 
+    klientInfo         : 'klient.info'
     klientShare        : 'klient.share'
     klientUnshare      : 'klient.unshare'
     klientShared       : 'klient.shared'

--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -16,6 +16,7 @@ KiteCache            = require '../kite/kitecache'
 ComputeStateChecker  = require './computestatechecker'
 ComputeEventListener = require './computeeventlistener'
 ComputeController_UI = require './computecontroller.ui'
+ManagedKiteChecker   = require './managed/managedkitechecker'
 
 require './config'
 
@@ -43,8 +44,9 @@ module.exports = class ComputeController extends KDController
 
       @fetchStacks =>
 
-        @eventListener = new ComputeEventListener
-        @stateChecker  = new ComputeStateChecker
+        @eventListener      = new ComputeEventListener
+        @managedKiteChecker = new ManagedKiteChecker
+        @stateChecker       = new ComputeStateChecker
 
         @stateChecker.machines = @machines
         @stateChecker.start()

--- a/client/app/lib/providers/managed/helpers.coffee
+++ b/client/app/lib/providers/managed/helpers.coffee
@@ -126,9 +126,7 @@ heartbeatKites = (interval = HEARTBEAT_INTERVAL, callback = kd.noop) ->
         # can popup a Provider specific modal
         # TODO: Is there a better way to get the klient kite?
         klient = computeController.machinesById[machine._id].getBaseKite()
-        klient.klientInfo()
-          .then (payload) -> kallback null, payload
-          .catch    (err) -> kallback err
+        klient.klientInfo().nodeify kallback
 
     queryPromise.catch (err) ->
       kallback err  if err

--- a/client/app/lib/providers/managed/helpers.coffee
+++ b/client/app/lib/providers/managed/helpers.coffee
@@ -1,5 +1,6 @@
-nick = require 'app/util/nick'
-kd   = require 'kd'
+kd      = require 'kd'
+nick    = require 'app/util/nick'
+Machine = require '../machine'
 
 
 # The maximum number of heartbeat attempts when looking for
@@ -76,7 +77,7 @@ updateMachineData = ({machine, kite}, callback)->
 ###
 heartbeatKites = (interval = HEARTBEAT_INTERVAL, callback = kd.noop) ->
 
-  { router, computeController } = kd.singletons
+  { router } = kd.singletons
 
   beatCount  = 0
   oldKites   = {}
@@ -116,16 +117,17 @@ heartbeatKites = (interval = HEARTBEAT_INTERVAL, callback = kd.noop) ->
       unless newKite
         return
 
-      createMachine newKite, (err, machine) ->
+      createMachine newKite, (err, jMachine) ->
         return kallback err  if err
 
         # Route to the IDE
-        kd.utils.defer -> router.handleRoute "/IDE/#{machine.slug}"
+        kd.utils.defer -> router.handleRoute "/IDE/#{jMachine.slug}"
+
+        machine = Machine { machine: jMachine }
 
         # Get the klient kite, and the info from that klient so we
         # can popup a Provider specific modal
-        # TODO: Is there a better way to get the klient kite?
-        klient = computeController.machinesById[machine._id].getBaseKite()
+        klient = machine.getBaseKite()
         klient.klientInfo().nodeify kallback
 
     queryPromise.catch (err) ->

--- a/client/app/lib/providers/managed/helpers.coffee
+++ b/client/app/lib/providers/managed/helpers.coffee
@@ -144,6 +144,7 @@ heartbeatKites = (interval = HEARTBEAT_INTERVAL, callback = kd.noop) ->
       heartbeat()
     .catch (err) =>
       kallback err
+  return
 
 
 module.exports = {

--- a/client/app/lib/providers/managed/helpers.coffee
+++ b/client/app/lib/providers/managed/helpers.coffee
@@ -81,6 +81,7 @@ heartbeatKites = (interval = HEARTBEAT_INTERVAL, callback = kd.noop) ->
 
   # A callback wrapper, to help ensure clearInterval is always called
   kallback = (err) ->
+
     # It's expected that clearInterval gets called twice, but that
     # is not a problem in Chrome at least.
     clearInterval intervalId

--- a/client/app/lib/providers/managed/helpers.coffee
+++ b/client/app/lib/providers/managed/helpers.coffee
@@ -130,8 +130,8 @@ heartbeatKites = (interval = HEARTBEAT_INTERVAL, callback = kd.noop) ->
           .then (payload) -> kallback null, payload
           .catch    (err) -> kallback err
 
-    queryPromise.catch (err) =>
-        kallback err  if err
+    queryPromise.catch (err) ->
+      kallback err  if err
 
   # First, query for the kites to find the original kites
   # After that's done, start the heartbeat.
@@ -142,7 +142,7 @@ heartbeatKites = (interval = HEARTBEAT_INTERVAL, callback = kd.noop) ->
       # Call the heartbeat immediately *after* setInterval,
       # so we can clear it if it is immediately available.
       heartbeat()
-    .catch (err) =>
+    .catch (err) ->
       kallback err
   return
 

--- a/client/app/lib/providers/managed/helpers.coffee
+++ b/client/app/lib/providers/managed/helpers.coffee
@@ -81,7 +81,7 @@ heartbeatKites = (interval = HEARTBEAT_INTERVAL, callback = kd.noop) ->
 
   # A callback wrapper, to help ensure clearInterval is always called
   kallback = (err) ->
-    # It's possible that clearInterval gets called twice, but that
+    # It's expected that clearInterval gets called twice, but that
     # is not a problem in Chrome at least.
     clearInterval intervalId
     callback err

--- a/client/app/lib/providers/managed/helpers.coffee
+++ b/client/app/lib/providers/managed/helpers.coffee
@@ -130,7 +130,7 @@ heartbeatKites = (interval = HEARTBEAT_INTERVAL, callback = kd.noop) ->
         # Route to the IDE
         kd.utils.defer -> router.handleRoute "/IDE/#{jMachine.slug}"
 
-        machine = Machine { machine: jMachine }
+        machine = new Machine { machine: jMachine }
 
         # Get the klient kite, and the info from that klient so we
         # can popup a Provider specific modal

--- a/client/app/lib/providers/managed/helpers.coffee
+++ b/client/app/lib/providers/managed/helpers.coffee
@@ -69,7 +69,10 @@ updateMachineData = ({machine, kite}, callback)->
  * a kite is found.
  *
  * @param {Number} interval - The heartbeat interval (in seconds).
- * @param {Function(err:Error)} callback
+ * @param {Function(err:Error, info:Object)} callback - A callback for
+ *  when the new kite is connected. Info is the returned object from
+ *  the klient kite's `klient.info` method. This contains the
+ *  `providerName` key, among other things.
 ###
 heartbeatKites = (interval = HEARTBEAT_INTERVAL, callback = kd.noop) ->
 
@@ -80,12 +83,12 @@ heartbeatKites = (interval = HEARTBEAT_INTERVAL, callback = kd.noop) ->
   intervalId = null
 
   # A callback wrapper, to help ensure clearInterval is always called
-  kallback = (err) ->
+  kallback = (err, info) ->
 
     # It's expected that clearInterval gets called twice, but that
     # is not a problem in Chrome at least.
     clearInterval intervalId
-    callback err
+    callback err, info
 
   # Called on every interval, until canceled
   heartbeat = ->
@@ -122,10 +125,10 @@ heartbeatKites = (interval = HEARTBEAT_INTERVAL, callback = kd.noop) ->
         # Get the klient kite, and the info from that klient so we
         # can popup a Provider specific modal
         # TODO: Is there a better way to get the klient kite?
-        # TODO: Uncomment, after klientInfo method is available.
-        #klient = computeController.machinesById[machine._id].getBaseKite()
-        #klient.klientInfo kallback
-        kallback null
+        klient = computeController.machinesById[machine._id].getBaseKite()
+        klient.klientInfo()
+          .then (payload) -> kallback null, payload
+          .catch    (err) -> kallback err
 
     queryPromise.catch (err) =>
         kallback err  if err

--- a/client/app/lib/providers/managed/helpers.coffee
+++ b/client/app/lib/providers/managed/helpers.coffee
@@ -1,6 +1,15 @@
 nick = require 'app/util/nick'
 kd   = require 'kd'
 
+
+# The maximum number of heartbeat attempts when looking for
+# a new kite.
+MAX_HEARTBEATS = 60
+# The default heartbeat interval, in seconds.
+HEARTBEAT_INTERVAL = 5
+
+
+# Not exported
 getIp = (url)->
   el = global.document.createElement 'a'
   el.href = url
@@ -8,50 +17,136 @@ getIp = (url)->
   return el.hostname
 
 
-module.exports =
+queryKites = ->
 
-  queryKites: ->
+  { generateQueryString } = require 'app/kite/kitecache'
+  { computeController, kontrol } = kd.singletons
 
-    { generateQueryString } = require 'app/kite/kitecache'
-    { computeController, kontrol } = kd.singletons
+  return kontrol
+    .queryKites
+      query         :
+        username    : nick()
+        environment : 'managed'
+    .timeout 5000
+    .then (result)->
 
-    return kontrol
-      .queryKites
-        query         :
-          username    : nick()
-          environment : 'managed'
-      .timeout 5000
-      .then (result)->
-
-        if result?.kites?.length
-          {kites} = result
-          kites.forEach (kite)->
-            kite.queryString = generateQueryString kite.kite
-            kite.machine     = computeController
-              .findMachineFromQueryString kite.queryString
-            kite.ipAddress   = getIp kite.url
-          return kites
-        else
-          return []
+      if result?.kites?.length
+        {kites} = result
+        kites.forEach (kite)->
+          kite.queryString = generateQueryString kite.kite
+          kite.machine     = computeController
+            .findMachineFromQueryString kite.queryString
+          kite.ipAddress   = getIp kite.url
+        return kites
+      else
+        return []
 
 
-  createMachine: (kite, callback)->
+createMachine = (kite, callback)->
 
-    { computeController } = kd.singletons
+  { computeController } = kd.singletons
 
-    stack = computeController.stacks.first._id
+  stack = computeController.stacks.first._id
 
-    computeController.create {
-      provider    : 'managed'
-      queryString : kite.queryString
-      ipAddress   : kite.ipAddress
-      label       : kite.kite.hostname
-      stack
-    }, callback
+  computeController.create {
+    provider    : 'managed'
+    queryString : kite.queryString
+    ipAddress   : kite.ipAddress
+    label       : kite.kite.hostname
+    stack
+  }, callback
 
 
-  updateMachineData: ({machine, kite}, callback)->
+updateMachineData = ({machine, kite}, callback)->
 
-    { queryString, ipAddress } = kite
-    { computeController } = kd.singletons
-    computeController.update machine, {queryString, ipAddress}, callback
+  { queryString, ipAddress } = kite
+  { computeController } = kd.singletons
+  computeController.update machine, {queryString, ipAddress}, callback
+
+
+###*
+ * Repeatedly queryKites at the rate of interval (per second) until
+ * a kite is found.
+ *
+ * @param {Number} interval - The heartbeat interval (in seconds).
+ * @param {Function(err:Error)} callback
+###
+heartbeatKites = (interval = HEARTBEAT_INTERVAL, callback = kd.noop) ->
+
+  { router, computeController } = kd.singletons
+
+  beatCount  = 0
+  oldKites   = {}
+  intervalId = null
+
+  # A callback wrapper, to help ensure clearInterval is always called
+  kallback = (err) ->
+    # It's possible that clearInterval gets called twice, but that
+    # is not a problem in Chrome at least.
+    clearInterval intervalId
+    callback err
+
+  # Called on every interval, until canceled
+  heartbeat = ->
+
+    beatCount++
+    if beatCount > MAX_HEARTBEATS
+      return kallback new Error "Maximum heartbeat limit of
+        #{MAX_HEARTBEATS} reached."
+
+    queryPromise = queryKites()
+    queryPromise.then (kites) ->
+      # No kites ready, wait for another heartbeat
+      return unless kites?.length
+
+      clearInterval intervalId
+
+      # Check the old kites vs the new kites
+      newKite = null
+      for kite in kites
+        if oldKites[kite.keyId]
+          newKite = kite
+          break
+
+      # If there is no newKite, return and wait for another heartbeat
+      unless newKite
+        return
+
+      createMachine newKite, (err, machine) ->
+        return kallback err  if err
+
+        # Route to the IDE
+        kd.utils.defer -> router.handleRoute "/IDE/#{machine.slug}"
+
+        # Get the klient kite, and the info from that klient so we
+        # can popup a Provider specific modal
+        # TODO: Is there a better way to get the klient kite?
+        # TODO: Uncomment, after klientInfo method is available.
+        #klient = computeController.machinesById[machine._id].getBaseKite()
+        #klient.klientInfo kallback
+        kallback null
+
+    queryPromise.catch (err) =>
+        kallback err  if err
+
+  # First, query for the kites to find the original kites
+  # After that's done, start the heartbeat.
+  queryKites()
+    .then (kites = []) ->
+      oldKites[kite.keyId] = kite  for kite in kites
+      intervalId = setInterval heartbeat, interval * 1000
+      # Call the heartbeat immediately *after* setInterval,
+      # so we can clear it if it is immediately available.
+      heartbeat()
+    .catch (err) =>
+      kallback err
+
+
+module.exports = {
+  createMachine
+  heartbeatKites
+  updateMachineData
+  queryKites
+}
+
+

--- a/client/app/lib/providers/managed/managedkitechecker.coffee
+++ b/client/app/lib/providers/managed/managedkitechecker.coffee
@@ -202,10 +202,10 @@ module.exports = class ManagedKiteChecker extends kd.Object
    * will not be notified of that kite. See ManagedKiteChecker for a
    * high level understanding of why this is.
    *
-   * @param {Function(err:Error, info:Object)} listener - A callback for
-   *  when the new kite is connected. Info is the returned object from
-   *  the klient kite's `klient.info` method. This contains the
-   *  `providerName` key, among other things.
+   * @param {Function(err:Error, info:Object, machine:Machine)} listener -
+   *  A callback for when the new kite is connected. Info is the
+   *  returned object from the klient kite's `klient.info` method.
+   *  This contains the `providerName` key, among other things.
   ###
   addListener: (listener) ->
 
@@ -232,10 +232,10 @@ module.exports = class ManagedKiteChecker extends kd.Object
    * are currently listening, any Polling (ticking) that may be occuring
    * is halted.
    *
-   * @param {Function(err:Error, info:Object)} listener - A callback for
-   *  when the new kite is connected. Info is the returned object from
-   *  the klient kite's `klient.info` method. This contains the
-   *  `providerName` key, among other things.
+   * @param {Function(err:Error, info:Object, machine:Machine)} listener -
+   *  A callback for when the new kite is connected. Info is the
+   *  returned object from the klient kite's `klient.info` method.
+   *  This contains the `providerName` key, among other things.
   ###
   removeListener: (listener = kd.noop) ->
 

--- a/client/app/lib/providers/managed/managedkitechecker.coffee
+++ b/client/app/lib/providers/managed/managedkitechecker.coffee
@@ -79,6 +79,7 @@ module.exports = class ManagedKiteChecker extends kd.Object
    * @returns {Function()} listener
   ###
   _getListener: ->
+
     listener = @_listeners[0]
     @removeListener listener
     return listener

--- a/client/app/lib/providers/managed/managedkitechecker.coffee
+++ b/client/app/lib/providers/managed/managedkitechecker.coffee
@@ -112,7 +112,8 @@ module.exports = class ManagedKiteChecker extends kd.Object
     unless @_listeners.length
       return
 
-    { createMachine } = helpers
+    { computeController } = kd.singletons
+    { createMachine }     = helpers
 
     listener = @_getListener()
 
@@ -127,6 +128,13 @@ module.exports = class ManagedKiteChecker extends kd.Object
       klient = machine.getBaseKite()
       klient.klientInfo().nodeify (err, payload) =>
         return kd.error err if err
+
+        # Record the vmProvider in the machine. We don't need to
+        # wait for the callback though.
+        vmProvider = payload.providerName
+        computeController.update machine, { vmProvider }
+
+        # Notify the lisetener, and emit the event.
         listener payload, machine
         @emit 'NewKite', kite, payload, machine
 

--- a/client/app/lib/providers/managed/managedkitechecker.coffee
+++ b/client/app/lib/providers/managed/managedkitechecker.coffee
@@ -52,10 +52,10 @@ module.exports = class ManagedKiteChecker extends kd.Object
       maxTicks : options.maxTicks ? DEFAULT_MAX_TICKS
 
     @_listeners = []
-    @_delaying = no
-    @_ticking = no
+    @_delaying  = no
+    @_ticking   = no
     @_tickCount = 0
-    @_timerId = null
+    @_timerId   = null
 
 
   ###*

--- a/client/app/lib/providers/managed/managedkitechecker.coffee
+++ b/client/app/lib/providers/managed/managedkitechecker.coffee
@@ -303,7 +303,6 @@ module.exports = class ManagedKiteChecker extends kd.Object
         @_stop()
         @_startDelay()
 
-
     queryPromise.catch (err) =>
       @_callListener err  if err
 

--- a/client/app/lib/providers/managed/managedkitechecker.coffee
+++ b/client/app/lib/providers/managed/managedkitechecker.coffee
@@ -129,10 +129,10 @@ module.exports = class ManagedKiteChecker extends kd.Object
       klient.klientInfo().nodeify (err, payload) =>
         return kd.error err  if err
 
-        # Record the vmProvider in the machine. We don't need to
+        # Record the managedProvider in the machine. We don't need to
         # wait for the callback though.
-        vmProvider = payload.providerName
-        computeController.update machine, { vmProvider }
+        managedProvider = payload.providerName
+        computeController.update machine, { managedProvider }
 
         # Notify the lisetener, and emit the event.
         listener payload, machine

--- a/client/app/lib/providers/managed/managedkitechecker.coffee
+++ b/client/app/lib/providers/managed/managedkitechecker.coffee
@@ -127,7 +127,7 @@ module.exports = class ManagedKiteChecker extends kd.Object
       # can popup a Provider specific modal
       klient = machine.getBaseKite()
       klient.klientInfo().nodeify (err, payload) =>
-        return kd.error err if err
+        return kd.error err  if err
 
         # Record the vmProvider in the machine. We don't need to
         # wait for the callback though.

--- a/client/app/lib/providers/managed/managedkitechecker.coffee
+++ b/client/app/lib/providers/managed/managedkitechecker.coffee
@@ -117,7 +117,7 @@ module.exports = class ManagedKiteChecker extends kd.Object
 
     # Create a machine for this kite.
     createMachine kite, (err, jMachine) =>
-      return listener err  if err
+      return kd.error err  if err
 
       machine = new Machine { machine: jMachine }
 
@@ -125,7 +125,7 @@ module.exports = class ManagedKiteChecker extends kd.Object
       # can popup a Provider specific modal
       klient = machine.getBaseKite()
       klient.klientInfo().nodeify (err, payload) =>
-        listener null, payload, machine
+        listener payload, machine
         @emit 'NewKite', kite, payload, machine
 
 
@@ -164,7 +164,7 @@ module.exports = class ManagedKiteChecker extends kd.Object
 
     # Be paranoid about duplicating timers.
     if @_delaying or @_ticking
-      return @_callListener() new Error "ManagedKiteChecker:
+      return kd.error "ManagedKiteChecker:
         _startDelay called with pre-existing timer or interval"
 
     @_delaying = yes
@@ -185,7 +185,7 @@ module.exports = class ManagedKiteChecker extends kd.Object
 
     # Be paranoid about duplicating timers.
     if @_delaying or @_ticking
-      return @_callListener() new Error "ManagedKiteChecker:
+      return kd.error "ManagedKiteChecker:
         _startTicking called with pre-existing timer or interval"
 
     @_ticking = yes
@@ -206,7 +206,7 @@ module.exports = class ManagedKiteChecker extends kd.Object
    * will not be notified of that kite. See ManagedKiteChecker for a
    * high level understanding of why this is.
    *
-   * @param {Function(err:Error, info:Object, machine:Machine)} listener -
+   * @param {Function(info:Object, machine:Machine)} listener -
    *  A callback for when the new kite is connected. Info is the
    *  returned object from the klient kite's `klient.info` method.
    *  This contains the `providerName` key, among other things.
@@ -236,7 +236,7 @@ module.exports = class ManagedKiteChecker extends kd.Object
    * are currently listening, any Polling (ticking) that may be occuring
    * is halted.
    *
-   * @param {Function(err:Error, info:Object, machine:Machine)} listener -
+   * @param {Function(info:Object, machine:Machine)} listener -
    *  A callback for when the new kite is connected. Info is the
    *  returned object from the klient kite's `klient.info` method.
    *  This contains the `providerName` key, among other things.
@@ -284,7 +284,7 @@ module.exports = class ManagedKiteChecker extends kd.Object
       return
 
     if @_tickCount > @getOption 'maxTicks'
-      return @_callListener new Error "Maximum tick limit of
+      return kd.error "ManagedKiteChecker: Maximum tick limit of
         #{@getOption 'maxTicks'} reached."
 
     queryPromise = queryKites()
@@ -309,6 +309,6 @@ module.exports = class ManagedKiteChecker extends kd.Object
         @_startDelay()
 
     queryPromise.catch (err) =>
-      @_callListener err  if err
+      kd.error err  if err
 
 

--- a/client/app/lib/providers/managed/managedkitechecker.coffee
+++ b/client/app/lib/providers/managed/managedkitechecker.coffee
@@ -68,7 +68,13 @@ module.exports = class ManagedKiteChecker extends kd.Object
    *
    * @param {...} args - The arguments to pass to the listener.
   ###
-  _callListener: (args...) -> @_getListener() args...
+  _callListener: (args...) ->
+    unless @_listeners.length
+      kd.warn "ManagedKiteChecker: _callListener called without
+        and listeners"
+      return
+
+    @_getListener() args...
 
 
   ###*

--- a/client/app/lib/providers/managed/managedkitechecker.coffee
+++ b/client/app/lib/providers/managed/managedkitechecker.coffee
@@ -126,6 +126,7 @@ module.exports = class ManagedKiteChecker extends kd.Object
       # can popup a Provider specific modal
       klient = machine.getBaseKite()
       klient.klientInfo().nodeify (err, payload) =>
+        return kd.error err if err
         listener payload, machine
         @emit 'NewKite', kite, payload, machine
 

--- a/client/app/lib/providers/managed/managedkitechecker.coffee
+++ b/client/app/lib/providers/managed/managedkitechecker.coffee
@@ -25,8 +25,9 @@ DEFAULT_MAX_TICKS = 60
 # kite.
 #
 # If (for some reason) you need to listen for all new kites, kites
-# are also emitted via @emit, and can be subscribed to with @on and
-# @off, as expected.
+# are also emitted via an @emit on 'NewKite', and can be subscribed to
+# with @on and @off, as expected. It's worth noting that a listener is
+# required for the NewKite event to be emitted, currently.
 #
 module.exports = class ManagedKiteChecker extends kd.Object
 

--- a/client/app/lib/providers/managed/managedkitechecker.coffee
+++ b/client/app/lib/providers/managed/managedkitechecker.coffee
@@ -139,19 +139,19 @@ module.exports = class ManagedKiteChecker extends kd.Object
   ###
   _stop: ->
 
-    stopped = false
+    stopped = no
 
     if @_delaying
       @_delaying = no
       if @_timerId
         kd.utils.killWait @_timerId
-        stopped = true
+        stopped = yes
 
     if @_ticking
       @_ticking = no
       if @_timerId
         kd.utils.killRepeat @_timerId
-        stopped = true
+        stopped = yes
 
     return stopped
 
@@ -293,12 +293,12 @@ module.exports = class ManagedKiteChecker extends kd.Object
       unless kites?.length
         return
 
-      foundNewKite = false
+      foundNewKite = no
       # Find a new kite, from the kite list.
       # We are judging a "new" kite, as one that doesn't have a machine.
       for kite in kites
         continue  if kite?.machine
-        foundNewKite = true
+        foundNewKite = yes
         @_handleNewKiteIfListener kite
 
       # If we found new kites, stop the current interval and then

--- a/client/app/lib/providers/managed/managedkitechecker.coffee
+++ b/client/app/lib/providers/managed/managedkitechecker.coffee
@@ -158,9 +158,8 @@ module.exports = class ManagedKiteChecker extends kd.Object
 
     # Be paranoid about duplicating timers.
     if @_delaying or @_ticking
-      kd.warn "ManagedKiteChecker: _startDelay called with pre-existing
-        timerId"
-      return
+      return @_callListener() new Error "ManagedKiteChecker:
+        _startDelay called with pre-existing timer or interval"
 
     @_delaying = yes
     @_timerId  = kd.utils.wait @getOption('delay'), =>
@@ -180,9 +179,8 @@ module.exports = class ManagedKiteChecker extends kd.Object
 
     # Be paranoid about duplicating timers.
     if @_delaying or @_ticking
-      kd.warn "ManagedKiteChecker: _startDelay called with pre-existing
-        timerId"
-      return
+      return @_callListener() new Error "ManagedKiteChecker:
+        _startTicking called with pre-existing timer or interval"
 
     @_ticking = yes
     @_timerId = kd.utils.repeat @getOption('interval'), @bound 'tick'

--- a/client/app/lib/providers/managed/managedkitechecker.coffee
+++ b/client/app/lib/providers/managed/managedkitechecker.coffee
@@ -1,0 +1,310 @@
+kd      = require 'kd'
+nick    = require 'app/util/nick'
+helpers = require './helpers'
+Machine = require '../machine'
+
+
+# The default delay (in seconds) that ManagedKiteChecker will wait on
+# new listenrs.
+DEFAULT_DELAY = 30
+
+# The default interval (in seconds) between ticks.
+DEFAULT_INTERVAL = 10
+
+# The default maximum number of ticks that a single listener will
+# trigger via the interval.
+DEFAULT_MAX_TICKS = 60
+
+
+# ManagedKiteChecker is a singleton in ComputeController for listening for
+# new managed kites from Kontrol.
+#
+# ManagedKiteChecker will inform a *single* listener of a new kite at a
+# time. New kites are not broadcasted to listeners. The logic behind
+# this is that a ManagedKiteChecker listener has ownership of the new
+# kite.
+#
+# If (for some reason) you need to listen for all new kites, kites
+# are also emitted via @emit, and can be subscribed to with @on and
+# @off, as expected.
+#
+module.exports = class ManagedKiteChecker extends kd.Object
+
+  ###*
+   * @param {Number} options.delay - The delay (in seconds) that the
+   *  first tick will be called after. This applies to each listener
+   *  currently, and is not offset from actual total waited time. Eg,
+   *  if the 5th listener has been waiting for 4 other listeners, it
+   *  will wait (at minimum) `options.delay * 5`.
+   *
+   * @param {Number} options.interval - The interval rate (in seconds)
+   *  at which @tick is called.
+   *
+   * @param {Number} options.maxTicks - The maximum number of ticks
+   *  that ManagedKiteChecker will poll Kontrol for a single
+   *  listener. The Tick Count is reset for each new current listener.
+  ###
+  constructor: (options = {}) ->
+
+    super
+      delay    : (options.delay ? DEFAULT_DELAY) * 1000
+      interval : (options.interval ? DEFAULT_INTERVAL) * 1000
+      maxTicks : options.maxTicks ? DEFAULT_MAX_TICKS
+
+    @_listeners = []
+    @_delaying = no
+    @_ticking = no
+    @_tickCount = 0
+    @_timerId = null
+
+
+  ###*
+   * _callListener is a conenience func for calling the zero index
+   * listener, removing it from the listeners list, and stopping
+   * listening if there are no other listeners.
+   *
+   * This is useful to call it a listener with an error, without having
+   * to muck about with anything else.
+   *
+   * @param {...} args - The arguments to pass to the listener.
+  ###
+  _callListener: (args...) -> @_getListener() args...
+
+
+  ###*
+   * _getListener is a conenience func for getting the zero index
+   * listener, removing it from the listeners list, and stopping
+   * listening if there are no other listeners.
+   *
+   * @returns {Function()} listener
+  ###
+  _getListener: ->
+    listener = @_listeners[0]
+    @removeListener listener
+    return listener
+
+
+  ###*
+   * Handle a new kite if there are any listeners for it. If there are not,
+   * it is ignored.
+   *
+   * Note that a single @tick may return multiple new Kites, which will
+   * then trigger this func multiple times. This is why we aggressively
+   * shift a listener off of the listener list on each call to this func.
+   *
+   * @emits NewKite~Kite,info,machine - The NewKite event is emitted
+   *  for all new kites. The kite is the kite itself, info is the
+   *  response from `klient.info` (containing information about the VM),
+   *  and machine is the Machine created for the given kite.
+  ###
+  _handleNewKiteIfListener: (kite) ->
+
+    # If there are no listeners to handle this kite, do nothing. Future
+    # queries will still return the no-machine kite, so they handle it.
+    unless @_listeners.length
+      return
+
+    { createMachine } = helpers
+
+    listener = @_getListener()
+
+    # Create a machine for this kite.
+    createMachine kite, (err, jMachine) =>
+      return listener err  if err
+
+      machine = new Machine { machine: jMachine }
+
+      # Get the klient kite, and the info from that klient so we
+      # can popup a Provider specific modal
+      klient = machine.getBaseKite()
+      klient.klientInfo().nodeify (err, payload) =>
+        listener null, payload, machine
+        @emit 'NewKite', kite, payload, machine
+
+
+  ###*
+   * _stop will stop any currently running ticker or delay (if any), as
+   * well as healing any inconsistencies in the delaying/ticking state
+   * tracking _(not that there should be any)_.
+   *
+   * @returns {Boolean} stopped - If true, a ticker or delay was stopped.
+   *  If false, nothing was stopped.
+  ###
+  _stop: ->
+
+    stopped = false
+
+    if @_delaying
+      @_delaying = no
+      if @_timerId
+        kd.utils.killWait @_timerId
+        stopped = true
+
+    if @_ticking
+      @_ticking = no
+      if @_timerId
+        kd.utils.killRepeat @_timerId
+        stopped = true
+
+    return stopped
+
+
+  ###*
+   * _startDelay sets a single timeout, and starting the ticker at the
+   * end.
+  ###
+  _startDelay: ->
+
+    # Be paranoid about duplicating timers.
+    if @_delaying or @_ticking
+      kd.warn "ManagedKiteChecker: _startDelay called with pre-existing
+        timerId"
+      return
+
+    @_delaying = yes
+    @_timerId  = kd.utils.wait @getOption('delay'), =>
+      @_delaying = no
+      @_startTicking yes
+
+
+  ###*
+   * _startTicking starts an interval timer to @tick at the rate of
+   * @options.interval.
+   *
+   * @param {Boolean} immediate - If true, a @tick will be called without
+   * any interval delay. Subsequent ticks will be called at interval rate
+   * as expected.
+  ###
+  _startTicking: (immediate = no)->
+
+    # Be paranoid about duplicating timers.
+    if @_delaying or @_ticking
+      kd.warn "ManagedKiteChecker: _startDelay called with pre-existing
+        timerId"
+      return
+
+    @_ticking = yes
+    @_timerId = kd.utils.repeat @getOption('interval'), @bound 'tick'
+
+    # Call @tick *after* setting the interval, so that @tick can
+    # stop it immediately, if wanted.
+    @tick()  if immediate
+
+
+  ###*
+   * Add a listener to be notified of a new kite. This listener will
+   * only be notified of the Nth new kite, where N is the total number
+   * of listeners.
+   *
+   * For example, if this listener is the first listener, it will be
+   * notified of the first new kite. The second, third, and etc listeners
+   * will not be notified of that kite. See ManagedKiteChecker for a
+   * high level understanding of why this is.
+   *
+   * @param {Function(err:Error, info:Object)} listener - A callback for
+   *  when the new kite is connected. Info is the returned object from
+   *  the klient kite's `klient.info` method. This contains the
+   *  `providerName` key, among other things.
+  ###
+  addListener: (listener) ->
+
+    # Rather than defaulting listener and start ticking, if callback
+    # is null, don't do anything.
+    unless listener
+      return
+
+    @_listeners.push listener
+
+    # If we're already running, nothing needs to be done.
+    return  if @running()
+
+    # Now simply start the delay. Which will then call the ticker, and
+    # start ticking - eventually calling the listener.
+    @_startDelay()
+
+    # Don't return the delay id
+    return
+
+
+  ###*
+   * Remove a listener from ManagedKiteChecker. If no other listeners
+   * are currently listening, any Polling (ticking) that may be occuring
+   * is halted.
+   *
+   * @param {Function(err:Error, info:Object)} listener - A callback for
+   *  when the new kite is connected. Info is the returned object from
+   *  the klient kite's `klient.info` method. This contains the
+   *  `providerName` key, among other things.
+  ###
+  removeListener: (listener = kd.noop) ->
+
+    # If there are no listeners, we have nothing to do.
+    unless @_listeners.length
+      return
+
+    indexOf = @_listeners.indexOf listener
+
+    return  if indexOf < 0
+
+    @_listeners.splice indexOf, 1
+
+    # If there are no more listeners, stop our timeout/interval.
+    @_stop()  if @_listeners.length is 0
+
+
+  ###*
+   * Returns whether or not the ManagedKiteChecker is currently running.
+   * Ie, has listeners and is actively listening.
+   *
+   * @returns {Boolean}
+  ###
+  running: -> @_delaying or @_ticking
+
+
+  ###*
+   * Tick is a heartbeat of the ManagedKiteChecker, called on each
+   * interval.
+  ###
+  tick: ->
+
+    { queryKites } = helpers
+
+    # Increase the tickCount above all else - something called this,
+    # so this position makes sure we have a record of the attempt..
+    # if it's ever needed.
+    @_tickCount++
+
+    # If there are no listeners, there's not much we can tick.
+    unless @_listeners.length
+      return
+
+    if @_tickCount > @getOption 'maxTicks'
+      return @_callListener new Error "Maximum tick limit of
+        #{@getOption 'maxTicks'} reached."
+
+    queryPromise = queryKites()
+    queryPromise.then (kites) =>
+      # No kites ready, wait for another tick
+      unless kites?.length
+        return
+
+      foundNewKite = false
+      # Find a new kite, from the kite list.
+      # We are judging a "new" kite, as one that doesn't have a machine.
+      for kite in kites
+        continue  if kite?.machine
+        foundNewKite = true
+        @_handleNewKiteIfListener kite
+
+      # If we found new kites, stop the current interval and then
+      # start the delay. This ensures that a listener never queries from
+      # Kontrol in less time than the delay.
+      if foundNewKite and @_listeners.length
+        @_stop()
+        @_startDelay()
+
+
+    queryPromise.catch (err) =>
+      @_callListener err  if err
+
+

--- a/workers/social/lib/social/models/computeproviders/managed.coffee
+++ b/workers/social/lib/social/models/computeproviders/managed.coffee
@@ -107,7 +107,7 @@ module.exports = class Managed extends ProviderInterface
 
   @update = (client, options, callback)->
 
-    { machineId, queryString, ipAddress, storage } = options
+    { machineId, queryString, ipAddress, storage, managedProvider } = options
     { r: { group, user, account } } = client
 
     unless machineId? or (queryString? or ipAddress? or storage?)
@@ -123,7 +123,9 @@ module.exports = class Managed extends ProviderInterface
       fieldsToUpdate = {domain, ipAddress}
 
     fieldsToUpdate.queryString = getKiteIdOnly queryString  if queryString?
-    fieldsToUpdate['meta.storage'] = storage  if storage?
+
+    fieldsToUpdate['meta.storage']         = storage          if storage?
+    fieldsToUpdate['meta.managedProvider'] = managedProvider  if managedProvider?
 
     JMachine = require './machine'
     selector = JMachine.getSelectorFor client, { machineId, owner: yes }


### PR DESCRIPTION
Added `heartbeatKites` function to integrate into new managed UI.

This should not be merged until i push the new `klient.klientInfo` method, so we can callback with the managed provider.

**DO NOT MERGE YET**

Todo:
- [x] Integrate with new `klient.klientInfo` method, callback with klientInfo
- [x] Added klientInfo to func docstring
- [x] Bug: Return null _(or something else)_ to avoid returning a promise. _(By accident, it's returning a promise which is erroneous if used by the caller)_
