### PR TITLE
kloud: fix destroy returning to early

### DIFF
--- a/go/src/koding/kites/kloud/provider/koding/destroy.go
+++ b/go/src/koding/kites/kloud/provider/koding/destroy.go
@@ -2,7 +2,6 @@ package koding
 
 import (
 	"fmt"
-	"koding/kites/kloud/api/amazon"
 	"koding/kites/kloud/machinestate"
 
 	"labix.org/v2/mgo"
@@ -33,7 +32,7 @@ func (m *Machine) Destroy(ctx context.Context) (err error) {
 	if m.Meta.InstanceId != "" {
 		m.Log.Debug("Destroying machine")
 		err := m.Session.AWSClient.Destroy(ctx, 10, 50)
-		if err != nil && err != amazon.ErrNoInstances {
+		if err != nil && !isInvalidInstanceID(err) {
 			// if it's something else return it
 			return err
 		}

--- a/go/src/koding/kites/kloud/provider/koding/utils.go
+++ b/go/src/koding/kites/kloud/provider/koding/utils.go
@@ -53,3 +53,12 @@ func isAddressNotFoundError(err error) bool {
 
 	return ec2Error.Code == "InvalidAddress.NotFound"
 }
+
+func isInvalidInstanceID(err error) bool {
+	ec2Error, ok := err.(*ec2.Error)
+	if !ok {
+		return false
+	}
+
+	return ec2Error.Code == "InvalidInstanceID.NotFound"
+}


### PR DESCRIPTION
Underlying method never returned ErrNoInstances, instead we have to
type assert and check with the correct error type.
