### PR TITLE
Implemented 'Remove "please upgrade your plan" line from vm turn on modal when network limit is reached for a paying user.' [completes #89949106]

### DIFF
--- a/client/app/lib/providers/environmentsmachinestatemodal.coffee
+++ b/client/app/lib/providers/environmentsmachinestatemodal.coffee
@@ -61,6 +61,9 @@ module.exports = class EnvironmentsMachineStateModal extends BaseModalView
 
     {computeController, marketingController} = kd.singletons
 
+    computeController.fetchUserPlan (plan) =>
+      @userSubscription = plan
+
     computeController.ready => whoami().isEmailVerified (err, verified) =>
 
       kd.warn err  if err?
@@ -102,8 +105,6 @@ module.exports = class EnvironmentsMachineStateModal extends BaseModalView
 
     {status, percentage, error} = event
 
-    { paymentController } = kd.singletons
-
     if status is @state
       @updatePercentage percentage  if percentage?
 
@@ -119,22 +120,20 @@ module.exports = class EnvironmentsMachineStateModal extends BaseModalView
             usage limit for this week.</p>
           "
 
-          paymentController.subscriptions (err, subscription) =>
+          if @userSubscription is 'free'
+            @customErrorMessage = "
+              #{limitReachedNotice}<span>
+              Please upgrade your <a href='/Pricing'>plan</a> or
+              <span class='contact-support'>contact support</span> for further
+              assistance.</span>
+            "
 
-            if subscription.planTitle is 'free'
-              @customErrorMessage = "
-                #{limitReachedNotice}<span>
-                Please upgrade your <a href='/Pricing'>plan</a> or
-                <span class='contact-support'>contact support</span> for further
-                assistance.</span>
-              "
-
-            else
-              @customErrorMessage = "
-                #{limitReachedNotice}<span>
-                Please <span class='contact-support'>contact support</span> 
-                for further assistance.</span>
-              "
+          else
+            @customErrorMessage = "
+              #{limitReachedNotice}<span>
+              Please <span class='contact-support'>contact support</span> 
+              for further assistance.</span>
+            "
 
         unless error.code is ComputeController.Error.NotVerified
           @hasError = yes

--- a/client/app/lib/providers/environmentsmachinestatemodal.coffee
+++ b/client/app/lib/providers/environmentsmachinestatemodal.coffee
@@ -102,6 +102,8 @@ module.exports = class EnvironmentsMachineStateModal extends BaseModalView
 
     {status, percentage, error} = event
 
+    { paymentController } = kd.singletons
+
     if status is @state
       @updatePercentage percentage  if percentage?
 
@@ -111,13 +113,25 @@ module.exports = class EnvironmentsMachineStateModal extends BaseModalView
       if error
 
         if /NetworkOut/i.test error
-          @customErrorMessage = "
-            <p>You've reached your outbound network usage
-            limit for this week.</p><span>
-            Please upgrade your <a href='/Pricing'>plan</a> or
-            <span class='contact-support'>contact support</span> for further
-            assistance.</span>
-          "
+
+          paymentController.subscriptions (err, subscription) =>
+            
+            if subscription.planTitle is 'free'
+              @customErrorMessage = "
+                <p>You've reached your outbound network usage
+                limit for this week.</p><span>
+                Please upgrade your <a href='/Pricing'>plan</a> or
+                <span class='contact-support'>contact support</span> for further
+                assistance.</span>
+              "
+
+            else
+              @customErrorMessage = "
+                <p>You've reached your outbound network usage
+                limit for this week.</p><span>
+                Please <span class='contact-support'>contact support</span> 
+                for further assistance.</span>
+              "
 
         unless error.code is ComputeController.Error.NotVerified
           @hasError = yes

--- a/client/app/lib/providers/environmentsmachinestatemodal.coffee
+++ b/client/app/lib/providers/environmentsmachinestatemodal.coffee
@@ -114,12 +114,16 @@ module.exports = class EnvironmentsMachineStateModal extends BaseModalView
 
         if /NetworkOut/i.test error
 
+          limitReachedNotice = "
+            <p>You've reached your outbound network 
+            usage limit for this week.</p>
+          "
+
           paymentController.subscriptions (err, subscription) =>
 
             if subscription.planTitle is 'free'
               @customErrorMessage = "
-                <p>You've reached your outbound network usage
-                limit for this week.</p><span>
+                #{limitReachedNotice}<span>
                 Please upgrade your <a href='/Pricing'>plan</a> or
                 <span class='contact-support'>contact support</span> for further
                 assistance.</span>
@@ -127,8 +131,7 @@ module.exports = class EnvironmentsMachineStateModal extends BaseModalView
 
             else
               @customErrorMessage = "
-                <p>You've reached your outbound network usage
-                limit for this week.</p><span>
+                #{limitReachedNotice}<span>
                 Please <span class='contact-support'>contact support</span> 
                 for further assistance.</span>
               "

--- a/client/app/lib/providers/environmentsmachinestatemodal.coffee
+++ b/client/app/lib/providers/environmentsmachinestatemodal.coffee
@@ -115,7 +115,7 @@ module.exports = class EnvironmentsMachineStateModal extends BaseModalView
         if /NetworkOut/i.test error
 
           paymentController.subscriptions (err, subscription) =>
-            
+
             if subscription.planTitle is 'free'
               @customErrorMessage = "
                 <p>You've reached your outbound network usage


### PR DESCRIPTION
Free plan
![screenshot at 22-25-20](https://cloud.githubusercontent.com/assets/1278794/8682855/e45ff9ca-2a77-11e5-8d62-5630724f168c.png)

All paid plans
![screenshot at 22-25-34](https://cloud.githubusercontent.com/assets/1278794/8682856/e477878e-2a77-11e5-97cb-294936989273.png)

**The story:** https://www.pivotaltracker.com/story/show/89949106

**Notes:** Had some issues while testing this, but I managed to test it by removing this check https://github.com/koding/koding/blob/7ba9893bcab9ec26f476634c8f299ab8ce37260d/client/app/lib/providers/environmentsmachinestatemodal.coffee#L113 and setting this to false https://github.com/koding/koding/blob/master/go/src/koding/vmwatcher/checker.go#L73

cc. @sinan @gniting 
