### PR TITLE
computecontroller: update plans after paypal request finishes [fixes #99038764]

### DIFF
--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -50,7 +50,7 @@ module.exports = class ComputeController extends KDController
         @stateChecker.start()
 
         kd.singletons
-          .paymentController.on 'UserPlanUpdated', =>
+          .paymentController.on ['UserPlanUpdated', 'PaypalRequestFinished'], =>
             @lastKnownUserPlan = null
             @fetchUserPlan()
 


### PR DESCRIPTION
[User subscribed to 'Developer plan' using PayPal couldn't create a new VM right after subscription.](https://www.pivotaltracker.com/story/show/99038764)

ComputeController wasn't listening to paypal finish event that is being emitted [here](https://github.com/koding/koding/blob/master/client/app/lib/payment/paymentcontroller.coffee#L82)

/cc @gokmen @sent-hil 
