### PR TITLE
janitor: fix broken tests; return test run as return code

### DIFF
--- a/go/src/koding/db/mongodb/modelhelper/user.go
+++ b/go/src/koding/db/mongodb/modelhelper/user.go
@@ -189,3 +189,15 @@ func GetUserByQuery(selector bson.M) (*models.User, error) {
 
 	return user, Mongo.Run(UserColl, query)
 }
+
+func CountUsersByQuery(selector bson.M) (int, error) {
+	var count int
+	var err error
+
+	var query = func(c *mgo.Collection) error {
+		count, err = c.Find(selector).Count()
+		return err
+	}
+
+	return count, Mongo.Run(UserColl, query)
+}

--- a/go/src/koding/workers/janitor/action.go
+++ b/go/src/koding/workers/janitor/action.go
@@ -4,9 +4,7 @@ import (
 	"errors"
 	"koding/db/models"
 	"koding/db/mongodb/modelhelper"
-	"math/rand"
 	"socialapi/workers/email/emailsender"
-	"time"
 )
 
 var subjects = map[string]string{
@@ -69,9 +67,6 @@ func DeleteVMs(user *models.User, _ string) error {
 	var topErr error
 
 	for _, machine := range machines {
-		// avoid spamming kloud
-		time.Sleep(time.Millisecond * time.Duration(rand.Intn(500)))
-
 		_, err := j.kiteClient.Tell("destroy", &requestArgs{
 			MachineID: machine.ObjectId.Hex(),
 			Provider:  "koding",

--- a/go/src/koding/workers/janitor/exempt_test.go
+++ b/go/src/koding/workers/janitor/exempt_test.go
@@ -18,17 +18,10 @@ import (
 )
 
 func TestIsUserPaid(t *testing.T) {
-	warning := &Warning{}
-
 	Convey("Given user who is paid", t, func() {
 		username := "paiduser"
 		user, _, err := modeltesthelper.CreateUser(username)
 		So(err, ShouldBeNil)
-
-		Convey("Then it returns error if error fetching plan", func() {
-			_, err := IsUserPaidFn(user, warning)
-			So(err, ShouldNotBeNil)
-		})
 
 		Convey("Then it returns true if user is paid", func() {
 			mux := http.NewServeMux()

--- a/go/src/koding/workers/janitor/main.go
+++ b/go/src/koding/workers/janitor/main.go
@@ -25,9 +25,6 @@ const (
 	// DefaultRangeForQuery defines the range of interval for the queries.
 	DefaultRangeForQuery = 3
 
-	// DefaultLimitPerRun defines how many users to be processed in a day by one worker.
-	DefaultLimitPerRun = 500
-
 	// DailyAtTenPM specifies interval; cron runs at utc, 5 UTC is 10pm PST
 	// with daylight savings time.
 	DailyAtTenPM = "0 0 5 * * *"
@@ -70,7 +67,12 @@ func main() {
 			// clone warning so local changes don't affect next run
 			warning := *w
 
-			result := warning.Run()
+			result, err := warning.Run()
+			if err != nil {
+				j.log.Error(err.Error())
+				continue
+			}
+
 			j.log.Info(result.String())
 		}
 	})

--- a/go/src/koding/workers/janitor/test.sh
+++ b/go/src/koding/workers/janitor/test.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
 go test -c
+
 ./janitor.test -c ../../../socialapi/config/test.toml -test.v=true
+RESULT=$?
+
 rm janitor.test
+
+exit $RESULT

--- a/go/src/koding/workers/janitor/warning.go
+++ b/go/src/koding/workers/janitor/warning.go
@@ -199,7 +199,7 @@ func (w *Warning) ReleaseUser(user *models.User) error {
 // when calculated time is too short or too long.
 func (w *Warning) getSleepTime() (time.Duration, error) {
 	count, err := w.getCount()
-	if err != nil {
+	if err != nil || count == 0 {
 		return 0, err
 	}
 

--- a/go/src/koding/workers/janitor/warning.go
+++ b/go/src/koding/workers/janitor/warning.go
@@ -198,7 +198,7 @@ func (w *Warning) ReleaseUser(user *models.User) error {
 // on total number of documents. It defaults to sleeping 1 seconds
 // when calculated time is too short or too long.
 func (w *Warning) getSleepTime() (time.Duration, error) {
-	count, err := w.getCount()
+	count, err := modelhelper.CountUsersByQuery(w.buildSelectQuery())
 	if err != nil || count == 0 {
 		return 0, err
 	}
@@ -213,19 +213,6 @@ func (w *Warning) getSleepTime() (time.Duration, error) {
 	}
 
 	return time.Duration(sleepInSec), nil
-}
-
-// getCount returns count of total documents that'll be processed in this run.
-func (w *Warning) getCount() (int, error) {
-	var count int
-	var err error
-
-	var query = func(c *mgo.Collection) error {
-		count, err = c.Find(w.buildSelectQuery()).Count()
-		return err
-	}
-
-	return count, modelhelper.Mongo.Run(modelhelper.UserColl, query)
 }
 
 func (w *Warning) buildSelectQuery() bson.M {

--- a/go/src/koding/workers/janitor/warning_test.go
+++ b/go/src/koding/workers/janitor/warning_test.go
@@ -219,7 +219,7 @@ func TestGetCount(t *testing.T) {
 
 		So(count, ShouldEqual, 2)
 
-		Convey("It should return maximum sleep", func() {
+		Convey("It should return minimum sleep", func() {
 			sleepTime, err := warning.getSleepTime()
 			So(err, ShouldBeNil)
 

--- a/go/src/koding/workers/janitor/warning_test.go
+++ b/go/src/koding/workers/janitor/warning_test.go
@@ -214,7 +214,7 @@ func TestGetCount(t *testing.T) {
 
 		warning := VMDeletionWarning1
 
-		count, err := warning.getCount()
+		count, err := modelhelper.CountUsersByQuery(warning.buildSelectQuery())
 		So(err, ShouldBeNil)
 
 		So(count, ShouldEqual, 2)

--- a/go/src/koding/workers/janitor/warning_test.go
+++ b/go/src/koding/workers/janitor/warning_test.go
@@ -203,3 +203,32 @@ func TestAct(t *testing.T) {
 		})
 	})
 }
+
+func TestGetCount(t *testing.T) {
+	Convey("It should return count", t, func() {
+		user1, err := createInactiveUser(21)
+		So(err, ShouldBeNil)
+
+		user2, err := createInactiveUser(21)
+		So(err, ShouldBeNil)
+
+		warning := VMDeletionWarning1
+
+		count, err := warning.getCount()
+		So(err, ShouldBeNil)
+
+		So(count, ShouldEqual, 2)
+
+		Convey("It should return maximum sleep", func() {
+			sleepTime, err := warning.getSleepTime()
+			So(err, ShouldBeNil)
+
+			So(sleepTime, ShouldEqual, 1*time.Second)
+
+			Reset(func() {
+				deleteUserWithUsername(user1)
+				deleteUserWithUsername(user2)
+			})
+		})
+	})
+}

--- a/go/src/koding/workers/janitor/warnings.go
+++ b/go/src/koding/workers/janitor/warnings.go
@@ -21,6 +21,8 @@ var VMDeletionWarning1 = &Warning{
 	},
 
 	Action: SendEmail,
+
+	Throttled: false,
 }
 
 var VMDeletionWarning2 = &Warning{
@@ -42,6 +44,8 @@ var VMDeletionWarning2 = &Warning{
 	},
 
 	Action: SendEmail,
+
+	Throttled: false,
 }
 
 var DeleteInactiveUserVM = &Warning{
@@ -63,6 +67,8 @@ var DeleteInactiveUserVM = &Warning{
 	},
 
 	Action: DeleteVMs,
+
+	Throttled: true,
 }
 
 var DeleteBlockedUserVM = &Warning{
@@ -71,7 +77,7 @@ var DeleteBlockedUserVM = &Warning{
 	Description: "Find blocked users inactive > 14 days, delete ALL their vms",
 
 	Select: []bson.M{
-		bson.M{"lastLoginDate": moreThanDaysQuery(14)},
+		bson.M{"lastLoginDate": dayRangeQuery(14, DefaultRangeForQuery)},
 		bson.M{"inactive.warning": bson.M{"$exists": false}},
 		bson.M{"status": "blocked"},
 	},
@@ -79,4 +85,6 @@ var DeleteBlockedUserVM = &Warning{
 	ExemptCheckers: []*ExemptChecker{IsUserVMsEmpty},
 
 	Action: DeleteVMs,
+
+	Throttled: true,
 }

--- a/go/src/koding/workers/janitor/warnings_test.go
+++ b/go/src/koding/workers/janitor/warnings_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"koding/db/mongodb/modelhelper"
 	"testing"
 	"time"
@@ -71,8 +70,6 @@ func TestWarningsFull(t *testing.T) {
 	Convey("Given user who is inactive & not warned", t, func() {
 		user, err := createInactiveUser(21)
 		So(err, ShouldBeNil)
-
-		fmt.Println(user.LastLoginDate, user.Inactive)
 
 		resetFakeEmails()
 

--- a/go/src/koding/workers/janitor/warnings_test.go
+++ b/go/src/koding/workers/janitor/warnings_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"koding/db/mongodb/modelhelper"
 	"testing"
 	"time"
@@ -68,14 +69,17 @@ func TestWarningsQuery(t *testing.T) {
 
 func TestWarningsFull(t *testing.T) {
 	Convey("Given user who is inactive & not warned", t, func() {
-		user, err := createInactiveUser(46)
+		user, err := createInactiveUser(21)
 		So(err, ShouldBeNil)
+
+		fmt.Println(user.LastLoginDate, user.Inactive)
 
 		resetFakeEmails()
 
 		warning := VMDeletionWarning1
 		warning.ExemptCheckers = []*ExemptChecker{}
 		warning.Action = fakeEmailActionFn()
+
 		warning.Run()
 
 		Convey("Then they should get an email", func() {
@@ -89,7 +93,7 @@ func TestWarningsFull(t *testing.T) {
 	})
 
 	Convey("Given user who is inactive & been warned", t, func() {
-		user, err := createInactiveUser(46)
+		user, err := createInactiveUser(21)
 		So(err, ShouldBeNil)
 
 		resetFakeEmails()
@@ -110,7 +114,7 @@ func TestWarningsFull(t *testing.T) {
 			Convey("Then they should get another email", func() {
 				selector := bson.M{"username": user.Name}
 				update := bson.M{
-					"lastLoginDate": timeNow().Add(-time.Hour * 24 * time.Duration(53)),
+					"lastLoginDate": timeNow().Add(-time.Hour * 24 * time.Duration(25)),
 				}
 
 				err := modelhelper.UpdateUser(selector, update)
@@ -123,6 +127,7 @@ func TestWarningsFull(t *testing.T) {
 				warning := VMDeletionWarning2
 				warning.ExemptCheckers = []*ExemptChecker{}
 				warning.Action = fakeEmailActionFn()
+
 				warning.Run()
 
 				So(len(fakeEmails), ShouldEqual, 1)


### PR DESCRIPTION
- fix broken tests due to changes in query
- change `test.sh` to return code for running tests, so wercker will fail when tests fail
- sleep dynamically based on number of docs to process
- follow golint specs for comments
- run warnings in parallel in goroutines
- add `modelhelper.CountUsersByQuery` for user count queries
