### PR TITLE
onboarding: remove onboarding items when logging out [fixes #99281284]

### DIFF
--- a/client/app/lib/maincontroller.coffee
+++ b/client/app/lib/maincontroller.coffee
@@ -244,6 +244,8 @@ class MainController extends KDController
 
     KiteCache.clearAll()
 
+    kd.singletons.onboarding.stop()
+
     remote.api.JUser.logout (err) =>
 
       mainView._logoutAnimation()


### PR DESCRIPTION
@sinan, can you please review this fix? It's for [this bug](https://www.pivotaltracker.com/story/show/99281284). It just stops onboarding and remove all onboarding items from the page when user starts logging out
