### PR TITLE
Managed demo improvements

### DIFF
--- a/client/activity/lib/views/activityannouncementwidget.coffee
+++ b/client/activity/lib/views/activityannouncementwidget.coffee
@@ -16,6 +16,6 @@ module.exports = class ActivityAnnouncementWidget extends JView
     return """
       <div class="logo"></div>
       <h3>New: Connect your own machine!</h3>
-      <p>You can now connect any Ubuntu Linux machine with a public IP address your Koding account.</p>
+      <p>You can now connect any Ubuntu Linux machine with a public IP address to your Koding account.</p>
       <a href="http://learn.koding.com/connect_your_machine">Learn how.</a>
     """

--- a/client/activity/lib/views/activityannouncementwidget.coffee
+++ b/client/activity/lib/views/activityannouncementwidget.coffee
@@ -19,3 +19,5 @@ module.exports = class ActivityAnnouncementWidget extends JView
       <p>You can now connect any Ubuntu Linux machine with a public IP address to your Koding account.</p>
       <a href="http://learn.koding.com/connect_your_machine">Learn how.</a>
     """
+
+

--- a/client/activity/lib/views/activitywidgetsbar.coffee
+++ b/client/activity/lib/views/activitywidgetsbar.coffee
@@ -1,5 +1,6 @@
 kd                         = require 'kd'
 KDCustomHTMLView           = kd.CustomHTMLView
+checkFlag                  = require 'app/util/checkFlag'
 ActivityGuideWidget        = require './activityguidewidget'
 ActivityTopicsWidget       = require './activitytopicswidget'
 ActivityUniversityWidget   = require './activityuniversitywidget'
@@ -16,7 +17,8 @@ module.exports = class ActivityWidgetsBar extends KDCustomHTMLView
 
     super options
 
-    @addSubView new ActivityAnnouncementWidget
+    if checkFlag ['super-admin', 'super-digitalocean']
+      @addSubView new ActivityAnnouncementWidget
     @addSubView new ActivityGuideWidget
     @addSubView new ActivityTopicsWidget
     @addSubView new ActivityUniversityWidget

--- a/client/app/lib/environment/environmentlistitem.coffee
+++ b/client/app/lib/environment/environmentlistitem.coffee
@@ -39,7 +39,7 @@ module.exports = class EnvironmentListItem extends kd.ListItemView
     if isKoding()
       addVMMenu['Create Koding VM'] = callback: @generateMenuCallback 'koding'
 
-    addVMMenu['Add Your own VM']  = callback: @generateMenuCallback 'managed'
+    addVMMenu['Add Your Own Machine']  = callback: @generateMenuCallback 'managed'
 
 
     @addVMButton  = new kd.ButtonView

--- a/client/app/lib/environment/environmentlistitem.coffee
+++ b/client/app/lib/environment/environmentlistitem.coffee
@@ -39,7 +39,8 @@ module.exports = class EnvironmentListItem extends kd.ListItemView
     if isKoding()
       addVMMenu['Create Koding VM'] = callback: @generateMenuCallback 'koding'
 
-    addVMMenu['Add Your Own Machine']  = callback: @generateMenuCallback 'managed'
+    if checkFlag ['super-admin', 'super-digitalocean']
+      addVMMenu['Add Your Own Machine']  = callback: @generateMenuCallback 'managed'
 
 
     @addVMButton  = new kd.ButtonView

--- a/client/app/lib/providers/managed/addmanagedmachinemodal.coffee
+++ b/client/app/lib/providers/managed/addmanagedmachinemodal.coffee
@@ -1,11 +1,14 @@
-kd      = require 'kd'
-globals = require 'globals'
-whoami  = require 'app/util/whoami'
+kd        = require 'kd'
+globals   = require 'globals'
+checkFlag = require 'app/util/checkFlag'
+whoami    = require 'app/util/whoami'
 
 
 module.exports = class AddManagedMachineModal extends kd.ModalView
 
   constructor: (options = {}, data) ->
+
+    return  unless checkFlag ['super-admin', 'super-digitalocean']
 
     options.cssClass = 'add-managed-vm'
     options.title    = 'Add Your Own Machine'

--- a/client/app/lib/providers/managed/addmanagedmachinemodal.coffee
+++ b/client/app/lib/providers/managed/addmanagedmachinemodal.coffee
@@ -62,7 +62,7 @@ module.exports = class AddManagedMachineModal extends kd.ModalView
         then "export KONTROLURL=#{globals.config.newkontrol.url}; "
         else ''
 
-        cmd = "#{kontrolUrl}curl -sSL s3.amazonaws.com/koding-klient/install.sh | bash -s #{token}"
+        cmd = "#{kontrolUrl}curl -sSL https://kodi.ng/s | bash -s #{token}"
 
         @loader.destroy()
         @code.addSubView input = new kd.InputView

--- a/client/app/lib/providers/managed/viewhelpers.coffee
+++ b/client/app/lib/providers/managed/viewhelpers.coffee
@@ -19,7 +19,7 @@ kontrolUrl = if globals.config.environment in ['dev', 'sandbox'] \
 
 contents  =
   install : """#{kontrolUrl}
-    $ curl -sSL s3.amazonaws.com/koding-klient/install.sh | bash -s %%TOKEN%%
+    $ curl -sSL https://kodi.ng/s | bash -s %%TOKEN%%
   """
 
 module.exports   = view =


### PR DESCRIPTION
This PR implements a handful of the clientside changes needed as a result of the DO mtg today.
1. Added new `super-digitalocean` flag to hide the new ui elements behind.
2. Added the short url for the installer script (using `https`, currently)
3. Corrected `Add Your Own VM` text
4. Corrected typo in announcement text

@gokmen Regarding item 1 (c09b5ac67e73d73391afddea026ed53d80854211), you'll notice that i also added the `super-admin` flag check. On my local koding, i wasn't finding that super-admin was automatically working with `super-digitalocean`. [The source of checkFlag()](https://github.com/koding/koding/blob/42166f349c0c8d2f5ff9900443b122316a33abc8/client/app/lib/util/checkFlag.coffee) does not seem to auto approve `super-admin`. So, i added the flag manually in the three checks. Please let me know if this is incorrect.

@gokmen Since i've already pinged you, would you mind review/merging? Thanks :)
