### PR TITLE
reactivity: text change, style fixes [fixes #98517888]

### DIFF
--- a/client/activity/lib/components/suggestionmenu/index.coffee
+++ b/client/activity/lib/components/suggestionmenu/index.coffee
@@ -59,7 +59,7 @@ module.exports = class SuggestionMenu extends React.Component
       </div>
       <SuggestionList suggestions={suggestions} />
       <div className="ActivitySuggestionMenu-footer">
-        None of the above answers your questions? Post yours
+        If none of these are relevant, post yours
         <button type="submit" className="kdbutton solid green small" onClick={@props.onSubmit}>
           <span className="button-title">SEND</span>
         </button>

--- a/client/activity/lib/components/suggestionmenu/styl/suggestionmenu.styl
+++ b/client/activity/lib/components/suggestionmenu/styl/suggestionmenu.styl
@@ -27,7 +27,8 @@
   rel()
   font-size          12px
   text-align         right
-  padding            25px 105px 27px 0px
+  padding            25px 100px 27px 0px
+  font-style         italic
 
   .kdbutton.solid.small
     abs()

--- a/client/activity/lib/styl/activity.inputwidget.styl
+++ b/client/activity/lib/styl/activity.inputwidget.styl
@@ -86,7 +86,7 @@ activity.inputwidget.styl
     .preview-icon
       display         block
       r-sprite        "activity", "markdown"
-      margin          4px 9px 0 0
+      margin          3px 9px 0 0
       cursor          pointer
       fr()
 


### PR DESCRIPTION
@sinan, @usirin, can you review these changes?

Some screenshots:
Text change:
![text-change](https://cloud.githubusercontent.com/assets/492219/8820873/c99a7dbe-3061-11e5-9e09-142917f28175.jpg)

If to make markdown button and SEND button the same height, it looks weird:
![same-buttons-height](https://cloud.githubusercontent.com/assets/492219/8820925/2362441c-3062-11e5-94c0-02cbe9ec66b5.jpg)

That's why I aligned markdown button vertically relative to SEND button:
![markdown-vertical-alignment](https://cloud.githubusercontent.com/assets/492219/8820938/4d73fa5c-3062-11e5-836a-2f4f3369aea1.jpg)
