### PR TITLE
kloud: parse and use accountID for contentID

### DIFF
--- a/go/src/github.com/mitchellh/goamz/iam/iam.go
+++ b/go/src/github.com/mitchellh/goamz/iam/iam.go
@@ -4,12 +4,13 @@ package iam
 
 import (
 	"encoding/xml"
-	"github.com/mitchellh/goamz/aws"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/mitchellh/goamz/aws"
 )
 
 // The IAM type encapsulates operations operations with the IAM endpoint.
@@ -149,6 +150,18 @@ func (iam *IAM) GetUser(name string) (*GetUserResp, error) {
 	params := map[string]string{
 		"Action":   "GetUser",
 		"UserName": name,
+	}
+	resp := new(GetUserResp)
+	if err := iam.query(params, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// GetDefaultUser gets the user making the request
+func (iam *IAM) GetDefaultUser() (*GetUserResp, error) {
+	params := map[string]string{
+		"Action": "GetUser",
 	}
 	resp := new(GetUserResp)
 	if err := iam.query(params, resp); err != nil {

--- a/go/src/koding/kites/kloud/kloud/plan.go
+++ b/go/src/koding/kites/kloud/kloud/plan.go
@@ -54,6 +54,9 @@ func (t *terraformCredential) awsCredentials() (string, string, error) {
 		return "", "", fmt.Errorf("provider '%s' is not supported", t.Provider)
 	}
 
+	// we do not check for key existency here because the key might exists but
+	// with an empty value, so just checking for the emptiness of the value is
+	// better
 	accessKey := t.Data["access_key"]
 	if accessKey == "" {
 		return "", "", fmt.Errorf("accessKey for publicKey '%s' is not set", t.PublicKey)
@@ -61,7 +64,7 @@ func (t *terraformCredential) awsCredentials() (string, string, error) {
 
 	secretKey := t.Data["secret_key"]
 	if secretKey == "" {
-		return "", "", fmt.Errorf("accessKey for publicKey '%s' is not set", t.PublicKey)
+		return "", "", fmt.Errorf("secretKey for publicKey '%s' is not set", t.PublicKey)
 	}
 
 	return accessKey, secretKey, nil

--- a/go/src/koding/kites/kloud/kloud/plan.go
+++ b/go/src/koding/kites/kloud/kloud/plan.go
@@ -49,6 +49,24 @@ func (t *terraformCredential) region() (string, error) {
 	return region, nil
 }
 
+func (t *terraformCredential) awsCredentials() (string, string, error) {
+	if t.Provider != "aws" {
+		return "", "", fmt.Errorf("provider '%s' is not supported", t.Provider)
+	}
+
+	accessKey := t.Data["access_key"]
+	if accessKey == "" {
+		return "", "", fmt.Errorf("accessKey for publicKey '%s' is not set", t.PublicKey)
+	}
+
+	secretKey := t.Data["secret_key"]
+	if secretKey == "" {
+		return "", "", fmt.Errorf("accessKey for publicKey '%s' is not set", t.PublicKey)
+	}
+
+	return accessKey, secretKey, nil
+}
+
 // appendAWSVariable appends the credentials aws data to the given template and
 // returns it back.
 func (t *terraformCredential) appendAWSVariable(template string) (string, error) {
@@ -88,12 +106,17 @@ func (t *terraformCredential) appendAWSVariable(template string) (string, error)
 		data.Variable = make(map[string]map[string]interface{})
 	}
 
+	accessKey, secretKey, err := t.awsCredentials()
+	if err != nil {
+		return "", err
+	}
+
 	data.Variable["access_key"] = map[string]interface{}{
-		"default": t.Data["access_key"],
+		"default": accessKey,
 	}
 
 	data.Variable["secret_key"] = map[string]interface{}{
-		"default": t.Data["secret_key"],
+		"default": secretKey,
 	}
 
 	data.Variable["region"] = map[string]interface{}{

--- a/go/src/koding/kites/kloud/kloud/terraformutils.go
+++ b/go/src/koding/kites/kloud/kloud/terraformutils.go
@@ -331,3 +331,15 @@ func checkKlients(ctx context.Context, kiteIds map[string]string) error {
 func isVariable(v string) bool {
 	return v[0] == '$'
 }
+
+// parseAccountID parses an AWS arn string to get the Account ID
+func parseAccountID(arn string) (string, error) {
+	// example arn string: "arn:aws:iam::213456789:user/username"
+	// returns: 213456789.
+	splitted := strings.Split(strings.TrimPrefix(arn, "arn:aws:iam::"), ":")
+	if len(splitted) != 2 {
+		return "", fmt.Errorf("Couldn't parse arn string: %s", arn)
+	}
+
+	return splitted[0], nil
+}

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -165,7 +165,7 @@ func init() {
 	kiteURL := &url.URL{Scheme: "http", Host: "localhost:4002", Path: "/kite"}
 	_, err := kloudKite.Register(kiteURL)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal("kloud ", err.Error())
 	}
 
 	provider = kodingProvider()
@@ -207,12 +207,12 @@ func init() {
 
 	t, err := terraformer.New(tConf, common.NewLogger("terraformer", false))
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Fatal("terraformer ", err.Error())
 	}
 
 	terraformerKite, err := terraformer.NewKite(t, tConf)
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Fatal("terraformer ", err.Error())
 	}
 
 	// no need to register to kontrol, kloud talks directly via a secret key
@@ -766,8 +766,8 @@ func createUser(username, groupname, region string) (*singleUser, error) {
 		PublicKey: credPublicKey,
 		OriginId:  accountId,
 		Meta: bson.M{
-			"access_key": "",
-			"secret_key": "",
+			"access_key": os.Getenv("KLOUD_TESTACCOUNT_ACCESSKEY"),
+			"secret_key": os.Getenv("KLOUD_TESTACCOUNT_SECRETKEY"),
 			"region":     region,
 		},
 	}


### PR DESCRIPTION
We now use the accountID for contentID:

![image](https://cloud.githubusercontent.com/assets/438920/8826400/e0a240fa-308e-11e5-9249-56e1b2a3d711.png)
