### PR TITLE
Socialapi: fix parsing problem of channelids

### DIFF
--- a/go/src/socialapi/workers/team/team.go
+++ b/go/src/socialapi/workers/team/team.go
@@ -74,7 +74,8 @@ func (c *Controller) handleDefaultChannels(defaultChannels []string, cp *models.
 	for _, channelId := range defaultChannels {
 		ci, err := strconv.ParseInt(channelId, 10, 64)
 		if err != nil {
-			return err
+			c.log.Error("Couldnt parse channelId: %s, err: %s", channelId, err.Error())
+			continue
 		}
 
 		if err := c.handleDefaultChannel(ci, cp); err != nil {


### PR DESCRIPTION
this error consumed all quota of paper trail
https://papertrailapp.com/systems/94061664/events?centered_on_id=560532108993712132
