### PR TITLE
Fixes "/Recover does not work for logged in users" [fixes #91571992]

### DIFF
--- a/client/account/bant.json
+++ b/client/account/bant.json
@@ -4,7 +4,8 @@
   "routes": {
     "/:name?/Account": "profile",
     "/:name?/Account/:section": "section",
-    "/:name?/Account/Referrer": "referrer"
+    "/:name?/Account/Referrer": "referrer",
+    "/:name?/Recover": "recover"
   },
   "sprites": [
     "./lib/sprites"

--- a/client/account/lib/routehandler.coffee
+++ b/client/account/lib/routehandler.coffee
@@ -1,4 +1,5 @@
 kd = require 'kd'
+kookies = require 'kookies'
 KDNotificationView = kd.NotificationView
 lazyrouter = require 'app/lazyrouter'
 
@@ -27,4 +28,6 @@ module.exports = -> lazyrouter.bind 'account', (type, info, state, path, ctx) ->
       ctx.clear()
     when 'referrer' then kd.singletons.router.handleRoute '/'
     when 'section' then handle info, path
-
+    when 'recover'
+      kookies.expire 'clientId'
+      global.location.href = '/Recover'

--- a/client/app/lib/commonviews/verifypasswordmodal.coffee
+++ b/client/app/lib/commonviews/verifypasswordmodal.coffee
@@ -30,6 +30,7 @@ module.exports = class VerifyPasswordModal extends KDModalViewWithForms
                 title             : "Forgot Password?"
                 callback          : =>
                   @destroy()
+                  kd.singletons.appManager.tell 'Account', 'closeModal'
                   {entryPoint} = globals.config
                   kd.singleton("router").handleRoute "/Recover", {entryPoint}
 

--- a/client/app/lib/commonviews/verifypasswordmodal.coffee
+++ b/client/app/lib/commonviews/verifypasswordmodal.coffee
@@ -29,9 +29,9 @@ module.exports = class VerifyPasswordModal extends KDModalViewWithForms
                 style             : "solid light-gray medium"
                 title             : "Forgot Password?"
                 callback          : =>
+                  @destroy()
                   {entryPoint} = globals.config
                   kd.singleton("router").handleRoute "/Recover", {entryPoint}
-                  @destroy()
 
             fields                :
               password            :

--- a/client/app/lib/routehandler.coffee
+++ b/client/app/lib/routehandler.coffee
@@ -4,7 +4,6 @@ KDModalView    = kd.ModalView
 
 remote         = require('./remote').getInstance()
 globals        = require 'globals'
-kookies        = require 'kookies'
 
 lazyrouter     = require './lazyrouter'
 trackEvent     = require './util/trackEvent'

--- a/client/app/lib/routehandler.coffee
+++ b/client/app/lib/routehandler.coffee
@@ -89,9 +89,4 @@ module.exports = -> lazyrouter.bind 'app', (type, info, state, path, ctx) ->
         remote.cacheable info.params.name, (err, models, name) =>
           if models?
           then open.call this, info, models.first
-          else 
-           if info.params.name is 'Recover'
-             kookies.expire 'clientId'
-             global.location.href = '/Recover'
-           else 
-             ctx.handleNotFound info.params.name
+          else ctx.handleNotFound info.params.name

--- a/client/app/lib/routehandler.coffee
+++ b/client/app/lib/routehandler.coffee
@@ -88,4 +88,7 @@ module.exports = -> lazyrouter.bind 'app', (type, info, state, path, ctx) ->
         remote.cacheable info.params.name, (err, models, name) =>
           if models?
           then open.call this, info, models.first
-          else ctx.handleNotFound info.params.name
+          else 
+           if info.params.name is 'Recover'
+           then kd.singletons.mainController.doLogout()
+           else ctx.handleNotFound info.params.name

--- a/client/app/lib/routehandler.coffee
+++ b/client/app/lib/routehandler.coffee
@@ -4,6 +4,7 @@ KDModalView    = kd.ModalView
 
 remote         = require('./remote').getInstance()
 globals        = require 'globals'
+kookies        = require 'kookies'
 
 lazyrouter     = require './lazyrouter'
 trackEvent     = require './util/trackEvent'
@@ -90,5 +91,7 @@ module.exports = -> lazyrouter.bind 'app', (type, info, state, path, ctx) ->
           then open.call this, info, models.first
           else 
            if info.params.name is 'Recover'
-           then kd.singletons.mainController.doLogout()
-           else ctx.handleNotFound info.params.name
+             kookies.expire 'clientId'
+             global.location.href = '/Recover'
+           else 
+             ctx.handleNotFound info.params.name


### PR DESCRIPTION
![4fcxsrqlbl](https://cloud.githubusercontent.com/assets/1278794/8836412/69ff9052-30c9-11e5-9f5b-606df830b167.gif)

**The story:** https://www.pivotaltracker.com/story/show/91571992

**Notes:** When the user clicks the Forgot password button in Account Settings he/she is logged out and redirected to /Recover. We destroy the email modal then the Account Settings modal and instead of dropping a not found for /Recover it will drop the auth cookie and redirect to /Recover.

cc. @sinan @gniting 
