### PR TITLE
managed: Added new klient.stop method, to stop Klient after a managed disconnect

### DIFF
--- a/client/app/lib/kite/kites/klient.coffee
+++ b/client/app/lib/kite/kites/klient.coffee
@@ -35,6 +35,7 @@ module.exports = class KodingKite_KlientKite extends require('../kodingkite')
     klientShare        : 'klient.share'
     klientUnshare      : 'klient.unshare'
     klientShared       : 'klient.shared'
+    klientStop         : 'klient.stop'
 
     sshKeysAdd         : 'sshkeys.add'
 

--- a/client/app/lib/kite/kites/klient.coffee
+++ b/client/app/lib/kite/kites/klient.coffee
@@ -31,7 +31,7 @@ module.exports = class KodingKite_KlientKite extends require('../kodingkite')
     webtermPing        : 'webterm.ping'
     webtermRename      : 'webterm.rename'
 
-    klientDisconnect   : 'klient.disconnect'
+    klientDisable      : 'klient.disable'
     klientInfo         : 'klient.info'
     klientShare        : 'klient.share'
     klientUnshare      : 'klient.unshare'

--- a/client/app/lib/kite/kites/klient.coffee
+++ b/client/app/lib/kite/kites/klient.coffee
@@ -31,11 +31,11 @@ module.exports = class KodingKite_KlientKite extends require('../kodingkite')
     webtermPing        : 'webterm.ping'
     webtermRename      : 'webterm.rename'
 
+    klientDisconnect   : 'klient.disconnect'
     klientInfo         : 'klient.info'
     klientShare        : 'klient.share'
     klientUnshare      : 'klient.unshare'
     klientShared       : 'klient.shared'
-    klientStop         : 'klient.stop'
 
     sshKeysAdd         : 'sshkeys.add'
 

--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -425,8 +425,9 @@ module.exports = class ComputeController extends KDController
     destroy = (machine)=>
 
       baseKite = machine.getBaseKite( createIfNotExists = no )
-      baseKite.klientStop?()  if machine?.provider is 'managed'
-      baseKite.disconnect()
+      if machine?.provider is 'managed' and baseKite.klientDisconnect?
+      then baseKite.klientDisconnect().finally -> baseKite.disconnect()
+      else baseKite.disconnect()
 
       if machine?.provider is 'managed'
 

--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -817,3 +817,5 @@ module.exports = class ComputeController extends KDController
 
         if stack.machines.length isnt machineCount
           @emit 'StacksInconsistent', stack
+
+

--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -425,8 +425,8 @@ module.exports = class ComputeController extends KDController
     destroy = (machine)=>
 
       baseKite = machine.getBaseKite( createIfNotExists = no )
-      if machine?.provider is 'managed' and baseKite.klientDisconnect?
-      then baseKite.klientDisconnect().finally -> baseKite.disconnect()
+      if machine?.provider is 'managed' and baseKite.klientDisable?
+      then baseKite.klientDisable().finally -> baseKite.disconnect()
       else baseKite.disconnect()
 
       if machine?.provider is 'managed'

--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -427,7 +427,7 @@ module.exports = class ComputeController extends KDController
       baseKite = machine.getBaseKite( createIfNotExists = no )
 
       if machine?.provider is 'managed'
-      then baseKite.klientStop().disconnect()
+      then baseKite.klientStop?().disconnect()
       else baseKite.disconnect()
 
       if machine?.provider is 'managed'

--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -424,7 +424,11 @@ module.exports = class ComputeController extends KDController
 
     destroy = (machine)=>
 
-      machine.getBaseKite( createIfNotExists = no ).disconnect()
+      baseKite = machine.getBaseKite( createIfNotExists = no )
+
+      if machine?.provider is 'managed'
+      then baseKite.klientStop().disconnect()
+      else baseKite.disconnect()
 
       if machine?.provider is 'managed'
 

--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -425,10 +425,8 @@ module.exports = class ComputeController extends KDController
     destroy = (machine)=>
 
       baseKite = machine.getBaseKite( createIfNotExists = no )
-
-      if machine?.provider is 'managed'
-      then baseKite.klientStop?().disconnect()
-      else baseKite.disconnect()
+      baseKite.klientStop?()  if machine?.provider is 'managed'
+      baseKite.disconnect()
 
       if machine?.provider is 'managed'
 

--- a/client/app/lib/providers/machinesettingsadvancedview.coffee
+++ b/client/app/lib/providers/machinesettingsadvancedview.coffee
@@ -21,7 +21,7 @@ module.exports = class MachineSettingsAdvancedView extends KDView
       reinitButton.hide()
       reassignButton.show()
       terminateTitle = 'Disconnect your VM'
-      terminateText  = 'Remove the connection between your VM and Koding.'
+      terminateText  = 'Remove the connection between your Machine and Koding.'
     else
       reassignButton.hide()
 


### PR DESCRIPTION
Note that i chain `.disconnect()` after the `klientStop()` method. I did this in the event that `kite.disconnect` provided any additional logic to stop watching for the klient's existence. This may not be needed, but it seemed safest.
cc @gokmen 

**DO NOT MERGE YET** _(until klient changes are merged)_
