### PR TITLE
managed: Removed -S flag from curl command

### DIFF
--- a/client/app/lib/providers/managed/addmanagedmachinemodal.coffee
+++ b/client/app/lib/providers/managed/addmanagedmachinemodal.coffee
@@ -65,7 +65,7 @@ module.exports = class AddManagedMachineModal extends kd.ModalView
         then "export KONTROLURL=#{globals.config.newkontrol.url}; "
         else ''
 
-        cmd = "#{kontrolUrl}curl -sSL https://kodi.ng/s | bash -s #{token}"
+        cmd = "#{kontrolUrl}curl -sL https://kodi.ng/s | bash -s #{token}"
 
         @loader.destroy()
         @code.addSubView input = new kd.InputView

--- a/client/app/lib/providers/managed/viewhelpers.coffee
+++ b/client/app/lib/providers/managed/viewhelpers.coffee
@@ -19,7 +19,7 @@ kontrolUrl = if globals.config.environment in ['dev', 'sandbox'] \
 
 contents  =
   install : """#{kontrolUrl}
-    $ curl -sSL https://kodi.ng/s | bash -s %%TOKEN%%
+    $ curl -sL https://kodi.ng/s | bash -s %%TOKEN%%
   """
 
 module.exports   = view =


### PR DESCRIPTION
In an effort to reduce the number of flags, the `-S` flag has been removed. `-S` suppresses errors, which would prevent a response error (404/etc) from piping to bash and being interpreted as code. It's a valid flag, but technically we can remove it.

`-L` is still required currently, as we are using a redirect on `kodi.ng/s`.

`-s` prevents the loading progress characters from printing to bash, i believe this will always be required.
