### PR TITLE
onboarding: remove auto reset for admin [fixes #99121436]

### DIFF
--- a/client/app/lib/onboarding/onboardingcontroller.coffee
+++ b/client/app/lib/onboarding/onboardingcontroller.coffee
@@ -74,23 +74,12 @@ module.exports = class OnboardingController extends KDController
 
 
   ###*
-   * It is executed once all data is loaded
-   * If it's preview mode (super admin), it resets all onboardings so admin can see them again
-   * Also, it runs all onboardings which were requested while data was loading
-   * and therefore were added to pending queue
+   * It is executed once all data is loaded.
+   * It marks controller as ready to work and runs all onboardings
+   * which were requested while data was loading and therefore
+   * were added to pending queue
   ###
   ready: ->
-
-    if @isPreviewMode()
-      @reset @bound 'processPendingQueue'
-    else
-      @processPendingQueue()
-
-
-  ###*
-   * Marks controller as ready to work and runs onboardings in pending queue
-  ###
-  processPendingQueue: ->
 
     @isReady = yes
     @run args...  for args in @pendingQueue


### PR DESCRIPTION
@sinan, could you please review one more onboarding fix. It's about [this bug](https://www.pivotaltracker.com/story/show/99121436) and remove useless onboarding auto reset for admin. Before this fix, throbbers appeared again after page reload even if admin closed them before. With this fix, closed throbbers will appear again only if admin resets onboarding on Support modal (the same behavior as for regular users)
