### PR TITLE
kloud: enable "count" directive

### DIFF
--- a/go/src/koding/kites/kloud/kloud/apply.go
+++ b/go/src/koding/kites/kloud/kloud/apply.go
@@ -354,7 +354,7 @@ func apply(ctx context.Context, username, groupname, stackId string) error {
 		return err
 	}
 
-	fmt.Printf(string(d))
+	sess.Log.Debug("Updated machines\n%s", string(d))
 
 	ev.Push(&eventer.Event{
 		Message:    "Checking klient connections",
@@ -362,6 +362,7 @@ func apply(ctx context.Context, username, groupname, stackId string) error {
 		Status:     machinestate.Building,
 	})
 
+	sess.Log.Debug("Checking total '%d' klients", len(buildData.KiteIds))
 	return checkKlients(ctx, buildData.KiteIds)
 }
 

--- a/go/src/koding/kites/kloud/kloud/bootstrap.go
+++ b/go/src/koding/kites/kloud/kloud/bootstrap.go
@@ -49,7 +49,6 @@ func (k *Kloud) Bootstrap(r *kite.Request) (interface{}, error) {
 		return nil, NewError(ErrNoArguments)
 	}
 
-	k.Log.Debug("Received arguments: %v", r.Args)
 	var args *TerraformBootstrapRequest
 	if err := r.Args.One().Unmarshal(&args); err != nil {
 		return nil, err

--- a/go/src/koding/kites/kloud/kloud/terraformutils.go
+++ b/go/src/koding/kites/kloud/kloud/terraformutils.go
@@ -281,7 +281,14 @@ func injectKodingData(ctx context.Context, content, username string, creds *terr
 				return nil, err
 			}
 
-			kiteIds[resourceName] = kiteId
+			// if the count is greater than 1, terraform will change the labels
+			// and append a number(starting with index 0) to each label
+			if count != 1 {
+				kiteIds[resourceName+"."+strconv.Itoa(i)] = kiteId
+			} else {
+				kiteIds[resourceName] = kiteId
+			}
+
 			countKeys[strconv.Itoa(i)] = kiteKey
 		}
 

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -389,8 +389,8 @@ func TestTerraformStack(t *testing.T) {
 		t.Error(err)
 	}
 
-	fmt.Printf("\n=== Test is stopped for 5 minutes, now is your time to debug FATIH! ===\n\n")
-	time.Sleep(time.Minute * 5)
+	// fmt.Printf("\n=== Test is stopped for 5 minutes, now is your time to debug FATIH! ===\n\n")
+	// time.Sleep(time.Minute * 5)
 
 	destroyArgs := &kloud.TerraformApplyRequest{
 		StackId:   userData.StackId,

--- a/go/src/koding/kites/kloud/main_test.go
+++ b/go/src/koding/kites/kloud/main_test.go
@@ -91,7 +91,7 @@ var (
 
 	errNoSnapshotFound = errors.New("No snapshot found for the given user")
 
-	machineCount      = 1
+	machineCount      = 2
 	terraformTemplate = `{
     "provider": {
         "aws": {

--- a/go/src/koding/kites/kloud/userdata/userdata.go
+++ b/go/src/koding/kites/kloud/userdata/userdata.go
@@ -210,9 +210,13 @@ final_message: "All done!"
 
 func (u *Userdata) Create(c *CloudInitConfig) ([]byte, error) {
 	var err error
-	c.KiteKey, err = u.Keycreator.Create(c.Username, c.KiteId)
-	if err != nil {
-		return nil, err
+
+	// only change it KiteKey was not passed from outside
+	if c.KiteKey == "" {
+		c.KiteKey, err = u.Keycreator.Create(c.Username, c.KiteId)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	latestKlientPath, err := u.Bucket.LatestDeb()

--- a/go/src/koding/kites/kloud/userdata/userdata.go
+++ b/go/src/koding/kites/kloud/userdata/userdata.go
@@ -83,12 +83,10 @@ var (
 			}
 
 			lines := strings.Split(cmd, "\n")
-			fmt.Printf("lines = %+v\n", lines)
 			c := "  - |\n"
 			for _, line := range lines {
 				c += fmt.Sprintf("    %s\n", line)
 			}
-			fmt.Printf("c = %+v\n", c)
 			return c
 		},
 	}


### PR DESCRIPTION
This PR enables the `count` directive in Terraform templates. The problem with
`count` was that the userdata was equal (same kite id) for each machine.
However each machine needs to be unique so we can track them
(start/stop/destroy/etc..). 

To change the Userdata and make it unique we use terraforms `${count.index}`
interpolation with the builtin function `lookup`. First we create a map of
generated KiteKeys and store them in map with the keys being the count index
itself. 

In userdata, instead of adding the `kiteKey` directly we add this line:

```
${lookup(var.kitekeys, count.index)}
```

Each machine's userdata will have this line, which terraform transforms and
replaces with the precreated kite keys we passed with the `var.kitekeys`
variable. This is how it looks like:

![image](https://cloud.githubusercontent.com/assets/438920/8879620/3ac618d8-323b-11e5-9ac8-ccdf4519fedd.png)

And this is how it's being used in user data:

![image](https://cloud.githubusercontent.com/assets/438920/8879641/620a91a8-323b-11e5-9c9b-159fcf2e471b.png)
