### PR TITLE
integration: show integration as the post owner [completes #99276336]

### DIFF
--- a/client/activity/lib/views/activitylistitemview.coffee
+++ b/client/activity/lib/views/activitylistitemview.coffee
@@ -66,7 +66,7 @@ module.exports = class ActivityListItemView extends ActivityBaseListItemView
       cssClass : 'author-avatar'
       origin   : origin
 
-    @author = new ProfileLinkView { origin }
+    @author = new ProfileLinkView { origin, integration: data.integration }
 
     {commentViewClass} = options
 

--- a/client/activity/lib/views/activitylistitemview.coffee
+++ b/client/activity/lib/views/activitylistitemview.coffee
@@ -60,11 +60,12 @@ module.exports = class ActivityListItemView extends ActivityBaseListItemView
       id              : data.account._id
 
     @avatar = new AvatarView
-      size     :
-        width  : 37
-        height : 37
-      cssClass : 'author-avatar'
-      origin   : origin
+      size        :
+        width     : 37
+        height    : 37
+      cssClass    : 'author-avatar'
+      origin      : origin
+      integration : data.integration
 
     @author = new ProfileLinkView { origin, integration: data.integration }
 

--- a/client/app/lib/commonviews/avatarviews/avatarview.coffee
+++ b/client/app/lib/commonviews/avatarviews/avatarview.coffee
@@ -112,11 +112,15 @@ module.exports = class AvatarView extends LinkView
 
     width         = width * @dpr
     height        = height * @dpr
-    minAvatarSize = 30 * @dpr 
+    minAvatarSize = 30 * @dpr
 
     if profile.avatar?.match regexps.webProtocolRegExp
       resizedAvatar = proxifyUrl profile.avatar, {crop: yes, width, height}
       avatarURI     = resizedAvatar
+
+    {integration} = @getOptions()
+    if integration?.iconPath
+      avatarURI = proxifyUrl integration.iconPath, {crop: yes, width, height}
 
     @setAvatar avatarURI
 
@@ -132,7 +136,13 @@ module.exports = class AvatarView extends LinkView
 
     kd.getSingleton("groupsController").ready =>
       {slug} = kd.getSingleton("groupsController").getCurrentGroup()
-      href = if slug is "koding" then "/#{profile.nickname}" else "/#{slug}/#{profile.nickname}"
+      href = if integration
+        "/Admin/Integrations/Configure/#{integration.id}"
+      else if slug is 'koding'
+        "/#{profile.nickname}"
+      else
+        "/#{slug}/#{profile.nickname}"
+
       @setAttribute "href", href
 
     @showStatus()  if @getOptions().showStatus

--- a/client/app/lib/commonviews/linkviews/profilelinkview.coffee
+++ b/client/app/lib/commonviews/linkviews/profilelinkview.coffee
@@ -43,8 +43,12 @@ module.exports = class ProfileLinkView extends LinkView
 
 
   updateHref: ->
+    { integration } = @getOptions()
     nickname = @getData().profile?.nickname
-    @setAttribute "href", "/#{nickname}"  if nickname
+    href = if integration then "/Admin/Integrations/Configure/#{integration.id}"
+    else if nickname then "/#{nickname}"
+
+    @setAttribute "href", href  if href
 
 
   render: (fields) ->
@@ -58,9 +62,12 @@ module.exports = class ProfileLinkView extends LinkView
     super fields
 
   pistachio:->
+    { integration } = @getOptions()
     {profile} = @getData()
     JView::pistachio.call this,
-      if profile.firstName is "" and profile.lastName is ""
+      if integration
+      then "#{integration.title}"
+      else if profile.firstName is "" and profile.lastName is ""
       then "{{#(profile.nickname)}} {{> @troll}}"
       else "{{#(profile.firstName)+' '+#(profile.lastName)}} {{> @troll}}"
 

--- a/client/app/lib/linkcontroller.coffee
+++ b/client/app/lib/linkcontroller.coffee
@@ -15,9 +15,15 @@ module.exports = class LinkController extends KDController
     options = {}
     route   = switch data.constructor
       when JAccount
+        { integration } = link.options
         {slug} = getGroup()
         {profile: {nickname}} = data
-        href = if slug is "koding" then "/#{nickname}" else "/#{slug}/#{nickname}"
+        href = if integration
+          "/Admin/Integrations/Configure/#{integration.id}"
+        else if slug is 'koding'
+          "/#{nickname}"
+        else
+          "/#{slug}/#{nickname}"
       when JGroup
         "/#{data.slug}"
 

--- a/client/app/lib/socialapicontroller.coffee
+++ b/client/app/lib/socialapicontroller.coffee
@@ -138,6 +138,8 @@ module.exports = class SocialApiController extends KDController
     m.repliesCount = data.repliesCount
     m.isFollowed   = data.isFollowed
 
+    m.integration = data.integration
+
     # this is sent by the server when
     # response for pinned messages
     m.unreadRepliesCount = data.unreadRepliesCount

--- a/go/src/socialapi/models/channelmessage.go
+++ b/go/src/socialapi/models/channelmessage.go
@@ -71,7 +71,8 @@ const (
 	ChannelMessage_TYPE_BOT             = "bot"
 	ChannelMessage_TYPE_SYSTEM          = "system"
 
-	ChannelMessagePayloadKeyLocation = "location"
+	ChannelMessagePayloadKeyLocation    = "location"
+	ChannelMessagePayloadKeyIntegration = "channelIntegrationId"
 )
 
 func (c *ChannelMessage) Location() *string {
@@ -211,7 +212,7 @@ func (c *ChannelMessage) BuildMessage(query *request.Query) (*ChannelMessageCont
 	}
 
 	// return cmc, cmc.AddIsFollowed(query).AddIsInteracted(query).Err
-	return cmc, cmc.AddIsInteracted(query).Err
+	return cmc, cmc.AddIntegration().AddIsInteracted(query).Err
 }
 
 func (c *ChannelMessage) CheckIsMessageFollowed(query *request.Query) (bool, error) {

--- a/go/src/socialapi/models/integrationhelper.go
+++ b/go/src/socialapi/models/integrationhelper.go
@@ -1,0 +1,102 @@
+// For the sake of resolving circular dependency, we have added
+// read only integration helper here
+package models
+
+import (
+	"github.com/jinzhu/gorm"
+	"github.com/koding/bongo"
+)
+
+const ChannelIntegrationBongoName = "integration.channel_integration"
+
+const IntegrationBongoName = "integration.integration"
+
+/////////////// ChannelIntegrationMeta ///////////////////
+
+type ChannelIntegrationMeta struct {
+	Id       int64  `json:"id,string"`
+	IconPath string `json:"iconPath"`
+	Title    string `json:"title"`
+}
+
+func NewChannelIntegrationMeta() *ChannelIntegrationMeta {
+	return &ChannelIntegrationMeta{}
+}
+
+func (cim *ChannelIntegrationMeta) Populate(ci *ChannelIntegration, i *Integration) {
+	// Later on, also image will be customizable
+	cim.Id = ci.Id
+	cim.IconPath = i.IconPath
+	cim.Title = i.Title
+
+	if ci.Settings == nil {
+		return
+	}
+
+	val, ok := ci.Settings["customName"]
+	if ok && val != nil && *val != "" {
+		cim.Title = *val
+	}
+}
+
+func (cim *ChannelIntegrationMeta) ByChannelIntegrationId(id int64) error {
+	ci := new(ChannelIntegration)
+	if err := ci.ById(id); err != nil {
+		return err
+	}
+
+	i := new(Integration)
+	if err := i.ById(ci.IntegrationId); err != nil {
+		return err
+	}
+
+	cim.Populate(ci, i)
+
+	return nil
+}
+
+/////////////// ChannelIntegration ///////////////////
+
+type ChannelIntegration struct {
+	// unique identifier of the channel integration
+	Id int64
+
+	// Settings field used for storing custom bot name, icon path and various
+	// other data
+	Settings gorm.Hstore
+
+	// Id of the integration
+	IntegrationId int64
+}
+
+func (i ChannelIntegration) GetId() int64 {
+	return i.Id
+}
+
+func (i ChannelIntegration) BongoName() string {
+	return ChannelIntegrationBongoName
+}
+
+func (i *ChannelIntegration) ById(id int64) error {
+	return bongo.B.ById(i, id)
+}
+
+/////////////// Integration ///////////////////
+
+type Integration struct {
+	Id       int64
+	IconPath string
+	Title    string
+}
+
+func (i Integration) GetId() int64 {
+	return i.Id
+}
+
+func (i Integration) BongoName() string {
+	return IntegrationBongoName
+}
+
+func (i *Integration) ById(id int64) error {
+	return bongo.B.ById(i, id)
+}

--- a/go/src/socialapi/models/integrationhelper_test.go
+++ b/go/src/socialapi/models/integrationhelper_test.go
@@ -1,0 +1,37 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/jinzhu/gorm"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestChannelIntegrationMetaPopulate(t *testing.T) {
+	Convey("while populating the channel integration meta", t, func() {
+		cim := NewChannelIntegrationMeta()
+		ci := new(ChannelIntegration)
+		i := new(Integration)
+
+		i.Title = "Testing"
+		i.IconPath = "http://hehehe.png"
+
+		Convey("it should return integration data when customName is not set", func() {
+			cim.Populate(ci, i)
+
+			So(cim.Title, ShouldEqual, i.Title)
+			So(cim.IconPath, ShouldEqual, i.IconPath)
+		})
+
+		Convey("it should return customName as title when it is set", func() {
+			ci.Settings = gorm.Hstore{}
+			customName := "Test me"
+			ci.Settings["customName"] = &customName
+
+			cim.Populate(ci, i)
+
+			So(cim.Title, ShouldEqual, customName)
+			So(cim.IconPath, ShouldEqual, i.IconPath)
+		})
+	})
+}


### PR DESCRIPTION
We had a circular dependency issue while showing integration data in channel messages. For this reason first we have discussed about moving containers under a new package, but there were also so many dependencies from models package. 

@cihangir You suggested moving all integrations under models, I instead created a read only struct. 

![Image](https://www.evernote.com/l/AKDwgRoD-HBKyYS9Sx-t4WsNcpS5kNEMpNwB/image.png)
