### PR TITLE
Remove multi-cursor (single) movement command shortcuts [fixes #96881688]

### DIFF
--- a/client/app/lib/defaultshortcuts/editor.json
+++ b/client/app/lib/defaultshortcuts/editor.json
@@ -84,30 +84,6 @@
     ]
   },
   {
-    "name": "addCursorAboveSkipCurrent",
-    "description": "Move Multi-cursor to the Line Above",
-    "binding": [
-      [
-        "ctrl+alt+shift+up"
-      ],
-      [
-        "ctrl+alt+shift+up"
-      ]
-    ]
-  },
-  {
-    "name": "addCursorBelowSkipCurrent",
-    "description": "Move Multi-cursor to the Line Below",
-    "binding": [
-      [
-        "ctrl+alt+shift+down"
-      ],
-      [
-        "ctrl+alt+shift+down"
-      ]
-    ]
-  },
-  {
     "name": "selectMoreBefore",
     "description": "Add Previous Occurence to Multi-selection",
     "binding": [


### PR DESCRIPTION
[Move Multi-cursor and Move Tab shortcuts use the same combinations on windows](https://www.pivotaltracker.com/story/show/96881688)
