### PR TITLE
kloud: template passed to plan should be the same as apply

### DIFF
--- a/go/src/koding/kites/kloud/kloud/plan.go
+++ b/go/src/koding/kites/kloud/kloud/plan.go
@@ -189,6 +189,12 @@ func (k *Kloud) Plan(r *kite.Request) (interface{}, error) {
 		}
 	}
 
+	buildData, err := injectKodingData(ctx, stackTemplate.Template.Content, r.Username, creds)
+	if err != nil {
+		return nil, err
+	}
+	stackTemplate.Template.Content = buildData.Template
+
 	plan, err := tfKite.Plan(&tf.TerraformRequest{
 		Content:   stackTemplate.Template.Content,
 		ContentID: r.Username + "-" + args.StackTemplateId,


### PR DESCRIPTION
Previously we would pass plan without anything injected, now we inject and sent
the final template so it's consistent with `apply`. This might cause problems (because the
generated kite.key will be different), however in my tests I couldn't find any
issues and the revert is very easy to do (just remove 5 lines), so there
shouldn't be any big problems.
