### PR TITLE
kloud: fix if no count directive is given

### DIFF
--- a/go/src/koding/kites/kloud/kloud/terraformutils.go
+++ b/go/src/koding/kites/kloud/kloud/terraformutils.go
@@ -230,7 +230,7 @@ func injectKodingData(ctx context.Context, content, username string, creds *terr
 		// means there will be several instances, we need to create a userdata
 		// with count interpolation, because each machine must have an unique
 		// kite id.
-		var count int = 0
+		var count int = 1
 		if c, ok := instance["count"]; ok {
 			// we receive it as float64
 			if cFloat, ok := c.(float64); !ok {


### PR DESCRIPTION
We should assume that if no `count` directive is given, that at least one
machine is going to be built. Otherwise a zero count will break the
userdata because no kitekeys will be produced.
