### PR TITLE
Reactivity suggestions algolia fix

### DIFF
--- a/client/activity/lib/components/suggestionitem/index.coffee
+++ b/client/activity/lib/components/suggestionitem/index.coffee
@@ -23,6 +23,7 @@ module.exports = class SuggestionItem extends React.Component
     { suggestion }  = @props
     message         = suggestion.get 'message'
     highlightResult = suggestion.get 'highlightResult'
+    messageBody     = highlightResult?.getIn(['body', 'value']) ? message.get('body')
 
     { makeAvatar, makeProfileLink, makeInfoText } = helper
 
@@ -31,7 +32,7 @@ module.exports = class SuggestionItem extends React.Component
         {makeAvatar message.get('account')}
       </div>
       <div className="ActivitySuggestionItem-messageBody">
-        <SuggestionMessageBody source={highlightResult.getIn(['body', 'value'])} />
+        <SuggestionMessageBody source={messageBody} />
       </div>
       <div>
         <span className="ActivitySuggestionItem-info ActivitySuggestionItem-profileLink">

--- a/client/app/lib/searchcontroller.coffee
+++ b/client/app/lib/searchcontroller.coffee
@@ -168,8 +168,9 @@ module.exports = class SearchController extends KDObject
     @_searchChannel seed, channelId, itemResultFunc, options
 
 
-  searchChannelWithHighlighting: (seed, channelId, options) ->
+  searchChannelWithHighlighting: (seed, channelId, options = {}) ->
 
+    options.attributesToHighlight or= 'body'
     itemResultFunc = (message, highlightResult) -> { message, highlightResult }
     @_searchChannel seed, channelId, itemResultFunc, options
 


### PR DESCRIPTION
@usirin, can you please review the fix? It's for not working suggestions on production.
- I added `attributesToHighlight` setting to Algolia request
- also I added handling for such issues in `SuggestionItem` to avoid possible exceptions in the future. If Algolia doesn't return highlighting data, suggestion item should appear but without highlighting
