### PR TITLE
cleaner: add elastic IP releaser

### DIFF
--- a/go/src/koding/kites/kloud/cleaners/cmd/cleaner/elasticips.go
+++ b/go/src/koding/kites/kloud/cleaners/cmd/cleaner/elasticips.go
@@ -1,0 +1,18 @@
+package main
+
+type ElasticIPs struct {
+}
+
+func (i *ElasticIPs) Process() {
+}
+
+func (i *ElasticIPs) Run() {
+}
+
+func (i *ElasticIPs) Result() string {
+	return ""
+}
+
+func (i *ElasticIPs) Info() *taskInfo {
+	return nil
+}

--- a/go/src/koding/kites/kloud/cleaners/cmd/cleaner/elasticips.go
+++ b/go/src/koding/kites/kloud/cleaners/cmd/cleaner/elasticips.go
@@ -34,6 +34,7 @@ func (e *ElasticIPs) Process() {
 }
 
 func (e *ElasticIPs) Run() {
+
 }
 
 func (e *ElasticIPs) Result() string {
@@ -45,5 +46,8 @@ func (e *ElasticIPs) Result() string {
 }
 
 func (e *ElasticIPs) Info() *taskInfo {
-	return nil
+	return &taskInfo{
+		Title: "ElasticIPs",
+		Desc:  "Release(delete) elasticIPs which are not associated to any instance",
+	}
 }

--- a/go/src/koding/kites/kloud/cleaners/cmd/cleaner/elasticips.go
+++ b/go/src/koding/kites/kloud/cleaners/cmd/cleaner/elasticips.go
@@ -3,27 +3,47 @@ package main
 import (
 	"fmt"
 	"koding/kites/kloud/cleaners/lookup"
+
+	"github.com/mitchellh/goamz/ec2"
 )
 
 type ElasticIPs struct {
 	Lookup *lookup.Lookup
+
+	nonused map[string][]ec2.Address
+	err     error
 }
 
-func (i *ElasticIPs) Process() {
-	addressess := i.Lookup.FetchIpAddresses()
+func (e *ElasticIPs) Process() {
+	addressess := e.Lookup.FetchIpAddresses()
+
+	e.nonused = make(map[string][]ec2.Address)
 
 	for region, a := range addressess {
-		fmt.Printf("%s has total %d addressess\n", region, len(a))
+		nonAssociatedAddressess := make([]ec2.Address, 0)
+		for _, address := range a {
+			if address.AssociationId == "" {
+				nonAssociatedAddressess = append(nonAssociatedAddressess, address)
+			}
+		}
+
+		fmt.Printf("region '%s' has %d addresses (which %d are not associated) \n",
+			region, len(a), len(nonAssociatedAddressess))
+		e.nonused[region] = nonAssociatedAddressess
 	}
 }
 
-func (i *ElasticIPs) Run() {
+func (e *ElasticIPs) Run() {
 }
 
-func (i *ElasticIPs) Result() string {
+func (e *ElasticIPs) Result() string {
+	if e.err != nil {
+		return fmt.Sprintf("elasticIPs: error '%s'", e.err.Error())
+	}
+
 	return ""
 }
 
-func (i *ElasticIPs) Info() *taskInfo {
+func (e *ElasticIPs) Info() *taskInfo {
 	return nil
 }

--- a/go/src/koding/kites/kloud/cleaners/cmd/cleaner/elasticips.go
+++ b/go/src/koding/kites/kloud/cleaners/cmd/cleaner/elasticips.go
@@ -1,9 +1,20 @@
 package main
 
+import (
+	"fmt"
+	"koding/kites/kloud/cleaners/lookup"
+)
+
 type ElasticIPs struct {
+	Lookup *lookup.Lookup
 }
 
 func (i *ElasticIPs) Process() {
+	addressess := i.Lookup.FetchIpAddresses()
+
+	for region, a := range addressess {
+		fmt.Printf("%s has total %d addressess\n", region, len(a))
+	}
 }
 
 func (i *ElasticIPs) Run() {

--- a/go/src/koding/kites/kloud/cleaners/cmd/cleaner/elasticips.go
+++ b/go/src/koding/kites/kloud/cleaners/cmd/cleaner/elasticips.go
@@ -23,7 +23,7 @@ func (e *ElasticIPs) Run() {
 		return
 	}
 
-	// e.Lookup.ReleaseAll(e.nonused)
+	e.Lookup.ReleaseAll(e.nonused)
 }
 
 func (e *ElasticIPs) Result() string {

--- a/go/src/koding/kites/kloud/cleaners/cmd/cleaner/main.go
+++ b/go/src/koding/kites/kloud/cleaners/cmd/cleaner/main.go
@@ -143,7 +143,9 @@ func (c *Cleaner) collectAndProcess() error {
 		&TestDomains{
 			DNS: c.DNSDev,
 		},
-		&ElasticIPs{},
+		&ElasticIPs{
+			Lookup: c.AWS,
+		},
 		&AlwaysOn{
 			MongoDB:          c.MongoDB,
 			IsPaid:           artifacts.IsPaid,

--- a/go/src/koding/kites/kloud/cleaners/cmd/cleaner/main.go
+++ b/go/src/koding/kites/kloud/cleaners/cmd/cleaner/main.go
@@ -143,6 +143,7 @@ func (c *Cleaner) collectAndProcess() error {
 		&TestDomains{
 			DNS: c.DNSDev,
 		},
+		&ElasticIPs{},
 		&AlwaysOn{
 			MongoDB:          c.MongoDB,
 			IsPaid:           artifacts.IsPaid,

--- a/go/src/koding/kites/kloud/cleaners/lookup/addresses.go
+++ b/go/src/koding/kites/kloud/cleaners/lookup/addresses.go
@@ -53,6 +53,8 @@ func (a Addresses) Release(client *ec2.EC2) {
 			fmt.Printf("[%s] release ip address error: %s\n", client.Region.Name, err)
 		}
 	}
+
+	fmt.Printf("Releasing is done for region %s\n", client.Region.Name)
 }
 
 // ReleaseAll releases all the given addresses

--- a/go/src/koding/kites/kloud/cleaners/lookup/addresses.go
+++ b/go/src/koding/kites/kloud/cleaners/lookup/addresses.go
@@ -1,0 +1,76 @@
+package lookup
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/mitchellh/goamz/ec2"
+)
+
+// Instances represents a list of ec2.Instances
+type Addresses map[string][]ec2.Address
+
+func (a Addresses) Count() int {
+	var count int = 0
+
+	for _, addrs := range a {
+		count += len(addrs)
+	}
+
+	return count
+}
+
+// NotAssociated returns a list of addresses which are not
+// associated
+func (a Addresses) NotAssociated() Addresses {
+	filtered := make(Addresses, 0)
+
+	for region, addrs := range a {
+		nonAssociatedAddressess := make([]ec2.Address, 0)
+		for _, addr := range addrs {
+			if addr.AssociationId == "" {
+				nonAssociatedAddressess = append(nonAssociatedAddressess, addr)
+			}
+		}
+
+		filtered[region] = nonAssociatedAddressess
+	}
+
+	return filtered
+}
+
+// Release releases all address for the given region/client
+func (a Addresses) Release(client *ec2.EC2) {
+	if len(a) == 0 {
+		return
+	}
+
+	addresses := a[client.Region.Name]
+	fmt.Printf("Releasing %d addresses for region %s\n", len(addresses), client.Region.Name)
+	for _, addr := range addresses {
+		_, err := client.ReleaseAddress(addr.AllocationId)
+		if err != nil {
+			fmt.Printf("[%s] release ip address error: %s\n", client.Region.Name, err)
+		}
+	}
+}
+
+// ReleaseAll releases all the given addresses
+func (l *Lookup) ReleaseAll(addressess Addresses) {
+	if len(addressess) == 0 {
+		return
+	}
+
+	var wg sync.WaitGroup
+
+	for _, client := range l.clients.Regions() {
+		wg.Add(1)
+
+		go func(client *ec2.EC2, a Addresses) {
+			a.Release(client)
+			wg.Done()
+		}(client, addressess)
+	}
+
+	wg.Wait()
+}

--- a/go/src/koding/kites/kloud/cleaners/lookup/lookup.go
+++ b/go/src/koding/kites/kloud/cleaners/lookup/lookup.go
@@ -40,7 +40,7 @@ func (l *Lookup) IpAddresses(client *ec2.EC2) ([]ec2.Address, error) {
 }
 
 // FetchIpAddresses fetches all IpAddresses from all regions
-func (l *Lookup) FetchIpAddresses() map[string][]ec2.Address {
+func (l *Lookup) FetchIpAddresses() Addresses {
 	var wg sync.WaitGroup
 
 	allAddressess := make(map[string][]ec2.Address, 0)
@@ -52,7 +52,7 @@ func (l *Lookup) FetchIpAddresses() map[string][]ec2.Address {
 
 			addressess, err := l.IpAddresses(client)
 			if err != nil {
-				fmt.Printf("[%s] fetching error: %s\n", region, err)
+				fmt.Printf("[%s] fetching ip addresses error: %s\n", region, err)
 				return
 			}
 


### PR DESCRIPTION
This adds a new task which is responsible of releasing(deleting) elastic IP's
which are not associated anymore.
