### PR TITLE
managed: Removed Node Search

### DIFF
--- a/client/app/lib/providers/environmentsmachinestatemodal.coffee
+++ b/client/app/lib/providers/environmentsmachinestatemodal.coffee
@@ -395,6 +395,8 @@ module.exports = class EnvironmentsMachineStateModal extends BaseModalView
 
     if @state is 'NotFound'
       @createStateLabel 'NotFound'
+    else if @isManaged and @state is Stopped
+      @createStateLabel 'ManagedStopped'
     else
       @createStateLabel()
 
@@ -475,7 +477,7 @@ module.exports = class EnvironmentsMachineStateModal extends BaseModalView
   createStateLabel: (customState) ->
 
     states       =
-      NotFound   : "
+      NotFound      : "
         <h1>You don't have any VMs!</h1>
         <span>
           This can happen if you have deleted all your VMs or if your
@@ -484,12 +486,29 @@ module.exports = class EnvironmentsMachineStateModal extends BaseModalView
           Learn more</a> about inactive VM cleanup.
         </span>
       "
-      NoTemplate : "
+      NoTemplate     : "
         <h1>Compute Stacks not configured yet!</h1>
         <span>
           Your team currently is not providing any compute resources.
           Please contact with your team admins for more information.
         </span>
+      "
+      ManagedStopped : "
+        <h1>Cannot connect to your machine!</h1>
+        <p>
+          Unfortunately, we cannot communicate with your machine. This can happen if:
+        </p>
+        <ol>
+          <li>Your machine is turned off</li>
+          <li>The Koding Service Connector is not running.</li>
+        </ol>
+        <p>
+          Please ensure that your machine is running and that the
+          Koding Service Connector is running.
+          <a href='http://learn.koding.com/guides/connect-your-machine/' target='_blank'>
+            Learn more</a>.
+        </p>
+        <p>If you want, you can also <a class='managed-disconnect'>disconnect</a> this machine.</p>
       "
 
     if customState is 'NotFound' and not isKoding()
@@ -500,6 +519,12 @@ module.exports = class EnvironmentsMachineStateModal extends BaseModalView
       tagName  : 'p'
       partial  : states[customState] or customState or @getStateLabel()
       cssClass : "state-label #{@state.toLowerCase()}"
+      click: (event) =>
+        if 'managed-disconnect' in event.target.classList
+          kd.utils.stopDOMEvent event
+          MachineSettingsModal = require './machinesettingsmodal'
+          settingsModal        = new MachineSettingsModal {}, @machine
+          settingsModal.tabView.showPaneByName 'Advanced'
 
     @container.addSubView @label
 
@@ -515,8 +540,8 @@ module.exports = class EnvironmentsMachineStateModal extends BaseModalView
         return  unless groupsController.currentGroupHasStack()
 
     else if @isManaged
-      title    = 'Search for Nodes'
-      callback = 'findNodes'
+      # Display no button for managed.
+      return
     else
       title    = 'Turn it on'
       callback = 'turnOnMachine'

--- a/client/app/lib/providers/environmentsmachinestatemodal.coffee
+++ b/client/app/lib/providers/environmentsmachinestatemodal.coffee
@@ -494,21 +494,15 @@ module.exports = class EnvironmentsMachineStateModal extends BaseModalView
         </span>
       "
       ManagedStopped : "
-        <h1>Cannot connect to your machine!</h1>
+        <h1><strong>Cannot connect to your machine!</strong></h1>
         <p>
-          Unfortunately, we cannot communicate with your machine. This can happen if:
-        </p>
-        <ol>
-          <li>Your machine is turned off</li>
-          <li>The Koding Service Connector is not running.</li>
-        </ol>
-        <p>
-          Please ensure that your machine is running and that the
-          Koding Service Connector is running.
+          This can happen either if your machine is turned off or the
           <a href='http://learn.koding.com/guides/connect-your-machine/' target='_blank'>
-            Learn more</a>.
+          Koding Service Connector</a> is not running.</p>
+        <p>
+          If you want, you can also <a class='managed-disconnect'>
+          disconnect</a> this machine.
         </p>
-        <p>If you want, you can also <a class='managed-disconnect'>disconnect</a> this machine.</p>
       "
 
     if customState is 'NotFound' and not isKoding()

--- a/client/app/lib/providers/machinesettingsadvancedview.coffee
+++ b/client/app/lib/providers/machinesettingsadvancedview.coffee
@@ -13,15 +13,17 @@ module.exports = class MachineSettingsAdvancedView extends KDView
     @machine = data
 
     reinitButton   = @createButton 'Reinitialize your VM', 'reinit', 'This will take your VM back to its original state. (Note: you will lose all your data)'
+    terminateClass = 'terminate'
     terminateTitle = 'Terminate your VM'
     terminateText  = 'This will delete your VM completely. (Note: you will lose all your data)'
 
     if @machine.isManaged()
       reinitButton.hide()
+      terminateClass = 'terminate terminate-managed'
       terminateTitle = 'Disconnect your VM'
       terminateText  = 'Remove the connection between your Machine and Koding.'
 
-    terminateButton = @createButton terminateTitle, 'terminate', terminateText
+    terminateButton = @createButton terminateTitle, terminateClass, terminateText
 
 
   createButton: (title, className, desc) ->

--- a/client/app/lib/providers/machinesettingsadvancedview.coffee
+++ b/client/app/lib/providers/machinesettingsadvancedview.coffee
@@ -13,17 +13,13 @@ module.exports = class MachineSettingsAdvancedView extends KDView
     @machine = data
 
     reinitButton   = @createButton 'Reinitialize your VM', 'reinit', 'This will take your VM back to its original state. (Note: you will lose all your data)'
-    reassignButton = @createButton 'Reassign your VM', 'reassign', 'Reassign your VM to another node'
     terminateTitle = 'Terminate your VM'
     terminateText  = 'This will delete your VM completely. (Note: you will lose all your data)'
 
     if @machine.isManaged()
       reinitButton.hide()
-      reassignButton.show()
       terminateTitle = 'Disconnect your VM'
       terminateText  = 'Remove the connection between your Machine and Koding.'
-    else
-      reassignButton.hide()
 
     terminateButton = @createButton terminateTitle, 'terminate', terminateText
 

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -1182,48 +1182,48 @@ paymentGrayLighter  = #f8f8f8
 
 
   .state-label
-    padding             20px
-    font-size           18px
-    color               #7D7D7D
+    padding                 20px
+    font-size               18px
+    color                   #7D7D7D
 
-    font-weight         400
+    font-weight             400
     strong
-      color             #404040
+      color                 #404040
     .icon
-      display           inline-block
-      r-sprite          'ide', 'vm-state-stopped'
-      margin-right      11px
-      vertical-align    middle
+      display               inline-block
+      r-sprite              'ide', 'vm-state-stopped'
+      margin-right          11px
+      vertical-align        middle
     &.starting
     &.building
       .icon
-        r-sprite        'ide', 'vm-state-starting'
+        r-sprite            'ide', 'vm-state-starting'
     &.running
       .icon
-        r-sprite        'ide', 'vm-state-running'
+        r-sprite            'ide', 'vm-state-running'
     &.notfound
       h1
-        margin-bottom   25px
+        margin-bottom       25px
       span
-        font-size       16px
+        font-size           16px
       a
-        color           #1aaf5d
+        color               #1aaf5d
     &.stopped
       h1
-        margin-bottom   25px
+        margin-bottom       25px
       p, ol
-        font-size       16px
-        margin-bottom   15px
+        font-size           16px
+        margin-bottom       15px
       p:last-child
-        margin-bottom   0
+        margin-bottom       0
       ol
-        margin-left     16px
-        list-style      decimal inside
+        margin-left         16px
+        list-style          decimal inside
       a
-        color           #1aaf5d
+        color               #1aaf5d
       a.managed-disconnect
-        text-decoration  underline
-        cursor           pointer
+        text-decoration     underline
+        cursor              pointer
 
   .footer
     .upgrade-link

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -1212,7 +1212,6 @@ paymentGrayLighter  = #f8f8f8
       h1
         margin-bottom   25px
       p, ol
-        text-align      left
         font-size       16px
         margin-bottom   15px
       p:last-child

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -1208,6 +1208,23 @@ paymentGrayLighter  = #f8f8f8
         font-size       16px
       a
         color           #1aaf5d
+    &.stopped
+      h1
+        margin-bottom   25px
+      p, ol
+        text-align      left
+        font-size       16px
+        margin-bottom   15px
+      p:last-child
+        margin-bottom   0
+      ol
+        margin-left     16px
+        list-style      decimal inside
+      a
+        color           #1aaf5d
+      a.managed-disconnect
+        text-decoration  underline
+        cursor           pointer
 
   .footer
     .upgrade-link
@@ -1575,7 +1592,7 @@ paymentGrayLighter  = #f8f8f8
         margin-left         50px
 
       &.terminate
-        margin-left         56px
+        margin-left         167px
 
 
     &:first-child

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -1595,7 +1595,11 @@ paymentGrayLighter  = #f8f8f8
         margin-left         56px
 
       &.terminate-managed
-        margin-left         167px
+        margin-left         152px
+        width               200px
+
+        figure
+          margin-left       55px
 
 
     &:first-child

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -1592,6 +1592,9 @@ paymentGrayLighter  = #f8f8f8
         margin-left         50px
 
       &.terminate
+        margin-left         56px
+
+      &.terminate-managed
         margin-left         167px
 
 


### PR DESCRIPTION
This commit makes two main changes:
1. On the State Modal for Managed VMs, when it is in the Stopped state
   the "Search Nodes" button is no longer displayed. Instead, text is
   displayed to inform the user of what is happening.
2. The Reassign button in Advanced Settings has been removed - to
   disable that route of accessing the Search Nodes modal.

Accompanying css has also been included to pretty up new additions.

State modal: http://take.ms/N3sDa
Advanced settings: http://take.ms/5STYy
Video of links in action: http://take.ms/3BGFL

cc @usirin 
