### PR TITLE
Disable react router routes

### DIFF
--- a/client/activity/lib/routehandler.coffee
+++ b/client/activity/lib/routehandler.coffee
@@ -1,8 +1,9 @@
-React      = require 'kd-react'
-Router     = require 'app/components/router'
-Location   = require 'react-router/lib/Location'
-handlers   = require './routehandlers'
-lazyrouter = require 'app/lazyrouter'
+React               = require 'kd-react'
+Router              = require 'app/components/router'
+Location            = require 'react-router/lib/Location'
+handlers            = require './routehandlers'
+lazyrouter          = require 'app/lazyrouter'
+isReactivityEnabled = require 'app/util/isReactivityEnabled'
 
 module.exports = -> lazyrouter.bind 'activity', (type, info, state, path, ctx) ->
 
@@ -15,9 +16,11 @@ module.exports = -> lazyrouter.bind 'activity', (type, info, state, path, ctx) -
     'SinglePostWithSummary'
   ]
 
-
   if type in reactivityRoutes
-  then handleReactivity info, ctx
+    if isReactivityEnabled()
+    then handleReactivity info, ctx
+    # unless reactivity is enabled redirect reactivity routes to `Public`
+    else ctx.handleRoute '/Activity/Public'
   else handle type
 
 

--- a/client/app/lib/util/isReactivityEnabled.coffee
+++ b/client/app/lib/util/isReactivityEnabled.coffee
@@ -1,0 +1,4 @@
+checkFlag = require 'app/util/checkFlag'
+
+module.exports = -> checkFlag 'reactivity'
+


### PR DESCRIPTION
This PR will redirect users who doesn't have `reactivity` flag back to `Public` if they hit a `Reactivity` route.
