### PR TITLE
Account from login fix

### DIFF
--- a/client/account/lib/accounttwofactorauth.coffee
+++ b/client/account/lib/accounttwofactorauth.coffee
@@ -182,8 +182,8 @@ module.exports = class AccountTwoFactorAuth extends kd.View
       cssClass   : 'main-loader'
       showLoader : yes
       size       :
-        width    : 40
-        height   : 40
+        width    : 25
+        height   : 25
 
   getLearnLink: ->
     "

--- a/client/account/lib/index.coffee
+++ b/client/account/lib/index.coffee
@@ -20,7 +20,6 @@ KDListViewController  = kd.ListViewController
 AccountNavigationItem = require './accountnavigationitem'
 require('./routehandler')()
 
-
 module.exports = class AccountAppController extends AppController
 
   @options =
@@ -109,7 +108,7 @@ module.exports = class AccountAppController extends AppController
       replaceState    : yes
 
 
-  loadView: (modal) ->
+  loadView: (modal) -> kd.singletons.mainController.ready =>
 
     @navController?.destroy()
     @navController = new KDListViewController

--- a/client/account/lib/index.coffee
+++ b/client/account/lib/index.coffee
@@ -84,7 +84,7 @@ module.exports = class AccountAppController extends AppController
 
     @mainView.destroy()
 
-  openSection: (section, query) ->
+  openSection: (section, query) -> kd.singletons.mainController.ready =>
 
     if section is 'Oauth' and query.provider?
       @handleOauthRedirect query

--- a/client/account/lib/styl/account.styl
+++ b/client/account/lib/styl/account.styl
@@ -16,6 +16,13 @@ app.settings.styl
 .CreditCardModal--update
   z-index                   10003
 
+
+.AccountEmailNotifications-loader
+  top                       220px
+  position                  absolute
+  left                      50%
+  margin-left               -15px
+
 // Account AppModal Styles
 .AppModal--account
 
@@ -815,8 +822,10 @@ app.settings.styl
         text-decoration     underline !important
 
     .main-loader
-      left                  46%
-      margin-top            50%
+      top                   220px
+      position              absolute
+      left                  50%
+      margin-left           -15px
 
     .intro
       margin-bottom         20px

--- a/client/account/lib/views/accountemailnotifications.coffee
+++ b/client/account/lib/views/accountemailnotifications.coffee
@@ -12,9 +12,17 @@ module.exports = class AccountEmailNotifications extends KDView
 
   viewAppended: ->
 
+    @addSubView loader = new kd.LoaderView
+      cssClass   : 'AccountEmailNotifications-loader'
+      showLoader : yes
+      size       :
+        width    : 25
+        height   : 25
+
     whoami().fetchEmailFrequency (err, frequency) =>
       @putContents frequency or {}
       @handleGlobalState frequency.global
+      loader.destroy()
 
     @on 'EmailPrefSwitched', (flag, state) => @["handle#{flag.capitalize()}State"]? state
 

--- a/client/app/bant.json
+++ b/client/app/bant.json
@@ -6,6 +6,7 @@
     "/": "home",
     "/R/:username": "referrer",
     "/:name?/Login": "login",
+    "/:name?/Register": "register",
     "/:name?/Logout": "logout",
     "/:slug/:name": "members",
     "/member/:username": "member",

--- a/client/app/lib/routehandler.coffee
+++ b/client/app/lib/routehandler.coffee
@@ -60,9 +60,12 @@ module.exports = -> lazyrouter.bind 'app', (type, info, state, path, ctx) ->
     when 'logout'
       kd.singletons.mainController.doLogout()
 
-    when 'login'
-      {params:{name}} = info
-      handleRoot()
+    when 'login', 'register'
+      {query:{redirectTo}} = info
+      if redirectTo
+        redirectTo = "/#{redirectTo}"  unless redirectTo[0] is '/'
+        kd.singletons.router.handleRoute redirectTo
+      else handleRoot()
 
     when 'referrer'
       {params:{username}} = info


### PR DESCRIPTION
Fixes account modal loading problems where you are redirecting from login with `redirectTo` parameter.

Account modal now waits for `kd.singletons.mainController.ready` to be rendered.

Also this pr adds support for `redirectTo` query parameters on `/Login` and `/Register` routes.

/cc @sinan 
