### PR TITLE
Collaboration: Chat: Don't scroll to input when edit mode is active. [fixes #99671822]

### DIFF
--- a/client/activity/lib/views/activitylistitemview.coffee
+++ b/client/activity/lib/views/activitylistitemview.coffee
@@ -153,16 +153,14 @@ module.exports = class ActivityListItemView extends ActivityBaseListItemView
       @embedBoxWrapper.hide()
 
     kd.utils.defer =>
-      {typeConstant} = @getData()
-      {input} = @editWidget
-      {body}  = global.document
+      { typeConstant }  = @getData()
+      { input }         = @editWidget
+      { body }          = global.document
       input.setFocus()
       input.resize()
       input.setCaretPosition input.getValue().length
 
       return  unless typeConstant is 'privatemessage'
-
-      input.getElement().scrollIntoView yes
 
     @editWidgetWrapper.show()
 


### PR DESCRIPTION
Before:
![csl7wciwey](https://cloud.githubusercontent.com/assets/728733/8987064/c72aa4d2-36e7-11e5-9bd3-2a150ff518cb.gif)

After:
![hp1dpihj5s](https://cloud.githubusercontent.com/assets/728733/8987074/cf1cd26e-36e7-11e5-83bf-7a55012eb589.gif)

I've removed this line https://github.com/koding/koding/commit/3a265ecbb40153a565a75b7a237931bab09cfbf2#diff-e6a4fe777006bc2570a6461ef93eab4aL165. `Edit post` is working well in collaboration chat panel when this line was removed. Also i tested in activity. But i couldn't see any anormal situation.

/cc @sinan @usirin @gokmen @fatihacet 
