### PR TITLE
vmwatcher: switch to using the new aws go sdk, other performance improvements

### DIFF
--- a/go/src/koding/vmwatcher/cloudwatch.go
+++ b/go/src/koding/vmwatcher/cloudwatch.go
@@ -29,6 +29,8 @@ type Limits map[string]float64
 type Cloudwatch struct {
 	Name   string
 	Limits Limits
+
+	clientCreds *credentials.Credentials
 }
 
 func (c *Cloudwatch) GetName() string {
@@ -99,7 +101,7 @@ func (c *Cloudwatch) GetMetric(instanceId, region string) (float64, error) {
 		sum float64
 
 		config = &aws.Config{
-			Credentials: credentials.NewStaticCredentials(AWS_KEY, AWS_SECRET, ""),
+			Credentials: c.clientCreds,
 			Region:      region,
 		}
 

--- a/go/src/koding/vmwatcher/cloudwatch.go
+++ b/go/src/koding/vmwatcher/cloudwatch.go
@@ -19,10 +19,9 @@ import (
 )
 
 var (
-	AWS_NAMESPACE       = "AWS/EC2"
-	AWS_PERIOD    int64 = 604800
-
-	GB_TO_MB float64 = 1024
+	AWS_NAMESPACE         = "AWS/EC2"
+	AWS_PERIOD    int64   = 3600
+	GB_TO_MB      float64 = 1024
 )
 
 type Limits map[string]float64

--- a/go/src/koding/vmwatcher/cloudwatch.go
+++ b/go/src/koding/vmwatcher/cloudwatch.go
@@ -81,17 +81,17 @@ func (c *Cloudwatch) normalizeMeta(machine *models.Machine) (string, string, err
 		return "", "", errors.New("queued machine has no meta")
 	}
 
-	region, ok := meta["region"].(string)
-	if !ok || isEmpty(region) {
-		return "", "", errors.New("queued machine has no region")
-	}
-
 	instanceId, ok := meta["instanceId"].(string)
 	if !ok || isEmpty(instanceId) {
 		return "", "", errors.New("queued machine has no instanceId")
 	}
 
-	return region, instanceId, nil
+	region, ok := meta["region"].(string)
+	if !ok || isEmpty(region) {
+		return "", "", errors.New("queued machine has no region")
+	}
+
+	return instanceId, region, nil
 }
 
 func (c *Cloudwatch) GetMetric(instanceId, region string) (float64, error) {
@@ -108,8 +108,7 @@ func (c *Cloudwatch) GetMetric(instanceId, region string) (float64, error) {
 		metricName    = c.GetName()
 		statistic     = "Sum"
 		dimensionName = "InstanceId"
-
-		dimension = cloudwatch.Dimension{
+		dimension     = cloudwatch.Dimension{
 			Name:  &dimensionName,
 			Value: &instanceId,
 		}

--- a/go/src/koding/vmwatcher/controller.go
+++ b/go/src/koding/vmwatcher/controller.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"github.com/crowdmob/goamz/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/koding/kite"
 )
 
 type VmController struct {
 	Redis  *RedisStorage
 	Klient *kite.Client
-	Aws    aws.Auth
+	Aws    *credentials.Credentials
 }

--- a/go/src/koding/vmwatcher/init.go
+++ b/go/src/koding/vmwatcher/init.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff"
-	"github.com/crowdmob/goamz/aws"
 	"github.com/jinzhu/now"
 	"github.com/koding/kite"
 	kiteConfig "github.com/koding/kite/config"
@@ -57,7 +56,6 @@ func initialize() {
 	controller = &VmController{}
 
 	initializeRedis(controller)
-	initializeAws(controller)
 
 	if conf.ConnectToKlient {
 		initializeKlient(controller)
@@ -92,19 +90,6 @@ func initializeMongo() {
 	modelhelper.Initialize(conf.Mongo)
 
 	// Log.Debug("Connected to mongo: %s", conf.MongoURL)
-}
-
-func initializeAws(c *VmController) {
-	var err error
-
-	// initialize cloudwatch api client
-	// arguments are: key, secret, token, expiration
-	auth, err = aws.GetAuth(AWS_KEY, AWS_SECRET, "", now.BeginningOfWeek())
-	if err != nil {
-		Log.Fatal(err.Error())
-	}
-
-	c.Aws = auth
 }
 
 func initializeKlient(c *VmController) {

--- a/go/src/koding/vmwatcher/main.go
+++ b/go/src/koding/vmwatcher/main.go
@@ -24,6 +24,8 @@ var (
 	WorkerName    = "vmwatcher"
 	WorkerVersion = "0.0.1"
 
+	ParallelWorkerCount = 4
+
 	NetworkOut = "NetworkOut"
 
 	NetworkOutLimit    float64 = 2 * 1024 // 2GB/week

--- a/go/src/koding/vmwatcher/main.go
+++ b/go/src/koding/vmwatcher/main.go
@@ -24,7 +24,7 @@ var (
 	WorkerName    = "vmwatcher"
 	WorkerVersion = "0.0.1"
 
-	ParallelWorkerCount = 4
+	ParallelWorkerCount = 8
 
 	NetworkOut = "NetworkOut"
 

--- a/go/src/koding/vmwatcher/main.go
+++ b/go/src/koding/vmwatcher/main.go
@@ -17,6 +17,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/robfig/cron"
 )
 
@@ -37,10 +38,14 @@ var (
 	// defines list of metrics, all queue/fetch/save operations
 	// must iterate this list and not use metric directly
 	metricsToSave = []Metric{
-		&Cloudwatch{Name: NetworkOut, Limits: Limits{
-			StopLimitKey:  NetworkOutLimit,
-			BlockLimitKey: NetworkOutLimit * BlockMultiplier,
-		}},
+		&Cloudwatch{
+			Name: NetworkOut,
+			Limits: Limits{
+				StopLimitKey:  NetworkOutLimit,
+				BlockLimitKey: NetworkOutLimit * BlockMultiplier,
+			},
+			clientCreds: credentials.NewStaticCredentials(AWS_KEY, AWS_SECRET, ""),
+		},
 	}
 )
 

--- a/go/src/koding/vmwatcher/main.go
+++ b/go/src/koding/vmwatcher/main.go
@@ -35,17 +35,21 @@ var (
 
 	BlockDuration = time.Hour * 24 * 365
 
+	limits = Limits{
+		StopLimitKey:  NetworkOutLimit,
+		BlockLimitKey: NetworkOutLimit * BlockMultiplier,
+	}
+
+	creds = credentials.NewStaticCredentials(AWS_KEY, AWS_SECRET, "")
+
+	regions = []string{
+		"us-east-1", "us-west-2", "eu-west-1", "ap-southeast-2",
+	}
+
 	// defines list of metrics, all queue/fetch/save operations
 	// must iterate this list and not use metric directly
 	metricsToSave = []Metric{
-		&Cloudwatch{
-			Name: NetworkOut,
-			Limits: Limits{
-				StopLimitKey:  NetworkOutLimit,
-				BlockLimitKey: NetworkOutLimit * BlockMultiplier,
-			},
-			clientCreds: credentials.NewStaticCredentials(AWS_KEY, AWS_SECRET, ""),
-		},
+		NewCloudwatch(NetworkOut, limits, creds, regions),
 	}
 )
 

--- a/go/src/koding/vmwatcher/vmwatcher.go
+++ b/go/src/koding/vmwatcher/vmwatcher.go
@@ -26,10 +26,10 @@ func getAndSaveQueueMachineMetrics() error {
 	}()
 
 	var queue = make(chan *metricQueueMsg)
-	var waitG sync.WaitGroup
+	var waitg sync.WaitGroup
 
 	for i := 0; i < ParallelWorkerCount; i++ {
-		waitG.Add(1)
+		waitg.Add(1)
 
 		go func() {
 			for msg := range queue {
@@ -41,7 +41,7 @@ func getAndSaveQueueMachineMetrics() error {
 				}
 			}
 
-			waitG.Done()
+			waitg.Done()
 		}()
 	}
 
@@ -70,7 +70,7 @@ func getAndSaveQueueMachineMetrics() error {
 	}
 
 	close(queue)
-	waitG.Wait()
+	waitg.Wait()
 
 	return nil
 }
@@ -88,6 +88,8 @@ func dealWithMachinesOverLimit() error {
 	)
 
 	for i := 0; i < ParallelWorkerCount; i++ {
+		waitg.Add(1)
+
 		go func() {
 			for msg := range queue {
 				act(msg.Machines, msg.Limit, msg.Action)

--- a/go/src/koding/vmwatcher/vmwatcher.go
+++ b/go/src/koding/vmwatcher/vmwatcher.go
@@ -28,7 +28,7 @@ func getAndSaveQueueMachineMetrics() error {
 	var queue = make(chan *metricQueueMsg)
 	var waitG sync.WaitGroup
 
-	for i := 0; i < WorkerCount; i++ {
+	for i := 0; i < ParallelWorkerCount; i++ {
 		waitG.Add(1)
 
 		go func() {
@@ -75,8 +75,6 @@ func getAndSaveQueueMachineMetrics() error {
 	return nil
 }
 
-var WorkerCount = 4
-
 type actionQueueMsg struct {
 	Machines []*models.Machine
 	Limit    string
@@ -89,7 +87,7 @@ func dealWithMachinesOverLimit() error {
 		waitg sync.WaitGroup
 	)
 
-	for i := 0; i < WorkerCount; i++ {
+	for i := 0; i < ParallelWorkerCount; i++ {
 		go func() {
 			for msg := range queue {
 				act(msg.Machines, msg.Limit, msg.Action)

--- a/go/src/koding/vmwatcher/vmwatcher.go
+++ b/go/src/koding/vmwatcher/vmwatcher.go
@@ -3,11 +3,17 @@ package main
 import (
 	"koding/db/models"
 	"koding/db/mongodb/modelhelper"
+	"sync"
 )
 
 var limitsToAction = map[string]func(string, string, string) error{
 	StopLimitKey:  stopVm,
 	BlockLimitKey: blockUserAndDestroyVm,
+}
+
+type metricQueueMsg struct {
+	Metric  Metric
+	Machine *models.Machine
 }
 
 // pops username from set in db and gets metrics for machines belonging
@@ -18,6 +24,26 @@ func getAndSaveQueueMachineMetrics() error {
 	defer func() {
 		Log.Debug("Fetched: %d machine entries for queued usernames", index)
 	}()
+
+	var queue = make(chan *metricQueueMsg)
+	var waitG sync.WaitGroup
+
+	for i := 0; i < WorkerCount; i++ {
+		waitG.Add(1)
+
+		go func() {
+			for msg := range queue {
+				index += 1
+
+				err := msg.Metric.GetAndSaveData(msg.Machine.Credential)
+				if err != nil {
+					Log.Error(err.Error())
+				}
+			}
+
+			waitG.Done()
+		}()
+	}
 
 	for _, metric := range metricsToSave {
 		for {
@@ -37,21 +63,42 @@ func getAndSaveQueueMachineMetrics() error {
 				continue
 			}
 
-			for _, machine := range machines {
-				index += 1
-
-				err := metric.GetAndSaveData(machine.Credential)
-				if err != nil {
-					Log.Error(err.Error())
-				}
+			for i := range machines {
+				queue <- &metricQueueMsg{Metric: metric, Machine: machines[i]}
 			}
 		}
 	}
 
+	close(queue)
+	waitG.Wait()
+
 	return nil
 }
 
+var WorkerCount = 4
+
+type actionQueueMsg struct {
+	Machines []*models.Machine
+	Limit    string
+	Action   func(string, string, string) error
+}
+
 func dealWithMachinesOverLimit() error {
+	var (
+		queue = make(chan *actionQueueMsg)
+		waitg sync.WaitGroup
+	)
+
+	for i := 0; i < WorkerCount; i++ {
+		go func() {
+			for msg := range queue {
+				act(msg.Machines, msg.Limit, msg.Action)
+			}
+
+			waitg.Done()
+		}()
+	}
+
 	for _, metric := range metricsToSave {
 		for limit, action := range limitsToAction {
 			for {
@@ -70,10 +117,13 @@ func dealWithMachinesOverLimit() error {
 					len(machines), metric.GetName(), limit,
 				)
 
-				act(machines, limit, action)
+				queue <- &actionQueueMsg{Machines: machines, Limit: limit, Action: action}
 			}
 		}
 	}
+
+	close(queue)
+	waitg.Wait()
 
 	return nil
 }


### PR DESCRIPTION
- switch to using github.com/aws/aws-sdk-go/aws
- get metrics from aws api in parallel and in hourly increments
- stop machines in parallel
- using "fanout" pattern from http://blog.golang.org/pipelines

[Existing tests](https://github.com/koding/koding/blob/8e05bb1cb1c2feb0d94e0f3658cf171518553667/go/src/koding/vmwatcher/cloudwatch_test.go#L1) cover implementation changes so no need to write new ones.
