### PR TITLE
IDE: Collaboration: Don't call focus method in ace.coffee when collaboration chat input is active.

### DIFF
--- a/client/ace/lib/ace.coffee
+++ b/client/ace/lib/ace.coffee
@@ -121,7 +121,7 @@ class Ace extends KDView
 
       @prepareEditor()
 
-      @focus()
+      @focus()  unless kd.singletons.appManager.frontApp.isChatInputFocused()
       @show()
 
       kd.utils.defer @lazyBound 'emit', 'ready'


### PR DESCRIPTION
/cc @usirin @gokmen @sinan @fatihacet @szkl 

I know you don't like this usage. But `Ace` focus method fires before `IDEPane`. So I had to use in this way.
