### PR TITLE
Render reactivity in own container

### DIFF
--- a/client/activity/lib/activityappview.coffee
+++ b/client/activity/lib/activityappview.coffee
@@ -84,6 +84,20 @@ module.exports = class ActivityAppView extends KDView
       pane?.refreshContent? path
 
 
+  switchToReactivityContainer: ->
+
+    @tabs.hide()
+    @setClass 'Reactivity'
+    @reactivityContainer.show()
+
+
+  switchToTabs: ->
+
+    @reactivityContainer.hide()
+    @unsetClass 'Reactivity'
+    @tabs.show()
+
+
   viewAppended: ->
 
     # see above for the terrible hack note - SY

--- a/client/activity/lib/activityappview.coffee
+++ b/client/activity/lib/activityappview.coffee
@@ -66,6 +66,10 @@ module.exports = class ActivityAppView extends KDView
         type = 'privatemessage'  if type is 'bot'
         @tabs.setAttribute 'class', kd.utils.curry 'kdview kdtabview', type
 
+    @addSubView @reactivityContainer = new KDCustomHTMLView
+      cssClass: 'ReactivityContainer hidden'
+
+
     { router } = kd.singletons
 
     router.on 'AlreadyHere', (path, options) =>

--- a/client/activity/lib/activityappview.coffee
+++ b/client/activity/lib/activityappview.coffee
@@ -16,7 +16,6 @@ globals                = require 'globals'
 isChannelCollaborative = require 'app/util/isChannelCollaborative'
 isKoding               = require 'app/util/isKoding'
 isGroup                = require 'app/util/isGroup'
-isReactivityEnabled    = require 'app/util/isReactivityEnabled'
 ChatSearchModal        = require 'app/activity/sidebar/chatsearchmodal'
 isSuggestionEnabled    = require 'activity/util/isSuggestionEnabled'
 
@@ -34,9 +33,6 @@ module.exports = class ActivityAppView extends KDView
 
     options.cssClass   = 'content-page activity clearfix'
     options.domId      = 'content-page-activity'
-
-    if isReactivityEnabled()
-      options.cssClass = kd.utils.curry 'Reactivity', options.cssClass
 
     super options, data
 

--- a/client/activity/lib/routehandler.coffee
+++ b/client/activity/lib/routehandler.coffee
@@ -38,7 +38,7 @@ handleReactivity = ({ query }, router) ->
         <Router {...state}>
           {routes}
         </Router>
-        view.getElement()
+        view.reactivityContainer.getElement()
       )
 
 

--- a/client/activity/lib/routehandler.coffee
+++ b/client/activity/lib/routehandler.coffee
@@ -45,6 +45,8 @@ handleReactivity = ({ query }, router) ->
 activityView = (callback) ->
   {appManager} = require('kd').singletons
   appManager.open 'Activity', (app) ->
-    callback app.getView()
+    view = app.getView()
+    view.switchToReactivityContainer()
+    callback view
 
 

--- a/client/activity/lib/routehandlers.coffee
+++ b/client/activity/lib/routehandlers.coffee
@@ -104,6 +104,7 @@ activityPane = (callback) ->
   {appManager} = kd.singletons
   appManager.open 'Activity', (app) ->
     view = app.getView()
+    view.switchToTabs()
 
     kd.singleton('mainController').ready ->
       view.open 'topic', 'public'
@@ -113,6 +114,8 @@ activityPane = (callback) ->
 handleChannel = (type, slug, callback) ->
   callback    ?= (app) -> app.getView().open type, slug
   {appManager, mainController} = kd.singletons
-  mainController.ready -> appManager.open 'Activity', callback
+  mainController.ready -> appManager.open 'Activity', (app) ->
+    app.getView().switchToTabs()
+    callback app
 
 


### PR DESCRIPTION
Since reactivity routes were using the full element of `ActivityAppView`, routing to a non-reactivity route wasn't working because the dom elements were overriden by React. This PR adds a `reactivityContainer` to `ActivityAppView`.

If a route a `Reactivity` route:
- Add `Reactivity` cssClass to `ActivityAppView` so that new typography css classes will work: https://github.com/koding/koding/blob/master/client/activity/lib/styl/activity.typography.styl#L1
- Hide `activityAppView.tabs`
- Show `activityAppView.reactivityContainer`
- `react-router` will use `activityAppView.reactivityContainer` to render assigned components.

If a route is non-`Reactivity` route.
- Remove `Reactivity` cssClass from `ActivityAppView`.
- Hide `activityAppView.reactivityContainer`
- Show `activityAppView.tabs`
