### PR TITLE
Introduce `sanitizedEmail` field to `JUser` schema [fixes #100622484]

### DIFF
--- a/client/test/lib/register/register.coffee
+++ b/client/test/lib/register/register.coffee
@@ -12,29 +12,29 @@ expectValidationError = (browser) ->
 module.exports =
 
 
-  registerWithGravatarEmail: (browser) ->
+  # registerWithGravatarEmail: (browser) ->
 
-    user =
-      email    : 'kodingtestuser@gmail.com'
-      username : 'kodingtestuser'
-      password : 'passwordfortestuser'
-      gravatar : yes
+  #   user =
+  #     email    : 'kodingtestuser@gmail.com'
+  #     username : 'kodingtestuser'
+  #     password : 'passwordfortestuser'
+  #     gravatar : yes
 
-    helpers.attemptEnterEmailAndPasswordOnRegister(browser, user)
+  #   helpers.attemptEnterEmailAndPasswordOnRegister(browser, user)
 
-    browser
-      .pause   5000
-      .element 'css selector', '[testpath=main-sidebar]', (result) =>
+  #   browser
+  #     .pause   5000
+  #     .element 'css selector', '[testpath=main-sidebar]', (result) =>
 
-        if result.status is 0
-          browser.end()
-        else
-          helpers.attemptEnterUsernameOnRegister(browser, user)
+  #       if result.status is 0
+  #         browser.end()
+  #       else
+  #         helpers.attemptEnterUsernameOnRegister(browser, user)
 
-          browser
-            .waitForElementVisible '[testpath=main-header]', 50000 # Assertion
-            .waitForElementVisible '[testpath=AvatarAreaIconLink]', 50000 # Assertion
-            .end()
+  #         browser
+  #           .waitForElementVisible '[testpath=main-header]', 50000 # Assertion
+  #           .waitForElementVisible '[testpath=AvatarAreaIconLink]', 50000 # Assertion
+  #           .end()
 
 
   registerWithoutGravatarEmail: (browser) ->

--- a/scripts/sanitize-email/index.js
+++ b/scripts/sanitize-email/index.js
@@ -1,0 +1,2 @@
+require('coffee-script/register');
+module.exports = require('./main.coffee');

--- a/scripts/sanitize-email/main.coffee
+++ b/scripts/sanitize-email/main.coffee
@@ -1,0 +1,138 @@
+fs   = require 'fs'
+path = require 'path'
+
+_ = require 'underscore'
+
+Bongo   = require 'bongo'
+{daisy} = Bongo
+
+argv   = require('minimist') process.argv
+KONFIG = require('koding-config-manager').load("main.#{argv.c}")
+mongo  = "mongodb://#{KONFIG.mongo}"
+
+modelPath = '../../workers/social/lib/social/models'
+rekuire   = (p) -> require path.join modelPath, p
+
+JUser = rekuire 'user'
+
+koding = new Bongo
+  root   : __dirname
+  mongo  : mongo
+  models : modelPath
+
+emailsanitize = rekuire 'user/emailsanitize'
+
+sanitizeEmail = (user, callback) ->
+
+  {_id, email, sanitizedEmail} =  user
+
+  unless sanitizedEmail
+    sanitizedEmail = emailsanitize email, excludeDots: yes, excludePlus: yes
+    user.sanitizedEmail = sanitizedEmail
+
+  query   = {_id}
+  update  = $set: {sanitizedEmail}
+  options = {}
+
+  JUser.update query, update, options, callback
+
+
+abuseMap = {}
+
+handleAbuse = (user) ->
+
+  {_id, username, email, sanitizedEmail} = user
+
+  entry = abuseMap[sanitizedEmail] ?=
+    count     : 0
+    email     : sanitizedEmail
+    usernames : []
+
+  entry.usernames.push username
+  entry.count++
+
+  console.warn "abuse: #{_id} #{username} #{email} #{sanitizedEmail}"
+
+
+handleError = (user, err) ->
+
+  switch err.code
+    when 11000 # duplicate key error
+      handleAbuse user
+    else
+      console.error "error: #{JSON.stringify err}"
+
+
+getFailover = (user) ->
+
+  {email, sanitizedEmail} = user
+
+  [local, host] = email.split '@'
+  [sanitizedLocal] = sanitizedEmail.split '@'
+
+  # This failover value is generated to avoid null values in sanitized
+  # email field
+  return "#{sanitizedLocal}+#{local}@#{host}"
+
+
+printReport = ->
+
+  list = (Object.keys abuseMap).map (key) -> abuseMap[key]
+  list = (_.sortBy list, 'count').reverse()
+
+  report = ''
+  for entry in list
+    {email, count, usernames} = entry
+    report += "#{count} #{email}\n"
+    report += usernames.join "\n"
+    report += "\n\n"
+
+  fs.writeFileSync 'ABUSE_REPORT', report
+
+
+koding.once 'dbClientReady', ->
+
+  fields = _id: 1, username: 1, email: 1, sanitizedEmail: 1
+
+  JUser.someData {}, fields, {}, (err, cursor) ->
+
+    return console.error err  if err
+
+    migrate = (user, fallback, callback) ->
+
+      {username, email, sanitizedEmail} = user
+
+      sanitizeEmail user, (err) ->
+        return callback()  unless err
+
+        if fallback
+          console.error "migrate: #{email} fallback has failed"
+          console.error JSON.stringify err
+          return callback()
+
+        handleError user, err
+        user.sanitizedEmail = getFailover user
+        migrate user, yes, callback
+
+    iterate = do (i = 0) ->
+
+      next = -> process.nextTick iterate
+
+      ->
+
+        cursor.nextObject (err, user) ->
+
+          if err
+            console.error 'error: cursor next object fetcher failed'
+            console.error JSON.stringify err
+            return process.exit 1
+
+          unless user
+            printReport()
+            return process.exit 0
+
+          if user.sanitizedEmail
+          then next()
+          else migrate user, no, next
+
+    iterate()

--- a/servers/lib/server/handlers/register.test.coffee
+++ b/servers/lib/server/handlers/register.test.coffee
@@ -138,6 +138,42 @@ runTests = -> describe 'server.handlers.register', ->
     daisy queue
 
 
+  it 'should send HTTP 400 if dotted gmail address is in use', (done) ->
+
+    email = "kodingtestuser+#{generateRandomString()}@gmail.com"
+
+    queue = [
+
+      ->
+
+        registerParams = generateRegisterRequestParams body: {email}
+
+        request.post registerParams, (err, res, body) ->
+          expect(err)             .to.not.exist
+          expect(res.statusCode)  .to.be.equal 200
+          queue.next()
+
+      ->
+
+        [username, host] = email.split '@'
+
+        username  = username.replace /(.)/g, '$1.'
+        email = "#{username}@#{host}"
+
+        registerParams = generateRegisterRequestParams body: {email}
+
+        request.post registerParams, (err, res, body) ->
+          expect(err)             .to.not.exist
+          expect(res.statusCode)  .to.be.equal 400
+          queue.next()
+
+      -> done()
+
+    ]
+
+    daisy queue
+
+
   it 'should send HTTP 400 if agree is set as off', (done) ->
 
     postParams = generateRegisterRequestParams

--- a/servers/lib/server/handlers/register.test.coffee
+++ b/servers/lib/server/handlers/register.test.coffee
@@ -142,36 +142,17 @@ runTests = -> describe 'server.handlers.register', ->
 
     email = "kodingtestuser+#{generateRandomString()}@gmail.com"
 
-    queue = [
+    [username, host] = email.split '@'
 
-      ->
+    username  = username.replace /(.)/g, '$1.'
+    email = "#{username}@#{host}"
 
-        registerParams = generateRegisterRequestParams body: {email}
+    registerParams = generateRegisterRequestParams body: {email}
 
-        request.post registerParams, (err, res, body) ->
-          expect(err)             .to.not.exist
-          expect(res.statusCode)  .to.be.equal 200
-          queue.next()
-
-      ->
-
-        [username, host] = email.split '@'
-
-        username  = username.replace /(.)/g, '$1.'
-        email = "#{username}@#{host}"
-
-        registerParams = generateRegisterRequestParams body: {email}
-
-        request.post registerParams, (err, res, body) ->
-          expect(err)             .to.not.exist
-          expect(res.statusCode)  .to.be.equal 400
-          queue.next()
-
-      -> done()
-
-    ]
-
-    daisy queue
+    request.post registerParams, (err, res, body) ->
+      expect(err)             .to.not.exist
+      expect(res.statusCode)  .to.be.equal 400
+      done()
 
 
   it 'should send HTTP 400 if agree is set as off', (done) ->

--- a/servers/lib/server/handlers/validateemail.test.coffee
+++ b/servers/lib/server/handlers/validateemail.test.coffee
@@ -148,7 +148,7 @@ runTests = -> describe 'server.handlers.validateemail', ->
         request.post validateEmailRequestParams, (err, res, body) ->
           expect(err)             .to.not.exist
           expect(res.statusCode)  .to.be.equal 400
-          expect(body)            .to.be.equal 'Email is taken!'
+          expect(body)            .to.be.equal 'Bad request'
           queue.next()
 
       -> done()

--- a/servers/lib/server/handlers/validateemail.test.coffee
+++ b/servers/lib/server/handlers/validateemail.test.coffee
@@ -65,7 +65,6 @@ runTests = -> describe 'server.handlers.validateemail', ->
       done()
 
 
-  # returns 200 with invalid email address, needs to be investigated
   it 'should send HTTP 400 if email is not valid', (done) ->
 
     validateEmailRequestParams = generateValidateEmailRequestParams
@@ -108,6 +107,48 @@ runTests = -> describe 'server.handlers.validateemail', ->
           expect(err)             .to.not.exist
           expect(res.statusCode)  .to.be.equal 400
           expect(body)            .to.be.equal 'Bad request'
+          queue.next()
+
+      -> done()
+
+    ]
+
+    daisy queue
+
+
+  it 'should send HTTP 400 if dotted gmail address is in use', (done) ->
+
+    email     = generateRandomEmail 'gmail.com'
+    username  = generateRandomUsername()
+
+    registerRequestParams = generateRegisterRequestParams
+      body     :
+        email  : email
+
+    [username, host] = email.split '@'
+
+    username  = username.replace /(.)/g, '$1.'
+    candidate = "#{username}@#{host}"
+
+    validateEmailRequestParams = generateValidateEmailRequestParams
+      body     :
+        email  : candidate
+
+    queue = [
+
+      ->
+        # registering a new user
+        request.post registerRequestParams, (err, res, body) ->
+          expect(err)             .to.not.exist
+          expect(res.statusCode)  .to.be.equal 200
+          queue.next()
+
+      ->
+        # expecting email validation to fail using already registered email
+        request.post validateEmailRequestParams, (err, res, body) ->
+          expect(err)             .to.not.exist
+          expect(res.statusCode)  .to.be.equal 400
+          expect(body)            .to.be.equal 'Email is taken!'
           queue.next()
 
       -> done()

--- a/servers/lib/server/handlers/validateemail.test.coffee
+++ b/servers/lib/server/handlers/validateemail.test.coffee
@@ -134,28 +134,12 @@ runTests = -> describe 'server.handlers.validateemail', ->
       body     :
         email  : candidate
 
-    queue = [
-
-      ->
-        # registering a new user
-        request.post registerRequestParams, (err, res, body) ->
-          expect(err)             .to.not.exist
-          expect(res.statusCode)  .to.be.equal 200
-          queue.next()
-
-      ->
-        # expecting email validation to fail using already registered email
-        request.post validateEmailRequestParams, (err, res, body) ->
-          expect(err)             .to.not.exist
-          expect(res.statusCode)  .to.be.equal 400
-          expect(body)            .to.be.equal 'Bad request'
-          queue.next()
-
-      -> done()
-
-    ]
-
-    daisy queue
+    # expecting email validation to fail using already registered email
+    request.post validateEmailRequestParams, (err, res, body) ->
+      expect(err)             .to.not.exist
+      expect(res.statusCode)  .to.be.equal 400
+      expect(body)            .to.be.equal 'Bad request'
+      done()
 
 
   it 'should send HTTP 400 if email is in use and password is invalid', (done) ->

--- a/workers/social/lib/social/models/campaigndata.coffee
+++ b/workers/social/lib/social/models/campaigndata.coffee
@@ -1,5 +1,7 @@
 jraphical = require 'jraphical'
 
+emailsanitize = require './user/emailsanitize'
+
 module.exports = class JCampaignData extends jraphical.Module
 
   @set
@@ -8,7 +10,7 @@ module.exports = class JCampaignData extends jraphical.Module
         type     : String
         required : yes
         validate : require('./name').validateEmail
-        set      : (value) -> value.toLowerCase()
+        set      : emailsanitize
       campaign   :
         required : yes
         type     : String
@@ -27,6 +29,8 @@ module.exports = class JCampaignData extends jraphical.Module
     return callback message: 'Campaign info is missing!'  unless data.campaign
 
     { campaign, email } = data
+
+    email = emailsanitize email
 
     JCampaignData.one { campaign, email }, {}, (err, model) ->
 

--- a/workers/social/lib/social/models/invitation.coffee
+++ b/workers/social/lib/social/models/invitation.coffee
@@ -10,6 +10,8 @@ KodingError = require '../error'
 { protocol, hostname } = KONFIG
 { secure, signature, dash } = Bongo
 
+emailsanitize = require './user/emailsanitize'
+
 module.exports = class JInvitation extends jraphical.Module
 
   @trait __dirname, '../traits/grouprelated'
@@ -64,6 +66,7 @@ module.exports = class JInvitation extends jraphical.Module
       email         :
         type        : String
         required    : yes
+        set         : emailsanitize
       hash          :
         type        : String
         required    : yes

--- a/workers/social/lib/social/models/name.coffee
+++ b/workers/social/lib/social/models/name.coffee
@@ -135,7 +135,10 @@ module.exports = class JName extends Model
   @validateEmail = (candidate)->
 
     isEmailValid = require './user/emailchecker'
+    sanitize     = require './user/emailsanitize'
     {check}      = require 'validator'
+
+    candidate = sanitize candidate
 
     return check(candidate).isEmail() and isEmailValid candidate
 

--- a/workers/social/lib/social/models/passwordrecovery.coffee
+++ b/workers/social/lib/social/models/passwordrecovery.coffee
@@ -1,5 +1,7 @@
 jraphical = require 'jraphical'
 
+emailsanitize = require './user/emailsanitize'
+
 module.exports = class JPasswordRecovery extends jraphical.Module
   # TODO - Refactor this file, now it is not only for password recovery
   # but also for email verification
@@ -35,7 +37,9 @@ module.exports = class JPasswordRecovery extends jraphical.Module
     indexes       :
       token       : 'unique'
     schema        :
-      email       : String
+      email       :
+        type      : String
+        set       : emailsanitize
       username    : String
       token       : String
       redeemedAt  : Date
@@ -92,6 +96,8 @@ module.exports = class JPasswordRecovery extends jraphical.Module
     JUser = require './user'
     { email } = options
 
+    email = emailsanitize email
+
     JUser.count { email }, (err, num) =>
       unless num
         return callback null # pretend like everything went fine.
@@ -105,6 +111,8 @@ module.exports = class JPasswordRecovery extends jraphical.Module
     token = createId()
 
     {email, verb, expiryPeriod} = options
+
+    email = emailsanitize email
 
     options.resetPassword ?= no
 

--- a/workers/social/lib/social/models/referrableemail.coffee
+++ b/workers/social/lib/social/models/referrableemail.coffee
@@ -1,4 +1,7 @@
 jraphical = require "jraphical"
+
+emailsanitize = require './user/emailsanitize'
+
 module.exports = class JReferrableEmail extends jraphical.Module
   JAccount = require "./account"
   Tracker  = require "./tracker"
@@ -29,6 +32,7 @@ module.exports = class JReferrableEmail extends jraphical.Module
       email       :
         type      : String
         email     : yes
+        set       : emailsanitize
       invited     :
         type      : Boolean
         default   : false

--- a/workers/social/lib/social/models/user/emailsanitize.coffee
+++ b/workers/social/lib/social/models/user/emailsanitize.coffee
@@ -1,20 +1,39 @@
-module.exports = emailSanitize = (email)->
+sanitize = (email, options = {}) ->
 
-  email = email.toLowerCase()
+  email = email.trim().toLowerCase()
 
-  # Special rules for Gmail and Googlemail. Googlemail is for users
-  # in Germany, Poland and Russia.
-  if /^(.)+@(gmail|googlemail).com/.test email
-    [name, domain] = email.split '@'
+  return switch
+    when checkGmail email then sanitizeGmail email, options
+    else email
 
-    # . have no meaning, they're being abused to create fake accounts
-    name = name.replace '.', ''
 
-    # + have meaning, but they ultimately belong to email before +
-    # so we check for uniqueness before +, but let user save + in email
-    if email.indexOf('+') > -1
-      name = (name.split '+')[0]
+sanitizeGmail = (email, options = {}) ->
 
-    email = "#{name}@#{domain}"
+  options.excludeDots or= yes
+  options.excludePlus or= no
 
-  return email
+  [username, host] = email.split '@'
+
+  # . have no meaning, they're being abused to create fake accounts
+  username = excludeDots username  if options.excludeDots
+
+  # + have meaning, but they ultimately belong to user before +
+  # so we check for uniqueness before +, but let user save + in email
+  username = excludePlus username  if options.excludePlus
+
+  return "#{username}@#{host}"
+
+
+# Special rules for Gmail and Googlemail. Googlemail is for users
+# in Germany, Poland and Russia.
+checkGmail = (email) -> /^(.)+@(gmail|googlemail).com/.test email
+
+
+excludeDots = (username) -> username.replace /\./g, ''
+
+
+excludePlus = (username) ->
+  parts[0]  if (parts = username.split '+').length > 1
+
+
+module.exports = sanitize

--- a/workers/social/lib/social/models/user/emailsanitize.coffee
+++ b/workers/social/lib/social/models/user/emailsanitize.coffee
@@ -12,7 +12,10 @@ sanitizeGmail = (email, options = {}) ->
   options.excludeDots or= yes
   options.excludePlus or= no
 
-  [username, host] = email.split '@'
+  [local, host]     = email.split '@'
+  [username, label...] = local.split '+'
+
+  label = label.join '+'
 
   # . have no meaning, they're being abused to create fake accounts
   username = excludeDots username  if options.excludeDots
@@ -21,7 +24,11 @@ sanitizeGmail = (email, options = {}) ->
   # so we check for uniqueness before +, but let user save + in email
   username = excludePlus username  if options.excludePlus
 
-  return "#{username}@#{host}"
+  if label and not options.excludePlus
+  then local = "#{username}+#{label}"
+  else local = username
+
+  return "#{local}@#{host}"
 
 
 # Special rules for Gmail and Googlemail. Googlemail is for users
@@ -33,7 +40,7 @@ excludeDots = (username) -> username.replace /\./g, ''
 
 
 excludePlus = (username) ->
-  parts[0]  if (parts = username.split '+').length > 1
+  parts[0]  if (parts = username.split '+').length
 
 
 module.exports = sanitize

--- a/workers/social/lib/social/models/user/emailsanitize.coffee
+++ b/workers/social/lib/social/models/user/emailsanitize.coffee
@@ -9,7 +9,7 @@ sanitize = (email, options = {}) ->
 
 sanitizeGmail = (email, options = {}) ->
 
-  options.excludeDots or= yes
+  options.excludeDots or= no
   options.excludePlus or= no
 
   [local, host]     = email.split '@'

--- a/workers/social/lib/social/models/user/emailsanitize.coffee
+++ b/workers/social/lib/social/models/user/emailsanitize.coffee
@@ -1,14 +1,5 @@
 sanitize = (email, options = {}) ->
 
-  email = email.trim().toLowerCase()
-
-  return switch
-    when checkGmail email then sanitizeGmail email, options
-    else email
-
-
-sanitizeGmail = (email, options = {}) ->
-
   options.excludeDots or= no
   options.excludePlus or= no
 
@@ -36,6 +27,9 @@ sanitizeGmail = (email, options = {}) ->
 checkGmail = (email) -> /^(.)+@(gmail|googlemail).com/.test email
 
 
+checkKoding = (email) -> /^(.)+@koding.com/.test email
+
+
 excludeDots = (username) -> username.replace /\./g, ''
 
 
@@ -43,4 +37,10 @@ excludePlus = (username) ->
   parts[0]  if (parts = username.split '+').length
 
 
-module.exports = sanitize
+module.exports = (email, options = {}) ->
+
+  email = email.trim().toLowerCase()
+
+  if checkKoding email
+  then email
+  else sanitize email, options

--- a/workers/social/lib/social/models/user/emailsanitize.test.coffee
+++ b/workers/social/lib/social/models/user/emailsanitize.test.coffee
@@ -1,39 +1,52 @@
-{expect}      = require "chai"
-emailSanitize = require "./emailsanitize"
+{expect}   = require "chai"
+
+sanitize = require "./emailsanitize"
 
 describe 'Gmail Validation', ->
   it 'downcases', ->
     expected = 'INDIANAJONES@gmail.com'
-    expect(emailSanitize(expected)).to.equal expected.toLowerCase()
+    expect(sanitize(expected)).to.equal expected.toLowerCase()
 
   it 'removes dots', ->
     expected = 'indiana.jones@gmail.com'
     equals   = 'indianajones@gmail.com'
 
-    expect(emailSanitize(expected)).to.equal equals
+    expect(sanitize(expected)).to.equal equals
 
-  it 'removes pluses and characters till @', ->
+  it 'removes dots before plus label', ->
+    expected = 'ind.iana+jones@gmail.com'
+    equals   = 'indiana+jones@gmail.com'
+
+    expect(sanitize(expected)).to.equal equals
+
+  it 'removes dots till @', ->
+    expected = 'ind.iana+j.o.n.e.s@gmail.com'
+    equals   = 'indiana+jones@gmail.com'
+
+    expect(sanitize(expected)).to.equal equals
+
+  it 'removes plus label and characters till @', ->
     expected = 'indiana+jones@gmail.com'
     equals   = 'indiana@gmail.com'
 
-    expect(emailSanitize(expected)).to.equal equals
+    expect(sanitize(expected, excludePlus: yes)).to.equal equals
 
-  it 'removes dots & plus and characters till @', ->
+  it 'removes dots & plus label and characters till @', ->
     expected = 'ind.iana+jones@gmail.com'
     equals   = 'indiana@gmail.com'
 
-    expect(emailSanitize(expected)).to.equal equals
+    expect(sanitize(expected, excludePlus: yes)).to.equal equals
 
   it 'ignores other domains', ->
     expected = 'ind.iana+jones@koding.com'
-    expect(emailSanitize(expected)).to.equal expected
+    expect(sanitize(expected)).to.equal expected
 
   it 'removes dots & plus in googlemail as well', ->
     expected = 'ind.iana+jones@googlemail.com'
     equals   = 'indiana@googlemail.com'
 
-    expect(emailSanitize(expected)).to.equal equals
+    expect(sanitize(expected, excludePlus: yes)).to.equal equals
 
   it 'ignores other google domains', ->
     expected = 'ind.iana+jones@gmail.uk'
-    expect(emailSanitize(expected)).to.equal expected
+    expect(sanitize(expected)).to.equal expected

--- a/workers/social/lib/social/models/user/emailsanitize.test.coffee
+++ b/workers/social/lib/social/models/user/emailsanitize.test.coffee
@@ -19,9 +19,9 @@ describe 'Gmail Validation', ->
 
     expect(sanitize(expected)).to.equal equals
 
-  it 'removes dots till @', ->
+  it 'removes dots till +', ->
     expected = 'ind.iana+j.o.n.e.s@gmail.com'
-    equals   = 'indiana+jones@gmail.com'
+    equals   = 'indiana+j.o.n.e.s@gmail.com'
 
     expect(sanitize(expected)).to.equal equals
 

--- a/workers/social/lib/social/models/user/emailsanitize.test.coffee
+++ b/workers/social/lib/social/models/user/emailsanitize.test.coffee
@@ -7,6 +7,10 @@ describe 'Gmail Validation', ->
     expected = 'INDIANAJONES@gmail.com'
     expect(sanitize(expected)).to.equal expected.toLowerCase()
 
+  it 'trims whitespace', ->
+    expected = '  indianajones@gmail.com  '
+    expect(sanitize(expected)).to.equal expected.trim()
+
   it 'removes dots', ->
     expected = 'indiana.jones@gmail.com'
     equals   = 'indianajones@gmail.com'

--- a/workers/social/lib/social/models/user/emailsanitize.test.coffee
+++ b/workers/social/lib/social/models/user/emailsanitize.test.coffee
@@ -11,19 +11,19 @@ describe 'Gmail Validation', ->
     expected = 'indiana.jones@gmail.com'
     equals   = 'indianajones@gmail.com'
 
-    expect(sanitize(expected)).to.equal equals
+    expect(sanitize(expected, excludeDots: yes)).to.equal equals
 
   it 'removes dots before plus label', ->
     expected = 'ind.iana+jones@gmail.com'
     equals   = 'indiana+jones@gmail.com'
 
-    expect(sanitize(expected)).to.equal equals
+    expect(sanitize(expected, excludeDots: yes)).to.equal equals
 
   it 'removes dots till +', ->
     expected = 'ind.iana+j.o.n.e.s@gmail.com'
     equals   = 'indiana+j.o.n.e.s@gmail.com'
 
-    expect(sanitize(expected)).to.equal equals
+    expect(sanitize(expected, excludeDots: yes)).to.equal equals
 
   it 'removes plus label and characters till @', ->
     expected = 'indiana+jones@gmail.com'
@@ -35,7 +35,7 @@ describe 'Gmail Validation', ->
     expected = 'ind.iana+jones@gmail.com'
     equals   = 'indiana@gmail.com'
 
-    expect(sanitize(expected, excludePlus: yes)).to.equal equals
+    expect(sanitize(expected, excludeDots: yes, excludePlus: yes)).to.equal equals
 
   it 'ignores other domains', ->
     expected = 'ind.iana+jones@koding.com'
@@ -45,7 +45,7 @@ describe 'Gmail Validation', ->
     expected = 'ind.iana+jones@googlemail.com'
     equals   = 'indiana@googlemail.com'
 
-    expect(sanitize(expected, excludePlus: yes)).to.equal equals
+    expect(sanitize(expected, excludeDots: yes, excludePlus: yes)).to.equal equals
 
   it 'ignores other google domains', ->
     expected = 'ind.iana+jones@gmail.uk'

--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -5,6 +5,7 @@ request          = require "request"
 KONFIG           = require('koding-config-manager').load("main.#{argv.c}")
 Flaggable        = require '../../traits/flaggable'
 KodingError      = require '../../error'
+emailsanitize    = require './emailsanitize'
 { extend, uniq } = require 'underscore'
 
 module.exports = class JUser extends jraphical.Module
@@ -107,7 +108,7 @@ module.exports = class JUser extends jraphical.Module
       email         :
         type        : String
         validate    : require('../name').validateEmail
-        set         : (value) -> value.trim().toLowerCase()
+        set         : emailsanitize
       password      : String
       salt          : String
       twofactorkey  : String
@@ -1468,6 +1469,8 @@ module.exports = class JUser extends jraphical.Module
 
     unless typeof email is 'string'
       return callback new KodingError 'Not a valid email!'
+
+    email = emailsanitize email
 
     @count {email}, (err, count) ->
       callback err, count is 0

--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -421,7 +421,8 @@ module.exports = class JUser extends jraphical.Module
   @normalizeLoginId = (loginId, callback) ->
 
     if /@/.test loginId
-      JUser.someData { email: loginId }, { username: 1 }, (err, cursor) ->
+      email = emailsanitize loginId
+      JUser.someData { email }, { username: 1 }, (err, cursor) ->
         return callback err  if err
 
         cursor.nextObject (err, data) ->
@@ -595,6 +596,8 @@ module.exports = class JUser extends jraphical.Module
 
     { password, email }           = options
     { connection : { delegate } } = client
+
+    email = emailsanitize email  if email
 
     # handles error and decide to invalidate pin or not
     # depending on email and user variables
@@ -1076,7 +1079,7 @@ module.exports = class JUser extends jraphical.Module
 
     { account, oldUsername, email } = options
     # prevent from leading and trailing spaces
-    email = email.trim()
+    email = emailsanitize email
     @update { username: oldUsername }, { $set: { email } }, (err, res) =>
       return callback err  if err
       account.profile.hash = getHash email
@@ -1142,7 +1145,7 @@ module.exports = class JUser extends jraphical.Module
     firstName = username  if not firstName or firstName is ''
     lastName  = ''        if not lastName
 
-    email = userFormData.email = email.trim()
+    email = userFormData.email = emailsanitize email
 
     if error = validateConvertInput userFormData, client
       return callback error
@@ -1451,6 +1454,8 @@ module.exports = class JUser extends jraphical.Module
 
     {email} = options
 
+    email = options.email = emailsanitize email
+
     account = client.connection.delegate
     account.fetchUser (err, user) =>
       return callback new KodingError 'Something went wrong please try again!' if err
@@ -1529,6 +1534,8 @@ module.exports = class JUser extends jraphical.Module
     JVerificationToken = require '../verificationtoken'
 
     {email, pin} = options
+
+    email = options.email = emailsanitize email
 
     if account.type is 'unregistered'
       @update $set: { email }, (err) ->

--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -1545,9 +1545,10 @@ module.exports = class JUser extends jraphical.Module
     {email, pin} = options
 
     email = options.email = emailsanitize email
+    sanitizedEmail = emailsanitize email, excludeDots: yes, excludePlus: yes
 
     if account.type is 'unregistered'
-      @update $set: { email }, (err) ->
+      @update $set: { email, sanitizedEmail }, (err) ->
         return callback err  if err
 
         callback null
@@ -1577,7 +1578,7 @@ module.exports = class JUser extends jraphical.Module
 
         oldEmail = @getAt 'email'
 
-        @update $set: {email}, (err, res)=>
+        @update $set: {email, sanitizedEmail}, (err, res)=>
           return callback err  if err
 
           account.profile.hash = getHash email

--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -1484,9 +1484,9 @@ module.exports = class JUser extends jraphical.Module
     unless typeof email is 'string'
       return callback new KodingError 'Not a valid email!'
 
-    email = emailsanitize email
+    sanitizedEmail = emailsanitize email, excludeDots: yes, excludePlus: yes
 
-    @count {email}, (err, count) ->
+    @count {sanitizedEmail}, (err, count) ->
       callback err, count is 0
 
 

--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -64,6 +64,7 @@ module.exports = class JUser extends jraphical.Module
     indexes         :
       username      : 'unique'
       email         : 'unique'
+      sanitizedEmail: ['unique', 'sparse']
       'foreignAuth.github.foreignId'   : 'ascending'
       'foreignAuth.odesk.foreignId'    : 'ascending'
       'foreignAuth.facebook.foreignId' : 'ascending'
@@ -109,6 +110,10 @@ module.exports = class JUser extends jraphical.Module
         type        : String
         validate    : JName.validateEmail
         set         : emailsanitize
+      sanitizedEmail:
+        type        : String
+        validate    : JName.validateEmail
+        set         : (value) -> emailsanitize value, excludeDots: yes, excludePlus: yes
       password      : String
       salt          : String
       twofactorkey  : String
@@ -922,6 +927,8 @@ module.exports = class JUser extends jraphical.Module
     { username, email, password, passwordStatus,
       firstName, lastName, foreignAuth, silence, emailFrequency } = userInfo
 
+    sanitizedEmail = emailsanitize email, excludeDots: yes, excludePlus: yes
+
     emailFrequencyDefaults = {
       global         : on
       daily          : on
@@ -955,6 +962,7 @@ module.exports = class JUser extends jraphical.Module
       user = new JUser {
         username
         email
+        sanitizedEmail
         salt
         password         : hashPassword password, salt
         passwordStatus   : passwordStatus or 'valid'

--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -99,7 +99,7 @@ module.exports = class JUser extends jraphical.Module
     schema          :
       username      :
         type        : String
-        validate    : require('../name').validateName
+        validate    : JName.validateName
         set         : (value) -> value.toLowerCase()
       oldUsername   : String
       uid           :
@@ -107,7 +107,7 @@ module.exports = class JUser extends jraphical.Module
         set         : Math.floor
       email         :
         type        : String
-        validate    : require('../name').validateEmail
+        validate    : JName.validateEmail
         set         : emailsanitize
       password      : String
       salt          : String

--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -927,6 +927,7 @@ module.exports = class JUser extends jraphical.Module
     { username, email, password, passwordStatus,
       firstName, lastName, foreignAuth, silence, emailFrequency } = userInfo
 
+    email = emailsanitize email
     sanitizedEmail = emailsanitize email, excludeDots: yes, excludePlus: yes
 
     emailFrequencyDefaults = {

--- a/workers/social/lib/social/models/verificationtoken.coffee
+++ b/workers/social/lib/social/models/verificationtoken.coffee
@@ -1,6 +1,8 @@
 {Module} = require 'jraphical'
 KodingError = require '../error'
 
+emailsanitize = require './user/emailsanitize'
+
 class PINExistsError extends Error
   constructor:(message)->
     return new PINExistsError(message) unless @ instanceof PINExistsError
@@ -26,7 +28,7 @@ module.exports = class JVerificationToken extends Module
       email       :
         type      : String
         email     : yes
-        set       : (value) -> value.toLowerCase()
+        set       : emailsanitize
       pin         : String
       createdAt   :
         type      : Date
@@ -46,6 +48,9 @@ module.exports = class JVerificationToken extends Module
   @requestNewPin = (options, callback)->
 
     {action, email, subject, user, firstName, resendIfExists} = options
+
+    email = emailsanitize email  if email
+
     subject   or= Tracker.types.REQUEST_EMAIL_CHANGE
     username    = user.getAt 'username'
     email     or= user.getAt 'email'
@@ -87,6 +92,8 @@ module.exports = class JVerificationToken extends Module
 
     {pin, email, action, username} = options
 
+    email = emailsanitize email
+
     @one {email, action, pin, username}, (err, confirmation)->
 
       return callback err  if err
@@ -110,6 +117,9 @@ module.exports = class JVerificationToken extends Module
 
   @invalidatePin = (options, callback)->
     {email, action, username} = options
+
+    email = emailsanitize email
+
     @one {email, action, username}, (err, verify)->
       return callback err  if err
       return callback new KodingError "token not found" unless verify
@@ -120,6 +130,8 @@ module.exports = class JVerificationToken extends Module
   @createNewPin = (options, callback)->
     {username, action, email} = options
     pin = hat 16
+
+    email = emailsanitize email
 
     confirmation = new JVerificationToken {username, action, email, pin}
     confirmation.save (err)-> callback err, confirmation


### PR DESCRIPTION
- [x] Disable default dot exclusion in email sanitization procedure
- [x] Check email availability on sanitized email field
- [x] Implement migration script

Dot exclusion will be applied only if requested.
Only default (downcasing and stripping whitespaces) sanitization procedures will be applied to email parameters.
Email availability check during registration will be based on `sanitizedEmail` field of `JUser` schema.
