### PR TITLE
kloud: Enabled method start logging, to help debug stop usage

### DIFF
--- a/go/src/koding/kites/kloud/kloud/controller.go
+++ b/go/src/koding/kites/kloud/kloud/controller.go
@@ -155,7 +155,7 @@ func (k *Kloud) coreMethods(r *kite.Request, fn machineFunc) (result interface{}
 			Percentage: 100,
 		}
 
-		k.Log.Debug("[%s] ======> %s started <======", args.MachineId, strings.ToUpper(r.Method))
+		k.Log.Info("[%s] ======> %s started <======", args.MachineId, strings.ToUpper(r.Method))
 		start := time.Now()
 		err := fn(ctx, machine)
 		if err != nil {


### PR DESCRIPTION
By using info, it helps us debug when the method was triggered. This in
turn, tells us if a machine is actually in a locked status or not.

cc @fatih 
