### PR TITLE
Connect SocialChannel & SocialMessage Realtime events to flux architecture [completes #100848630 #100862466]

### DIFF
--- a/client/activity/lib/flux/actions/channel.coffee
+++ b/client/activity/lib/flux/actions/channel.coffee
@@ -87,8 +87,9 @@ loadFollowedPrivateChannels = (options = {}) ->
       dispatch LOAD_FOLLOWED_PRIVATE_CHANNELS_FAIL, { err }
       return
 
-    channels.forEach (channel) ->
-      dispatch LOAD_FOLLOWED_PRIVATE_CHANNEL_SUCCESS, { channel, options }
+    kd.singletons.reactor.batch ->
+      channels.forEach (channel) ->
+        dispatch LOAD_FOLLOWED_PRIVATE_CHANNEL_SUCCESS, { channel, options }
 
 
 ###*
@@ -110,8 +111,9 @@ loadFollowedPublicChannels = (options = {}) ->
       dispatch LOAD_FOLLOWED_PUBLIC_CHANNELS_FAIL, { err }
       return
 
-    channels.forEach (channel) ->
-      dispatch LOAD_FOLLOWED_PUBLIC_CHANNEL_SUCCESS, { channel, options }
+    kd.singletons.reactor.batch ->
+      channels.forEach (channel) ->
+        dispatch LOAD_FOLLOWED_PUBLIC_CHANNEL_SUCCESS, { channel, options }
 
 
 ###*

--- a/client/activity/lib/flux/actions/channel.coffee
+++ b/client/activity/lib/flux/actions/channel.coffee
@@ -36,7 +36,7 @@ loadChannelByName = (name) ->
       dispatch LOAD_CHANNEL_BY_NAME_FAIL, { err }
       return
 
-    realtimeActionCreators.wrapChannel channel
+    realtimeActionCreators.bindChannelEvents channel
     dispatch LOAD_CHANNEL_SUCCESS, { channelId: channel.id, channel }
     MessageActions.loadMessages channel.id
 
@@ -91,7 +91,7 @@ loadFollowedPrivateChannels = (options = {}) ->
 
     kd.singletons.reactor.batch ->
       channels.forEach (channel) ->
-        realtimeActionCreators.wrapChannel channel
+        realtimeActionCreators.bindChannelEvents channel
         dispatch LOAD_FOLLOWED_PRIVATE_CHANNEL_SUCCESS, { channel, options }
 
 
@@ -116,7 +116,7 @@ loadFollowedPublicChannels = (options = {}) ->
 
     kd.singletons.reactor.batch ->
       channels.forEach (channel) ->
-        realtimeActionCreators.wrapChannel channel
+        realtimeActionCreators.bindChannelEvents channel
         dispatch LOAD_FOLLOWED_PUBLIC_CHANNEL_SUCCESS, { channel, options }
 
 

--- a/client/activity/lib/flux/actions/channel.coffee
+++ b/client/activity/lib/flux/actions/channel.coffee
@@ -1,9 +1,10 @@
-kd                = require 'kd'
-actionTypes       = require './actiontypes'
-fetchChatChannels = require 'activity/util/fetchChatChannels'
-isKoding          = require 'app/util/isKoding'
-getGroup          = require 'app/util/getGroup'
-MessageActions    = require './message'
+kd                      = require 'kd'
+actionTypes             = require './actiontypes'
+fetchChatChannels       = require 'activity/util/fetchChatChannels'
+isKoding                = require 'app/util/isKoding'
+getGroup                = require 'app/util/getGroup'
+MessageActions          = require './message'
+realtimeActionCreators  = require './realtime/actioncreators'
 { actions: appActions } = require 'app/flux'
 
 dispatch = (args...) -> kd.singletons.reactor.dispatch args...
@@ -35,6 +36,7 @@ loadChannelByName = (name) ->
       dispatch LOAD_CHANNEL_BY_NAME_FAIL, { err }
       return
 
+    realtimeActionCreators.wrapChannel channel
     dispatch LOAD_CHANNEL_SUCCESS, { channelId: channel.id, channel }
     MessageActions.loadMessages channel.id
 
@@ -89,6 +91,7 @@ loadFollowedPrivateChannels = (options = {}) ->
 
     kd.singletons.reactor.batch ->
       channels.forEach (channel) ->
+        realtimeActionCreators.wrapChannel channel
         dispatch LOAD_FOLLOWED_PRIVATE_CHANNEL_SUCCESS, { channel, options }
 
 
@@ -113,6 +116,7 @@ loadFollowedPublicChannels = (options = {}) ->
 
     kd.singletons.reactor.batch ->
       channels.forEach (channel) ->
+        realtimeActionCreators.wrapChannel channel
         dispatch LOAD_FOLLOWED_PUBLIC_CHANNEL_SUCCESS, { channel, options }
 
 

--- a/client/activity/lib/flux/actions/message.coffee
+++ b/client/activity/lib/flux/actions/message.coffee
@@ -43,7 +43,7 @@ dispatchLoadMessageSuccess = (channelId, message) ->
 
   channel = kd.singletons.socialapi.retrieveCachedItemById channelId
 
-  realtimeActionCreators.wrapMessage message
+  realtimeActionCreators.bindMessageEvents message
   dispatch actionTypes.LOAD_MESSAGE_SUCCESS, { channelId, channel, message }
 
 
@@ -102,7 +102,7 @@ createMessage = (channelId, body, payload) ->
 
     channel = socialapi.retrieveCachedItemById channelId
 
-    realtimeActionCreators.wrapMessage message
+    realtimeActionCreators.bindMessageEvents message
     dispatch CREATE_MESSAGE_SUCCESS, {
       message, channelId, clientRequestId, channel
     }
@@ -205,7 +205,7 @@ editMessage = (messageId, body, payload) ->
       dispatch EDIT_MESSAGE_FAIL, { err, messageId }
       return
 
-    realtimeActionCreators.wrapMessage message
+    realtimeActionCreators.bindMessageEvents message
     dispatch EDIT_MESSAGE_SUCCESS, { message, messageId }
 
 
@@ -232,7 +232,7 @@ loadComments = (messageId, from, limit) ->
 
     kd.singletons.reactor.batch ->
       comments.forEach (comment) ->
-        realtimeActionCreators.wrapMessage comment
+        realtimeActionCreators.bindMessageEvents comment
         dispatch LOAD_COMMENT_SUCCESS, { messageId, comment }
 
 
@@ -261,7 +261,7 @@ createComment = (messageId, body, payload) ->
       dispatch CREATE_COMMENT_FAIL, { err, comment, clientRequestId }
       return
 
-    realtimeActionCreators.wrapMessage comment
+    realtimeActionCreators.bindMessageEvents comment
     dispatch CREATE_COMMENT_SUCCESS, { messageId, comment, clientRequestId }
 
 

--- a/client/activity/lib/flux/actions/message.coffee
+++ b/client/activity/lib/flux/actions/message.coffee
@@ -261,7 +261,10 @@ createComment = (messageId, body, payload) ->
       dispatch CREATE_COMMENT_FAIL, { err, comment, clientRequestId }
       return
 
+    addMessageReply = require 'activity/mixins/addmessagereply'
+    message         = socialapi.retrieveCachedItemById messageId
     realtimeActionCreators.bindMessageEvents comment
+    addMessageReply message, comment
     dispatch CREATE_COMMENT_SUCCESS, { messageId, comment, clientRequestId }
 
 

--- a/client/activity/lib/flux/actions/message.coffee
+++ b/client/activity/lib/flux/actions/message.coffee
@@ -32,6 +32,22 @@ loadMessages = (channelId) ->
     kd.singletons.reactor.batch ->
       messages.forEach (message) ->
         dispatch LOAD_MESSAGE_SUCCESS, { channelId, channel, message }
+###*
+ * An action creator to group load message action operations.
+ * It wraps given message with realtimeActionCreators to transform realtime
+ * events to flux actions.
+ *
+ * @param {string} channelId
+ * @param {SocialMessage} message
+ * @api private
+###
+dispatchLoadMessageSuccess = (channelId, message) ->
+
+  channel = kd.singletons.socialapi.retrieveCachedItemById channelId
+
+  realtimeActionCreators.wrapMessage message
+  dispatch actionTypes.LOAD_MESSAGE_SUCCESS, { channelId, channel, message }
+
 
 
 ###*

--- a/client/activity/lib/flux/actions/realtime/actioncreators.coffee
+++ b/client/activity/lib/flux/actions/realtime/actioncreators.coffee
@@ -20,11 +20,11 @@ bindMessageEvents = (message) ->
   messageId = message.id
   { initialChannelId: channelId } = message
 
-  message.on 'LikeAdded', ({ accountId }) ->
-    dispatch actions.LIKE_MESSAGE_SUCCESS, { userId: accountId, messageId }
+  message.on 'LikeAdded', ({ accountId: userId }) ->
+    dispatch actions.LIKE_MESSAGE_SUCCESS, { userId, messageId }
 
-  message.on 'LikeRemoved', ({ accountId }) ->
-    dispatch actions.UNLIKE_MESSAGE_SUCCESS, { userId: accountId, messageId }
+  message.on 'LikeRemoved', ({ accountId: userId }) ->
+    dispatch actions.UNLIKE_MESSAGE_SUCCESS, { userId, messageId }
 
   message.on 'AddReply', (comment) ->
     dispatch actions.LOAD_COMMENT_SUCCESS, { messageId, comment }

--- a/client/activity/lib/flux/actions/realtime/actioncreators.coffee
+++ b/client/activity/lib/flux/actions/realtime/actioncreators.coffee
@@ -3,19 +3,19 @@ actions = require '../actiontypes'
 
 dispatch = (args...) -> kd.singletons.reactor.dispatch args...
 
-wrapChannel = (channel) ->
+bindChannelEvents = (channel) ->
 
   kd.singletons.socialapi.onChannelReady channel, ->
 
     channel.on 'MessageAdded', (message) ->
-      wrapMessage message
+      bindMessageEvents message
       dispatch actions.LOAD_MESSAGE_SUCCESS, { channel, message, channelId: channel.id }
 
     channel.on 'MessageRemoved', (message) ->
       dispatch actions.REMOVE_MESSAGE_SUCCESS, { messageId: message.id }
 
 
-wrapMessage = (message) ->
+bindMessageEvents = (message) ->
 
   messageId = message.id
   { initialChannelId: channelId } = message
@@ -38,6 +38,6 @@ wrapMessage = (message) ->
 
 
 module.exports = {
-  wrapChannel
-  wrapMessage
+  bindChannelEvents
+  bindMessageEvents
 }

--- a/client/activity/lib/flux/actions/realtime/actioncreators.coffee
+++ b/client/activity/lib/flux/actions/realtime/actioncreators.coffee
@@ -1,0 +1,43 @@
+kd = require 'kd'
+actions = require '../actiontypes'
+
+dispatch = (args...) -> kd.singletons.reactor.dispatch args...
+
+wrapChannel = (channel) ->
+
+  kd.singletons.socialapi.onChannelReady channel, ->
+
+    channel.on 'MessageAdded', (message) ->
+      wrapMessage message
+      dispatch actions.LOAD_MESSAGE_SUCCESS, { channel, message, channelId: channel.id }
+
+    channel.on 'MessageRemoved', (message) ->
+      dispatch actions.REMOVE_MESSAGE_SUCCESS, { messageId: message.id }
+
+
+wrapMessage = (message) ->
+
+  messageId = message.id
+  { initialChannelId: channelId } = message
+
+  message.on 'LikeAdded', ({ accountId }) ->
+    dispatch actions.LIKE_MESSAGE_SUCCESS, { userId: accountId, messageId }
+
+  message.on 'LikeRemoved', ({ accountId }) ->
+    dispatch actions.UNLIKE_MESSAGE_SUCCESS, { userId: accountId, messageId }
+
+  message.on 'AddReply', (comment) ->
+    dispatch actions.LOAD_COMMENT_SUCCESS, { messageId, comment }
+
+  message.on 'RemoveReply', (comment) ->
+    dispatch actions.REMOVE_MESSAGE_SUCCESS, { messageId: comment.id }
+
+  message.on 'update', ->
+    channel = kd.singletons.socialapi.retrieveCachedItemById channelId
+    dispatch actions.LOAD_MESSAGE_SUCCESS, { channelId, message, channel }
+
+
+module.exports = {
+  wrapChannel
+  wrapMessage
+}

--- a/client/activity/lib/flux/helpers/message.coffee
+++ b/client/activity/lib/flux/helpers/message.coffee
@@ -1,3 +1,5 @@
+_ = require 'lodash'
+
 ###*
  * Sanitizes given payload to meet the request criteria.
  *
@@ -6,7 +8,7 @@
 ###
 sanitizePayload = (payload) ->
 
-  unless typeof payload is 'object'
+  unless _.isPlainObject payload
     payload = {}
 
   return payload

--- a/client/activity/lib/flux/stores/channelthreadsstore.coffee
+++ b/client/activity/lib/flux/stores/channelthreadsstore.coffee
@@ -138,7 +138,7 @@ module.exports = class ChannelThreadsStore extends Nuclear.Store
    * @param {string} messageId
    * @param {IMTreadCollection} nextState
   ###
-  handleRemoveMessageSuccess: (threads, { channelId, messageId }) ->
+  handleRemoveMessageSuccess: (threads, { messageId }) ->
 
     return removeMessage threads, messageId
 

--- a/client/activity/lib/flux/stores/messagethreadssstore.coffee
+++ b/client/activity/lib/flux/stores/messagethreadssstore.coffee
@@ -26,6 +26,7 @@ module.exports = class MessageThreadsStore extends KodingFluxStore
   initialize: ->
 
     @on actions.LOAD_MESSAGE_SUCCESS, @ensureThread
+    @on actions.CREATE_MESSAGE_SUCCESS, @ensureThread
 
     @on actions.LOAD_COMMENT_SUCCESS, @handleLoadSuccess
 

--- a/client/activity/lib/flux/stores/messagethreadssstore.coffee
+++ b/client/activity/lib/flux/stores/messagethreadssstore.coffee
@@ -34,6 +34,8 @@ module.exports = class MessageThreadsStore extends KodingFluxStore
     @on actions.CREATE_COMMENT_SUCCESS, @handleCreateSuccess
     @on actions.CREATE_COMMENT_FAIL, @handleCreateFail
 
+    @on actions.REMOVE_MESSAGE_SUCCESS, @handleRemoveMessageSuccess
+
 
   ###*
    * Creates a new thread if it doesn't exist.
@@ -109,6 +111,20 @@ module.exports = class MessageThreadsStore extends KodingFluxStore
   handleCreateFail: (threads, { messageId, clientRequestId }) ->
 
     return removeComment threads, messageId, clientRequestId
+
+
+  ###*
+   * Remove given messageId from all the threads.
+   *
+   * @param {IMThreadCollection} threads
+   * @param {object} payload
+   * @param {string} payload.messageId
+   * @return {IMThreadCollection} nextState
+  ###
+  handleRemoveMessageSuccess: (threads, { messageId }) ->
+
+    threads.map (thread) ->
+      thread.update 'comments', (comments) -> comments.remove messageId
 
 
 ###*

--- a/client/activity/lib/flux/test/messagethreadsstore.coffee
+++ b/client/activity/lib/flux/test/messagethreadsstore.coffee
@@ -105,3 +105,19 @@ describe 'MessageThreadsStore', ->
       storeState = @reactor.evaluateToJS ['MessageThreadsStore']
       expect(storeState['123']['comments']['007']).to.eql '007'
 
+
+  describe '#handleRemoveMessageSuccess', ->
+
+    it 'removes deleted message from message thread lists', ->
+
+      comment = createFakeMessage '007', 'bond'
+      @reactor.dispatch actions.CREATE_COMMENT_SUCCESS, { comment, messageId: '123' }
+
+      storeState = @reactor.evaluateToJS ['MessageThreadsStore']
+      expect(storeState['123']['comments']['007']).to.eql '007'
+
+      @reactor.dispatch actions.REMOVE_MESSAGE_SUCCESS, { messageId: comment.id }
+
+      storeState = @reactor.evaluateToJS ['MessageThreadsStore']
+      expect(storeState['123']['comments']['007']).to.be.undefined
+

--- a/client/app/lib/messageeventmanager.coffee
+++ b/client/app/lib/messageeventmanager.coffee
@@ -57,7 +57,7 @@ module.exports = class MessageEventManager extends KDObject
     like.actorsPreview.unshift accountOldId  if accountOldId not in like.actorsPreview
     like.isInteracted = yes  if whoami().getId() is accountOldId
 
-    message.emit "LikeAdded"
+    message.emit "LikeAdded", { accountId: accountOldId }
     message.emit "update"
 
 
@@ -73,7 +73,7 @@ module.exports = class MessageEventManager extends KDObject
 
     like.isInteracted = no  if whoami().getId() is accountOldId
 
-    message.emit "LikeRemoved"
+    message.emit "LikeRemoved", { accountId: accountOldId }
     message.emit "update"
 
 


### PR DESCRIPTION
This PR transforms channel & message realtime events to Flux action dispatches.

Also fixes couple of issues in edit message and remove comment.

/cc @gokhansongul @alex-ionochkin 
