### PR TITLE
wercker: build all configs each time to check for integrity

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -61,6 +61,11 @@ build:
         name: copy prod creds
         code: ./scripts/copy-prod-creds.sh
     - script:
+        name: check configs
+        code: |
+          ./configure --config sandbox
+          ./configure --config prod
+    - script:
         name: configure build
         code: ./configure --config $CONFIG --projectRoot $WERCKER_SOURCE_DIR --ebEnvName $EB_ENV_NAME
     - script:


### PR DESCRIPTION
Check to catch any mistakes in sandbox or prod configs early on. Keep making stupid mistakes that aren't caught till we deploy.
