### PR TITLE
FileTree: DND Uploader: Fix for Chrome OS / Chromium [fixes #99383548]

### DIFF
--- a/client/app/lib/commonviews/dnduploader.coffee
+++ b/client/app/lib/commonviews/dnduploader.coffee
@@ -84,6 +84,9 @@ module.exports = class DNDUploader extends KDView
 
       for item in items
         entry = item.webkitGetAsEntry()
+
+        return  unless entry  # Fix for Chrome OS / Chromium
+
         if entry.isDirectory
           @walkDirectory entry.filesystem.root, (file)=>
             # upload walked file


### PR DESCRIPTION
/cc @sinan @usirin @gokmen @szkl @fatihacet 

![chrome os-2015-08-12t14-21-52-082388500z](https://cloud.githubusercontent.com/assets/728733/9226663/50c29a12-4118-11e5-96db-2cf26a373a5a.gif)
