### PR TITLE
kloud.info: Added Stop() call, replacing Mongo Stopped write.

### DIFF
--- a/go/src/koding/kites/kloud/provider/koding/info.go
+++ b/go/src/koding/kites/kloud/provider/koding/info.go
@@ -66,7 +66,7 @@ func (m *Machine) Info(ctx context.Context) (map[string]string, error) {
 					machine.Log.Debug("Info decision: Error while Stopping machine. Err: %v",
 						machine.Id, err)
 				}
-				m.Log.Info("======> STOP finished (inconsistent state)<======")
+				machine.Log.Info("======> STOP finished (inconsistent state)<======")
 			}(m)
 			return
 		}

--- a/go/src/koding/kites/kloud/provider/koding/info.go
+++ b/go/src/koding/kites/kloud/provider/koding/info.go
@@ -52,19 +52,19 @@ func (m *Machine) Info(ctx context.Context) (map[string]string, error) {
 		if resultState == machinestate.Stopped {
 			// Note that this Stop() call is done in a goroutine so that it
 			// does not block the Info() call.
-			go func() {
+			go func(machine *Machine) {
 				// Note that we are ignoring any potential Lock Errors, as
 				// we are Forcing the Stop state. In the future we may want to
 				// queue the Stop method, to avoid race conditions.
-				m.Lock()
-				defer m.Unlock()
+				machine.Lock()
+				defer machine.Unlock()
 
-				err := m.Stop(ctx)
+				err := machine.Stop(ctx)
 				if err != nil {
-					m.Log.Debug("Info decision: Error while Stopping machine. Err: %v",
-						m.Id, err)
+					machine.Log.Debug("Info decision: Error while Stopping machine. Err: %v",
+						machine.Id, err)
 				}
-			}()
+			}(m)
 			return
 		}
 

--- a/go/src/koding/kites/kloud/provider/koding/info.go
+++ b/go/src/koding/kites/kloud/provider/koding/info.go
@@ -50,6 +50,8 @@ func (m *Machine) Info(ctx context.Context) (map[string]string, error) {
 		// This ensures that the machine will never store Stopped in the
 		// database, while still running on the provider.
 		if resultState == machinestate.Stopped {
+			m.Log.Info("======> STOP started (inconsistent state)<======")
+
 			// Note that this Stop() call is done in a goroutine so that it
 			// does not block the Info() call.
 			go func(machine *Machine) {
@@ -64,6 +66,7 @@ func (m *Machine) Info(ctx context.Context) (map[string]string, error) {
 					machine.Log.Debug("Info decision: Error while Stopping machine. Err: %v",
 						machine.Id, err)
 				}
+				m.Log.Info("======> STOP finished (inconsistent state)<======")
 			}(m)
 			return
 		}

--- a/go/src/koding/kites/kloud/provider/koding/machine.go
+++ b/go/src/koding/kites/kloud/provider/koding/machine.go
@@ -5,6 +5,7 @@ import (
 	"koding/kites/kloud/contexthelper/session"
 	"koding/kites/kloud/eventer"
 	"koding/kites/kloud/klient"
+	"koding/kites/kloud/kloud"
 	"koding/kites/kloud/machinestate"
 	"koding/kites/kloud/plans"
 	"time"
@@ -54,6 +55,7 @@ type Machine struct {
 	Checker  plans.Checker          `bson:"-"`
 	Session  *session.Session       `bson:"-"`
 	Log      logging.Logger         `bson:"-"`
+	locker   kloud.Locker           `bson:"-"`
 
 	// cleanFuncs are a list of functions that are called when after a method
 	// is finished
@@ -204,4 +206,24 @@ func (m *Machine) isKlientReady() bool {
 	}
 
 	return true
+}
+
+// Lock performs a Lock on this Machine
+func (m *Machine) Lock() error {
+	if !m.Id.Valid() {
+		return kloud.NewError(kloud.ErrMachineIdMissing)
+	}
+
+	return m.locker.Lock(m.Id.Hex())
+}
+
+// Unlock performs an Unlock on this Machine instance
+func (m *Machine) Unlock() error {
+	if !m.Id.Valid() {
+		return kloud.NewError(kloud.ErrMachineIdMissing)
+	}
+
+	// Unlock does not return an error
+	m.locker.Unlock(m.Id.Hex())
+	return nil
 }

--- a/go/src/koding/kites/kloud/provider/koding/provider.go
+++ b/go/src/koding/kites/kloud/provider/koding/provider.go
@@ -160,6 +160,7 @@ func (p *Provider) attachSession(ctx context.Context, machine *Machine) error {
 	machine.User = user
 	machine.cleanFuncs = make([]func(), 0)
 	machine.Checker = checker
+	machine.locker = p
 
 	ev, ok := eventer.FromContext(ctx)
 	if ok {


### PR DESCRIPTION
As a stop-gap measure, to prevent Leaking VMs and State mismatch, `kloud.info` now calls the `Machine.Stop` method, to put the machine through a normal stopping process. This means that if Klient is not running, the machine will shutdown.

A few points of interest:
- I've added a `locker` to the Machine instances.
- Repeated calls to `kloud.info` are safe because `Stop()` will immediately set the machine (and database) to `Stopping` state. And, this PR will only work when there's a state mismatch.
- The Info() method has a fair amount of legacy logic, so i think it needs a rewrite. But CostControl is most pressing atm, so this PR is mainly focused on healing the leak/mismatch, than rewriting the full Info method.

cc @fatih 
