### PR TITLE
kloud: fix panicing

### DIFF
--- a/go/src/koding/kites/kloud/kloud/terraformutils.go
+++ b/go/src/koding/kites/kloud/kloud/terraformutils.go
@@ -168,7 +168,8 @@ func injectKodingData(ctx context.Context, content, username string, creds *terr
 		return nil, errors.New("session context is not passed")
 	}
 
-	var awsOutput *AwsBootstrapOutput
+	awsOutput := &AwsBootstrapOutput{}
+
 	for _, cred := range creds.Creds {
 		if cred.Provider != "aws" {
 			continue


### PR DESCRIPTION
If the credentials are empty, awsOutput variable didn't get
initialiazed at all, so a nil value would be passed to HasZero, which
would panic it. Instead initialize it first and then try to decode.
This prevents panicing.
