### PR TITLE
terraformer: fix panicing

### DIFF
--- a/go/src/koding/kites/terraformer/kodingcontext/context.go
+++ b/go/src/koding/kites/terraformer/kodingcontext/context.go
@@ -93,8 +93,8 @@ func (c *context) Get(contentID string) (*KodingContext, error) {
 	kc.Provisioners = c.Provisioners
 	kc.LocalStorage = c.LocalStorage
 	kc.RemoteStorage = c.RemoteStorage
-
 	kc.ContentID = contentID
+	kc.log = c.log
 
 	return kc, nil
 }


### PR DESCRIPTION
When used the logger terraformer just panics if the context was created
via Get().
