### PR TITLE
Teams: Settings: Resize avatar of team logo in dashboard modal [fixes #96160132]

### DIFF
--- a/client/admin/lib/styl/app.group.admin.styl
+++ b/client/admin/lib/styl/app.group.admin.styl
@@ -684,10 +684,10 @@ Admin main styles
         top                 70px
 
       .avatar
-        bg                  size, 106px 110px
+        bg                  size, 110px 110px
 
     .avatar
-      size                  106px, 110px
+      size                  110px, 110px
       rounded               7px
       border                1px inset transparent
       margin-right          35px


### PR DESCRIPTION
I just made it square (1:1).

/cc @fatihacet @szkl @sinan 

<img width="149" alt="monosnap 2015-08-18 14-53-26" src="https://cloud.githubusercontent.com/assets/728733/9329294/f4e6a030-45b8-11e5-8514-1be748aca76f.png">
