### PR TITLE
kloud: Stop VM if Klient will not connect

### DIFF
--- a/go/src/koding/kites/kloud/provider/koding/machine.go
+++ b/go/src/koding/kites/kloud/provider/koding/machine.go
@@ -1,6 +1,7 @@
 package koding
 
 import (
+	"fmt"
 	"koding/db/models"
 	"koding/kites/kloud/contexthelper/session"
 	"koding/kites/kloud/eventer"
@@ -10,10 +11,14 @@ import (
 	"koding/kites/kloud/plans"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/koding/logging"
 	"labix.org/v2/mgo"
 	"labix.org/v2/mgo/bson"
 )
+
+var callCount int
 
 // Machine represents a single MongodDB document that represents a Koding
 // Provider from the jMachines collection.
@@ -24,8 +29,9 @@ type Machine struct {
 	QueryString string        `bson:"queryString"`
 	IpAddress   string        `bson:"ipAddress"`
 	Assignee    struct {
-		InProgress bool      `bson:"inProgress"`
-		AssignedAt time.Time `bson:"assignedAt"`
+		InProgress      bool      `bson:"inProgress"`
+		AssignedAt      time.Time `bson:"assignedAt"`
+		KlientMissingAt time.Time `bson:"klientMissingAt"`
 	} `bson:"assignee"`
 	Status struct {
 		State      string    `bson:"state"`
@@ -214,6 +220,10 @@ func (m *Machine) Lock() error {
 		return kloud.NewError(kloud.ErrMachineIdMissing)
 	}
 
+	if m.locker == nil {
+		return fmt.Errorf("Machine '%s' missing Locker", m.Id.Hex())
+	}
+
 	return m.locker.Lock(m.Id.Hex())
 }
 
@@ -223,7 +233,80 @@ func (m *Machine) Unlock() error {
 		return kloud.NewError(kloud.ErrMachineIdMissing)
 	}
 
+	if m.locker == nil {
+		return fmt.Errorf("Machine '%s' missing Locker", m.Id.Hex())
+	}
+
 	// Unlock does not return an error
 	m.locker.Unlock(m.Id.Hex())
+	return nil
+}
+
+// klientIsNotMissing will unset the `assignee.klientMissingAt` value
+// from the database, only if the Machine.Assignee.KlientMissingAt value
+// has data. Therefor it is safe to call as frequently.
+func (m *Machine) klientIsNotMissing() error {
+	if m.Assignee.KlientMissingAt.IsZero() {
+		return nil
+	}
+
+	m.Log.Debug("Clearing assignee.klientMissingAt")
+
+	return m.Session.DB.Run("jMachines", func(c *mgo.Collection) error {
+		return c.UpdateId(
+			m.Id,
+			bson.M{"$unset": bson.M{"assignee.klientMissingAt": ""}},
+		)
+	})
+}
+
+// stopIfKlientIsMissing will stop the current Machine X minutes after
+// the `assignee.klientMissingAt` value. If the value does not exist in
+// the databse, it will write it and return.
+//
+// Therefor, this method is expected be called as often as needed,
+// and will shutdown the Machine if klient has been missing for too long.
+func (m *Machine) stopIfKlientIsMissing(ctx context.Context) error {
+
+	// If this is the first time Klient has been found missing,
+	// set the missingat time and return
+	if m.Assignee.KlientMissingAt.IsZero() {
+		m.Log.Debug("Klient has been reported missing, recording this as the first time it went missing")
+
+		return m.Session.DB.Run("jMachines", func(c *mgo.Collection) error {
+			return c.UpdateId(
+				m.Id,
+				bson.M{"$set": bson.M{"assignee.klientMissingAt": time.Now().UTC()}},
+			)
+		})
+	}
+
+	// If the klient has been missing less than X minutes, don't stop
+	if time.Since(m.Assignee.KlientMissingAt) < time.Minute*5 {
+		return nil
+	}
+
+	// lock so it doesn't interfere with others.
+	err := m.Lock()
+	defer m.Unlock()
+	if err != nil {
+		return err
+	}
+
+	callCount++
+
+	// Hasta la vista, baby!
+	m.Log.Info("======> STOP started (missing klient) <======")
+	if err := m.Stop(ctx); err != nil {
+		m.Log.Info("======> STOP aborted (missing klient: %s) <======", err)
+		return err
+	}
+	m.Log.Info("======> STOP finished (missing klient) <======")
+
+	// Clear the klientMissingAt field, or we risk Stopping the user's
+	// machine next time they run it, without waiting the proper X minute
+	// timeout.
+	m.klientIsNotMissing()
+
 	return nil
 }

--- a/go/src/koding/kites/kloud/provider/koding/machine.go
+++ b/go/src/koding/kites/kloud/provider/koding/machine.go
@@ -290,7 +290,7 @@ func (m *Machine) stopIfKlientIsMissing(ctx context.Context) error {
 	defer func(m *Machine) {
 		err := m.Unlock()
 		if err != nil {
-			m.Log.Error("Defer Error: Unlocking machine failed, " + err.Error())
+			m.Log.Error("Defer Error: Unlocking machine failed, %s", err.Error())
 		}
 	}(m)
 
@@ -305,17 +305,17 @@ func (m *Machine) stopIfKlientIsMissing(ctx context.Context) error {
 	defer func(m *Machine) {
 		err := m.klientIsNotMissing()
 		if err != nil {
-			m.Log.Error("Defer Error: Call to klientIsNotMissing failed, " + err.Error())
+			m.Log.Error("Defer Error: Call to klientIsNotMissing failed, %s", err.Error())
 		}
 	}(m)
 
 	// Hasta la vista, baby!
-	m.Log.Info("======> STOP started (missing klient) <======")
+	m.Log.Info("======> STOP started (missing klient) <======, username:%s", m.Credential)
 	if err := m.Stop(ctx); err != nil {
 		m.Log.Info("======> STOP failed (missing klient: %s) <======", err)
 		return err
 	}
-	m.Log.Info("======> STOP finished (missing klient) <======")
+	m.Log.Info("======> STOP finished (missing klient) <======, username:%s", m.Credential)
 
 	return nil
 }

--- a/go/src/koding/kites/kloud/provider/koding/machine.go
+++ b/go/src/koding/kites/kloud/provider/koding/machine.go
@@ -294,7 +294,7 @@ func (m *Machine) stopIfKlientIsMissing(ctx context.Context) error {
 	// Hasta la vista, baby!
 	m.Log.Info("======> STOP started (missing klient) <======")
 	if err := m.Stop(ctx); err != nil {
-		m.Log.Info("======> STOP aborted (missing klient: %s) <======", err)
+		m.Log.Info("======> STOP failed (missing klient: %s) <======", err)
 		return err
 	}
 	m.Log.Info("======> STOP finished (missing klient) <======")

--- a/go/src/koding/kites/kloud/provider/koding/machine.go
+++ b/go/src/koding/kites/kloud/provider/koding/machine.go
@@ -18,8 +18,6 @@ import (
 	"labix.org/v2/mgo/bson"
 )
 
-var callCount int
-
 // Machine represents a single MongodDB document that represents a Koding
 // Provider from the jMachines collection.
 type Machine struct {
@@ -292,8 +290,6 @@ func (m *Machine) stopIfKlientIsMissing(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-
-	callCount++
 
 	// Hasta la vista, baby!
 	m.Log.Info("======> STOP started (missing klient) <======")

--- a/go/src/koding/kites/kloud/provider/koding/queue.go
+++ b/go/src/koding/kites/kloud/provider/koding/queue.go
@@ -69,7 +69,8 @@ func (p *Provider) CheckUsage(m *Machine) error {
 	// Check klient state before rushing to AWS.
 	klientRef, err := klient.Connect(m.Session.Kite, m.QueryString)
 	if err != nil {
-		m.Log.Debug("Error connecting to klient, stopping if needed. Error: " + err.Error())
+		m.Log.Debug("Error connecting to klient, stopping if needed. Error: %s",
+			err.Error())
 		return m.stopIfKlientIsMissing(ctx)
 	}
 
@@ -83,7 +84,8 @@ func (p *Provider) CheckUsage(m *Machine) error {
 	klientRef.Close()
 	klientRef = nil
 	if err != nil {
-		m.Log.Debug("Error getting klient usage, stopping if needed. Error: " + err.Error())
+		m.Log.Debug("Error getting klient usage, stopping if needed. Error: %s",
+			err.Error())
 		return m.stopIfKlientIsMissing(ctx)
 	}
 

--- a/go/src/koding/kites/kloud/provider/koding/queue.go
+++ b/go/src/koding/kites/kloud/provider/koding/queue.go
@@ -181,7 +181,3 @@ func (p *Provider) FetchOne() (*Machine, error) {
 
 	return machine, nil
 }
-
-func (p *Provider) StopUnlessKlientConn(m *Machine) error {
-	return nil
-}


### PR DESCRIPTION
As part of the normal Klient timeout vm stoppage, Kloud now tracks
whether the machine's Klient is not connecting properly, and how long
that has been. If it has been longer than X minutes, Kloud stops the VM.
This helps ensure that a user can't simply stop Klient, and then get a
Free VM for until Cleaner catches it.

A few additional notes:
- A new _(temporary)_ field, `assignee.klientMissingAt` has been added to Mongo, which holds a timestamp.
- If klient cannot be connect to, `machine.stopIfKlientIsMissing()` is called. `assignee.klientMissingAt` is written to on the **first** call to `Machine.stopIfKlientIsMissing()`. Subsequent calls compare the timestamp value to the current value.
- If klient reconnects, `Machine.klientIsNotMissing()` is called. This will clear any pre-existing `assignee.klientMissingAt` value, only if needed, ensuring that a reconnect of Klient will not let Kloud continue to stop Klient.
- The Queue function is called very, very frequently on Prod (every 500ms i believe), so repeated calls to both of the new Machine methods are intended to not write to Mongo unless absolutely required (recording and clearing the timestamp only. No updates of last communicated, or count of klient failures)

assigned to @fatih
cc @sent-hil 
