### PR TITLE
Input widget optimization [fixes #101645062]

### DIFF
--- a/client/activity/lib/components/channeldropup/index.coffee
+++ b/client/activity/lib/components/channeldropup/index.coffee
@@ -1,14 +1,18 @@
-kd                = require 'kd'
-React             = require 'kd-react'
-immutable         = require 'immutable'
-classnames        = require 'classnames'
-ActivityFlux      = require 'activity/flux'
-Dropup            = require 'activity/components/dropup'
-ChannelDropupItem = require 'activity/components/channeldropupitem'
-scrollToTarget    = require 'activity/util/scrollToTarget'
+kd                   = require 'kd'
+React                = require 'kd-react'
+immutable            = require 'immutable'
+classnames           = require 'classnames'
+ActivityFlux         = require 'activity/flux'
+Dropup               = require 'activity/components/dropup'
+ChannelDropupItem    = require 'activity/components/channeldropupitem'
+scrollToTarget       = require 'activity/util/scrollToTarget'
+ImmutableRenderMixin = require 'react-immutable-render-mixin'
 
 
 module.exports = class ChannelDropup extends React.Component
+
+  @include [ImmutableRenderMixin]
+
 
   @defaultProps =
     items        : immutable.List()

--- a/client/activity/lib/components/emojidropup/index.coffee
+++ b/client/activity/lib/components/emojidropup/index.coffee
@@ -1,15 +1,19 @@
-$               = require 'jquery'
-kd              = require 'kd'
-React           = require 'kd-react'
-immutable       = require 'immutable'
-classnames      = require 'classnames'
-formatEmojiName = require 'activity/util/formatEmojiName'
-ActivityFlux    = require 'activity/flux'
-Dropup          = require 'activity/components/dropup'
-EmojiDropupItem = require 'activity/components/emojidropupitem'
+$                    = require 'jquery'
+kd                   = require 'kd'
+React                = require 'kd-react'
+immutable            = require 'immutable'
+classnames           = require 'classnames'
+formatEmojiName      = require 'activity/util/formatEmojiName'
+ActivityFlux         = require 'activity/flux'
+Dropup               = require 'activity/components/dropup'
+EmojiDropupItem      = require 'activity/components/emojidropupitem'
+ImmutableRenderMixin = require 'react-immutable-render-mixin'
 
 
 module.exports = class EmojiDropup extends React.Component
+
+  @include [ImmutableRenderMixin]
+
 
   @defaultProps =
     items        : immutable.List()

--- a/client/activity/lib/components/emojiselector/index.coffee
+++ b/client/activity/lib/components/emojiselector/index.coffee
@@ -1,17 +1,23 @@
-$                 = require 'jquery'
-kd                = require 'kd'
-React             = require 'kd-react'
-classnames        = require 'classnames'
-immutable         = require 'immutable'
-emojify           = require 'emojify.js'
-formatEmojiName   = require 'activity/util/formatEmojiName'
-ActivityFlux      = require 'activity/flux'
-Dropup            = require 'activity/components/dropup'
-EmojiSelectorItem = require 'activity/components/emojiselectoritem'
+$                    = require 'jquery'
+kd                   = require 'kd'
+React                = require 'kd-react'
+classnames           = require 'classnames'
+immutable            = require 'immutable'
+emojify              = require 'emojify.js'
+formatEmojiName      = require 'activity/util/formatEmojiName'
+ActivityFlux         = require 'activity/flux'
+Dropup               = require 'activity/components/dropup'
+EmojiSelectorItem    = require 'activity/components/emojiselectoritem'
+ImmutableRenderMixin = require 'react-immutable-render-mixin'
+
 
 module.exports = class EmojiSelector extends React.Component
 
   ESC = 27
+
+
+  @include [ImmutableRenderMixin]
+
 
   @defaultProps =
     items        : immutable.List()

--- a/client/activity/lib/components/userdropup/index.coffee
+++ b/client/activity/lib/components/userdropup/index.coffee
@@ -1,14 +1,18 @@
-kd             = require 'kd'
-React          = require 'kd-react'
-immutable      = require 'immutable'
-classnames     = require 'classnames'
-ActivityFlux   = require 'activity/flux'
-Dropup         = require 'activity/components/dropup'
-UserDropupItem = require 'activity/components/userdropupitem'
-scrollToTarget  = require 'activity/util/scrollToTarget'
+kd                   = require 'kd'
+React                = require 'kd-react'
+immutable            = require 'immutable'
+classnames           = require 'classnames'
+ActivityFlux         = require 'activity/flux'
+Dropup               = require 'activity/components/dropup'
+UserDropupItem       = require 'activity/components/userdropupitem'
+scrollToTarget       = require 'activity/util/scrollToTarget'
+ImmutableRenderMixin = require 'react-immutable-render-mixin'
 
 
 module.exports = class UserDropup extends React.Component
+
+  @include [ImmutableRenderMixin]
+
 
   @defaultProps =
     items        : immutable.List()
@@ -28,7 +32,7 @@ module.exports = class UserDropup extends React.Component
   confirmSelectedItem: ->
 
     { selectedItem } = @props
-    
+
     @props.onItemConfirmed? "@#{selectedItem.getIn ['profile', 'nickname']}"
     @close()
 

--- a/client/package.json
+++ b/client/package.json
@@ -42,6 +42,7 @@
     "raf": "2.0.4",
     "react": "0.13.3",
     "react-autosize-textarea": "0.2.4",
+    "react-immutable-render-mixin": "0.8.1",
     "react-portal": "0.7.0",
     "react-router": "1.0.0-beta3",
     "record-shortcuts": "0.1.4",


### PR DESCRIPTION
Since we are using controlled state in `TextArea` it was causing all the children to be rerendered when the text area value is changed, and trying to render the dropups with every keydown even if there is no change for the dropup values was causing consequent keydown events to block the main thread and resulting in a very poor UX.

With this PR, we are introducing [react-immutable-render-mixin](https://www.npmjs.com/package/react-immutable-render-mixin). And since we are using `immutable-js` objects, and the `Dropup` API is working only with `props` and not using any state at all (kudos to @alex-ionochkin here), equality check is pretty performant in `shouldComponentUpdate`, and it works pretty smoothly.

/cc @alex-ionochkin @gokhansongul  
