### PR TITLE
kloud: Increased the Klient Missing timeout

### DIFF
--- a/go/src/koding/kites/kloud/provider/koding/machine.go
+++ b/go/src/koding/kites/kloud/provider/koding/machine.go
@@ -280,7 +280,7 @@ func (m *Machine) stopIfKlientIsMissing(ctx context.Context) error {
 	}
 
 	// If the klient has been missing less than X minutes, don't stop
-	if time.Since(m.Assignee.KlientMissingAt) < time.Minute*5 {
+	if time.Since(m.Assignee.KlientMissingAt) < time.Minute*50 {
 		return nil
 	}
 


### PR DESCRIPTION
QA ran into a timeout issue, where Kloud failed to talk to Klient, and
shutdown the VM. The 5m timeout may be too short and unforgiving. This
change increases it to 50m, until we can debug the Klient connection
more.

cc @fatih @sent-hil 
