### PR TITLE
Fixes "topic moderation styles are broken" [fixes #101653756]

### DIFF
--- a/client/admin/lib/styl/app.group.admin.styl
+++ b/client/admin/lib/styl/app.group.admin.styl
@@ -713,7 +713,7 @@ Admin main styles
 
 
 // Topic tab styling
-.AppModal--admin .topic-moderation
+.AppModal--admin .moderation
 
   .kdtabpaneview
     kalc                    height, (100% \- 62px)


### PR DESCRIPTION
![vxsbpzrq5k](https://cloud.githubusercontent.com/assets/1278794/9449939/8b15beb6-4aae-11e5-9443-583ccfa5e510.gif)

**Notes:** Somewhere in the PRs (I could not find where exactly) someone changed the slug for that section and thus the CSS class changed (the design the was designed for that section with that slug). I changed the class to reflect the current view. Tested and it works.

**The story:** https://www.pivotaltracker.com/story/show/101653756

cc. @sinan @gniting 
