### PR TITLE
kloud: inject dynamically created koding variables

### DIFF
--- a/go/src/koding/db/models/computestack.go
+++ b/go/src/koding/db/models/computestack.go
@@ -9,4 +9,7 @@ type ComputeStack struct {
 
 	// Points to a document in jStackTemplates
 	BaseStackId bson.ObjectId `bson:"baseStackId"`
+
+	// User injected credentials
+	Credentials map[string][]string `bson:"credentials"`
 }

--- a/go/src/koding/kites/kloud/kloud/apply.go
+++ b/go/src/koding/kites/kloud/kloud/apply.go
@@ -166,7 +166,7 @@ func destroy(ctx context.Context, username, groupname, stackId string) error {
 	})
 
 	sess.Log.Debug("Fetching '%d' credentials from user '%s'", len(stack.Credentials), username)
-	creds, err := fetchCredentials(username, groupname, sess.DB, flattenValues(stack.Credentials))
+	creds, err := fetchTerraformData(username, groupname, sess.DB, flattenValues(stack.Credentials))
 	if err != nil {
 		return err
 	}
@@ -252,7 +252,7 @@ func apply(ctx context.Context, username, groupname, stackId string) error {
 	})
 
 	sess.Log.Debug("Fetching '%d' credentials from user '%s'", len(stack.Credentials), username)
-	creds, err := fetchCredentials(username, groupname, sess.DB, flattenValues(stack.Credentials))
+	data, err := fetchTerraformData(username, groupname, sess.DB, flattenValues(stack.Credentials))
 	if err != nil {
 		return err
 	}
@@ -264,7 +264,7 @@ func apply(ctx context.Context, username, groupname, stackId string) error {
 	}
 	defer tfKite.Close()
 
-	for _, cred := range creds.Creds {
+	for _, cred := range data.Creds {
 		stack.Template, err = cred.appendAWSVariable(stack.Template)
 		if err != nil {
 			return err
@@ -274,7 +274,7 @@ func apply(ctx context.Context, username, groupname, stackId string) error {
 	sess.Log.Debug("Stack template before injecting Koding data:")
 	sess.Log.Debug(stack.Template)
 
-	buildData, err := injectKodingData(ctx, stack.Template, username, creds)
+	buildData, err := injectKodingData(ctx, stack.Template, username, data)
 	if err != nil {
 		return err
 	}

--- a/go/src/koding/kites/kloud/kloud/authenticate.go
+++ b/go/src/koding/kites/kloud/kloud/authenticate.go
@@ -47,14 +47,14 @@ func (k *Kloud) Authenticate(r *kite.Request) (interface{}, error) {
 		return nil, errors.New("session context is not passed")
 	}
 
-	creds, err := fetchCredentials(r.Username, args.GroupName, sess.DB, args.Identifiers)
+	data, err := fetchTerraformData(r.Username, args.GroupName, sess.DB, args.Identifiers)
 	if err != nil {
 		return nil, err
 	}
 
 	result := make(map[string]bool, 0)
 
-	for _, cred := range creds.Creds {
+	for _, cred := range data.Creds {
 		// We are going to support more providers in the future, for now only allow aws
 		if cred.Provider != "aws" {
 			return nil, fmt.Errorf("bootstrap is only supported for 'aws' provider. Got: '%s'", cred.Provider)

--- a/go/src/koding/kites/kloud/kloud/bootstrap.go
+++ b/go/src/koding/kites/kloud/kloud/bootstrap.go
@@ -68,7 +68,7 @@ func (k *Kloud) Bootstrap(r *kite.Request) (interface{}, error) {
 		return nil, errors.New("session context is not passed")
 	}
 
-	creds, err := fetchCredentials(r.Username, args.GroupName, sess.DB, args.Identifiers)
+	data, err := fetchTerraformData(r.Username, args.GroupName, sess.DB, args.Identifiers)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (k *Kloud) Bootstrap(r *kite.Request) (interface{}, error) {
 	defer tfKite.Close()
 
 	k.Log.Debug("Iterating over credentials")
-	for _, cred := range creds.Creds {
+	for _, cred := range data.Creds {
 		// We are going to support more providers in the future, for now only allow aws
 		if cred.Provider != "aws" {
 			return nil, fmt.Errorf("Bootstrap is only supported for 'aws' provider. Got: '%s'", cred.Provider)

--- a/go/src/koding/kites/kloud/kloud/plan.go
+++ b/go/src/koding/kites/kloud/kloud/plan.go
@@ -1,141 +1,21 @@
 package kloud
 
 import (
-	"encoding/json"
 	"errors"
-	"fmt"
-	"koding/db/models"
-	"koding/db/mongodb"
 	"koding/db/mongodb/modelhelper"
 	"koding/kites/kloud/contexthelper/session"
 	"koding/kites/kloud/terraformer"
 	tf "koding/kites/terraformer"
 
-	"labix.org/v2/mgo/bson"
-
 	"golang.org/x/net/context"
 
 	"github.com/koding/kite"
-	"github.com/mitchellh/mapstructure"
 )
 
 type TerraformPlanRequest struct {
 	StackTemplateId string `json:"stackTemplateId"`
 
 	GroupName string `json:"groupName"`
-}
-
-type terraformData struct {
-	Creds   []*terraformCredential
-	Account *models.Account
-	Group   *models.Group
-	User    *models.User
-}
-
-type terraformCredential struct {
-	Provider   string
-	Identifier string
-	Data       map[string]string `mapstructure:"data"`
-}
-
-// region returns the region from the credential data
-func (t *terraformCredential) region() (string, error) {
-	// for now we support only aws
-	if t.Provider != "aws" {
-		return "", fmt.Errorf("provider '%s' is not supported", t.Provider)
-	}
-
-	region := t.Data["region"]
-	if region == "" {
-		return "", fmt.Errorf("region for identifer '%s' is not set", t.Identifier)
-	}
-
-	return region, nil
-}
-
-func (t *terraformCredential) awsCredentials() (string, string, error) {
-	if t.Provider != "aws" {
-		return "", "", fmt.Errorf("provider '%s' is not supported", t.Provider)
-	}
-
-	// we do not check for key existency here because the key might exists but
-	// with an empty value, so just checking for the emptiness of the value is
-	// better
-	accessKey := t.Data["access_key"]
-	if accessKey == "" {
-		return "", "", fmt.Errorf("accessKey for identifier '%s' is not set", t.Identifier)
-	}
-
-	secretKey := t.Data["secret_key"]
-	if secretKey == "" {
-		return "", "", fmt.Errorf("secretKey for identifier '%s' is not set", t.Identifier)
-	}
-
-	return accessKey, secretKey, nil
-}
-
-// appendAWSVariable appends the credentials aws data to the given template and
-// returns it back.
-func (t *terraformCredential) appendAWSVariable(template string) (string, error) {
-	var data struct {
-		Output   map[string]map[string]interface{} `json:"output,omitempty"`
-		Resource map[string]map[string]interface{} `json:"resource,omitempty"`
-		Provider struct {
-			Aws struct {
-				Region    string `json:"region"`
-				AccessKey string `json:"access_key"`
-				SecretKey string `json:"secret_key"`
-			} `json:"aws"`
-		} `json:"provider"`
-		Variable map[string]map[string]interface{} `json:"variable,omitempty"`
-	}
-
-	if err := json.Unmarshal([]byte(template), &data); err != nil {
-		return "", err
-	}
-
-	credRegion := t.Data["region"]
-	if credRegion == "" {
-		return "", fmt.Errorf("region for identifier '%s' is not set", t.Identifier)
-	}
-
-	// if region is not added, add it via credRegion
-	region := data.Provider.Aws.Region
-	if region == "" {
-		data.Provider.Aws.Region = credRegion
-	} else if !isVariable(region) && region != credRegion {
-		// compare with the provider block's region. Don't allow if they are
-		// different.
-		return "", fmt.Errorf("region in the provider block doesn't match the region in credential data. Provider block: '%s'. Credential data: '%s'", region, credRegion)
-	}
-
-	if data.Variable == nil {
-		data.Variable = make(map[string]map[string]interface{})
-	}
-
-	accessKey, secretKey, err := t.awsCredentials()
-	if err != nil {
-		return "", err
-	}
-
-	data.Variable["aws_access_key"] = map[string]interface{}{
-		"default": accessKey,
-	}
-
-	data.Variable["aws_secret_key"] = map[string]interface{}{
-		"default": secretKey,
-	}
-
-	data.Variable["region"] = map[string]interface{}{
-		"default": credRegion,
-	}
-
-	out, err := json.MarshalIndent(data, "", "  ")
-	if err != nil {
-		return "", err
-	}
-
-	return string(out), nil
 }
 
 func (k *Kloud) Plan(r *kite.Request) (interface{}, error) {
@@ -220,111 +100,4 @@ func (k *Kloud) Plan(r *kite.Request) (interface{}, error) {
 	machines.AppendRegion(region)
 
 	return machines, nil
-}
-
-func fetchCredentials(username, groupname string, db *mongodb.MongoDB, identifiers []string) (*terraformData, error) {
-	// fetch jaccount from username
-	account, err := modelhelper.GetAccount(username)
-	if err != nil {
-		return nil, err
-	}
-
-	// fetch jGroup from group slug name
-	group, err := modelhelper.GetGroup(groupname)
-	if err != nil {
-		return nil, err
-	}
-
-	// fetch jUser from username
-	user, err := modelhelper.GetUser(username)
-	if err != nil {
-		return nil, err
-	}
-
-	// validate if username belongs to groupnam
-	selector := modelhelper.Selector{
-		"targetId": account.Id,
-		"sourceId": group.Id,
-		"as": bson.M{
-			"$in": []string{"member"},
-		},
-	}
-
-	count, err := modelhelper.RelationshipCount(selector)
-	if err != nil || count == 0 {
-		return nil, fmt.Errorf("username '%s' does not belong to group '%s'", username, groupname)
-	}
-
-	// 2- fetch credential from identifiers via args
-	credentials, err := modelhelper.GetCredentialsFromIdentifiers(identifiers...)
-	if err != nil {
-		return nil, err
-	}
-
-	// 3- count relationship with credential id and jaccount id as user or
-	// owner. Any non valid credentials will be discarded
-	validKeys := make(map[string]string, 0)
-
-	for _, cred := range credentials {
-		selector := modelhelper.Selector{
-			"targetId": cred.Id,
-			"sourceId": bson.M{
-				"$in": []bson.ObjectId{account.Id, group.Id},
-			},
-			"as": bson.M{
-				"$in": []string{"owner", "user"},
-			},
-		}
-
-		count, err := modelhelper.RelationshipCount(selector)
-		if err != nil || count == 0 {
-			// we return for any not validated identifier key.
-			return nil, fmt.Errorf("credential with identifier '%s' is not validated", cred.Identifier)
-		}
-
-		validKeys[cred.Identifier] = cred.Provider
-	}
-
-	// 4- fetch credentialdata with identifier
-	validIdentifiers := make([]string, 0)
-	for pKey := range validKeys {
-		validIdentifiers = append(identifiers, pKey)
-	}
-
-	credentialData, err := modelhelper.GetCredentialDatasFromIdentifiers(validIdentifiers...)
-	if err != nil {
-		return nil, err
-	}
-
-	// 5- return list of keys. We only support aws for now
-	data := &terraformData{
-		Account: account,
-		Group:   group,
-		User:    user,
-		Creds:   make([]*terraformCredential, 0),
-	}
-
-	for _, c := range credentialData {
-		provider, ok := validKeys[c.Identifier]
-		if !ok {
-			return nil, fmt.Errorf("provider is not found for identifer: %s", c.Identifier)
-		}
-		// for now we only support aws
-		if provider != "aws" {
-			continue
-		}
-
-		cred := &terraformCredential{
-			Provider:   provider,
-			Identifier: c.Identifier,
-		}
-
-		if err := mapstructure.Decode(c.Meta, &cred.Data); err != nil {
-			return nil, err
-		}
-
-		data.Creds = append(data.Creds, cred)
-	}
-
-	return data, nil
 }

--- a/go/src/koding/kites/kloud/kloud/plan.go
+++ b/go/src/koding/kites/kloud/kloud/plan.go
@@ -49,7 +49,7 @@ func (k *Kloud) Plan(r *kite.Request) (interface{}, error) {
 	}
 
 	k.Log.Debug("Fetching credentials for id %v", stackTemplate.Credentials)
-	creds, err := fetchCredentials(r.Username, args.GroupName, sess.DB, flattenValues(stackTemplate.Credentials))
+	data, err := fetchTerraformData(r.Username, args.GroupName, sess.DB, flattenValues(stackTemplate.Credentials))
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func (k *Kloud) Plan(r *kite.Request) (interface{}, error) {
 	defer tfKite.Close()
 
 	var region string
-	for _, cred := range creds.Creds {
+	for _, cred := range data.Creds {
 		region, err = cred.region()
 		if err != nil {
 			return nil, err
@@ -77,7 +77,7 @@ func (k *Kloud) Plan(r *kite.Request) (interface{}, error) {
 	}
 
 	sess.Log.Debug("Plan: stack template before injecting Koding data")
-	buildData, err := injectKodingData(ctx, stackTemplate.Template.Content, r.Username, creds)
+	buildData, err := injectKodingData(ctx, stackTemplate.Template.Content, r.Username, data)
 	if err != nil {
 		return nil, err
 	}

--- a/go/src/koding/kites/kloud/kloud/terraformutils.go
+++ b/go/src/koding/kites/kloud/kloud/terraformutils.go
@@ -299,18 +299,18 @@ func (t *terraformTemplate) injectKodingData(data *terraformData) {
 		collection string
 		fieldToAdd map[string]bool
 	}{
-		{"user",
+		{"User",
 			map[string]bool{
 				"username": true,
 				"email":    true,
 			},
 		},
-		{"account",
+		{"Account",
 			map[string]bool{
 				"profile": true,
 			},
 		},
-		{"group",
+		{"Group",
 			map[string]bool{
 				"title": true,
 				"slug":  true,
@@ -327,7 +327,7 @@ func (t *terraformTemplate) injectKodingData(data *terraformData) {
 		for _, field := range model.Fields() {
 			fieldName := strings.ToLower(field.Name())
 			if p.fieldToAdd[fieldName] {
-				varName := "koding_" + p.collection + "_" + fieldName
+				varName := "koding_" + strings.ToLower(p.collection) + "_" + fieldName
 				t.Variable[varName] = map[string]interface{}{
 					"default": field.Value(),
 				}

--- a/go/src/koding/kites/kloud/kloud/terraformutils.go
+++ b/go/src/koding/kites/kloud/kloud/terraformutils.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"koding/db/models"
+	"koding/db/mongodb"
+	"koding/db/mongodb/modelhelper"
 	"koding/kites/kloud/contexthelper/session"
 	"koding/kites/kloud/klient"
 	"koding/kites/kloud/userdata"
@@ -11,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"labix.org/v2/mgo/bson"
 
 	"golang.org/x/net/context"
 
@@ -38,6 +43,19 @@ type buildData struct {
 	Template string
 	Region   string
 	KiteIds  map[string]string
+}
+
+type terraformData struct {
+	Creds   []*terraformCredential
+	Account *models.Account
+	Group   *models.Group
+	User    *models.User
+}
+
+type terraformCredential struct {
+	Provider   string
+	Identifier string
+	Data       map[string]string `mapstructure:"data"`
 }
 
 type terraformTemplate struct {
@@ -78,6 +96,106 @@ func (m *Machines) WithLabel(label string) (TerraformMachine, error) {
 	}
 
 	return TerraformMachine{}, fmt.Errorf("couldn't find machine with label '%s", label)
+}
+
+// region returns the region from the credential data
+func (t *terraformCredential) region() (string, error) {
+	// for now we support only aws
+	if t.Provider != "aws" {
+		return "", fmt.Errorf("provider '%s' is not supported", t.Provider)
+	}
+
+	region := t.Data["region"]
+	if region == "" {
+		return "", fmt.Errorf("region for identifer '%s' is not set", t.Identifier)
+	}
+
+	return region, nil
+}
+
+func (t *terraformCredential) awsCredentials() (string, string, error) {
+	if t.Provider != "aws" {
+		return "", "", fmt.Errorf("provider '%s' is not supported", t.Provider)
+	}
+
+	// we do not check for key existency here because the key might exists but
+	// with an empty value, so just checking for the emptiness of the value is
+	// better
+	accessKey := t.Data["access_key"]
+	if accessKey == "" {
+		return "", "", fmt.Errorf("accessKey for identifier '%s' is not set", t.Identifier)
+	}
+
+	secretKey := t.Data["secret_key"]
+	if secretKey == "" {
+		return "", "", fmt.Errorf("secretKey for identifier '%s' is not set", t.Identifier)
+	}
+
+	return accessKey, secretKey, nil
+}
+
+// appendAWSVariable appends the credentials aws data to the given template and
+// returns it back.
+func (t *terraformCredential) appendAWSVariable(template string) (string, error) {
+	var data struct {
+		Output   map[string]map[string]interface{} `json:"output,omitempty"`
+		Resource map[string]map[string]interface{} `json:"resource,omitempty"`
+		Provider struct {
+			Aws struct {
+				Region    string `json:"region"`
+				AccessKey string `json:"access_key"`
+				SecretKey string `json:"secret_key"`
+			} `json:"aws"`
+		} `json:"provider"`
+		Variable map[string]map[string]interface{} `json:"variable,omitempty"`
+	}
+
+	if err := json.Unmarshal([]byte(template), &data); err != nil {
+		return "", err
+	}
+
+	credRegion := t.Data["region"]
+	if credRegion == "" {
+		return "", fmt.Errorf("region for identifier '%s' is not set", t.Identifier)
+	}
+
+	// if region is not added, add it via credRegion
+	region := data.Provider.Aws.Region
+	if region == "" {
+		data.Provider.Aws.Region = credRegion
+	} else if !isVariable(region) && region != credRegion {
+		// compare with the provider block's region. Don't allow if they are
+		// different.
+		return "", fmt.Errorf("region in the provider block doesn't match the region in credential data. Provider block: '%s'. Credential data: '%s'", region, credRegion)
+	}
+
+	if data.Variable == nil {
+		data.Variable = make(map[string]map[string]interface{})
+	}
+
+	accessKey, secretKey, err := t.awsCredentials()
+	if err != nil {
+		return "", err
+	}
+
+	data.Variable["aws_access_key"] = map[string]interface{}{
+		"default": accessKey,
+	}
+
+	data.Variable["aws_secret_key"] = map[string]interface{}{
+		"default": secretKey,
+	}
+
+	data.Variable["region"] = map[string]interface{}{
+		"default": credRegion,
+	}
+
+	out, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	return string(out), nil
 }
 
 func machinesFromState(state *terraform.State) (*Machines, error) {
@@ -176,12 +294,36 @@ func parseProviderAndLabel(resource string) (string, string, error) {
 	return provider, label, nil
 }
 
-func injectKodingVariables(ctx context.Context, content string) error {
-	return nil
-
-}
-
-func injectKodingData(ctx context.Context, content, username string, creds *terraformCredentials) (*buildData, error) {
+// func injectKodingVariables(ctx context.Context, content string) (string, error) {
+// 	sess, ok := session.FromContext(ctx)
+// 	if !ok {
+// 		return "", errors.New("session context is not passed")
+// 	}
+//
+// 	var data *terraformTemplate
+// 	if err := json.Unmarshal([]byte(content), &data); err != nil {
+// 		return "", err
+// 	}
+//
+// 	var allowedProps = []struct {
+// 		collection string
+// 		fields     []string
+// 	}{
+// 		{"jUsers", []string{"username", "email"}},
+// 		{"jAccounts", []string{"profile"}},
+// 		{"jGroups", []string{"title", "slug"}},
+// 	}
+//
+// 	// if err := sess.DB.Run("jMachines", func(c *mgo.Collection) error {
+// 	// 	return c.Find(bson.M{"_id": bson.M{"$in": mongodbIds}}).All(&machines)
+// 	// }); err != nil {
+// 	// 	return nil, err
+// 	// }
+//
+// 	return "", nil
+// }
+//
+func injectKodingData(ctx context.Context, content, username string, creds *terraformData) (*buildData, error) {
 	sess, ok := session.FromContext(ctx)
 	if !ok {
 		return nil, errors.New("session context is not passed")
@@ -318,7 +460,7 @@ func injectKodingData(ctx context.Context, content, username string, creds *terr
 	return b, nil
 }
 
-func varsFromCredentials(creds *terraformCredentials) map[string]string {
+func varsFromCredentials(creds *terraformData) map[string]string {
 	vars := make(map[string]string, 0)
 	for _, cred := range creds.Creds {
 		for k, v := range cred.Data {
@@ -365,6 +507,113 @@ func checkKlients(ctx context.Context, kiteIds map[string]string) error {
 	wg.Wait()
 
 	return multiErrors
+}
+
+func fetchCredentials(username, groupname string, db *mongodb.MongoDB, identifiers []string) (*terraformData, error) {
+	// fetch jaccount from username
+	account, err := modelhelper.GetAccount(username)
+	if err != nil {
+		return nil, err
+	}
+
+	// fetch jGroup from group slug name
+	group, err := modelhelper.GetGroup(groupname)
+	if err != nil {
+		return nil, err
+	}
+
+	// fetch jUser from username
+	user, err := modelhelper.GetUser(username)
+	if err != nil {
+		return nil, err
+	}
+
+	// validate if username belongs to groupnam
+	selector := modelhelper.Selector{
+		"targetId": account.Id,
+		"sourceId": group.Id,
+		"as": bson.M{
+			"$in": []string{"member"},
+		},
+	}
+
+	count, err := modelhelper.RelationshipCount(selector)
+	if err != nil || count == 0 {
+		return nil, fmt.Errorf("username '%s' does not belong to group '%s'", username, groupname)
+	}
+
+	// 2- fetch credential from identifiers via args
+	credentials, err := modelhelper.GetCredentialsFromIdentifiers(identifiers...)
+	if err != nil {
+		return nil, err
+	}
+
+	// 3- count relationship with credential id and jaccount id as user or
+	// owner. Any non valid credentials will be discarded
+	validKeys := make(map[string]string, 0)
+
+	for _, cred := range credentials {
+		selector := modelhelper.Selector{
+			"targetId": cred.Id,
+			"sourceId": bson.M{
+				"$in": []bson.ObjectId{account.Id, group.Id},
+			},
+			"as": bson.M{
+				"$in": []string{"owner", "user"},
+			},
+		}
+
+		count, err := modelhelper.RelationshipCount(selector)
+		if err != nil || count == 0 {
+			// we return for any not validated identifier key.
+			return nil, fmt.Errorf("credential with identifier '%s' is not validated", cred.Identifier)
+		}
+
+		validKeys[cred.Identifier] = cred.Provider
+	}
+
+	// 4- fetch credentialdata with identifier
+	validIdentifiers := make([]string, 0)
+	for pKey := range validKeys {
+		validIdentifiers = append(identifiers, pKey)
+	}
+
+	credentialData, err := modelhelper.GetCredentialDatasFromIdentifiers(validIdentifiers...)
+	if err != nil {
+		return nil, err
+	}
+
+	// 5- return list of keys. We only support aws for now
+	data := &terraformData{
+		Account: account,
+		Group:   group,
+		User:    user,
+		Creds:   make([]*terraformCredential, 0),
+	}
+
+	for _, c := range credentialData {
+		provider, ok := validKeys[c.Identifier]
+		if !ok {
+			return nil, fmt.Errorf("provider is not found for identifer: %s", c.Identifier)
+		}
+		// for now we only support aws
+		if provider != "aws" {
+			continue
+		}
+
+		cred := &terraformCredential{
+			Provider:   provider,
+			Identifier: c.Identifier,
+		}
+
+		if err := mapstructure.Decode(c.Meta, &cred.Data); err != nil {
+			return nil, err
+		}
+
+		data.Creds = append(data.Creds, cred)
+	}
+
+	return data, nil
 }
 
 // isVariable checkes whether the given string is a template variable, such as:

--- a/go/src/koding/kites/kloud/kloud/terraformutils.go
+++ b/go/src/koding/kites/kloud/kloud/terraformutils.go
@@ -40,6 +40,20 @@ type buildData struct {
 	KiteIds  map[string]string
 }
 
+type terraformTemplate struct {
+	Resource struct {
+		Aws_Instance map[string]map[string]interface{} `json:"aws_instance"`
+	} `json:"resource"`
+	Provider struct {
+		Aws struct {
+			Region    string `json:"region"`
+			AccessKey string `json:"access_key"`
+			SecretKey string `json:"secret_key"`
+		} `json:"aws"`
+	} `json:"provider"`
+	Variable map[string]map[string]interface{} `json:"variable,omitempty"`
+}
+
 func (m *Machines) AppendRegion(region string) {
 	for i, machine := range m.Machines {
 		machine.Region = region
@@ -162,6 +176,11 @@ func parseProviderAndLabel(resource string) (string, string, error) {
 	return provider, label, nil
 }
 
+func injectKodingVariables(ctx context.Context, content string) error {
+	return nil
+
+}
+
 func injectKodingData(ctx context.Context, content, username string, creds *terraformCredentials) (*buildData, error) {
 	sess, ok := session.FromContext(ctx)
 	if !ok {
@@ -184,20 +203,7 @@ func injectKodingData(ctx context.Context, content, username string, creds *terr
 		return nil, fmt.Errorf("Bootstrap data is incomplete: %v", awsOutput)
 	}
 
-	var data struct {
-		Resource struct {
-			Aws_Instance map[string]map[string]interface{} `json:"aws_instance"`
-		} `json:"resource"`
-		Provider struct {
-			Aws struct {
-				Region    string `json:"region"`
-				AccessKey string `json:"access_key"`
-				SecretKey string `json:"secret_key"`
-			} `json:"aws"`
-		} `json:"provider"`
-		Variable map[string]map[string]interface{} `json:"variable,omitempty"`
-	}
-
+	var data *terraformTemplate
 	if err := json.Unmarshal([]byte(content), &data); err != nil {
 		return nil, err
 	}

--- a/go/src/koding/kites/kloud/kloud/terraformutils.go
+++ b/go/src/koding/kites/kloud/kloud/terraformutils.go
@@ -294,7 +294,7 @@ func parseProviderAndLabel(resource string) (string, string, error) {
 	return provider, label, nil
 }
 
-// func injectKodingVariables(ctx context.Context, content string) (string, error) {
+// func injectKodingVariables(ctx context.Context, content string, data *terraformData) (string, error) {
 // 	sess, ok := session.FromContext(ctx)
 // 	if !ok {
 // 		return "", errors.New("session context is not passed")
@@ -322,7 +322,7 @@ func parseProviderAndLabel(resource string) (string, string, error) {
 //
 // 	return "", nil
 // }
-//
+
 func injectKodingData(ctx context.Context, content, username string, data *terraformData) (*buildData, error) {
 	sess, ok := session.FromContext(ctx)
 	if !ok {
@@ -509,7 +509,7 @@ func checkKlients(ctx context.Context, kiteIds map[string]string) error {
 	return multiErrors
 }
 
-func fetchCredentials(username, groupname string, db *mongodb.MongoDB, identifiers []string) (*terraformData, error) {
+func fetchTerraformData(username, groupname string, db *mongodb.MongoDB, identifiers []string) (*terraformData, error) {
 	// fetch jaccount from username
 	account, err := modelhelper.GetAccount(username)
 	if err != nil {


### PR DESCRIPTION
Given an ACL struct in form of:

```
var properties = []struct {
    collection string
    fieldToAdd map[string]bool
}{
    {"User",
        map[string]bool{
            "username": true,
            "email":    true,
        },
    },
    {"Account",
        map[string]bool{
            "profile": true,
        },
    },
    {"Group",
        map[string]bool{
            "title": true,
            "slug":  true,
        },
    },
}
```

creates and inject variables in the form of:

```
koding_user_username
koding_user_email
koding_group_slug
...
```

If the given field contains a subdocument (nested struct), the fields will be
recursively flattened, such as:

```
koding_account_profile_nickname
koding_account_profile_firstname
...
```

Currenty only `jGroups`, `jAccounts` and `jUsers` collections are supported.
