### PR TITLE
reactivity: chat input: fix for a bug of not highlighted selected item [fixes #98506352]

### DIFF
--- a/client/activity/lib/components/channeldropup/index.coffee
+++ b/client/activity/lib/components/channeldropup/index.coffee
@@ -17,6 +17,7 @@ module.exports = class ChannelDropup extends React.Component
   @defaultProps =
     items          : immutable.List()
     visible        : no
+    selectedIndex  : 0
     selectedItem   : null
     keyboardScroll : yes
 
@@ -71,10 +72,10 @@ module.exports = class ChannelDropup extends React.Component
 
   renderList: ->
 
-    { items, selectedItem } = @props
+    { items, selectedIndex } = @props
 
     items.map (item, index) =>
-      isSelected = item is selectedItem
+      isSelected = index is selectedIndex
 
       <ChannelDropupItem
         isSelected  = { isSelected }

--- a/client/activity/lib/components/chatinputwidget/index.coffee
+++ b/client/activity/lib/components/chatinputwidget/index.coffee
@@ -38,12 +38,14 @@ module.exports = class ChatInputWidget extends React.Component
 
     return {
       filteredEmojiList              : getters.filteredEmojiList
+      filteredEmojiListSelectedIndex : getters.filteredEmojiListSelectedIndex
       filteredEmojiListSelectedItem  : getters.filteredEmojiListSelectedItem
       filteredEmojiListQuery         : getters.filteredEmojiListQuery
       commonEmojiList                : getters.commonEmojiList
       commonEmojiListSelectedItem    : getters.commonEmojiListSelectedItem
       commonEmojiListVisibility      : getters.commonEmojiListVisibility
       channels                       : getters.chatInputChannels
+      channelsSelectedIndex          : getters.chatInputChannelsSelectedIndex
       channelsSelectedItem           : getters.chatInputChannelsSelectedItem
       channelsQuery                  : getters.chatInputChannelsQuery
       channelsVisibility             : getters.chatInputChannelsVisibility
@@ -178,10 +180,11 @@ module.exports = class ChatInputWidget extends React.Component
 
   renderEmojiDropup: ->
 
-    { filteredEmojiList, filteredEmojiListSelectedItem, filteredEmojiListQuery } = @state
+    { filteredEmojiList, filteredEmojiListSelectedIndex, filteredEmojiListSelectedItem, filteredEmojiListQuery } = @state
 
     <EmojiDropup
       items           = { filteredEmojiList }
+      selectedIndex   = { filteredEmojiListSelectedIndex }
       selectedItem    = { filteredEmojiListSelectedItem }
       query           = { filteredEmojiListQuery }
       onItemConfirmed = { @bound 'onDropupItemConfirmed' }
@@ -203,10 +206,11 @@ module.exports = class ChatInputWidget extends React.Component
 
   renderChannelDropup: ->
 
-    { channels, channelsSelectedItem, channelsQuery, channelsVisibility } = @state
+    { channels, channelsSelectedItem, channelsSelectedIndex, channelsQuery, channelsVisibility } = @state
 
     <ChannelDropup
       items           = { channels }
+      selectedIndex   = { channelsSelectedIndex }
       selectedItem    = { channelsSelectedItem }
       query           = { channelsQuery }
       visible         = { channelsVisibility }
@@ -217,10 +221,11 @@ module.exports = class ChatInputWidget extends React.Component
 
   renderUserDropup: ->
 
-    { users, usersSelectedItem, usersQuery, usersVisibility } = @state
+    { users, userSelectedIndex, usersSelectedItem, usersQuery, usersVisibility } = @state
 
     <UserDropup
       items           = { users }
+      selectedIndex   = { userSelectedIndex }
       selectedItem    = { usersSelectedItem }
       query           = { usersQuery }
       visible         = { usersVisibility }

--- a/client/activity/lib/components/emojidropup/index.coffee
+++ b/client/activity/lib/components/emojidropup/index.coffee
@@ -18,6 +18,7 @@ module.exports = class EmojiDropup extends React.Component
 
   @defaultProps =
     items          : immutable.List()
+    selectedIndex  : 0
     selectedItem   : null
     keyboardScroll : no
 
@@ -68,10 +69,10 @@ module.exports = class EmojiDropup extends React.Component
 
   renderList: ->
 
-    { items, selectedItem } = @props
+    { items, selectedIndex } = @props
 
     items.map (item, index) =>
-      isSelected = item is selectedItem
+      isSelected = index is selectedIndex
 
       <EmojiDropupItem
         isSelected  = { isSelected }

--- a/client/activity/lib/components/userdropup/index.coffee
+++ b/client/activity/lib/components/userdropup/index.coffee
@@ -17,6 +17,7 @@ module.exports = class UserDropup extends React.Component
   @defaultProps =
     items          : immutable.List()
     visible        : no
+    selectedIndex  : 0
     selectedItem   : null
     keyboardScroll : yes
 
@@ -71,10 +72,10 @@ module.exports = class UserDropup extends React.Component
 
   renderList: ->
 
-    { items, selectedItem } = @props
+    { items, selectedIndex } = @props
 
     items.map (item, index) =>
-      isSelected = item is selectedItem
+      isSelected = index is selectedIndex
 
       <UserDropupItem
         isSelected  = { isSelected }

--- a/client/activity/lib/flux/getters.coffee
+++ b/client/activity/lib/flux/getters.coffee
@@ -267,7 +267,6 @@ currentSuggestionsSelectedItem  = [
 ]
 
 filteredEmojiListQuery         = FilteredEmojiListQueryStore
-filteredEmojiListSelectedIndex = FilteredEmojiListSelectedIndexStore
 # Returns a list of emojis filtered by current query
 filteredEmojiList              = [
   EmojisStore
@@ -276,16 +275,15 @@ filteredEmojiList              = [
     return immutable.List()  unless query
     emojis.filter (emoji) -> emoji.indexOf(query) is 0
 ]
-# Returns emoji from emoji list by current selected index
+filteredEmojiListSelectedIndex = [
+  filteredEmojiList
+  FilteredEmojiListSelectedIndexStore
+  calculateListSelectedIndex
+]
 filteredEmojiListSelectedItem  = [
   filteredEmojiList
   filteredEmojiListSelectedIndex
-  (emojis, index) ->
-    return  unless emojis.size > 0
-
-    index = index % emojis.size  if index >= emojis.size
-    index = emojis.size + index  if index < 0
-    return emojis.get index
+  getListSelectedItem
 ]
 
 commonEmojiList              = EmojisStore
@@ -295,11 +293,10 @@ commonEmojiListVisibility    = CommonEmojiListVisibilityStore
 commonEmojiListSelectedItem  = [
   commonEmojiList
   commonEmojiListSelectedIndex
-  (emojis, index) -> emojis.get index
+  getListSelectedItem
 ]
 
 chatInputChannelsQuery         = ChatInputChannelsQueryStore
-chatInputChannelsSelectedIndex = ChatInputChannelsSelectedIndexStore
 # Returns a list of channels depending on the current query
 # If query if empty, returns popular channels
 # Otherwise, returns channels filtered by query
@@ -315,21 +312,19 @@ chatInputChannels              = [
       channelName = channel.get('name').toLowerCase()
       return channelName.indexOf(query) is 0
 ]
-# Returns a channel from channel list by current selected index
+chatInputChannelsSelectedIndex = [
+  chatInputChannels
+  ChatInputChannelsSelectedIndexStore
+  calculateListSelectedIndex
+]
 chatInputChannelsSelectedItem = [
   chatInputChannels
   chatInputChannelsSelectedIndex
-  (channels, index) ->
-    return  unless channels.size > 0
-
-    index = index % channels.size  if index >= channels.size
-    index = channels.size + index  if index < 0
-    return channels.get index
+  getListSelectedItem
 ]
 chatInputChannelsVisibility = ChatInputChannelsVisibilityStore
 
 chatInputUsersQuery         = ChatInputUsersQueryStore
-chatInputUsersSelectedIndex = ChatInputUsersSelectedIndexStore
 # Returns a list of users depending on the current query
 # If query is empty, returns selected channel participants
 # Otherwise, returns users filtered by query
@@ -345,16 +340,15 @@ chatInputUsers              = [
       userName = user.getIn(['profile', 'nickname']).toLowerCase()
       return userName.indexOf(query) is 0
 ]
-# Returns a user from user list by current selected index
+chatInputUsersSelectedIndex = [
+  chatInputUsers
+  ChatInputUsersSelectedIndexStore
+  calculateListSelectedIndex
+]
 chatInputUsersSelectedItem = [
   chatInputUsers
   chatInputUsersSelectedIndex
-  (users, index) ->
-    return  unless users.size > 0
-
-    index = index % users.size  if index >= users.size
-    index = users.size + index  if index < 0
-    return users.get index
+  getListSelectedItem
 ]
 chatInputUsersVisibility = ChatInputUsersVisibilityStore
 


### PR DESCRIPTION
@sinan, can you please review this fix? It fixes a problem that sometimes selected in dropup is not highlighted. It occurs because I considered that item is selected comparing item value in the list with value of selected item's getter. Since value is object, i.e. reference type, in some cases such comparison didn't work properly. Now I compare indexes when checking if item is selected and that's why there is no more problem with not equal references

/cc @usirin 
