### PR TITLE
activity: fix for search highlight markers [fixes #99778504]

### DIFF
--- a/client/activity/lib/flux/actions/searchconstants.coffee
+++ b/client/activity/lib/flux/actions/searchconstants.coffee
@@ -1,4 +1,4 @@
 module.exports =
-  HIGHLIGHT_PRE_MARKER  : '!em='
-  HIGHLIGHT_POST_MARKER : '=em!'
+  HIGHLIGHT_PRE_MARKER  : 'hPRE='
+  HIGHLIGHT_POST_MARKER : '=hPOST'
 


### PR DESCRIPTION
@sinan, can you please review this fix? It's for [this bug](https://www.pivotaltracker.com/story/show/99778504). 
If the word contains `_` symbol, and part of this word which goes after `_` is highlighted by Algolia, markdown processor thinks that `_` is a proper markdown symbol and replaces it with `<span>`. It happens because `HIGHLIGHT_PRE_MARKER` is started with `!`, i.e. with punctuation mark. I changed `HIGHLIGHT_PRE_MARKER` and `HIGHLIGHT_POST_MARKER` and removed `!` from there
