### PR TITLE
Teams: Members: Fetch user emails for group members & moderators and admins in members tab [fixes #99601572]

### DIFF
--- a/client/admin/lib/views/members/adminmembersview.coffee
+++ b/client/admin/lib/views/members/adminmembersview.coffee
@@ -27,9 +27,9 @@ module.exports = class AdminMembersView extends KDView
     tabView.addPane admins = new KDTabPaneView name: 'Admins'
     tabView.addPane mods   = new KDTabPaneView name: 'Moderators'
 
-    all.addSubView    @allView    = new TeamMembersCommonView { fetcherMethod: 'fetchMembersWithEmail' }, data
-    admins.addSubView @adminsView = new TeamMembersCommonView { fetcherMethod: 'fetchAdmins'           }, data
-    mods.addSubView   @modsView   = new TeamMembersCommonView { fetcherMethod: 'fetchModerators'       }, data
+    all.addSubView    @allView    = new TeamMembersCommonView { fetcherMethod: 'fetchMembersWithEmail'    }, data
+    admins.addSubView @adminsView = new TeamMembersCommonView { fetcherMethod: 'fetchAdminsWithEmail'     }, data
+    mods.addSubView   @modsView   = new TeamMembersCommonView { fetcherMethod: 'fetchModeratorsWithEmail' }, data
 
     if isKoding()
       tabView.addPane blockedMembersPane = new KDTabPaneView name: 'Blocked'

--- a/client/admin/lib/views/members/adminmembersview.coffee
+++ b/client/admin/lib/views/members/adminmembersview.coffee
@@ -27,9 +27,9 @@ module.exports = class AdminMembersView extends KDView
     tabView.addPane admins = new KDTabPaneView name: 'Admins'
     tabView.addPane mods   = new KDTabPaneView name: 'Moderators'
 
-    all.addSubView    @allView    = new TeamMembersCommonView { fetcherMethod: 'fetchMembers'    }, data
-    admins.addSubView @adminsView = new TeamMembersCommonView { fetcherMethod: 'fetchAdmins'     }, data
-    mods.addSubView   @modsView   = new TeamMembersCommonView { fetcherMethod: 'fetchModerators' }, data
+    all.addSubView    @allView    = new TeamMembersCommonView { fetcherMethod: 'fetchMembersWithEmail' }, data
+    admins.addSubView @adminsView = new TeamMembersCommonView { fetcherMethod: 'fetchAdmins'           }, data
+    mods.addSubView   @modsView   = new TeamMembersCommonView { fetcherMethod: 'fetchModerators'       }, data
 
     if isKoding()
       tabView.addPane blockedMembersPane = new KDTabPaneView name: 'Blocked'

--- a/client/admin/lib/views/members/memberitemview.coffee
+++ b/client/admin/lib/views/members/memberitemview.coffee
@@ -161,7 +161,7 @@ module.exports = class MemberItemView extends KDListItemView
     data     = @getData()
     fullname = getFullnameFromAccount data
     nickname = data.profile.nickname
-    email    = "#{nickname}@koding.com"
+    email    = data.profile.email
 
     return """
       <div class="details">

--- a/client/admin/lib/views/members/teammemberscommonview.coffee
+++ b/client/admin/lib/views/members/teammemberscommonview.coffee
@@ -15,7 +15,7 @@ module.exports = class TeamMembersCommonView extends KDView
 
     options.cssClass                 = 'members-commonview'
     options.itemLimit               ?= 10
-    options.fetcherMethod          or= 'fetchMembers'
+    options.fetcherMethod          or= 'fetchMembersWithEmail'
     options.noItemFoundWidget      or= new KDCustomHTMLView
     options.listViewItemClass      or= MemberItemView
     options.listViewItemOptions    or= {}

--- a/workers/social/lib/social/models/group/index.coffee
+++ b/workers/social/lib/social/models/group/index.coffee
@@ -161,7 +161,17 @@ module.exports = class JGroup extends Module
           (signature Object, Function)
           (signature Object, Object, Function)
         ]
+        fetchAdminsWithEmail: [
+          (signature Function)
+          (signature Object, Function)
+          (signature Object, Object, Function)
+        ]
         fetchModerators: [
+          (signature Function)
+          (signature Object, Function)
+          (signature Object, Object, Function)
+        ]
+        fetchModeratorsWithEmail: [
           (signature Function)
           (signature Object, Function)
           (signature Object, Object, Function)

--- a/workers/social/lib/social/models/group/index.coffee
+++ b/workers/social/lib/social/models/group/index.coffee
@@ -171,6 +171,11 @@ module.exports = class JGroup extends Module
           (signature Object, Function)
           (signature Object, Object, Function)
         ]
+        fetchMembersWithEmail: [
+          (signature Function)
+          (signature Object, Function)
+          (signature Object, Object, Function)
+        ]
         searchMembers: [
           (signature String, Object, Function)
         ]
@@ -703,6 +708,14 @@ module.exports = class JGroup extends Module
         cursor.toArray callback
 
   fetchMembers$: permit 'list members',
+    success:(client, rest...) ->
+      # when max limit is over 20 it starts giving "call stack exceeded" error
+      [selector, options, callback] = Module.limitEdges 10, 19, rest
+      # delete options.targetOptions
+      options.client = client
+      @fetchMembers selector, options, callback
+
+  fetchMembersWithEmail$: permit 'grant permissions',
     success:(client, rest...) ->
       # when max limit is over 20 it starts giving "call stack exceeded" error
       [selector, options, callback] = Module.limitEdges 10, 19, rest


### PR DESCRIPTION
Issue: [koding.com emails are displayed for users that registered using another emails](https://www.pivotaltracker.com/n/projects/1340878/stories/99601572)
/cc @koding/developers 

Thanks @cihangir for your helps :+1:  
