### PR TITLE
Account Settings: Billing: Show invoice detail in modal [completes #79387398]

### DIFF
--- a/client/account/lib/styl/account.styl
+++ b/client/account/lib/styl/account.styl
@@ -802,6 +802,15 @@ app.settings.styl
     margin-top              20px
     font-size               14px
 
+    .kdlistitemview
+      margin                10px 0
+
+      .show-detail
+        display             block
+        abs()
+        top                 -3px
+        right               0
+
   .payment-history-wrapper .no-item-found
     text-align              left
     padding-top             0

--- a/client/account/lib/styl/account.styl
+++ b/client/account/lib/styl/account.styl
@@ -927,3 +927,23 @@ app.settings.styl
         .button-title
           line-height       38px  !important
           color             white !important
+
+.kdmodal.ivoice-preview
+  .billing-info
+    text-align              right
+    font-size               14px
+
+    &:first-child
+      text-align            left
+      margin-bottom         30px
+
+      em
+        float               right
+
+    span
+      text-align            left
+      width                 70px
+      display               inline-block
+
+    em
+      font-weight           600

--- a/client/account/lib/views/invoicepreviewmodal.coffee
+++ b/client/account/lib/views/invoicepreviewmodal.coffee
@@ -1,0 +1,34 @@
+kd                = require 'kd'
+dateFormat        = require 'dateformat'
+KDModalView       = kd.ModalView
+KDCustomHTMLView  = kd.CustomHTMLView
+
+
+module.exports = class InvoicePreviewModal extends KDModalView
+
+
+  constructor: (options = {}, data) ->
+
+    options.width       = 450
+    options.cssClass  or= 'ivoice-preview'
+    options.title     or= 'Invoice Preview'
+
+    super options, data
+
+    { plan, amount, periodEnd } = @getData()
+    amount                      = amount / 100
+
+    plan = 'Developer'
+
+    @addSubView new KDCustomHTMLView
+      partial : """
+        <div class="billing-info">
+          Subscribed to
+          <em>#{plan} on #{dateFormat(periodEnd, 'mmm dd, yyyy')}</em>
+        </div>
+        <div class="billing-info">
+          <span>Total</span>
+          <em>$#{amount}</em>
+        </div>
+      """
+

--- a/client/account/lib/views/paymenthistorylistitem.coffee
+++ b/client/account/lib/views/paymenthistorylistitem.coffee
@@ -1,8 +1,12 @@
-kd = require 'kd'
-KDListItemView = kd.ListItemView
-dateFormat = require 'dateformat'
+kd                  = require 'kd'
+KDButtonView        = kd.ButtonView
+KDListItemView      = kd.ListItemView
+dateFormat          = require 'dateformat'
+InvoicePreviewModal = require './invoicepreviewmodal'
+
 
 module.exports = class PaymentHistoryListItem extends KDListItemView
+
 
   constructor: (options = {}, data) ->
 
@@ -26,5 +30,12 @@ module.exports = class PaymentHistoryListItem extends KDListItemView
     """
 
 
+  viewAppended: ->
 
+    super
 
+    @addSubView @showDetail = new KDButtonView
+      cssClass  : 'solid small green show-detail'
+      title     : 'DETAIL'
+      callback  : =>
+        new InvoicePreviewModal {}, @getData()


### PR DESCRIPTION
/cc @fatihacet @gokmen @szkl @usirin @sent-hil 

![monosnap 2015-08-31 14-37-04](https://cloud.githubusercontent.com/assets/728733/9577857/d04486a4-4fed-11e5-8945-09e31ace586e.png)

Could someone add `wip` label?
