### PR TITLE
Support for multiple same components on the page

### DIFF
--- a/client/activity/lib/components/channeldropup/index.coffee
+++ b/client/activity/lib/components/channeldropup/index.coffee
@@ -27,7 +27,10 @@ module.exports = class ChannelDropup extends React.Component
   getItemKey: (item) -> item.get 'id'
 
 
-  close: -> ActivityFlux.actions.channel.setChatInputChannelsVisibility no
+  close: ->
+
+    { actionInitiatorId } = @props
+    ActivityFlux.actions.channel.setChatInputChannelsVisibility actionInitiatorId, no
 
 
   moveToNextPosition: (keyInfo) ->
@@ -36,7 +39,10 @@ module.exports = class ChannelDropup extends React.Component
       @close()
       return no
 
-    ActivityFlux.actions.channel.moveToNextChatInputChannelsIndex()  unless @hasSingleItem()
+    { actionInitiatorId } = @props
+    unless @hasSingleItem()
+      ActivityFlux.actions.channel.moveToNextChatInputChannelsIndex actionInitiatorId
+
     return yes
 
 
@@ -46,7 +52,10 @@ module.exports = class ChannelDropup extends React.Component
       @close()
       return no
 
-    ActivityFlux.actions.channel.moveToPrevChatInputChannelsIndex()  unless @hasSingleItem()
+    { actionInitiatorId } = @props
+    unless @hasSingleItem()
+      ActivityFlux.actions.channel.moveToPrevChatInputChannelsIndex actionInitiatorId
+
     return yes
 
 
@@ -59,14 +68,16 @@ module.exports = class ChannelDropup extends React.Component
     return no  unless matchResult
 
     query = matchResult[1]
-    ActivityFlux.actions.channel.setChatInputChannelsQuery query
-    ActivityFlux.actions.channel.setChatInputChannelsVisibility yes
+    { actionInitiatorId } = @props
+    ActivityFlux.actions.channel.setChatInputChannelsQuery actionInitiatorId, query
+    ActivityFlux.actions.channel.setChatInputChannelsVisibility actionInitiatorId, yes
     return yes
 
 
   onItemSelected: (index) ->
 
-    ActivityFlux.actions.channel.setChatInputChannelsSelectedIndex index
+    { actionInitiatorId } = @props
+    ActivityFlux.actions.channel.setChatInputChannelsSelectedIndex actionInitiatorId, index
 
 
   renderList: ->

--- a/client/activity/lib/components/channeldropup/index.coffee
+++ b/client/activity/lib/components/channeldropup/index.coffee
@@ -29,8 +29,8 @@ module.exports = class ChannelDropup extends React.Component
 
   close: ->
 
-    { actionInitiatorId } = @props
-    ActivityFlux.actions.channel.setChatInputChannelsVisibility actionInitiatorId, no
+    { stateId } = @props
+    ActivityFlux.actions.channel.setChatInputChannelsVisibility stateId, no
 
 
   moveToNextPosition: (keyInfo) ->
@@ -39,9 +39,9 @@ module.exports = class ChannelDropup extends React.Component
       @close()
       return no
 
-    { actionInitiatorId } = @props
+    { stateId } = @props
     unless @hasSingleItem()
-      ActivityFlux.actions.channel.moveToNextChatInputChannelsIndex actionInitiatorId
+      ActivityFlux.actions.channel.moveToNextChatInputChannelsIndex stateId
 
     return yes
 
@@ -52,9 +52,9 @@ module.exports = class ChannelDropup extends React.Component
       @close()
       return no
 
-    { actionInitiatorId } = @props
+    { stateId } = @props
     unless @hasSingleItem()
-      ActivityFlux.actions.channel.moveToPrevChatInputChannelsIndex actionInitiatorId
+      ActivityFlux.actions.channel.moveToPrevChatInputChannelsIndex stateId
 
     return yes
 
@@ -68,16 +68,16 @@ module.exports = class ChannelDropup extends React.Component
     return no  unless matchResult
 
     query = matchResult[1]
-    { actionInitiatorId } = @props
-    ActivityFlux.actions.channel.setChatInputChannelsQuery actionInitiatorId, query
-    ActivityFlux.actions.channel.setChatInputChannelsVisibility actionInitiatorId, yes
+    { stateId } = @props
+    ActivityFlux.actions.channel.setChatInputChannelsQuery stateId, query
+    ActivityFlux.actions.channel.setChatInputChannelsVisibility stateId, yes
     return yes
 
 
   onItemSelected: (index) ->
 
-    { actionInitiatorId } = @props
-    ActivityFlux.actions.channel.setChatInputChannelsSelectedIndex actionInitiatorId, index
+    { stateId } = @props
+    ActivityFlux.actions.channel.setChatInputChannelsSelectedIndex stateId, index
 
 
   renderList: ->

--- a/client/activity/lib/components/chatinputwidget/index.coffee
+++ b/client/activity/lib/components/chatinputwidget/index.coffee
@@ -175,7 +175,7 @@ module.exports = class ChatInputWidget extends React.Component
 
   handleEmojiButtonClick: (event) ->
 
-    ActivityFlux.actions.emoji.setCommonListVisibility @id, yes
+    ActivityFlux.actions.emoji.setCommonListVisibility @stateId, yes
 
 
   renderEmojiDropup: ->
@@ -183,13 +183,13 @@ module.exports = class ChatInputWidget extends React.Component
     { filteredEmojiList, filteredEmojiListSelectedIndex, filteredEmojiListSelectedItem, filteredEmojiListQuery } = @state
 
     <EmojiDropup
-      items             = { filteredEmojiList }
-      selectedIndex     = { filteredEmojiListSelectedIndex }
-      selectedItem      = { filteredEmojiListSelectedItem }
-      query             = { filteredEmojiListQuery }
-      onItemConfirmed   = { @bound 'onDropupItemConfirmed' }
-      ref               = 'emojiDropup'
-      actionInitiatorId = { @id }
+      items           = { filteredEmojiList }
+      selectedIndex   = { filteredEmojiListSelectedIndex }
+      selectedItem    = { filteredEmojiListSelectedItem }
+      query           = { filteredEmojiListQuery }
+      onItemConfirmed = { @bound 'onDropupItemConfirmed' }
+      ref             = 'emojiDropup'
+      stateId         = { @stateId }
     />
 
 
@@ -198,11 +198,11 @@ module.exports = class ChatInputWidget extends React.Component
     { commonEmojiList, commonEmojiListVisibility, commonEmojiListSelectedItem } = @state
 
     <EmojiSelector
-      items             = { commonEmojiList }
-      visible           = { commonEmojiListVisibility }
-      selectedItem      = { commonEmojiListSelectedItem }
-      onItemConfirmed   = { @bound 'onSelectorItemConfirmed' }
-      actionInitiatorId = { @id }
+      items           = { commonEmojiList }
+      visible         = { commonEmojiListVisibility }
+      selectedItem    = { commonEmojiListSelectedItem }
+      onItemConfirmed = { @bound 'onSelectorItemConfirmed' }
+      stateId         = { @stateId }
     />
 
 
@@ -211,14 +211,14 @@ module.exports = class ChatInputWidget extends React.Component
     { channels, channelsSelectedItem, channelsSelectedIndex, channelsQuery, channelsVisibility } = @state
 
     <ChannelDropup
-      items             = { channels }
-      selectedIndex     = { channelsSelectedIndex }
-      selectedItem      = { channelsSelectedItem }
-      query             = { channelsQuery }
-      visible           = { channelsVisibility }
-      onItemConfirmed   = { @bound 'onDropupItemConfirmed' }
-      ref               = 'channelDropup'
-      actionInitiatorId = { @id }
+      items           = { channels }
+      selectedIndex   = { channelsSelectedIndex }
+      selectedItem    = { channelsSelectedItem }
+      query           = { channelsQuery }
+      visible         = { channelsVisibility }
+      onItemConfirmed = { @bound 'onDropupItemConfirmed' }
+      ref             = 'channelDropup'
+      stateId         = { @stateId }
     />
 
 
@@ -227,14 +227,14 @@ module.exports = class ChatInputWidget extends React.Component
     { users, userSelectedIndex, usersSelectedItem, usersQuery, usersVisibility } = @state
 
     <UserDropup
-      items             = { users }
-      selectedIndex     = { userSelectedIndex }
-      selectedItem      = { usersSelectedItem }
-      query             = { usersQuery }
-      visible           = { usersVisibility }
-      onItemConfirmed   = { @bound 'onDropupItemConfirmed' }
-      ref               = 'userDropup'
-      actionInitiatorId = { @id }
+      items           = { users }
+      selectedIndex   = { userSelectedIndex }
+      selectedItem    = { usersSelectedItem }
+      query           = { usersQuery }
+      visible         = { usersVisibility }
+      onItemConfirmed = { @bound 'onDropupItemConfirmed' }
+      ref             = 'userDropup'
+      stateId         = { @stateId }
     />
 
 
@@ -243,14 +243,14 @@ module.exports = class ChatInputWidget extends React.Component
     { searchItems, searchSelectedIndex, searchSelectedItem, searchQuery, searchVisibility } = @state
 
     <SearchDropup
-      items             = { searchItems }
-      selectedIndex     = { searchSelectedIndex }
-      selectedItem      = { searchSelectedItem }
-      query             = { searchQuery }
-      visible           = { searchVisibility }
-      onItemConfirmed   = { @bound 'onSearchItemConfirmed' }
-      ref               = 'searchDropup'
-      actionInitiatorId = { @id }
+      items           = { searchItems }
+      selectedIndex   = { searchSelectedIndex }
+      selectedItem    = { searchSelectedItem }
+      query           = { searchQuery }
+      visible         = { searchVisibility }
+      onItemConfirmed = { @bound 'onSearchItemConfirmed' }
+      ref             = 'searchDropup'
+      stateId         = { @stateId }
     />
 
 

--- a/client/activity/lib/components/chatinputwidget/index.coffee
+++ b/client/activity/lib/components/chatinputwidget/index.coffee
@@ -37,28 +37,28 @@ module.exports = class ChatInputWidget extends React.Component
     { getters } = ActivityFlux
 
     return {
-      filteredEmojiList              : getters.filteredEmojiList
-      filteredEmojiListSelectedIndex : getters.filteredEmojiListSelectedIndex
-      filteredEmojiListSelectedItem  : getters.filteredEmojiListSelectedItem
-      filteredEmojiListQuery         : getters.filteredEmojiListQuery
+      filteredEmojiList              : getters.filteredEmojiList @stateId
+      filteredEmojiListSelectedIndex : getters.filteredEmojiListSelectedIndex @stateId
+      filteredEmojiListSelectedItem  : getters.filteredEmojiListSelectedItem @stateId
+      filteredEmojiListQuery         : getters.filteredEmojiListQuery @stateId
       commonEmojiList                : getters.commonEmojiList
-      commonEmojiListSelectedItem    : getters.commonEmojiListSelectedItem
-      commonEmojiListVisibility      : getters.commonEmojiListVisibility
-      channels                       : getters.chatInputChannels
-      channelsSelectedIndex          : getters.chatInputChannelsSelectedIndex
-      channelsSelectedItem           : getters.chatInputChannelsSelectedItem
-      channelsQuery                  : getters.chatInputChannelsQuery
-      channelsVisibility             : getters.chatInputChannelsVisibility
-      users                          : getters.chatInputUsers
-      usersQuery                     : getters.chatInputUsersQuery
-      userSelectedIndex              : getters.chatInputUsersSelectedIndex
-      usersSelectedItem              : getters.chatInputUsersSelectedItem
-      usersVisibility                : getters.chatInputUsersVisibility
-      searchItems                    : getters.chatInputSearchItems
-      searchQuery                    : getters.chatInputSearchQuery
-      searchSelectedIndex            : getters.chatInputSearchSelectedIndex
-      searchSelectedItem             : getters.chatInputSearchSelectedItem
-      searchVisibility               : getters.chatInputSearchVisibility
+      commonEmojiListSelectedItem    : getters.commonEmojiListSelectedItem @stateId
+      commonEmojiListVisibility      : getters.commonEmojiListVisibility @stateId
+      channels                       : getters.chatInputChannels @stateId
+      channelsSelectedIndex          : getters.chatInputChannelsSelectedIndex @stateId
+      channelsSelectedItem           : getters.chatInputChannelsSelectedItem @stateId
+      channelsQuery                  : getters.chatInputChannelsQuery @stateId
+      channelsVisibility             : getters.chatInputChannelsVisibility @stateId
+      users                          : getters.chatInputUsers @stateId
+      usersQuery                     : getters.chatInputUsersQuery @stateId
+      userSelectedIndex              : getters.chatInputUsersSelectedIndex @stateId
+      usersSelectedItem              : getters.chatInputUsersSelectedItem @stateId
+      usersVisibility                : getters.chatInputUsersVisibility @stateId
+      searchItems                    : getters.chatInputSearchItems @stateId
+      searchQuery                    : getters.chatInputSearchQuery @stateId
+      searchSelectedIndex            : getters.chatInputSearchSelectedIndex @stateId
+      searchSelectedItem             : getters.chatInputSearchSelectedItem @stateId
+      searchVisibility               : getters.chatInputSearchVisibility @stateId
     }
 
 

--- a/client/activity/lib/components/chatinputwidget/index.coffee
+++ b/client/activity/lib/components/chatinputwidget/index.coffee
@@ -175,7 +175,7 @@ module.exports = class ChatInputWidget extends React.Component
 
   handleEmojiButtonClick: (event) ->
 
-    ActivityFlux.actions.emoji.setCommonListVisibility yes
+    ActivityFlux.actions.emoji.setCommonListVisibility @id, yes
 
 
   renderEmojiDropup: ->
@@ -183,12 +183,13 @@ module.exports = class ChatInputWidget extends React.Component
     { filteredEmojiList, filteredEmojiListSelectedIndex, filteredEmojiListSelectedItem, filteredEmojiListQuery } = @state
 
     <EmojiDropup
-      items           = { filteredEmojiList }
-      selectedIndex   = { filteredEmojiListSelectedIndex }
-      selectedItem    = { filteredEmojiListSelectedItem }
-      query           = { filteredEmojiListQuery }
-      onItemConfirmed = { @bound 'onDropupItemConfirmed' }
-      ref             = 'emojiDropup'
+      items             = { filteredEmojiList }
+      selectedIndex     = { filteredEmojiListSelectedIndex }
+      selectedItem      = { filteredEmojiListSelectedItem }
+      query             = { filteredEmojiListQuery }
+      onItemConfirmed   = { @bound 'onDropupItemConfirmed' }
+      ref               = 'emojiDropup'
+      actionInitiatorId = { @id }
     />
 
 
@@ -197,10 +198,11 @@ module.exports = class ChatInputWidget extends React.Component
     { commonEmojiList, commonEmojiListVisibility, commonEmojiListSelectedItem } = @state
 
     <EmojiSelector
-      items           = { commonEmojiList }
-      visible         = { commonEmojiListVisibility }
-      selectedItem    = { commonEmojiListSelectedItem }
-      onItemConfirmed = { @bound 'onSelectorItemConfirmed' }
+      items             = { commonEmojiList }
+      visible           = { commonEmojiListVisibility }
+      selectedItem      = { commonEmojiListSelectedItem }
+      onItemConfirmed   = { @bound 'onSelectorItemConfirmed' }
+      actionInitiatorId = { @id }
     />
 
 
@@ -209,13 +211,14 @@ module.exports = class ChatInputWidget extends React.Component
     { channels, channelsSelectedItem, channelsSelectedIndex, channelsQuery, channelsVisibility } = @state
 
     <ChannelDropup
-      items           = { channels }
-      selectedIndex   = { channelsSelectedIndex }
-      selectedItem    = { channelsSelectedItem }
-      query           = { channelsQuery }
-      visible         = { channelsVisibility }
-      onItemConfirmed = { @bound 'onDropupItemConfirmed' }
-      ref             = 'channelDropup'
+      items             = { channels }
+      selectedIndex     = { channelsSelectedIndex }
+      selectedItem      = { channelsSelectedItem }
+      query             = { channelsQuery }
+      visible           = { channelsVisibility }
+      onItemConfirmed   = { @bound 'onDropupItemConfirmed' }
+      ref               = 'channelDropup'
+      actionInitiatorId = { @id }
     />
 
 
@@ -224,13 +227,14 @@ module.exports = class ChatInputWidget extends React.Component
     { users, userSelectedIndex, usersSelectedItem, usersQuery, usersVisibility } = @state
 
     <UserDropup
-      items           = { users }
-      selectedIndex   = { userSelectedIndex }
-      selectedItem    = { usersSelectedItem }
-      query           = { usersQuery }
-      visible         = { usersVisibility }
-      onItemConfirmed = { @bound 'onDropupItemConfirmed' }
-      ref             = 'userDropup'
+      items             = { users }
+      selectedIndex     = { userSelectedIndex }
+      selectedItem      = { usersSelectedItem }
+      query             = { usersQuery }
+      visible           = { usersVisibility }
+      onItemConfirmed   = { @bound 'onDropupItemConfirmed' }
+      ref               = 'userDropup'
+      actionInitiatorId = { @id }
     />
 
 
@@ -239,13 +243,14 @@ module.exports = class ChatInputWidget extends React.Component
     { searchItems, searchSelectedIndex, searchSelectedItem, searchQuery, searchVisibility } = @state
 
     <SearchDropup
-      items           = { searchItems }
-      selectedIndex   = { searchSelectedIndex }
-      selectedItem    = { searchSelectedItem }
-      query           = { searchQuery }
-      visible         = { searchVisibility }
-      onItemConfirmed = { @bound 'onSearchItemConfirmed' }
-      ref             = 'searchDropup'
+      items             = { searchItems }
+      selectedIndex     = { searchSelectedIndex }
+      selectedItem      = { searchSelectedItem }
+      query             = { searchQuery }
+      visible           = { searchVisibility }
+      onItemConfirmed   = { @bound 'onSearchItemConfirmed' }
+      ref               = 'searchDropup'
+      actionInitiatorId = { @id }
     />
 
 

--- a/client/activity/lib/components/emojidropup/index.coffee
+++ b/client/activity/lib/components/emojidropup/index.coffee
@@ -30,8 +30,8 @@ module.exports = class EmojiDropup extends React.Component
 
   close: ->
 
-    { actionInitiatorId } = @props
-    ActivityFlux.actions.emoji.unsetFilteredListQuery actionInitiatorId
+    { stateId } = @props
+    ActivityFlux.actions.emoji.unsetFilteredListQuery stateId
 
 
   moveToNextPosition: (keyInfo) ->
@@ -40,9 +40,9 @@ module.exports = class EmojiDropup extends React.Component
       @close()
       return no
 
-    { actionInitiatorId } = @props
+    { stateId } = @props
     unless @hasSingleItem()
-      ActivityFlux.actions.emoji.moveToNextFilteredListIndex actionInitiatorId
+      ActivityFlux.actions.emoji.moveToNextFilteredListIndex stateId
 
     return yes
 
@@ -53,9 +53,9 @@ module.exports = class EmojiDropup extends React.Component
       @close()
       return no
 
-    { actionInitiatorId } = @props
+    { stateId } = @props
     unless @hasSingleItem()
-      ActivityFlux.actions.emoji.moveToPrevFilteredListIndex actionInitiatorId
+      ActivityFlux.actions.emoji.moveToPrevFilteredListIndex stateId
 
     return yes
 
@@ -69,15 +69,15 @@ module.exports = class EmojiDropup extends React.Component
     return no  unless matchResult
 
     query = matchResult[1]
-    { actionInitiatorId } = @props
-    ActivityFlux.actions.emoji.setFilteredListQuery actionInitiatorId, query
+    { stateId } = @props
+    ActivityFlux.actions.emoji.setFilteredListQuery stateId, query
     return yes
 
 
   onItemSelected: (index) ->
 
-    { actionInitiatorId } = @props
-    ActivityFlux.actions.emoji.setFilteredListSelectedIndex actionInitiatorId, index
+    { stateId } = @props
+    ActivityFlux.actions.emoji.setFilteredListSelectedIndex stateId, index
 
 
   renderList: ->

--- a/client/activity/lib/components/emojidropup/index.coffee
+++ b/client/activity/lib/components/emojidropup/index.coffee
@@ -28,7 +28,10 @@ module.exports = class EmojiDropup extends React.Component
   getItemKey: (item) -> item
 
 
-  close: -> ActivityFlux.actions.emoji.unsetFilteredListQuery()
+  close: ->
+
+    { actionInitiatorId } = @props
+    ActivityFlux.actions.emoji.unsetFilteredListQuery actionInitiatorId
 
 
   moveToNextPosition: (keyInfo) ->
@@ -37,7 +40,10 @@ module.exports = class EmojiDropup extends React.Component
       @close()
       return no
 
-    ActivityFlux.actions.emoji.moveToNextFilteredListIndex()  unless @hasSingleItem()
+    { actionInitiatorId } = @props
+    unless @hasSingleItem()
+      ActivityFlux.actions.emoji.moveToNextFilteredListIndex actionInitiatorId
+
     return yes
 
 
@@ -47,7 +53,10 @@ module.exports = class EmojiDropup extends React.Component
       @close()
       return no
 
-    ActivityFlux.actions.emoji.moveToPrevFilteredListIndex()  unless @hasSingleItem()
+    { actionInitiatorId } = @props
+    unless @hasSingleItem()
+      ActivityFlux.actions.emoji.moveToPrevFilteredListIndex actionInitiatorId
+
     return yes
 
 
@@ -60,13 +69,15 @@ module.exports = class EmojiDropup extends React.Component
     return no  unless matchResult
 
     query = matchResult[1]
-    ActivityFlux.actions.emoji.setFilteredListQuery query
+    { actionInitiatorId } = @props
+    ActivityFlux.actions.emoji.setFilteredListQuery actionInitiatorId, query
     return yes
 
 
   onItemSelected: (index) ->
 
-    ActivityFlux.actions.emoji.setFilteredListSelectedIndex index
+    { actionInitiatorId } = @props
+    ActivityFlux.actions.emoji.setFilteredListSelectedIndex actionInitiatorId, index
 
 
   renderList: ->

--- a/client/activity/lib/components/emojiselector/index.coffee
+++ b/client/activity/lib/components/emojiselector/index.coffee
@@ -47,8 +47,8 @@ module.exports = class EmojiSelector extends React.Component
 
   onItemSelected: (index) ->
 
-    { actionInitiatorId } = @props
-    ActivityFlux.actions.emoji.setCommonListSelectedIndex actionInitiatorId, index
+    { stateId } = @props
+    ActivityFlux.actions.emoji.setCommonListSelectedIndex stateId, index
 
 
   onItemConfirmed: ->
@@ -60,8 +60,8 @@ module.exports = class EmojiSelector extends React.Component
 
   close: ->
 
-    { actionInitiatorId } = @props
-    ActivityFlux.actions.emoji.setCommonListVisibility actionInitiatorId, no
+    { stateId } = @props
+    ActivityFlux.actions.emoji.setCommonListVisibility stateId, no
 
 
   handleKeyDown: (event) ->

--- a/client/activity/lib/components/emojiselector/index.coffee
+++ b/client/activity/lib/components/emojiselector/index.coffee
@@ -47,7 +47,8 @@ module.exports = class EmojiSelector extends React.Component
 
   onItemSelected: (index) ->
 
-    ActivityFlux.actions.emoji.setCommonListSelectedIndex index
+    { actionInitiatorId } = @props
+    ActivityFlux.actions.emoji.setCommonListSelectedIndex actionInitiatorId, index
 
 
   onItemConfirmed: ->
@@ -59,7 +60,8 @@ module.exports = class EmojiSelector extends React.Component
 
   close: ->
 
-    ActivityFlux.actions.emoji.setCommonListVisibility no
+    { actionInitiatorId } = @props
+    ActivityFlux.actions.emoji.setCommonListVisibility actionInitiatorId, no
 
 
   handleKeyDown: (event) ->

--- a/client/activity/lib/components/searchdropup/index.coffee
+++ b/client/activity/lib/components/searchdropup/index.coffee
@@ -29,18 +29,18 @@ module.exports = class SearchDropup extends React.Component
 
   close: ->
 
-    { actionInitiatorId } = @props
-    ActivityFlux.actions.chatInputSearch.setVisibility actionInitiatorId, no
-    ActivityFlux.actions.chatInputSearch.resetData actionInitiatorId
+    { stateId } = @props
+    ActivityFlux.actions.chatInputSearch.setVisibility stateId, no
+    ActivityFlux.actions.chatInputSearch.resetData stateId
 
 
   moveToNextPosition: (keyInfo) ->
 
     return no  if keyInfo.isRightArrow
 
-    { actionInitiatorId } = @props
+    { stateId } = @props
     unless @hasSingleItem()
-      ActivityFlux.actions.chatInputSearch.moveToNextIndex actionInitiatorId
+      ActivityFlux.actions.chatInputSearch.moveToNextIndex stateId
 
     return yes
 
@@ -49,9 +49,9 @@ module.exports = class SearchDropup extends React.Component
 
     return no  if keyInfo.isLeftArrow
 
-    { actionInitiatorId } = @props
+    { stateId } = @props
     unless @hasSingleItem()
-      ActivityFlux.actions.chatInputSearch.moveToPrevIndex actionInitiatorId
+      ActivityFlux.actions.chatInputSearch.moveToPrevIndex stateId
 
     return yes
 
@@ -64,17 +64,17 @@ module.exports = class SearchDropup extends React.Component
     return no  unless matchResult
 
     query = matchResult[1]
-    { actionInitiatorId } = @props
-    ActivityFlux.actions.chatInputSearch.setQuery actionInitiatorId, query
-    ActivityFlux.actions.chatInputSearch.setVisibility actionInitiatorId, yes
+    { stateId } = @props
+    ActivityFlux.actions.chatInputSearch.setQuery stateId, query
+    ActivityFlux.actions.chatInputSearch.setVisibility stateId, yes
 
     return yes
 
 
   onItemSelected: (index) ->
 
-    { actionInitiatorId } = @props
-    ActivityFlux.actions.chatInputSearch.setSelectedIndex actionInitiatorId, index
+    { stateId } = @props
+    ActivityFlux.actions.chatInputSearch.setSelectedIndex stateId, index
 
 
   renderList: ->

--- a/client/activity/lib/components/searchdropup/index.coffee
+++ b/client/activity/lib/components/searchdropup/index.coffee
@@ -29,15 +29,19 @@ module.exports = class SearchDropup extends React.Component
 
   close: ->
 
-    ActivityFlux.actions.chatInputSearch.setVisibility no
-    ActivityFlux.actions.chatInputSearch.resetData()
+    { actionInitiatorId } = @props
+    ActivityFlux.actions.chatInputSearch.setVisibility actionInitiatorId, no
+    ActivityFlux.actions.chatInputSearch.resetData actionInitiatorId
 
 
   moveToNextPosition: (keyInfo) ->
 
     return no  if keyInfo.isRightArrow
 
-    ActivityFlux.actions.chatInputSearch.moveToNextIndex()  unless @hasSingleItem()
+    { actionInitiatorId } = @props
+    unless @hasSingleItem()
+      ActivityFlux.actions.chatInputSearch.moveToNextIndex actionInitiatorId
+
     return yes
 
 
@@ -45,7 +49,10 @@ module.exports = class SearchDropup extends React.Component
 
     return no  if keyInfo.isLeftArrow
 
-    ActivityFlux.actions.chatInputSearch.moveToPrevIndex()  unless @hasSingleItem()
+    { actionInitiatorId } = @props
+    unless @hasSingleItem()
+      ActivityFlux.actions.chatInputSearch.moveToPrevIndex actionInitiatorId
+
     return yes
 
 
@@ -57,14 +64,17 @@ module.exports = class SearchDropup extends React.Component
     return no  unless matchResult
 
     query = matchResult[1]
-    ActivityFlux.actions.chatInputSearch.setQuery query
-    ActivityFlux.actions.chatInputSearch.setVisibility yes
+    { actionInitiatorId } = @props
+    ActivityFlux.actions.chatInputSearch.setQuery actionInitiatorId, query
+    ActivityFlux.actions.chatInputSearch.setVisibility actionInitiatorId, yes
+
     return yes
 
 
   onItemSelected: (index) ->
 
-    ActivityFlux.actions.chatInputSearch.setSelectedIndex index
+    { actionInitiatorId } = @props
+    ActivityFlux.actions.chatInputSearch.setSelectedIndex actionInitiatorId, index
 
 
   renderList: ->

--- a/client/activity/lib/components/userdropup/index.coffee
+++ b/client/activity/lib/components/userdropup/index.coffee
@@ -27,7 +27,10 @@ module.exports = class UserDropup extends React.Component
   getItemKey: (item) -> item.get '_id'
 
 
-  close: -> ActivityFlux.actions.user.setChatInputUsersVisibility no
+  close: ->
+
+    { actionInitiatorId } = @props
+    ActivityFlux.actions.user.setChatInputUsersVisibility actionInitiatorId, no
 
 
   moveToNextPosition: (keyInfo) ->
@@ -36,7 +39,10 @@ module.exports = class UserDropup extends React.Component
       @close()
       return no
 
-    ActivityFlux.actions.user.moveToNextChatInputUsersIndex()  unless @hasSingleItem()
+    { actionInitiatorId } = @props
+    unless @hasSingleItem()
+      ActivityFlux.actions.user.moveToNextChatInputUsersIndex actionInitiatorId
+
     return yes
 
 
@@ -46,7 +52,10 @@ module.exports = class UserDropup extends React.Component
       @close()
       return no
 
-    ActivityFlux.actions.user.moveToPrevChatInputUsersIndex()  unless @hasSingleItem()
+    { actionInitiatorId } = @props
+    unless @hasSingleItem()
+      ActivityFlux.actions.user.moveToPrevChatInputUsersIndex actionInitiatorId
+
     return yes
 
 
@@ -59,14 +68,17 @@ module.exports = class UserDropup extends React.Component
     return no  unless matchResult
 
     query = matchResult[1]
-    ActivityFlux.actions.user.setChatInputUsersQuery query
-    ActivityFlux.actions.user.setChatInputUsersVisibility yes
+    { actionInitiatorId } = @props
+    ActivityFlux.actions.user.setChatInputUsersQuery actionInitiatorId, query
+    ActivityFlux.actions.user.setChatInputUsersVisibility actionInitiatorId, yes
+
     return yes
 
 
   onItemSelected: (index) ->
 
-    ActivityFlux.actions.user.setChatInputUsersSelectedIndex index
+    { actionInitiatorId } = @props
+    ActivityFlux.actions.user.setChatInputUsersSelectedIndex actionInitiatorId, index
 
 
   renderList: ->

--- a/client/activity/lib/components/userdropup/index.coffee
+++ b/client/activity/lib/components/userdropup/index.coffee
@@ -29,8 +29,8 @@ module.exports = class UserDropup extends React.Component
 
   close: ->
 
-    { actionInitiatorId } = @props
-    ActivityFlux.actions.user.setChatInputUsersVisibility actionInitiatorId, no
+    { stateId } = @props
+    ActivityFlux.actions.user.setChatInputUsersVisibility stateId, no
 
 
   moveToNextPosition: (keyInfo) ->
@@ -39,9 +39,9 @@ module.exports = class UserDropup extends React.Component
       @close()
       return no
 
-    { actionInitiatorId } = @props
+    { stateId } = @props
     unless @hasSingleItem()
-      ActivityFlux.actions.user.moveToNextChatInputUsersIndex actionInitiatorId
+      ActivityFlux.actions.user.moveToNextChatInputUsersIndex stateId
 
     return yes
 
@@ -52,9 +52,9 @@ module.exports = class UserDropup extends React.Component
       @close()
       return no
 
-    { actionInitiatorId } = @props
+    { stateId } = @props
     unless @hasSingleItem()
-      ActivityFlux.actions.user.moveToPrevChatInputUsersIndex actionInitiatorId
+      ActivityFlux.actions.user.moveToPrevChatInputUsersIndex stateId
 
     return yes
 
@@ -68,17 +68,17 @@ module.exports = class UserDropup extends React.Component
     return no  unless matchResult
 
     query = matchResult[1]
-    { actionInitiatorId } = @props
-    ActivityFlux.actions.user.setChatInputUsersQuery actionInitiatorId, query
-    ActivityFlux.actions.user.setChatInputUsersVisibility actionInitiatorId, yes
+    { stateId } = @props
+    ActivityFlux.actions.user.setChatInputUsersQuery stateId, query
+    ActivityFlux.actions.user.setChatInputUsersVisibility stateId, yes
 
     return yes
 
 
   onItemSelected: (index) ->
 
-    { actionInitiatorId } = @props
-    ActivityFlux.actions.user.setChatInputUsersSelectedIndex actionInitiatorId, index
+    { stateId } = @props
+    ActivityFlux.actions.user.setChatInputUsersSelectedIndex stateId, index
 
 
   renderList: ->

--- a/client/activity/lib/flux/actions/channel.coffee
+++ b/client/activity/lib/flux/actions/channel.coffee
@@ -222,77 +222,89 @@ loadChannelsByQuery = (query, options = {}) ->
  * - if query is empty, it loads popular channels
  * - otherwise, it loads channels filtered by query
  *
+ * @param {string} initiatorId - id of initiated action component
  * @param {string} query
 ###
-setChatInputChannelsQuery = (query) ->
+setChatInputChannelsQuery = (initiatorId, query) ->
 
   if query
     { SET_CHAT_INPUT_CHANNELS_QUERY } = actionTypes
-    dispatch SET_CHAT_INPUT_CHANNELS_QUERY, { query }
-    resetChatInputChannelsSelectedIndex()
+    dispatch SET_CHAT_INPUT_CHANNELS_QUERY, { initiatorId, query }
+    resetChatInputChannelsSelectedIndex initiatorId
     loadChannelsByQuery query
   else
-    unsetChatInputChannelsQuery()
+    unsetChatInputChannelsQuery initiatorId
     loadPopularChannels()
 
 
 ###*
  * Action to unset current query of chat input channels.
  * Also, it resets channels selected index
+ *
+ * @param {string} initiatorId - id of initiated action component
 ###
-unsetChatInputChannelsQuery = ->
+unsetChatInputChannelsQuery = (initiatorId) ->
 
   { UNSET_CHAT_INPUT_CHANNELS_QUERY } = actionTypes
-  dispatch UNSET_CHAT_INPUT_CHANNELS_QUERY
+  dispatch UNSET_CHAT_INPUT_CHANNELS_QUERY, { initiatorId }
 
-  resetChatInputChannelsSelectedIndex()
+  resetChatInputChannelsSelectedIndex initiatorId
 
 
 ###*
  * Action to set selected index of chat input channels
  *
+ * @param {string} initiatorId - id of initiated action component
  * @param {number} index
 ###
-setChatInputChannelsSelectedIndex = (index) ->
+setChatInputChannelsSelectedIndex = (initiatorId, index) ->
 
   { SET_CHAT_INPUT_CHANNELS_SELECTED_INDEX } = actionTypes
-  dispatch SET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { index }
+  dispatch SET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { initiatorId, index }
 
 
 ###*
  * Action to increment channels selected index
+ *
+ * @param {string} initiatorId - id of initiated action component
 ###
-moveToNextChatInputChannelsIndex = ->
+moveToNextChatInputChannelsIndex = (initiatorId) ->
 
   { MOVE_TO_NEXT_CHAT_INPUT_CHANNELS_INDEX } = actionTypes
-  dispatch MOVE_TO_NEXT_CHAT_INPUT_CHANNELS_INDEX
+  dispatch MOVE_TO_NEXT_CHAT_INPUT_CHANNELS_INDEX, { initiatorId }
 
 
 ###*
  * Action to decrement channels selected index
+ *
+ * @param {string} initiatorId - id of initiated action component
 ###
-moveToPrevChatInputChannelsIndex = ->
+moveToPrevChatInputChannelsIndex = (initiatorId) ->
 
   { MOVE_TO_PREV_CHAT_INPUT_CHANNELS_INDEX } = actionTypes
-  dispatch MOVE_TO_PREV_CHAT_INPUT_CHANNELS_INDEX
+  dispatch MOVE_TO_PREV_CHAT_INPUT_CHANNELS_INDEX, { initiatorId }
 
 
 ###*
- * Action to reset channels selected index to initial value
+ * Action to reset channels selected index
+ *
+ * @param {string} initiatorId - id of initiated action component
 ###
-resetChatInputChannelsSelectedIndex = ->
+resetChatInputChannelsSelectedIndex = (initiatorId) ->
 
   { RESET_CHAT_INPUT_CHANNELS_SELECTED_INDEX } = actionTypes
-  dispatch RESET_CHAT_INPUT_CHANNELS_SELECTED_INDEX
+  dispatch RESET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { initiatorId }
 
 
 ###*
  * Action to set visibility of chat input channels
+ *
+ * @param {string} initiatorId - id of initiated action component
 ###
-setChatInputChannelsVisibility = (visible) ->
+setChatInputChannelsVisibility = (initiatorId, visible) ->
 
   { SET_CHAT_INPUT_CHANNELS_VISIBILITY } = actionTypes
-  dispatch SET_CHAT_INPUT_CHANNELS_VISIBILITY, { visible }
+  dispatch SET_CHAT_INPUT_CHANNELS_VISIBILITY, { initiatorId, visible }
 
 
 ###*

--- a/client/activity/lib/flux/actions/channel.coffee
+++ b/client/activity/lib/flux/actions/channel.coffee
@@ -222,18 +222,18 @@ loadChannelsByQuery = (query, options = {}) ->
  * - if query is empty, it loads popular channels
  * - otherwise, it loads channels filtered by query
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
  * @param {string} query
 ###
-setChatInputChannelsQuery = (initiatorId, query) ->
+setChatInputChannelsQuery = (stateId, query) ->
 
   if query
     { SET_CHAT_INPUT_CHANNELS_QUERY } = actionTypes
-    dispatch SET_CHAT_INPUT_CHANNELS_QUERY, { initiatorId, query }
-    resetChatInputChannelsSelectedIndex initiatorId
+    dispatch SET_CHAT_INPUT_CHANNELS_QUERY, { stateId, query }
+    resetChatInputChannelsSelectedIndex stateId
     loadChannelsByQuery query
   else
-    unsetChatInputChannelsQuery initiatorId
+    unsetChatInputChannelsQuery stateId
     loadPopularChannels()
 
 
@@ -241,70 +241,71 @@ setChatInputChannelsQuery = (initiatorId, query) ->
  * Action to unset current query of chat input channels.
  * Also, it resets channels selected index
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
 ###
-unsetChatInputChannelsQuery = (initiatorId) ->
+unsetChatInputChannelsQuery = (stateId) ->
 
   { UNSET_CHAT_INPUT_CHANNELS_QUERY } = actionTypes
-  dispatch UNSET_CHAT_INPUT_CHANNELS_QUERY, { initiatorId }
+  dispatch UNSET_CHAT_INPUT_CHANNELS_QUERY, { stateId }
 
-  resetChatInputChannelsSelectedIndex initiatorId
+  resetChatInputChannelsSelectedIndex stateId
 
 
 ###*
  * Action to set selected index of chat input channels
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
  * @param {number} index
 ###
-setChatInputChannelsSelectedIndex = (initiatorId, index) ->
+setChatInputChannelsSelectedIndex = (stateId, index) ->
 
   { SET_CHAT_INPUT_CHANNELS_SELECTED_INDEX } = actionTypes
-  dispatch SET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { initiatorId, index }
+  dispatch SET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { stateId, index }
 
 
 ###*
  * Action to increment channels selected index
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
 ###
-moveToNextChatInputChannelsIndex = (initiatorId) ->
+moveToNextChatInputChannelsIndex = (stateId) ->
 
   { MOVE_TO_NEXT_CHAT_INPUT_CHANNELS_INDEX } = actionTypes
-  dispatch MOVE_TO_NEXT_CHAT_INPUT_CHANNELS_INDEX, { initiatorId }
+  dispatch MOVE_TO_NEXT_CHAT_INPUT_CHANNELS_INDEX, { stateId }
 
 
 ###*
  * Action to decrement channels selected index
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
 ###
-moveToPrevChatInputChannelsIndex = (initiatorId) ->
+moveToPrevChatInputChannelsIndex = (stateId) ->
 
   { MOVE_TO_PREV_CHAT_INPUT_CHANNELS_INDEX } = actionTypes
-  dispatch MOVE_TO_PREV_CHAT_INPUT_CHANNELS_INDEX, { initiatorId }
+  dispatch MOVE_TO_PREV_CHAT_INPUT_CHANNELS_INDEX, { stateId }
 
 
 ###*
  * Action to reset channels selected index
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
 ###
-resetChatInputChannelsSelectedIndex = (initiatorId) ->
+resetChatInputChannelsSelectedIndex = (stateId) ->
 
   { RESET_CHAT_INPUT_CHANNELS_SELECTED_INDEX } = actionTypes
-  dispatch RESET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { initiatorId }
+  dispatch RESET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { stateId }
 
 
 ###*
  * Action to set visibility of chat input channels
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
+ * @param {bool} visible
 ###
-setChatInputChannelsVisibility = (initiatorId, visible) ->
+setChatInputChannelsVisibility = (stateId, visible) ->
 
   { SET_CHAT_INPUT_CHANNELS_VISIBILITY } = actionTypes
-  dispatch SET_CHAT_INPUT_CHANNELS_VISIBILITY, { initiatorId, visible }
+  dispatch SET_CHAT_INPUT_CHANNELS_VISIBILITY, { stateId, visible }
 
 
 ###*

--- a/client/activity/lib/flux/actions/chatinputsearch.coffee
+++ b/client/activity/lib/flux/actions/chatinputsearch.coffee
@@ -13,10 +13,11 @@ dispatch = (args...) -> kd.singletons.reactor.dispatch args...
 ###*
  * Action to search items by query
  *
+ * @param {string} initiatorId - id of initiated action component
  * @param {string} query
 ###
 
-fetchData = (query) ->
+fetchData = (initiatorId, query) ->
 
   { HIGHLIGHT_PRE_MARKER, HIGHLIGHT_POST_MARKER } = SearchConstants
   
@@ -33,15 +34,17 @@ fetchData = (query) ->
   dispatch actionTypes.CHAT_INPUT_SEARCH_BEGIN
   kd.singletons.search.searchChannelWithHighlighting query, socialApiChannelId, options
     .then (items) ->
-      dispatch actionTypes.CHAT_INPUT_SEARCH_SUCCESS, { items }
+      dispatch actionTypes.CHAT_INPUT_SEARCH_SUCCESS, { initiatorId, items }
     .catch (err) ->
-      dispatch actionTypes.CHAT_INPUT_SEARCH_FAIL, { err }
+      dispatch actionTypes.CHAT_INPUT_SEARCH_FAIL, { initiatorId, err }
 
 
 ###*
  * Action to clear stored search items
+ *
+ * @param {string} initiatorId - id of initiated action component
 ###
-resetData = -> dispatch actionTypes.CHAT_INPUT_SEARCH_RESET
+resetData = (initiatorId) -> dispatch actionTypes.CHAT_INPUT_SEARCH_RESET, { initiatorId }
 
 
 ###*
@@ -49,77 +52,89 @@ resetData = -> dispatch actionTypes.CHAT_INPUT_SEARCH_RESET
  * Also, it resets search items selected index and loads items
  * filtered by query if query is not empty
  *
+ * @param {string} initiatorId - id of initiated action component
  * @param {string} query
 ###
-setQuery = (query) ->
+setQuery = (initiatorId, query) ->
 
   if query
     { SET_CHAT_INPUT_SEARCH_QUERY } = actionTypes
-    dispatch SET_CHAT_INPUT_SEARCH_QUERY, { query }
-    resetSelectedIndex()
-    fetchData query
+    dispatch SET_CHAT_INPUT_SEARCH_QUERY, { initiatorId, query }
+    resetSelectedIndex initiatorId
+    fetchData initiatorId, query
   else
-    unsetQuery()
+    unsetQuery initiatorId
 
 
 ###*
  * Action to unset current search query.
  * Also, it resets search items selected index
+ *
+ * @param {string} initiatorId - id of initiated action component
 ###
-unsetQuery = ->
+unsetQuery = (initiatorId) ->
 
   { UNSET_CHAT_INPUT_SEARCH_QUERY } = actionTypes
-  dispatch UNSET_CHAT_INPUT_SEARCH_QUERY
+  dispatch UNSET_CHAT_INPUT_SEARCH_QUERY, { initiatorId }
 
-  resetSelectedIndex()
-  resetData()
+  resetSelectedIndex initiatorId
+  resetData initiatorId
 
 
 ###*
  * Action to set search items selected index
  *
+ * @param {string} initiatorId - id of initiated action component
  * @param {number} index
 ###
-setSelectedIndex = (index) ->
+setSelectedIndex = (initiatorId, index) ->
 
   { SET_CHAT_INPUT_SEARCH_SELECTED_INDEX } = actionTypes
-  dispatch SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { index }
+  dispatch SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId, index }
 
 
 ###*
  * Action to increment search items selected index
+ *
+ * @param {string} initiatorId - id of initiated action component
 ###
-moveToNextIndex = ->
+moveToNextIndex = (initiatorId) ->
 
   { MOVE_TO_NEXT_CHAT_INPUT_SEARCH_INDEX } = actionTypes
-  dispatch MOVE_TO_NEXT_CHAT_INPUT_SEARCH_INDEX
+  dispatch MOVE_TO_NEXT_CHAT_INPUT_SEARCH_INDEX, { initiatorId }
 
 
 ###*
  * Action to decrement search items selected index
+ *
+ * @param {string} initiatorId - id of initiated action component
 ###
-moveToPrevIndex = ->
+moveToPrevIndex = (initiatorId) ->
 
   { MOVE_TO_PREV_CHAT_INPUT_SEARCH_INDEX } = actionTypes
-  dispatch MOVE_TO_PREV_CHAT_INPUT_SEARCH_INDEX
+  dispatch MOVE_TO_PREV_CHAT_INPUT_SEARCH_INDEX, { initiatorId }
 
 
 ###*
- * Action to reset search items selected index to initial value
+ * Action to reset search items selected index
+ *
+ * @param {string} initiatorId - id of initiated action component
 ###
-resetSelectedIndex = ->
+resetSelectedIndex = (initiatorId) ->
 
   { RESET_CHAT_INPUT_SEARCH_SELECTED_INDEX } = actionTypes
-  dispatch RESET_CHAT_INPUT_SEARCH_SELECTED_INDEX
+  dispatch RESET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId }
 
 
 ###*
  * Action to set visibility of search items
+ *
+ * @param {string} initiatorId - id of initiated action component
 ###
-setVisibility = (visible) ->
+setVisibility = (initiatorId, visible) ->
 
   { SET_CHAT_INPUT_SEARCH_VISIBILITY } = actionTypes
-  dispatch SET_CHAT_INPUT_SEARCH_VISIBILITY, { visible }
+  dispatch SET_CHAT_INPUT_SEARCH_VISIBILITY, { initiatorId, visible }
 
 
 module.exports = {

--- a/client/activity/lib/flux/actions/chatinputsearch.coffee
+++ b/client/activity/lib/flux/actions/chatinputsearch.coffee
@@ -13,11 +13,11 @@ dispatch = (args...) -> kd.singletons.reactor.dispatch args...
 ###*
  * Action to search items by query
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
  * @param {string} query
 ###
 
-fetchData = (initiatorId, query) ->
+fetchData = (stateId, query) ->
 
   { HIGHLIGHT_PRE_MARKER, HIGHLIGHT_POST_MARKER } = SearchConstants
   
@@ -34,17 +34,17 @@ fetchData = (initiatorId, query) ->
   dispatch actionTypes.CHAT_INPUT_SEARCH_BEGIN
   kd.singletons.search.searchChannelWithHighlighting query, socialApiChannelId, options
     .then (items) ->
-      dispatch actionTypes.CHAT_INPUT_SEARCH_SUCCESS, { initiatorId, items }
+      dispatch actionTypes.CHAT_INPUT_SEARCH_SUCCESS, { stateId, items }
     .catch (err) ->
-      dispatch actionTypes.CHAT_INPUT_SEARCH_FAIL, { initiatorId, err }
+      dispatch actionTypes.CHAT_INPUT_SEARCH_FAIL, { stateId, err }
 
 
 ###*
  * Action to clear stored search items
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
 ###
-resetData = (initiatorId) -> dispatch actionTypes.CHAT_INPUT_SEARCH_RESET, { initiatorId }
+resetData = (stateId) -> dispatch actionTypes.CHAT_INPUT_SEARCH_RESET, { stateId }
 
 
 ###*
@@ -52,89 +52,90 @@ resetData = (initiatorId) -> dispatch actionTypes.CHAT_INPUT_SEARCH_RESET, { ini
  * Also, it resets search items selected index and loads items
  * filtered by query if query is not empty
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
  * @param {string} query
 ###
-setQuery = (initiatorId, query) ->
+setQuery = (stateId, query) ->
 
   if query
     { SET_CHAT_INPUT_SEARCH_QUERY } = actionTypes
-    dispatch SET_CHAT_INPUT_SEARCH_QUERY, { initiatorId, query }
-    resetSelectedIndex initiatorId
-    fetchData initiatorId, query
+    dispatch SET_CHAT_INPUT_SEARCH_QUERY, { stateId, query }
+    resetSelectedIndex stateId
+    fetchData stateId, query
   else
-    unsetQuery initiatorId
+    unsetQuery stateId
 
 
 ###*
  * Action to unset current search query.
  * Also, it resets search items selected index
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
 ###
-unsetQuery = (initiatorId) ->
+unsetQuery = (stateId) ->
 
   { UNSET_CHAT_INPUT_SEARCH_QUERY } = actionTypes
-  dispatch UNSET_CHAT_INPUT_SEARCH_QUERY, { initiatorId }
+  dispatch UNSET_CHAT_INPUT_SEARCH_QUERY, { stateId }
 
-  resetSelectedIndex initiatorId
-  resetData initiatorId
+  resetSelectedIndex stateId
+  resetData stateId
 
 
 ###*
  * Action to set search items selected index
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
  * @param {number} index
 ###
-setSelectedIndex = (initiatorId, index) ->
+setSelectedIndex = (stateId, index) ->
 
   { SET_CHAT_INPUT_SEARCH_SELECTED_INDEX } = actionTypes
-  dispatch SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId, index }
+  dispatch SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { stateId, index }
 
 
 ###*
  * Action to increment search items selected index
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
 ###
-moveToNextIndex = (initiatorId) ->
+moveToNextIndex = (stateId) ->
 
   { MOVE_TO_NEXT_CHAT_INPUT_SEARCH_INDEX } = actionTypes
-  dispatch MOVE_TO_NEXT_CHAT_INPUT_SEARCH_INDEX, { initiatorId }
+  dispatch MOVE_TO_NEXT_CHAT_INPUT_SEARCH_INDEX, { stateId }
 
 
 ###*
  * Action to decrement search items selected index
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
 ###
-moveToPrevIndex = (initiatorId) ->
+moveToPrevIndex = (stateId) ->
 
   { MOVE_TO_PREV_CHAT_INPUT_SEARCH_INDEX } = actionTypes
-  dispatch MOVE_TO_PREV_CHAT_INPUT_SEARCH_INDEX, { initiatorId }
+  dispatch MOVE_TO_PREV_CHAT_INPUT_SEARCH_INDEX, { stateId }
 
 
 ###*
  * Action to reset search items selected index
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
 ###
-resetSelectedIndex = (initiatorId) ->
+resetSelectedIndex = (stateId) ->
 
   { RESET_CHAT_INPUT_SEARCH_SELECTED_INDEX } = actionTypes
-  dispatch RESET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId }
+  dispatch RESET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { stateId }
 
 
 ###*
  * Action to set visibility of search items
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
+ * @param {bool} visible
 ###
-setVisibility = (initiatorId, visible) ->
+setVisibility = (stateId, visible) ->
 
   { SET_CHAT_INPUT_SEARCH_VISIBILITY } = actionTypes
-  dispatch SET_CHAT_INPUT_SEARCH_VISIBILITY, { initiatorId, visible }
+  dispatch SET_CHAT_INPUT_SEARCH_VISIBILITY, { stateId, visible }
 
 
 module.exports = {

--- a/client/activity/lib/flux/actions/emoji.coffee
+++ b/client/activity/lib/flux/actions/emoji.coffee
@@ -8,100 +8,114 @@ actionTypes = require '../actions/actiontypes'
  * Once the query is set, current selected index of
  * filtered emoji list should be reset
  *
+ * @param {string} initiatorId - id of initiated action component
  * @param {string} query
 ###
-setFilteredListQuery = (query) ->
+setFilteredListQuery = (initiatorId, query) ->
 
   if query
     { SET_FILTERED_EMOJI_LIST_QUERY } = actionTypes
-    dispatch SET_FILTERED_EMOJI_LIST_QUERY, { query }
-    resetFilteredListSelectedIndex()
+    dispatch SET_FILTERED_EMOJI_LIST_QUERY, { initiatorId, query }
+    resetFilteredListSelectedIndex initiatorId
   else
-    unsetFilteredListQuery()
+    unsetFilteredListQuery initiatorId
 
 
 ###*
  * Action to unset current query of filtered emoji list
+ *
+ * @param {string} initiatorId - id of initiated action component
 ###
-unsetFilteredListQuery = ->
+unsetFilteredListQuery = (initiatorId) ->
 
   { UNSET_FILTERED_EMOJI_LIST_QUERY } = actionTypes
-  dispatch UNSET_FILTERED_EMOJI_LIST_QUERY
+  dispatch UNSET_FILTERED_EMOJI_LIST_QUERY, { initiatorId }
 
-  resetFilteredListSelectedIndex()
+  resetFilteredListSelectedIndex { initiatorId }
 
 
 ###*
  * Action to set selected index of filtered emoji list
  *
+ * @param {string} initiatorId - id of initiated action component
  * @param {number} index
 ###
-setFilteredListSelectedIndex = (index) ->
+setFilteredListSelectedIndex = (initiatorId, index) ->
 
   { SET_FILTERED_EMOJI_LIST_SELECTED_INDEX } = actionTypes
-  dispatch SET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { index }
+  dispatch SET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { initiatorId, index }
 
 
 ###*
  * Action to move selected index of filtered emoji list
  * to the next position
+ *
+ * @param {string} initiatorId - id of initiated action component
 ###
-moveToNextFilteredListIndex = ->
+moveToNextFilteredListIndex = (initiatorId) ->
 
   { MOVE_TO_NEXT_FILTERED_EMOJI_LIST_INDEX } = actionTypes
-  dispatch MOVE_TO_NEXT_FILTERED_EMOJI_LIST_INDEX
+  dispatch MOVE_TO_NEXT_FILTERED_EMOJI_LIST_INDEX, { initiatorId }
 
 
 ###*
  * Action to move selected index of filtered emoji list
  * to the previous position
+ *
+ * @param {string} initiatorId - id of initiated action component
 ###
-moveToPrevFilteredListIndex = ->
+moveToPrevFilteredListIndex = (initiatorId) ->
 
   { MOVE_TO_PREV_FILTERED_EMOJI_LIST_INDEX } = actionTypes
-  dispatch MOVE_TO_PREV_FILTERED_EMOJI_LIST_INDEX
+  dispatch MOVE_TO_PREV_FILTERED_EMOJI_LIST_INDEX, { initiatorId }
 
 
 ###*
  * Action to reset selected index of filtered emoji list
  * to initial value
+ *
+ * @param {string} initiatorId - id of initiated action component
 ###
-resetFilteredListSelectedIndex = ->
+resetFilteredListSelectedIndex = (initiatorId) ->
 
   { RESET_FILTERED_EMOJI_LIST_SELECTED_INDEX } = actionTypes
-  dispatch RESET_FILTERED_EMOJI_LIST_SELECTED_INDEX
+  dispatch RESET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { initiatorId }
 
 
 ###*
  * Action to set selected index of common emoji list
  *
+ * @param {string} initiatorId - id of initiated action component
  * @param {number} index
 ###
-setCommonListSelectedIndex = (index) ->
+setCommonListSelectedIndex = (initiatorId, index) ->
 
   { SET_COMMON_EMOJI_LIST_SELECTED_INDEX } = actionTypes
-  dispatch SET_COMMON_EMOJI_LIST_SELECTED_INDEX, { index }
+  dispatch SET_COMMON_EMOJI_LIST_SELECTED_INDEX, { initiatorId, index }
 
 
 ###*
  * Action to reset selected index of common emoji list
  * to initial value
+ *
+ * @param {string} initiatorId - id of initiated action component
 ###
-resetCommonListSelectedIndex = ->
+resetCommonListSelectedIndex = (initiatorId) ->
 
   { RESET_COMMON_EMOJI_LIST_SELECTED_INDEX } = actionTypes
-  dispatch RESET_COMMON_EMOJI_LIST_SELECTED_INDEX
+  dispatch RESET_COMMON_EMOJI_LIST_SELECTED_INDEX, { initiatorId }
 
 
 ###*
  * Action to set visibility flag of common emoji list
  *
+ * @param {string} initiatorId - id of initiated action component
  * @param {bool} visible
 ###
-setCommonListVisibility = (visible) ->
+setCommonListVisibility = (initiatorId, visible) ->
 
   { SET_COMMON_EMOJI_LIST_VISIBILITY } = actionTypes
-  dispatch SET_COMMON_EMOJI_LIST_VISIBILITY, { visible }
+  dispatch SET_COMMON_EMOJI_LIST_VISIBILITY, { initiatorId, visible }
 
 
 dispatch = (args...) -> kd.singletons.reactor.dispatch args...

--- a/client/activity/lib/flux/actions/emoji.coffee
+++ b/client/activity/lib/flux/actions/emoji.coffee
@@ -8,114 +8,114 @@ actionTypes = require '../actions/actiontypes'
  * Once the query is set, current selected index of
  * filtered emoji list should be reset
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
  * @param {string} query
 ###
-setFilteredListQuery = (initiatorId, query) ->
+setFilteredListQuery = (stateId, query) ->
 
   if query
     { SET_FILTERED_EMOJI_LIST_QUERY } = actionTypes
-    dispatch SET_FILTERED_EMOJI_LIST_QUERY, { initiatorId, query }
-    resetFilteredListSelectedIndex initiatorId
+    dispatch SET_FILTERED_EMOJI_LIST_QUERY, { stateId, query }
+    resetFilteredListSelectedIndex stateId
   else
-    unsetFilteredListQuery initiatorId
+    unsetFilteredListQuery stateId
 
 
 ###*
  * Action to unset current query of filtered emoji list
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
 ###
-unsetFilteredListQuery = (initiatorId) ->
+unsetFilteredListQuery = (stateId) ->
 
   { UNSET_FILTERED_EMOJI_LIST_QUERY } = actionTypes
-  dispatch UNSET_FILTERED_EMOJI_LIST_QUERY, { initiatorId }
+  dispatch UNSET_FILTERED_EMOJI_LIST_QUERY, { stateId }
 
-  resetFilteredListSelectedIndex { initiatorId }
+  resetFilteredListSelectedIndex { stateId }
 
 
 ###*
  * Action to set selected index of filtered emoji list
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
  * @param {number} index
 ###
-setFilteredListSelectedIndex = (initiatorId, index) ->
+setFilteredListSelectedIndex = (stateId, index) ->
 
   { SET_FILTERED_EMOJI_LIST_SELECTED_INDEX } = actionTypes
-  dispatch SET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { initiatorId, index }
+  dispatch SET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { stateId, index }
 
 
 ###*
  * Action to move selected index of filtered emoji list
  * to the next position
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
 ###
-moveToNextFilteredListIndex = (initiatorId) ->
+moveToNextFilteredListIndex = (stateId) ->
 
   { MOVE_TO_NEXT_FILTERED_EMOJI_LIST_INDEX } = actionTypes
-  dispatch MOVE_TO_NEXT_FILTERED_EMOJI_LIST_INDEX, { initiatorId }
+  dispatch MOVE_TO_NEXT_FILTERED_EMOJI_LIST_INDEX, { stateId }
 
 
 ###*
  * Action to move selected index of filtered emoji list
  * to the previous position
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
 ###
-moveToPrevFilteredListIndex = (initiatorId) ->
+moveToPrevFilteredListIndex = (stateId) ->
 
   { MOVE_TO_PREV_FILTERED_EMOJI_LIST_INDEX } = actionTypes
-  dispatch MOVE_TO_PREV_FILTERED_EMOJI_LIST_INDEX, { initiatorId }
+  dispatch MOVE_TO_PREV_FILTERED_EMOJI_LIST_INDEX, { stateId }
 
 
 ###*
  * Action to reset selected index of filtered emoji list
  * to initial value
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
 ###
-resetFilteredListSelectedIndex = (initiatorId) ->
+resetFilteredListSelectedIndex = (stateId) ->
 
   { RESET_FILTERED_EMOJI_LIST_SELECTED_INDEX } = actionTypes
-  dispatch RESET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { initiatorId }
+  dispatch RESET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { stateId }
 
 
 ###*
  * Action to set selected index of common emoji list
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
  * @param {number} index
 ###
-setCommonListSelectedIndex = (initiatorId, index) ->
+setCommonListSelectedIndex = (stateId, index) ->
 
   { SET_COMMON_EMOJI_LIST_SELECTED_INDEX } = actionTypes
-  dispatch SET_COMMON_EMOJI_LIST_SELECTED_INDEX, { initiatorId, index }
+  dispatch SET_COMMON_EMOJI_LIST_SELECTED_INDEX, { stateId, index }
 
 
 ###*
  * Action to reset selected index of common emoji list
  * to initial value
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
 ###
-resetCommonListSelectedIndex = (initiatorId) ->
+resetCommonListSelectedIndex = (stateId) ->
 
   { RESET_COMMON_EMOJI_LIST_SELECTED_INDEX } = actionTypes
-  dispatch RESET_COMMON_EMOJI_LIST_SELECTED_INDEX, { initiatorId }
+  dispatch RESET_COMMON_EMOJI_LIST_SELECTED_INDEX, { stateId }
 
 
 ###*
  * Action to set visibility flag of common emoji list
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
  * @param {bool} visible
 ###
-setCommonListVisibility = (initiatorId, visible) ->
+setCommonListVisibility = (stateId, visible) ->
 
   { SET_COMMON_EMOJI_LIST_VISIBILITY } = actionTypes
-  dispatch SET_COMMON_EMOJI_LIST_VISIBILITY, { initiatorId, visible }
+  dispatch SET_COMMON_EMOJI_LIST_VISIBILITY, { stateId, visible }
 
 
 dispatch = (args...) -> kd.singletons.reactor.dispatch args...

--- a/client/activity/lib/flux/actions/user.coffee
+++ b/client/activity/lib/flux/actions/user.coffee
@@ -12,88 +12,89 @@ dispatch = (args...) -> kd.singletons.reactor.dispatch args...
  * Also, it resets users selected index and loads users
  * filtered by query if query is not empty
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
  * @param {string} query
 ###
-setChatInputUsersQuery = (initiatorId, query) ->
+setChatInputUsersQuery = (stateId, query) ->
 
   if query
     { SET_CHAT_INPUT_USERS_QUERY } = actionTypes
-    dispatch SET_CHAT_INPUT_USERS_QUERY, { initiatorId, query }
-    resetChatInputUsersSelectedIndex initiatorId
+    dispatch SET_CHAT_INPUT_USERS_QUERY, { stateId, query }
+    resetChatInputUsersSelectedIndex stateId
     appActions.user.searchAccounts query
   else
-    unsetChatInputUsersQuery initiatorId
+    unsetChatInputUsersQuery stateId
 
 
 ###*
  * Action to unset current query of chat input users.
  * Also, it resets users selected index
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
 ###
-unsetChatInputUsersQuery = (initiatorId) ->
+unsetChatInputUsersQuery = (stateId) ->
 
   { UNSET_CHAT_INPUT_USERS_QUERY } = actionTypes
-  dispatch UNSET_CHAT_INPUT_USERS_QUERY, { initiatorId }
+  dispatch UNSET_CHAT_INPUT_USERS_QUERY, { stateId }
 
-  resetChatInputUsersSelectedIndex initiatorId
+  resetChatInputUsersSelectedIndex stateId
 
 
 ###*
  * Action to set selected index of chat input users
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
  * @param {number} index
 ###
-setChatInputUsersSelectedIndex = (initiatorId, index) ->
+setChatInputUsersSelectedIndex = (stateId, index) ->
 
   { SET_CHAT_INPUT_USERS_SELECTED_INDEX } = actionTypes
-  dispatch SET_CHAT_INPUT_USERS_SELECTED_INDEX, { initiatorId, index }
+  dispatch SET_CHAT_INPUT_USERS_SELECTED_INDEX, { stateId, index }
 
 
 ###*
  * Action to increment users selected index
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
 ###
-moveToNextChatInputUsersIndex = (initiatorId) ->
+moveToNextChatInputUsersIndex = (stateId) ->
 
   { MOVE_TO_NEXT_CHAT_INPUT_USERS_INDEX } = actionTypes
-  dispatch MOVE_TO_NEXT_CHAT_INPUT_USERS_INDEX, { initiatorId }
+  dispatch MOVE_TO_NEXT_CHAT_INPUT_USERS_INDEX, { stateId }
 
 
 ###*
  * Action to decrement users selected index
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
 ###
-moveToPrevChatInputUsersIndex = (initiatorId) ->
+moveToPrevChatInputUsersIndex = (stateId) ->
 
   { MOVE_TO_PREV_CHAT_INPUT_USERS_INDEX } = actionTypes
-  dispatch MOVE_TO_PREV_CHAT_INPUT_USERS_INDEX, { initiatorId }
+  dispatch MOVE_TO_PREV_CHAT_INPUT_USERS_INDEX, { stateId }
 
 
 ###*
- * Action to reset users selected index to initial value
+ * Action to reset users selected index
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
 ###
-resetChatInputUsersSelectedIndex = (initiatorId) ->
+resetChatInputUsersSelectedIndex = (stateId) ->
 
   { RESET_CHAT_INPUT_USERS_SELECTED_INDEX } = actionTypes
-  dispatch RESET_CHAT_INPUT_USERS_SELECTED_INDEX, { initiatorId }
+  dispatch RESET_CHAT_INPUT_USERS_SELECTED_INDEX, { stateId }
 
 
 ###*
  * Action to set visibility of chat input users
  *
- * @param {string} initiatorId - id of initiated action component
+ * @param {string} stateId
+ * @param {bool} visible
 ###
-setChatInputUsersVisibility = (initiatorId, visible) ->
+setChatInputUsersVisibility = (stateId, visible) ->
 
   { SET_CHAT_INPUT_USERS_VISIBILITY } = actionTypes
-  dispatch SET_CHAT_INPUT_USERS_VISIBILITY, { initiatorId, visible }
+  dispatch SET_CHAT_INPUT_USERS_VISIBILITY, { stateId, visible }
 
 
 module.exports = {

--- a/client/activity/lib/flux/actions/user.coffee
+++ b/client/activity/lib/flux/actions/user.coffee
@@ -12,76 +12,88 @@ dispatch = (args...) -> kd.singletons.reactor.dispatch args...
  * Also, it resets users selected index and loads users
  * filtered by query if query is not empty
  *
+ * @param {string} initiatorId - id of initiated action component
  * @param {string} query
 ###
-setChatInputUsersQuery = (query) ->
+setChatInputUsersQuery = (initiatorId, query) ->
 
   if query
     { SET_CHAT_INPUT_USERS_QUERY } = actionTypes
-    dispatch SET_CHAT_INPUT_USERS_QUERY, { query }
-    resetChatInputUsersSelectedIndex()
+    dispatch SET_CHAT_INPUT_USERS_QUERY, { initiatorId, query }
+    resetChatInputUsersSelectedIndex initiatorId
     appActions.user.searchAccounts query
   else
-    unsetChatInputUsersQuery()
+    unsetChatInputUsersQuery initiatorId
 
 
 ###*
  * Action to unset current query of chat input users.
  * Also, it resets users selected index
+ *
+ * @param {string} initiatorId - id of initiated action component
 ###
-unsetChatInputUsersQuery = ->
+unsetChatInputUsersQuery = (initiatorId) ->
 
   { UNSET_CHAT_INPUT_USERS_QUERY } = actionTypes
-  dispatch UNSET_CHAT_INPUT_USERS_QUERY
+  dispatch UNSET_CHAT_INPUT_USERS_QUERY, { initiatorId }
 
-  resetChatInputUsersSelectedIndex()
+  resetChatInputUsersSelectedIndex initiatorId
 
 
 ###*
  * Action to set selected index of chat input users
  *
+ * @param {string} initiatorId - id of initiated action component
  * @param {number} index
 ###
-setChatInputUsersSelectedIndex = (index) ->
+setChatInputUsersSelectedIndex = (initiatorId, index) ->
 
   { SET_CHAT_INPUT_USERS_SELECTED_INDEX } = actionTypes
-  dispatch SET_CHAT_INPUT_USERS_SELECTED_INDEX, { index }
+  dispatch SET_CHAT_INPUT_USERS_SELECTED_INDEX, { initiatorId, index }
 
 
 ###*
  * Action to increment users selected index
+ *
+ * @param {string} initiatorId - id of initiated action component
 ###
-moveToNextChatInputUsersIndex = ->
+moveToNextChatInputUsersIndex = (initiatorId) ->
 
   { MOVE_TO_NEXT_CHAT_INPUT_USERS_INDEX } = actionTypes
-  dispatch MOVE_TO_NEXT_CHAT_INPUT_USERS_INDEX
+  dispatch MOVE_TO_NEXT_CHAT_INPUT_USERS_INDEX, { initiatorId }
 
 
 ###*
  * Action to decrement users selected index
+ *
+ * @param {string} initiatorId - id of initiated action component
 ###
-moveToPrevChatInputUsersIndex = ->
+moveToPrevChatInputUsersIndex = (initiatorId) ->
 
   { MOVE_TO_PREV_CHAT_INPUT_USERS_INDEX } = actionTypes
-  dispatch MOVE_TO_PREV_CHAT_INPUT_USERS_INDEX
+  dispatch MOVE_TO_PREV_CHAT_INPUT_USERS_INDEX, { initiatorId }
 
 
 ###*
  * Action to reset users selected index to initial value
+ *
+ * @param {string} initiatorId - id of initiated action component
 ###
-resetChatInputUsersSelectedIndex = ->
+resetChatInputUsersSelectedIndex = (initiatorId) ->
 
   { RESET_CHAT_INPUT_USERS_SELECTED_INDEX } = actionTypes
-  dispatch RESET_CHAT_INPUT_USERS_SELECTED_INDEX
+  dispatch RESET_CHAT_INPUT_USERS_SELECTED_INDEX, { initiatorId }
 
 
 ###*
  * Action to set visibility of chat input users
+ *
+ * @param {string} initiatorId - id of initiated action component
 ###
-setChatInputUsersVisibility = (visible) ->
+setChatInputUsersVisibility = (initiatorId, visible) ->
 
   { SET_CHAT_INPUT_USERS_VISIBILITY } = actionTypes
-  dispatch SET_CHAT_INPUT_USERS_VISIBILITY, { visible }
+  dispatch SET_CHAT_INPUT_USERS_VISIBILITY, { initiatorId, visible }
 
 
 module.exports = {

--- a/client/activity/lib/flux/getters.coffee
+++ b/client/activity/lib/flux/getters.coffee
@@ -261,18 +261,18 @@ currentSuggestionsSelectedIndex = [
   SuggestionsSelectedIndexStore
   calculateListSelectedIndex
 ]
-currentSuggestionsSelectedItem  = [
+currentSuggestionsSelectedItem = [
   SuggestionsStore
   currentSuggestionsSelectedIndex
   getListSelectedItem
 ]
 
-filteredEmojiListQuery         = (stateId) -> [
+filteredEmojiListQuery = (stateId) -> [
   FilteredEmojiListQueryStore
   (queries) -> queries.get stateId
 ]
 # Returns a list of emojis filtered by current query
-filteredEmojiList              = (stateId) -> [
+filteredEmojiList = (stateId) -> [
   EmojisStore
   filteredEmojiListQuery stateId
   (emojis, query) ->
@@ -288,7 +288,7 @@ filteredEmojiListSelectedIndex = (stateId) -> [
   filteredEmojiListRawIndex stateId
   calculateListSelectedIndex
 ]
-filteredEmojiListSelectedItem  = (stateId) -> [
+filteredEmojiListSelectedItem = (stateId) -> [
   filteredEmojiList stateId
   filteredEmojiListSelectedIndex stateId
   getListSelectedItem
@@ -299,25 +299,25 @@ commonEmojiListSelectedIndex = (stateId) -> [
   CommonEmojiListSelectedIndexStore
   (indexes) -> indexes.get stateId
 ]
-commonEmojiListVisibility    = (stateId) -> [
+commonEmojiListVisibility = (stateId) -> [
   CommonEmojiListVisibilityStore
   (visibilities) -> visibilities.get stateId
 ]
 # Returns emoji from emoji list by current selected index
-commonEmojiListSelectedItem  = (stateId) -> [
+commonEmojiListSelectedItem = (stateId) -> [
   commonEmojiList
   commonEmojiListSelectedIndex stateId
   getListSelectedItem
 ]
 
-chatInputChannelsQuery         = (stateId) -> [
+chatInputChannelsQuery = (stateId) -> [
   ChatInputChannelsQueryStore
   (queries) -> queries.get stateId
 ]
 # Returns a list of channels depending on the current query
 # If query if empty, returns popular channels
 # Otherwise, returns channels filtered by query
-chatInputChannels              = (stateId) -> [
+chatInputChannels = (stateId) -> [
   ChannelsStore
   popularChannels
   chatInputChannelsQuery stateId
@@ -329,7 +329,7 @@ chatInputChannels              = (stateId) -> [
       channelName = channel.get('name').toLowerCase()
       return channelName.indexOf(query) is 0
 ]
-chatInputChannelsRawIndex      = (stateId) -> [
+chatInputChannelsRawIndex = (stateId) -> [
   ChatInputChannelsSelectedIndexStore
   (indexes) -> indexes.get stateId
 ]
@@ -348,14 +348,14 @@ chatInputChannelsVisibility = (stateId) -> [
   (visibilities) -> visibilities.get stateId
 ]
 
-chatInputUsersQuery         = (stateId) -> [
+chatInputUsersQuery = (stateId) -> [
   ChatInputUsersQueryStore
   (queries) -> queries.get stateId
 ]
 # Returns a list of users depending on the current query
 # If query is empty, returns selected channel participants
 # Otherwise, returns users filtered by query
-chatInputUsers              = (stateId) -> [
+chatInputUsers = (stateId) -> [
   UsersStore
   selectedChannelParticipants
   chatInputUsersQuery stateId
@@ -367,7 +367,7 @@ chatInputUsers              = (stateId) -> [
       userName = user.getIn(['profile', 'nickname']).toLowerCase()
       return userName.indexOf(query) is 0
 ]
-chatInputUsersRawIndex      = (stateId) -> [
+chatInputUsersRawIndex = (stateId) -> [
   ChatInputUsersSelectedIndexStore
   (indexes) -> indexes.get stateId
 ]
@@ -386,15 +386,15 @@ chatInputUsersVisibility = (stateId) -> [
   (visibilities) -> visibilities.get stateId
 ]
 
-chatInputSearchItems         = (stateId) -> [
+chatInputSearchItems = (stateId) -> [
   ChatInputSearchStore
   (searchStore) -> searchStore.get stateId
 ]
-chatInputSearchQuery         = (stateId) -> [
+chatInputSearchQuery = (stateId) -> [
   ChatInputSearchQueryStore
   (queries) -> queries.get stateId
 ]
-chatInputSearchRawIndex      = (stateId) -> [
+chatInputSearchRawIndex = (stateId) -> [
   ChatInputSearchSelectedIndexStore
   (indexes) -> indexes.get stateId
 ]
@@ -403,12 +403,12 @@ chatInputSearchSelectedIndex = (stateId) -> [
   chatInputSearchRawIndex stateId
   calculateListSelectedIndex
 ]
-chatInputSearchSelectedItem  = (stateId) -> [
+chatInputSearchSelectedItem = (stateId) -> [
   chatInputSearchItems stateId
   chatInputSearchSelectedIndex stateId
   getListSelectedItem
 ]
-chatInputSearchVisibility    = (stateId) -> [
+chatInputSearchVisibility = (stateId) -> [
   ChatInputSearchVisibilityStore
   (visibilities) -> visibilities.get stateId
 ]

--- a/client/activity/lib/flux/getters.coffee
+++ b/client/activity/lib/flux/getters.coffee
@@ -231,10 +231,11 @@ selectedChannelParticipants = [
 # and < list.size
 calculateListSelectedIndex = (list, currentIndex) ->
 
-  { size } = list
-  return -1  unless size > 0
+  return -1  unless list and list.size > 0
 
-  index = currentIndex
+  { size } = list
+
+  index = currentIndex ? 0
   unless 0 <= index < size
     index = index % size
     index += size  if index < 0
@@ -247,7 +248,7 @@ calculateListSelectedIndex = (list, currentIndex) ->
 # It gets the list and its selected index
 # and returns item taken from the list by the index
 getListSelectedItem = (list, selectedIndex) ->
-  return  unless list.size > 0
+  return  unless list and list.size > 0
   return list.get selectedIndex
 
 
@@ -266,44 +267,60 @@ currentSuggestionsSelectedItem  = [
   getListSelectedItem
 ]
 
-filteredEmojiListQuery         = FilteredEmojiListQueryStore
+filteredEmojiListQuery         = (storeKey) -> [
+  FilteredEmojiListQueryStore
+  (queries) -> queries.get storeKey
+]
 # Returns a list of emojis filtered by current query
-filteredEmojiList              = [
+filteredEmojiList              = (storeKey) -> [
   EmojisStore
-  filteredEmojiListQuery
+  filteredEmojiListQuery storeKey
   (emojis, query) ->
     return immutable.List()  unless query
     emojis.filter (emoji) -> emoji.indexOf(query) is 0
 ]
-filteredEmojiListSelectedIndex = [
-  filteredEmojiList
+filteredEmojiListRawIndex = (storeKey) -> [
   FilteredEmojiListSelectedIndexStore
+  (indexes) -> indexes.get storeKey
+]
+filteredEmojiListSelectedIndex = (storeKey) -> [
+  filteredEmojiList storeKey
+  filteredEmojiListRawIndex storeKey
   calculateListSelectedIndex
 ]
-filteredEmojiListSelectedItem  = [
-  filteredEmojiList
-  filteredEmojiListSelectedIndex
+filteredEmojiListSelectedItem  = (storeKey) -> [
+  filteredEmojiList storeKey
+  filteredEmojiListSelectedIndex storeKey
   getListSelectedItem
 ]
 
 commonEmojiList              = EmojisStore
-commonEmojiListSelectedIndex = CommonEmojiListSelectedIndexStore
-commonEmojiListVisibility    = CommonEmojiListVisibilityStore
+commonEmojiListSelectedIndex = (storeKey) -> [
+  CommonEmojiListSelectedIndexStore
+  (indexes) -> indexes.get storeKey
+]
+commonEmojiListVisibility    = (storeKey) -> [
+  CommonEmojiListVisibilityStore
+  (visibilities) -> visibilities.get storeKey
+]
 # Returns emoji from emoji list by current selected index
-commonEmojiListSelectedItem  = [
+commonEmojiListSelectedItem  = (storeKey) -> [
   commonEmojiList
-  commonEmojiListSelectedIndex
+  commonEmojiListSelectedIndex storeKey
   getListSelectedItem
 ]
 
-chatInputChannelsQuery         = ChatInputChannelsQueryStore
+chatInputChannelsQuery         = (storeKey) -> [
+  ChatInputChannelsQueryStore
+  (queries) -> queries.get storeKey
+]
 # Returns a list of channels depending on the current query
 # If query if empty, returns popular channels
 # Otherwise, returns channels filtered by query
-chatInputChannels              = [
+chatInputChannels              = (storeKey) -> [
   ChannelsStore
   popularChannels
-  chatInputChannelsQuery
+  chatInputChannelsQuery storeKey
   (channels, popularChannels, query) ->
     return popularChannels.toList()  unless query
 
@@ -312,26 +329,36 @@ chatInputChannels              = [
       channelName = channel.get('name').toLowerCase()
       return channelName.indexOf(query) is 0
 ]
-chatInputChannelsSelectedIndex = [
-  chatInputChannels
+chatInputChannelsRawIndex      = (storeKey) -> [
   ChatInputChannelsSelectedIndexStore
+  (indexes) -> indexes.get storeKey
+]
+chatInputChannelsSelectedIndex = (storeKey) -> [
+  chatInputChannels storeKey
+  chatInputChannelsRawIndex storeKey
   calculateListSelectedIndex
 ]
-chatInputChannelsSelectedItem = [
-  chatInputChannels
-  chatInputChannelsSelectedIndex
+chatInputChannelsSelectedItem = (storeKey) -> [
+  chatInputChannels storeKey
+  chatInputChannelsSelectedIndex storeKey
   getListSelectedItem
 ]
-chatInputChannelsVisibility = ChatInputChannelsVisibilityStore
+chatInputChannelsVisibility = (storeKey) -> [
+  ChatInputChannelsVisibilityStore
+  (visibilities) -> visibilities.get storeKey
+]
 
-chatInputUsersQuery         = ChatInputUsersQueryStore
+chatInputUsersQuery         = (storeKey) -> [
+  ChatInputUsersQueryStore
+  (queries) -> queries.get storeKey
+]
 # Returns a list of users depending on the current query
 # If query is empty, returns selected channel participants
 # Otherwise, returns users filtered by query
-chatInputUsers              = [
+chatInputUsers              = (storeKey) -> [
   UsersStore
   selectedChannelParticipants
-  chatInputUsersQuery
+  chatInputUsersQuery storeKey
   (users, participants, query) ->
     return participants?.toList() ? immutable.List()  unless query
 
@@ -340,31 +367,51 @@ chatInputUsers              = [
       userName = user.getIn(['profile', 'nickname']).toLowerCase()
       return userName.indexOf(query) is 0
 ]
-chatInputUsersSelectedIndex = [
-  chatInputUsers
+chatInputUsersRawIndex      = (storeKey) -> [
   ChatInputUsersSelectedIndexStore
+  (indexes) -> indexes.get storeKey
+]
+chatInputUsersSelectedIndex = (storeKey) -> [
+  chatInputUsers storeKey
+  chatInputUsersRawIndex storeKey
   calculateListSelectedIndex
 ]
-chatInputUsersSelectedItem = [
-  chatInputUsers
-  chatInputUsersSelectedIndex
+chatInputUsersSelectedItem = (storeKey) -> [
+  chatInputUsers storeKey
+  chatInputUsersSelectedIndex storeKey
   getListSelectedItem
 ]
-chatInputUsersVisibility = ChatInputUsersVisibilityStore
+chatInputUsersVisibility = (storeKey) -> [
+  ChatInputUsersVisibilityStore
+  (visibilities) -> visibilities.get storeKey
+]
 
-chatInputSearchItems         = ChatInputSearchStore
-chatInputSearchQuery         = ChatInputSearchQueryStore
-chatInputSearchSelectedIndex = [
-  chatInputSearchItems
+chatInputSearchItems         = (storeKey) -> [
+  ChatInputSearchStore
+  (searchStore) -> searchStore.get storeKey
+]
+chatInputSearchQuery         = (storeKey) -> [
+  ChatInputSearchQueryStore
+  (queries) -> queries.get storeKey
+]
+chatInputSearchRawIndex      = (storeKey) -> [
   ChatInputSearchSelectedIndexStore
+  (indexes) -> indexes.get storeKey
+]
+chatInputSearchSelectedIndex = (storeKey) -> [
+  chatInputSearchItems storeKey
+  chatInputSearchRawIndex storeKey
   calculateListSelectedIndex
 ]
-chatInputSearchSelectedItem  = [
-  chatInputSearchItems
-  chatInputSearchSelectedIndex
+chatInputSearchSelectedItem  = (storeKey) -> [
+  chatInputSearchItems storeKey
+  chatInputSearchSelectedIndex storeKey
   getListSelectedItem
 ]
-chatInputSearchVisibility    = ChatInputSearchVisibilityStore
+chatInputSearchVisibility    = (storeKey) -> [
+  ChatInputSearchVisibilityStore
+  (visibilities) -> visibilities.get storeKey
+]
 
 module.exports = {
   followedPublicChannelThreads

--- a/client/activity/lib/flux/getters.coffee
+++ b/client/activity/lib/flux/getters.coffee
@@ -267,60 +267,60 @@ currentSuggestionsSelectedItem  = [
   getListSelectedItem
 ]
 
-filteredEmojiListQuery         = (storeKey) -> [
+filteredEmojiListQuery         = (stateId) -> [
   FilteredEmojiListQueryStore
-  (queries) -> queries.get storeKey
+  (queries) -> queries.get stateId
 ]
 # Returns a list of emojis filtered by current query
-filteredEmojiList              = (storeKey) -> [
+filteredEmojiList              = (stateId) -> [
   EmojisStore
-  filteredEmojiListQuery storeKey
+  filteredEmojiListQuery stateId
   (emojis, query) ->
     return immutable.List()  unless query
     emojis.filter (emoji) -> emoji.indexOf(query) is 0
 ]
-filteredEmojiListRawIndex = (storeKey) -> [
+filteredEmojiListRawIndex = (stateId) -> [
   FilteredEmojiListSelectedIndexStore
-  (indexes) -> indexes.get storeKey
+  (indexes) -> indexes.get stateId
 ]
-filteredEmojiListSelectedIndex = (storeKey) -> [
-  filteredEmojiList storeKey
-  filteredEmojiListRawIndex storeKey
+filteredEmojiListSelectedIndex = (stateId) -> [
+  filteredEmojiList stateId
+  filteredEmojiListRawIndex stateId
   calculateListSelectedIndex
 ]
-filteredEmojiListSelectedItem  = (storeKey) -> [
-  filteredEmojiList storeKey
-  filteredEmojiListSelectedIndex storeKey
+filteredEmojiListSelectedItem  = (stateId) -> [
+  filteredEmojiList stateId
+  filteredEmojiListSelectedIndex stateId
   getListSelectedItem
 ]
 
 commonEmojiList              = EmojisStore
-commonEmojiListSelectedIndex = (storeKey) -> [
+commonEmojiListSelectedIndex = (stateId) -> [
   CommonEmojiListSelectedIndexStore
-  (indexes) -> indexes.get storeKey
+  (indexes) -> indexes.get stateId
 ]
-commonEmojiListVisibility    = (storeKey) -> [
+commonEmojiListVisibility    = (stateId) -> [
   CommonEmojiListVisibilityStore
-  (visibilities) -> visibilities.get storeKey
+  (visibilities) -> visibilities.get stateId
 ]
 # Returns emoji from emoji list by current selected index
-commonEmojiListSelectedItem  = (storeKey) -> [
+commonEmojiListSelectedItem  = (stateId) -> [
   commonEmojiList
-  commonEmojiListSelectedIndex storeKey
+  commonEmojiListSelectedIndex stateId
   getListSelectedItem
 ]
 
-chatInputChannelsQuery         = (storeKey) -> [
+chatInputChannelsQuery         = (stateId) -> [
   ChatInputChannelsQueryStore
-  (queries) -> queries.get storeKey
+  (queries) -> queries.get stateId
 ]
 # Returns a list of channels depending on the current query
 # If query if empty, returns popular channels
 # Otherwise, returns channels filtered by query
-chatInputChannels              = (storeKey) -> [
+chatInputChannels              = (stateId) -> [
   ChannelsStore
   popularChannels
-  chatInputChannelsQuery storeKey
+  chatInputChannelsQuery stateId
   (channels, popularChannels, query) ->
     return popularChannels.toList()  unless query
 
@@ -329,36 +329,36 @@ chatInputChannels              = (storeKey) -> [
       channelName = channel.get('name').toLowerCase()
       return channelName.indexOf(query) is 0
 ]
-chatInputChannelsRawIndex      = (storeKey) -> [
+chatInputChannelsRawIndex      = (stateId) -> [
   ChatInputChannelsSelectedIndexStore
-  (indexes) -> indexes.get storeKey
+  (indexes) -> indexes.get stateId
 ]
-chatInputChannelsSelectedIndex = (storeKey) -> [
-  chatInputChannels storeKey
-  chatInputChannelsRawIndex storeKey
+chatInputChannelsSelectedIndex = (stateId) -> [
+  chatInputChannels stateId
+  chatInputChannelsRawIndex stateId
   calculateListSelectedIndex
 ]
-chatInputChannelsSelectedItem = (storeKey) -> [
-  chatInputChannels storeKey
-  chatInputChannelsSelectedIndex storeKey
+chatInputChannelsSelectedItem = (stateId) -> [
+  chatInputChannels stateId
+  chatInputChannelsSelectedIndex stateId
   getListSelectedItem
 ]
-chatInputChannelsVisibility = (storeKey) -> [
+chatInputChannelsVisibility = (stateId) -> [
   ChatInputChannelsVisibilityStore
-  (visibilities) -> visibilities.get storeKey
+  (visibilities) -> visibilities.get stateId
 ]
 
-chatInputUsersQuery         = (storeKey) -> [
+chatInputUsersQuery         = (stateId) -> [
   ChatInputUsersQueryStore
-  (queries) -> queries.get storeKey
+  (queries) -> queries.get stateId
 ]
 # Returns a list of users depending on the current query
 # If query is empty, returns selected channel participants
 # Otherwise, returns users filtered by query
-chatInputUsers              = (storeKey) -> [
+chatInputUsers              = (stateId) -> [
   UsersStore
   selectedChannelParticipants
-  chatInputUsersQuery storeKey
+  chatInputUsersQuery stateId
   (users, participants, query) ->
     return participants?.toList() ? immutable.List()  unless query
 
@@ -367,50 +367,50 @@ chatInputUsers              = (storeKey) -> [
       userName = user.getIn(['profile', 'nickname']).toLowerCase()
       return userName.indexOf(query) is 0
 ]
-chatInputUsersRawIndex      = (storeKey) -> [
+chatInputUsersRawIndex      = (stateId) -> [
   ChatInputUsersSelectedIndexStore
-  (indexes) -> indexes.get storeKey
+  (indexes) -> indexes.get stateId
 ]
-chatInputUsersSelectedIndex = (storeKey) -> [
-  chatInputUsers storeKey
-  chatInputUsersRawIndex storeKey
+chatInputUsersSelectedIndex = (stateId) -> [
+  chatInputUsers stateId
+  chatInputUsersRawIndex stateId
   calculateListSelectedIndex
 ]
-chatInputUsersSelectedItem = (storeKey) -> [
-  chatInputUsers storeKey
-  chatInputUsersSelectedIndex storeKey
+chatInputUsersSelectedItem = (stateId) -> [
+  chatInputUsers stateId
+  chatInputUsersSelectedIndex stateId
   getListSelectedItem
 ]
-chatInputUsersVisibility = (storeKey) -> [
+chatInputUsersVisibility = (stateId) -> [
   ChatInputUsersVisibilityStore
-  (visibilities) -> visibilities.get storeKey
+  (visibilities) -> visibilities.get stateId
 ]
 
-chatInputSearchItems         = (storeKey) -> [
+chatInputSearchItems         = (stateId) -> [
   ChatInputSearchStore
-  (searchStore) -> searchStore.get storeKey
+  (searchStore) -> searchStore.get stateId
 ]
-chatInputSearchQuery         = (storeKey) -> [
+chatInputSearchQuery         = (stateId) -> [
   ChatInputSearchQueryStore
-  (queries) -> queries.get storeKey
+  (queries) -> queries.get stateId
 ]
-chatInputSearchRawIndex      = (storeKey) -> [
+chatInputSearchRawIndex      = (stateId) -> [
   ChatInputSearchSelectedIndexStore
-  (indexes) -> indexes.get storeKey
+  (indexes) -> indexes.get stateId
 ]
-chatInputSearchSelectedIndex = (storeKey) -> [
-  chatInputSearchItems storeKey
-  chatInputSearchRawIndex storeKey
+chatInputSearchSelectedIndex = (stateId) -> [
+  chatInputSearchItems stateId
+  chatInputSearchRawIndex stateId
   calculateListSelectedIndex
 ]
-chatInputSearchSelectedItem  = (storeKey) -> [
-  chatInputSearchItems storeKey
-  chatInputSearchSelectedIndex storeKey
+chatInputSearchSelectedItem  = (stateId) -> [
+  chatInputSearchItems stateId
+  chatInputSearchSelectedIndex stateId
   getListSelectedItem
 ]
-chatInputSearchVisibility    = (storeKey) -> [
+chatInputSearchVisibility    = (stateId) -> [
   ChatInputSearchVisibilityStore
-  (visibilities) -> visibilities.get storeKey
+  (visibilities) -> visibilities.get stateId
 ]
 
 module.exports = {

--- a/client/activity/lib/flux/stores/chatinput/chatinputchannelsvisibilitystore.coffee
+++ b/client/activity/lib/flux/stores/chatinput/chatinputchannelsvisibilitystore.coffee
@@ -19,15 +19,15 @@ module.exports = class ChatInputChannelsVisibilityStore extends KodingFluxStore
 
 
   ###*
-   * It updates visibility flag for a given action initiator
+   * It updates visibility flag for a given stateId
    *
    * @param {immutable.Map} currentState
    * @param {object} payload
-   * @param {string} payload.initiatorId
+   * @param {string} payload.stateId
    * @param {bool} payload.visible
    * @return {immutable.Map} nextState
   ###
-  setVisibility: (currentState, { initiatorId, visible }) ->
+  setVisibility: (currentState, { stateId, visible }) ->
 
-    currentState.set initiatorId, visible
+    currentState.set stateId, visible
 

--- a/client/activity/lib/flux/stores/chatinput/chatinputchannelsvisibilitystore.coffee
+++ b/client/activity/lib/flux/stores/chatinput/chatinputchannelsvisibilitystore.coffee
@@ -1,15 +1,16 @@
 actions         = require 'activity/flux/actions/actiontypes'
 KodingFluxStore = require 'app/flux/store'
+immutable       = require 'immutable'
 
 ###*
- * Store to handle channels visibility flag
+ * Store to handle channels visibility flags
 ###
 module.exports = class ChatInputChannelsVisibilityStore extends KodingFluxStore
 
   @getterPath = 'ChatInputChannelsVisibilityStore'
 
 
-  getInitialState: -> no
+  getInitialState: -> immutable.Map()
 
 
   initialize: ->
@@ -18,12 +19,15 @@ module.exports = class ChatInputChannelsVisibilityStore extends KodingFluxStore
 
 
   ###*
-   * It updates current visibility flag with a given value
+   * It updates visibility flag for a given action initiator
    *
-   * @param {number} currentState
+   * @param {immutable.Map} currentState
    * @param {object} payload
+   * @param {string} payload.initiatorId
    * @param {bool} payload.visible
-   * @return {bool} nextState
+   * @return {immutable.Map} nextState
   ###
-  setVisibility: (currentState, { visible }) -> visible
+  setVisibility: (currentState, { initiatorId, visible }) ->
+
+    currentState.set initiatorId, visible
 

--- a/client/activity/lib/flux/stores/chatinput/chatinputquerystore.coffee
+++ b/client/activity/lib/flux/stores/chatinput/chatinputquerystore.coffee
@@ -1,11 +1,12 @@
 KodingFluxStore = require 'app/flux/store'
+immutable       = require 'immutable'
 
 ###*
- * Base class to store and manage a query of list
+ * Base class to store and manage list queries
 ###
 module.exports = class ChatInputQueryStore extends KodingFluxStore
 
-  getInitialState: -> null
+  getInitialState: -> immutable.Map()
 
 
   ###*
@@ -21,21 +22,28 @@ module.exports = class ChatInputQueryStore extends KodingFluxStore
 
 
   ###*
-   * It updates current query with a given value
+   * It updates query for a given action initiator
    *
-   * @param {string} currentState
+   * @param {immutable.Map} currentState
    * @param {object} payload
+   * @param {string} payload.initiatorId
    * @param {string} payload.query
-   * @return {string} nextState
+   * @return {immutable.Map} nextState
   ###
-  setQuery: (currentState, { query }) -> query
+  setQuery: (currentState, { initiatorId, query }) ->
+
+    currentState.set initiatorId, query
 
 
   ###*
-   * It resets current query to initial value
+   * It deletes query for a given action initiator
    *
-   * @param {string} currentState
-   * @return {string} nextState
+   * @param {immutable.Map} currentState
+   * @param {object} payload
+   * @param {string} payload.initiatorId
+   * @return {immutable.Map} nextState
   ###
-  unsetQuery: (currentState) -> null
+  unsetQuery: (currentState, { initiatorId }) ->
+
+    currentState.delete initiatorId
 

--- a/client/activity/lib/flux/stores/chatinput/chatinputquerystore.coffee
+++ b/client/activity/lib/flux/stores/chatinput/chatinputquerystore.coffee
@@ -22,28 +22,28 @@ module.exports = class ChatInputQueryStore extends KodingFluxStore
 
 
   ###*
-   * It updates query for a given action initiator
+   * It updates query for a given stateId
    *
    * @param {immutable.Map} currentState
    * @param {object} payload
-   * @param {string} payload.initiatorId
+   * @param {string} payload.stateId
    * @param {string} payload.query
    * @return {immutable.Map} nextState
   ###
-  setQuery: (currentState, { initiatorId, query }) ->
+  setQuery: (currentState, { stateId, query }) ->
 
-    currentState.set initiatorId, query
+    currentState.set stateId, query
 
 
   ###*
-   * It deletes query for a given action initiator
+   * It deletes query for a given stateId
    *
    * @param {immutable.Map} currentState
    * @param {object} payload
-   * @param {string} payload.initiatorId
+   * @param {string} payload.stateId
    * @return {immutable.Map} nextState
   ###
-  unsetQuery: (currentState, { initiatorId }) ->
+  unsetQuery: (currentState, { stateId }) ->
 
-    currentState.delete initiatorId
+    currentState.delete stateId
 

--- a/client/activity/lib/flux/stores/chatinput/chatinputsearchstore.coffee
+++ b/client/activity/lib/flux/stores/chatinput/chatinputsearchstore.coffee
@@ -24,29 +24,29 @@ module.exports = class ChatInputSearchStore extends KodingFluxStore
   ###*
    * Handler for CHAT_INPUT_SEARCH_SUCCESS action.
    * It replaces items list with successfully fetched items
-   * for a given action initiator
+   * for a given stateId
    *
    * @param {Immutable.Map} currentState
    * @param {object} payload
-   * @param {string} payload.initiatorId
+   * @param {string} payload.stateId
    * @param {array} payload.items
    * @return {Immutable.Map} nextState
   ###
-  handleSuccess: (currentState, { initiatorId, items }) ->
+  handleSuccess: (currentState, { stateId, items }) ->
 
-    currentState.set initiatorId, toImmutable items
+    currentState.set stateId, toImmutable items
 
 
   ###*
    * Handler for CHAT_INPUT_SEARCH_RESET and CHAT_INPUT_SEARCH_FAIL actions.
-   * It deletes items for a given action initiator
+   * It deletes items for a given stateId
    *
    * @param {Immutable.Map} currentState
    * @param {object} payload
-   * @param {string} payload.initiatorId
+   * @param {string} payload.stateId
    * @return {Immutable.Map} nextState
   ###
-  handleReset: (currentState, { initiatorId }) ->
+  handleReset: (currentState, { stateId }) ->
 
-    currentState.delete initiatorId
+    currentState.delete stateId
 

--- a/client/activity/lib/flux/stores/chatinput/chatinputsearchstore.coffee
+++ b/client/activity/lib/flux/stores/chatinput/chatinputsearchstore.coffee
@@ -11,7 +11,7 @@ module.exports = class ChatInputSearchStore extends KodingFluxStore
 
   @getterPath = 'ChatInputSearchStore'
 
-  getInitialState: -> immutable.List()
+  getInitialState: -> immutable.Map()
 
 
   initialize: ->
@@ -23,22 +23,30 @@ module.exports = class ChatInputSearchStore extends KodingFluxStore
 
   ###*
    * Handler for CHAT_INPUT_SEARCH_SUCCESS action.
-   * It replaces current items list with successfully fetched items
+   * It replaces items list with successfully fetched items
+   * for a given action initiator
    *
-   * @param {Immutable.List} currentItems
+   * @param {Immutable.Map} currentState
    * @param {object} payload
+   * @param {string} payload.initiatorId
    * @param {array} payload.items
-   * @return {Immutable.List} new items
+   * @return {Immutable.Map} nextState
   ###
-  handleSuccess: (currentItems, { items }) -> toImmutable items
+  handleSuccess: (currentState, { initiatorId, items }) ->
+
+    currentState.set initiatorId, toImmutable items
 
 
   ###*
    * Handler for CHAT_INPUT_SEARCH_RESET and CHAT_INPUT_SEARCH_FAIL actions.
-   * It sets current items to empty immutable list
+   * It deletes items for a given action initiator
    *
-   * @param {Immutable.List} items
-   * @return {Immutable.List} empty immutable list
+   * @param {Immutable.Map} currentState
+   * @param {object} payload
+   * @param {string} payload.initiatorId
+   * @return {Immutable.Map} nextState
   ###
-  handleReset: (items) -> immutable.List()
+  handleReset: (currentState, { initiatorId }) ->
+
+    currentState.delete initiatorId
 

--- a/client/activity/lib/flux/stores/chatinput/chatinputsearchvisibilitystore.coffee
+++ b/client/activity/lib/flux/stores/chatinput/chatinputsearchvisibilitystore.coffee
@@ -19,15 +19,15 @@ module.exports = class ChatInputSearchVisibilityStore extends KodingFluxStore
 
 
   ###*
-   * It updates visibility flag for a given action initiator
+   * It updates visibility flag for a given stateId
    *
    * @param {immutable.Map} currentState
    * @param {object} payload
-   * @param {bool} payload.initiatorId
+   * @param {bool} payload.stateId
    * @param {bool} payload.visible
    * @return {immutable.Map} nextState
   ###
-  setVisibility: (currentState, { initiatorId, visible }) ->
+  setVisibility: (currentState, { stateId, visible }) ->
 
-    currentState.set initiatorId, visible
+    currentState.set stateId, visible
 

--- a/client/activity/lib/flux/stores/chatinput/chatinputsearchvisibilitystore.coffee
+++ b/client/activity/lib/flux/stores/chatinput/chatinputsearchvisibilitystore.coffee
@@ -1,15 +1,16 @@
 actions         = require 'activity/flux/actions/actiontypes'
 KodingFluxStore = require 'app/flux/store'
+immutable       = require 'immutable'
 
 ###*
- * Store to handle chat input search visibility flag
+ * Store to handle chat input search visibility flags
 ###
 module.exports = class ChatInputSearchVisibilityStore extends KodingFluxStore
 
   @getterPath = 'ChatInputSearchVisibilityStore'
 
 
-  getInitialState: -> no
+  getInitialState: -> immutable.Map()
 
 
   initialize: ->
@@ -18,12 +19,15 @@ module.exports = class ChatInputSearchVisibilityStore extends KodingFluxStore
 
 
   ###*
-   * It updates current visibility flag with a given value
+   * It updates visibility flag for a given action initiator
    *
-   * @param {number} currentState
+   * @param {immutable.Map} currentState
    * @param {object} payload
+   * @param {bool} payload.initiatorId
    * @param {bool} payload.visible
-   * @return {bool} nextState
+   * @return {immutable.Map} nextState
   ###
-  setVisibility: (currentState, { visible }) -> visible
+  setVisibility: (currentState, { initiatorId, visible }) ->
+
+    currentState.set initiatorId, visible
 

--- a/client/activity/lib/flux/stores/chatinput/chatinputselectedindexstore.coffee
+++ b/client/activity/lib/flux/stores/chatinput/chatinputselectedindexstore.coffee
@@ -25,53 +25,53 @@ module.exports = class ChatInputSelectedIndexStore extends KodingFluxStore
 
 
   ###*
-   * It updates selected index for a given action initiator
+   * It updates selected index for a given stateId
    *
    * @param {immutable.Map} currentState
    * @param {object} payload
-   * @param {string} payload.initiatorId
+   * @param {string} payload.stateId
    * @param {number} payload.index
    * @return {immutable.Map} nextState
   ###
-  setIndex: (currentState, { initiatorId, index }) ->
+  setIndex: (currentState, { stateId, index }) ->
 
-    currentState.set initiatorId, index
+    currentState.set stateId, index
 
 
   ###*
-   * It increments selected index for a given action initiator
+   * It increments selected index for a given stateId
    *
    * @param {object} payload
-   * @param {string} payload.initiatorId
+   * @param {string} payload.stateId
    * @return {immutable.Map} nextState
   ###
-  moveToNextIndex: (currentState, { initiatorId }) ->
+  moveToNextIndex: (currentState, { stateId }) ->
 
-    index = currentState.get(initiatorId) ? 0
-    currentState.set initiatorId, index + 1
+    index = currentState.get(stateId) ? 0
+    currentState.set stateId, index + 1
 
 
   ###*
-   * It decrements selected index for a given action initiator
+   * It decrements selected index for a given stateId
    *
    * @param {object} payload
-   * @param {string} payload.initiatorId
+   * @param {string} payload.stateId
    * @return {immutable.Map} nextState
   ###
-  moveToPrevIndex: (currentState, { initiatorId }) ->
+  moveToPrevIndex: (currentState, { stateId }) ->
 
-    index = currentState.get(initiatorId) ? 0
-    currentState.set initiatorId, index - 1
+    index = currentState.get(stateId) ? 0
+    currentState.set stateId, index - 1
 
 
   ###*
-   * It deleted selected index for a given action initiator
+   * It deleted selected index for a given stateId
    *
    * @param {number} currentState
-   * @param {string} payload.initiatorId
+   * @param {string} payload.stateId
    * @return {number} nextState
   ###
-  resetIndex: (currentState, { initiatorId }) ->
+  resetIndex: (currentState, { stateId }) ->
 
-    currentState.delete initiatorId
+    currentState.delete stateId
 

--- a/client/activity/lib/flux/stores/chatinput/chatinputselectedindexstore.coffee
+++ b/client/activity/lib/flux/stores/chatinput/chatinputselectedindexstore.coffee
@@ -1,12 +1,13 @@
 KodingFluxStore = require 'app/flux/store'
 toImmutable     = require 'app/util/toImmutable'
+immutable       = require 'immutable'
 
 ###*
- * Base class to store and manage selected index of list
+ * Base class to store and manage list selected indexes
 ###
 module.exports = class ChatInputSelectedIndexStore extends KodingFluxStore
 
-  getInitialState: -> 0
+  getInitialState: -> immutable.Map()
 
 
   ###*
@@ -24,39 +25,53 @@ module.exports = class ChatInputSelectedIndexStore extends KodingFluxStore
 
 
   ###*
-   * It updates current selected index with a given value
+   * It updates selected index for a given action initiator
    *
-   * @param {number} currentState
+   * @param {immutable.Map} currentState
    * @param {object} payload
+   * @param {string} payload.initiatorId
    * @param {number} payload.index
-   * @return {number} nextState
+   * @return {immutable.Map} nextState
   ###
-  setIndex: (currentState, { index }) -> index
+  setIndex: (currentState, { initiatorId, index }) ->
+
+    currentState.set initiatorId, index
 
 
   ###*
-   * It increments current selected index
+   * It increments selected index for a given action initiator
    *
-   * @param {number} currentState
-   * @return {number} nextState
+   * @param {object} payload
+   * @param {string} payload.initiatorId
+   * @return {immutable.Map} nextState
   ###
-  moveToNextIndex: (currentState) -> currentState + 1
+  moveToNextIndex: (currentState, { initiatorId }) ->
+
+    index = currentState.get(initiatorId) ? 0
+    currentState.set initiatorId, index + 1
 
 
   ###*
-   * It decrements current selected index
+   * It decrements selected index for a given action initiator
    *
-   * @param {number} currentState
-   * @return {number} nextState
+   * @param {object} payload
+   * @param {string} payload.initiatorId
+   * @return {immutable.Map} nextState
   ###
-  moveToPrevIndex: (currentState) -> currentState - 1
+  moveToPrevIndex: (currentState, { initiatorId }) ->
+
+    index = currentState.get(initiatorId) ? 0
+    currentState.set initiatorId, index - 1
 
 
   ###*
-   * It resets current selected index to initial value
+   * It deleted selected index for a given action initiator
    *
    * @param {number} currentState
+   * @param {string} payload.initiatorId
    * @return {number} nextState
   ###
-  resetIndex: (currentState) -> 0
+  resetIndex: (currentState, { initiatorId }) ->
+
+    currentState.delete initiatorId
 

--- a/client/activity/lib/flux/stores/chatinput/chatinputusersvisibilitystore.coffee
+++ b/client/activity/lib/flux/stores/chatinput/chatinputusersvisibilitystore.coffee
@@ -1,15 +1,16 @@
 actions         = require 'activity/flux/actions/actiontypes'
 KodingFluxStore = require 'app/flux/store'
+immutable       = require 'immutable'
 
 ###*
- * Store to handle users visibility flag
+ * Store to handle users visibility flags
 ###
 module.exports = class ChatInputUsersVisibilityStore extends KodingFluxStore
 
   @getterPath = 'ChatInputUsersVisibilityStore'
 
 
-  getInitialState: -> no
+  getInitialState: -> immutable.Map()
 
 
   initialize: ->
@@ -18,12 +19,15 @@ module.exports = class ChatInputUsersVisibilityStore extends KodingFluxStore
 
 
   ###*
-   * It updates current visibility flag with a given value
+   * It updates visibility flag for a given action initiator
    *
-   * @param {number} currentState
+   * @param {immutable.Map} currentState
    * @param {object} payload
+   * @param {string} payload.initiatorId
    * @param {bool} payload.visible
-   * @return {bool} nextState
+   * @return {immutable.Map} nextState
   ###
-  setVisibility: (currentState, { visible }) -> visible
+  setVisibility: (currentState, { initiatorId, visible }) ->
+
+    currentState.set initiatorId, visible
 

--- a/client/activity/lib/flux/stores/chatinput/chatinputusersvisibilitystore.coffee
+++ b/client/activity/lib/flux/stores/chatinput/chatinputusersvisibilitystore.coffee
@@ -19,15 +19,15 @@ module.exports = class ChatInputUsersVisibilityStore extends KodingFluxStore
 
 
   ###*
-   * It updates visibility flag for a given action initiator
+   * It updates visibility flag for a given stateId
    *
    * @param {immutable.Map} currentState
    * @param {object} payload
-   * @param {string} payload.initiatorId
+   * @param {string} payload.stateId
    * @param {bool} payload.visible
    * @return {immutable.Map} nextState
   ###
-  setVisibility: (currentState, { initiatorId, visible }) ->
+  setVisibility: (currentState, { stateId, visible }) ->
 
-    currentState.set initiatorId, visible
+    currentState.set stateId, visible
 

--- a/client/activity/lib/flux/stores/chatinput/commonemojilistvisibilitystore.coffee
+++ b/client/activity/lib/flux/stores/chatinput/commonemojilistvisibilitystore.coffee
@@ -20,15 +20,15 @@ module.exports = class CommonEmojiListVisibilityStore extends KodingFluxStore
 
   ###*
    * Handler of SET_COMMON_EMOJI_LIST_VISIBILITY action
-   * It updates visible flag for a given action initiator
+   * It updates visible flag for a given stateId
    *
    * @param {Immutable.Map} currentState
    * @param {object} payload
-   * @param {bool} payload.initiatorId
+   * @param {bool} payload.stateId
    * @param {bool} payload.visible
    * @return {Immutable.Map} nextState
   ###
-  setVisibility: (currentState, { initiatorId, visible }) ->
+  setVisibility: (currentState, { stateId, visible }) ->
 
-    currentState.set initiatorId, visible
+    currentState.set stateId, visible
 

--- a/client/activity/lib/flux/stores/chatinput/commonemojilistvisibilitystore.coffee
+++ b/client/activity/lib/flux/stores/chatinput/commonemojilistvisibilitystore.coffee
@@ -1,15 +1,16 @@
 actions         = require 'activity/flux/actions/actiontypes'
 KodingFluxStore = require 'app/flux/store'
 toImmutable     = require 'app/util/toImmutable'
+immutable       = require 'immutable'
 
 ###*
- * Store to contain common emoji list visibility
+ * Store to contain common emoji list visibility flags
 ###
 module.exports = class CommonEmojiListVisibilityStore extends KodingFluxStore
 
   @getterPath = 'CommonEmojiListVisibilityStore'
 
-  getInitialState: -> no
+  getInitialState: -> immutable.Map()
 
 
   initialize: ->
@@ -19,12 +20,15 @@ module.exports = class CommonEmojiListVisibilityStore extends KodingFluxStore
 
   ###*
    * Handler of SET_COMMON_EMOJI_LIST_VISIBILITY action
-   * It updates current visible flag with a given value
+   * It updates visible flag for a given action initiator
    *
    * @param {Immutable.Map} currentState
    * @param {object} payload
+   * @param {bool} payload.initiatorId
    * @param {bool} payload.visible
-   * @return {bool} nextState
+   * @return {Immutable.Map} nextState
   ###
-  setVisibility: (currentState, { visible }) -> visible
+  setVisibility: (currentState, { initiatorId, visible }) ->
+
+    currentState.set initiatorId, visible
 

--- a/client/activity/lib/flux/test/chatinput/chatinputchannelsquerystore.coffee
+++ b/client/activity/lib/flux/test/chatinput/chatinputchannelsquerystore.coffee
@@ -19,15 +19,15 @@ describe 'ChatInputChannelsQueryStore', ->
 
       query1      = 'koding'
       query2      = 'tests'
-      initiatorId = 'qwerty'
+      stateId = 'qwerty'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_QUERY, { initiatorId, query : query1 }
-      query = @reactor.evaluate(['chatInputChannelsQuery']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_QUERY, { stateId, query : query1 }
+      query = @reactor.evaluate(['chatInputChannelsQuery']).get stateId
 
       expect(query).to.equal query1
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_QUERY, { initiatorId, query: query2 }
-      query = @reactor.evaluate(['chatInputChannelsQuery']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_QUERY, { stateId, query: query2 }
+      query = @reactor.evaluate(['chatInputChannelsQuery']).get stateId
 
       expect(query).to.equal query2
 
@@ -37,15 +37,15 @@ describe 'ChatInputChannelsQueryStore', ->
     it 'clears current query', ->
 
       testQuery   = 'koding'
-      initiatorId = 'qwerty'
+      stateId = 'qwerty'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_QUERY, { initiatorId, query : testQuery }
-      query = @reactor.evaluate(['chatInputChannelsQuery']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_QUERY, { stateId, query : testQuery }
+      query = @reactor.evaluate(['chatInputChannelsQuery']).get stateId
 
       expect(query).to.equal testQuery
 
-      @reactor.dispatch actions.UNSET_CHAT_INPUT_CHANNELS_QUERY, { initiatorId }
-      query = @reactor.evaluate(['chatInputChannelsQuery']).get initiatorId
+      @reactor.dispatch actions.UNSET_CHAT_INPUT_CHANNELS_QUERY, { stateId }
+      query = @reactor.evaluate(['chatInputChannelsQuery']).get stateId
 
       expect(query).to.be.undefined
 

--- a/client/activity/lib/flux/test/chatinput/chatinputchannelsquerystore.coffee
+++ b/client/activity/lib/flux/test/chatinput/chatinputchannelsquerystore.coffee
@@ -17,16 +17,17 @@ describe 'ChatInputChannelsQueryStore', ->
 
     it 'sets current query to a given value', ->
 
-      query1 = 'koding'
-      query2 = 'tests'
+      query1      = 'koding'
+      query2      = 'tests'
+      initiatorId = 'qwerty'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_QUERY, query : query1
-      query = @reactor.evaluate ['chatInputChannelsQuery']
+      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_QUERY, { initiatorId, query : query1 }
+      query = @reactor.evaluate(['chatInputChannelsQuery']).get initiatorId
 
       expect(query).to.equal query1
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_QUERY, query: query2
-      query = @reactor.evaluate ['chatInputChannelsQuery']
+      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_QUERY, { initiatorId, query: query2 }
+      query = @reactor.evaluate(['chatInputChannelsQuery']).get initiatorId
 
       expect(query).to.equal query2
 
@@ -35,15 +36,16 @@ describe 'ChatInputChannelsQueryStore', ->
 
     it 'clears current query', ->
 
-      testQuery = 'koding'
+      testQuery   = 'koding'
+      initiatorId = 'qwerty'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_QUERY, query : testQuery
-      query = @reactor.evaluate ['chatInputChannelsQuery']
+      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_QUERY, { initiatorId, query : testQuery }
+      query = @reactor.evaluate(['chatInputChannelsQuery']).get initiatorId
 
       expect(query).to.equal testQuery
 
-      @reactor.dispatch actions.UNSET_CHAT_INPUT_CHANNELS_QUERY
-      query = @reactor.evaluate ['chatInputChannelsQuery']
+      @reactor.dispatch actions.UNSET_CHAT_INPUT_CHANNELS_QUERY, { initiatorId }
+      query = @reactor.evaluate(['chatInputChannelsQuery']).get initiatorId
 
-      expect(query).to.be.null
+      expect(query).to.be.undefined
 

--- a/client/activity/lib/flux/test/chatinput/chatinputchannelsselectedindexstore.coffee
+++ b/client/activity/lib/flux/test/chatinput/chatinputchannelsselectedindexstore.coffee
@@ -18,9 +18,10 @@ describe 'ChatInputChannelsSelectedIndexStore', ->
     it 'sets selected index', ->
 
       index = 3
+      initiatorId = 'test'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { index }
-      selectedIndex = @reactor.evaluate ['chatInputChannelsSelectedIndex']
+      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { initiatorId, index }
+      selectedIndex = @reactor.evaluate(['chatInputChannelsSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal index
 
@@ -31,14 +32,15 @@ describe 'ChatInputChannelsSelectedIndexStore', ->
 
       index = 3
       nextIndex = index + 1
+      initiatorId = 'test'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { index }
-      selectedIndex = @reactor.evaluate ['chatInputChannelsSelectedIndex']
+      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { index, initiatorId }
+      selectedIndex = @reactor.evaluate(['chatInputChannelsSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal index
       
-      @reactor.dispatch actions.MOVE_TO_NEXT_CHAT_INPUT_CHANNELS_INDEX
-      selectedIndex = @reactor.evaluate ['chatInputChannelsSelectedIndex']
+      @reactor.dispatch actions.MOVE_TO_NEXT_CHAT_INPUT_CHANNELS_INDEX, { initiatorId }
+      selectedIndex = @reactor.evaluate(['chatInputChannelsSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal nextIndex
 
@@ -49,14 +51,15 @@ describe 'ChatInputChannelsSelectedIndexStore', ->
 
       index = 3
       prevIndex = index - 1
+      initiatorId = 'test'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { index }
-      selectedIndex = @reactor.evaluate ['chatInputChannelsSelectedIndex']
+      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { index, initiatorId }
+      selectedIndex = @reactor.evaluate(['chatInputChannelsSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal index
       
-      @reactor.dispatch actions.MOVE_TO_PREV_CHAT_INPUT_CHANNELS_INDEX
-      selectedIndex = @reactor.evaluate ['chatInputChannelsSelectedIndex']
+      @reactor.dispatch actions.MOVE_TO_PREV_CHAT_INPUT_CHANNELS_INDEX, { initiatorId }
+      selectedIndex = @reactor.evaluate(['chatInputChannelsSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal prevIndex
 
@@ -66,14 +69,15 @@ describe 'ChatInputChannelsSelectedIndexStore', ->
     it 'resets selected index', ->
 
       index = 3
+      initiatorId = 'test'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { index }
-      selectedIndex = @reactor.evaluate ['chatInputChannelsSelectedIndex']
+      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { index, initiatorId }
+      selectedIndex = @reactor.evaluate(['chatInputChannelsSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal index
 
-      @reactor.dispatch actions.RESET_CHAT_INPUT_CHANNELS_SELECTED_INDEX
-      selectedIndex = @reactor.evaluate ['chatInputChannelsSelectedIndex']
+      @reactor.dispatch actions.RESET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { initiatorId }
+      selectedIndex = @reactor.evaluate(['chatInputChannelsSelectedIndex']).get initiatorId
 
-      expect(selectedIndex).to.equal 0
+      expect(selectedIndex).to.be.undefined
 

--- a/client/activity/lib/flux/test/chatinput/chatinputchannelsselectedindexstore.coffee
+++ b/client/activity/lib/flux/test/chatinput/chatinputchannelsselectedindexstore.coffee
@@ -18,10 +18,10 @@ describe 'ChatInputChannelsSelectedIndexStore', ->
     it 'sets selected index', ->
 
       index = 3
-      initiatorId = 'test'
+      stateId = 'test'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { initiatorId, index }
-      selectedIndex = @reactor.evaluate(['chatInputChannelsSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { stateId, index }
+      selectedIndex = @reactor.evaluate(['chatInputChannelsSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal index
 
@@ -32,15 +32,15 @@ describe 'ChatInputChannelsSelectedIndexStore', ->
 
       index = 3
       nextIndex = index + 1
-      initiatorId = 'test'
+      stateId = 'test'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { index, initiatorId }
-      selectedIndex = @reactor.evaluate(['chatInputChannelsSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { index, stateId }
+      selectedIndex = @reactor.evaluate(['chatInputChannelsSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal index
       
-      @reactor.dispatch actions.MOVE_TO_NEXT_CHAT_INPUT_CHANNELS_INDEX, { initiatorId }
-      selectedIndex = @reactor.evaluate(['chatInputChannelsSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.MOVE_TO_NEXT_CHAT_INPUT_CHANNELS_INDEX, { stateId }
+      selectedIndex = @reactor.evaluate(['chatInputChannelsSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal nextIndex
 
@@ -51,15 +51,15 @@ describe 'ChatInputChannelsSelectedIndexStore', ->
 
       index = 3
       prevIndex = index - 1
-      initiatorId = 'test'
+      stateId = 'test'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { index, initiatorId }
-      selectedIndex = @reactor.evaluate(['chatInputChannelsSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { index, stateId }
+      selectedIndex = @reactor.evaluate(['chatInputChannelsSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal index
       
-      @reactor.dispatch actions.MOVE_TO_PREV_CHAT_INPUT_CHANNELS_INDEX, { initiatorId }
-      selectedIndex = @reactor.evaluate(['chatInputChannelsSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.MOVE_TO_PREV_CHAT_INPUT_CHANNELS_INDEX, { stateId }
+      selectedIndex = @reactor.evaluate(['chatInputChannelsSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal prevIndex
 
@@ -69,15 +69,15 @@ describe 'ChatInputChannelsSelectedIndexStore', ->
     it 'resets selected index', ->
 
       index = 3
-      initiatorId = 'test'
+      stateId = 'test'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { index, initiatorId }
-      selectedIndex = @reactor.evaluate(['chatInputChannelsSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { index, stateId }
+      selectedIndex = @reactor.evaluate(['chatInputChannelsSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal index
 
-      @reactor.dispatch actions.RESET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { initiatorId }
-      selectedIndex = @reactor.evaluate(['chatInputChannelsSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.RESET_CHAT_INPUT_CHANNELS_SELECTED_INDEX, { stateId }
+      selectedIndex = @reactor.evaluate(['chatInputChannelsSelectedIndex']).get stateId
 
       expect(selectedIndex).to.be.undefined
 

--- a/client/activity/lib/flux/test/chatinput/chatinputchannelsvisibilitystore.coffee
+++ b/client/activity/lib/flux/test/chatinput/chatinputchannelsvisibilitystore.coffee
@@ -17,15 +17,15 @@ describe 'ChatInputChannelsVisibilityStore', ->
 
     it 'sets visibility', ->
 
-      initiatorId = '123'
+      stateId = '123'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_VISIBILITY, { initiatorId, visible : yes }
-      visibility = @reactor.evaluate(['chatInputChannelsVisibility']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_VISIBILITY, { stateId, visible : yes }
+      visibility = @reactor.evaluate(['chatInputChannelsVisibility']).get stateId
 
       expect(visibility).to.be.true
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_VISIBILITY, { initiatorId, visible : no }
-      visibility = @reactor.evaluate(['chatInputChannelsVisibility']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_VISIBILITY, { stateId, visible : no }
+      visibility = @reactor.evaluate(['chatInputChannelsVisibility']).get stateId
 
       expect(visibility).to.be.false
 

--- a/client/activity/lib/flux/test/chatinput/chatinputchannelsvisibilitystore.coffee
+++ b/client/activity/lib/flux/test/chatinput/chatinputchannelsvisibilitystore.coffee
@@ -17,13 +17,15 @@ describe 'ChatInputChannelsVisibilityStore', ->
 
     it 'sets visibility', ->
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_VISIBILITY, { visible : yes }
-      visible = @reactor.evaluate ['chatInputChannelsVisibility']
+      initiatorId = '123'
 
-      expect(visible).to.be.true
+      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_VISIBILITY, { initiatorId, visible : yes }
+      visibility = @reactor.evaluate(['chatInputChannelsVisibility']).get initiatorId
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_VISIBILITY, { visible : no }
-      visible = @reactor.evaluate ['chatInputChannelsVisibility']
+      expect(visibility).to.be.true
 
-      expect(visible).to.be.false
+      @reactor.dispatch actions.SET_CHAT_INPUT_CHANNELS_VISIBILITY, { initiatorId, visible : no }
+      visibility = @reactor.evaluate(['chatInputChannelsVisibility']).get initiatorId
+
+      expect(visibility).to.be.false
 

--- a/client/activity/lib/flux/test/chatinput/chatinputsearchgetters.coffee
+++ b/client/activity/lib/flux/test/chatinput/chatinputsearchgetters.coffee
@@ -20,14 +20,16 @@ describe 'ChatInputSearchGetters', ->
 
   describe '#chatInputSearchSelectedIndex', ->
 
+    initiatorId = 'test'
+
     it 'gets -1 when search items are empty', ->
 
       { getters } = ActivityFlux
       items = []
 
-      @reactor.dispatch actions.CHAT_INPUT_SEARCH_SUCCESS, { items }
+      @reactor.dispatch actions.CHAT_INPUT_SEARCH_SUCCESS, { initiatorId, items }
 
-      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex
+      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex initiatorId
       expect(selectedIndex).to.equal -1
 
 
@@ -41,10 +43,10 @@ describe 'ChatInputSearchGetters', ->
         { id : '3' }
       ]
 
-      @reactor.dispatch actions.CHAT_INPUT_SEARCH_SUCCESS, { items }
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { index }
+      @reactor.dispatch actions.CHAT_INPUT_SEARCH_SUCCESS, { initiatorId, items }
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId, index }
 
-      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex
+      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex initiatorId
       expect(selectedIndex).to.equal index
 
 
@@ -60,17 +62,17 @@ describe 'ChatInputSearchGetters', ->
         { id : '5' }
       ]
 
-      @reactor.dispatch actions.CHAT_INPUT_SEARCH_SUCCESS, { items }
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { index }
+      @reactor.dispatch actions.CHAT_INPUT_SEARCH_SUCCESS, { initiatorId, items }
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId, index }
 
-      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex
+      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex initiatorId
       expect(selectedIndex).to.equal (index % items.length) + items.length
 
       index = -9
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { index }
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId, index }
 
-      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex
+      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex initiatorId
       expect(selectedIndex).to.equal (index % items.length) + items.length
 
 
@@ -84,21 +86,23 @@ describe 'ChatInputSearchGetters', ->
         { id : '3' }
       ]
 
-      @reactor.dispatch actions.CHAT_INPUT_SEARCH_SUCCESS, { items }
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { index }
+      @reactor.dispatch actions.CHAT_INPUT_SEARCH_SUCCESS, { initiatorId, items }
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId, index }
 
-      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex
+      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex initiatorId
       expect(selectedIndex).to.equal index % items.length
 
       index = 8
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { index }
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId, index }
 
-      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex
+      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex initiatorId
       expect(selectedIndex).to.equal index % items.length
 
 
   describe '#chatInputSelectedItem', ->
+
+    initiatorId = 'test'
 
     it 'gets item by specified selected index', ->
 
@@ -110,9 +114,9 @@ describe 'ChatInputSearchGetters', ->
         { id : '3' }
       ]
 
-      @reactor.dispatch actions.CHAT_INPUT_SEARCH_SUCCESS, { items }
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { index }
+      @reactor.dispatch actions.CHAT_INPUT_SEARCH_SUCCESS, { initiatorId, items }
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId, index }
 
-      selectedItem = @reactor.evaluateToJS getters.chatInputSearchSelectedItem
+      selectedItem = @reactor.evaluateToJS getters.chatInputSearchSelectedItem initiatorId
       expect(selectedItem.id).to.equal items[index].id
 

--- a/client/activity/lib/flux/test/chatinput/chatinputsearchgetters.coffee
+++ b/client/activity/lib/flux/test/chatinput/chatinputsearchgetters.coffee
@@ -20,16 +20,16 @@ describe 'ChatInputSearchGetters', ->
 
   describe '#chatInputSearchSelectedIndex', ->
 
-    initiatorId = 'test'
+    stateId = 'test'
 
     it 'gets -1 when search items are empty', ->
 
       { getters } = ActivityFlux
       items = []
 
-      @reactor.dispatch actions.CHAT_INPUT_SEARCH_SUCCESS, { initiatorId, items }
+      @reactor.dispatch actions.CHAT_INPUT_SEARCH_SUCCESS, { stateId, items }
 
-      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex initiatorId
+      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex stateId
       expect(selectedIndex).to.equal -1
 
 
@@ -43,10 +43,10 @@ describe 'ChatInputSearchGetters', ->
         { id : '3' }
       ]
 
-      @reactor.dispatch actions.CHAT_INPUT_SEARCH_SUCCESS, { initiatorId, items }
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId, index }
+      @reactor.dispatch actions.CHAT_INPUT_SEARCH_SUCCESS, { stateId, items }
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { stateId, index }
 
-      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex initiatorId
+      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex stateId
       expect(selectedIndex).to.equal index
 
 
@@ -62,17 +62,17 @@ describe 'ChatInputSearchGetters', ->
         { id : '5' }
       ]
 
-      @reactor.dispatch actions.CHAT_INPUT_SEARCH_SUCCESS, { initiatorId, items }
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId, index }
+      @reactor.dispatch actions.CHAT_INPUT_SEARCH_SUCCESS, { stateId, items }
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { stateId, index }
 
-      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex initiatorId
+      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex stateId
       expect(selectedIndex).to.equal (index % items.length) + items.length
 
       index = -9
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId, index }
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { stateId, index }
 
-      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex initiatorId
+      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex stateId
       expect(selectedIndex).to.equal (index % items.length) + items.length
 
 
@@ -86,23 +86,23 @@ describe 'ChatInputSearchGetters', ->
         { id : '3' }
       ]
 
-      @reactor.dispatch actions.CHAT_INPUT_SEARCH_SUCCESS, { initiatorId, items }
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId, index }
+      @reactor.dispatch actions.CHAT_INPUT_SEARCH_SUCCESS, { stateId, items }
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { stateId, index }
 
-      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex initiatorId
+      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex stateId
       expect(selectedIndex).to.equal index % items.length
 
       index = 8
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId, index }
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { stateId, index }
 
-      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex initiatorId
+      selectedIndex = @reactor.evaluate getters.chatInputSearchSelectedIndex stateId
       expect(selectedIndex).to.equal index % items.length
 
 
   describe '#chatInputSelectedItem', ->
 
-    initiatorId = 'test'
+    stateId = 'test'
 
     it 'gets item by specified selected index', ->
 
@@ -114,9 +114,9 @@ describe 'ChatInputSearchGetters', ->
         { id : '3' }
       ]
 
-      @reactor.dispatch actions.CHAT_INPUT_SEARCH_SUCCESS, { initiatorId, items }
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId, index }
+      @reactor.dispatch actions.CHAT_INPUT_SEARCH_SUCCESS, { stateId, items }
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { stateId, index }
 
-      selectedItem = @reactor.evaluateToJS getters.chatInputSearchSelectedItem initiatorId
+      selectedItem = @reactor.evaluateToJS getters.chatInputSearchSelectedItem stateId
       expect(selectedItem.id).to.equal items[index].id
 

--- a/client/activity/lib/flux/test/chatinput/chatinputsearchquerystore.coffee
+++ b/client/activity/lib/flux/test/chatinput/chatinputsearchquerystore.coffee
@@ -19,15 +19,15 @@ describe 'ChatInputSearchQueryStore', ->
 
       query1 = 'qwerty'
       query2 = '123456'
-      initiatorId = 'test'
+      stateId = 'test'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_QUERY, { initiatorId, query : query1 }
-      query = @reactor.evaluate(['chatInputSearchQuery']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_QUERY, { stateId, query : query1 }
+      query = @reactor.evaluate(['chatInputSearchQuery']).get stateId
 
       expect(query).to.equal query1
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_QUERY, { initiatorId, query: query2 }
-      query = @reactor.evaluate(['chatInputSearchQuery']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_QUERY, { stateId, query: query2 }
+      query = @reactor.evaluate(['chatInputSearchQuery']).get stateId
 
       expect(query).to.equal query2
 
@@ -37,15 +37,15 @@ describe 'ChatInputSearchQueryStore', ->
     it 'clears current query', ->
 
       testQuery = 'qwerty'
-      initiatorId = 'test'
+      stateId = 'test'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_QUERY, { initiatorId, query : testQuery }
-      query = @reactor.evaluate(['chatInputSearchQuery']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_QUERY, { stateId, query : testQuery }
+      query = @reactor.evaluate(['chatInputSearchQuery']).get stateId
 
       expect(query).to.equal testQuery
 
-      @reactor.dispatch actions.UNSET_CHAT_INPUT_SEARCH_QUERY, { initiatorId }
-      query = @reactor.evaluate(['chatInputSearchQuery']).get initiatorId
+      @reactor.dispatch actions.UNSET_CHAT_INPUT_SEARCH_QUERY, { stateId }
+      query = @reactor.evaluate(['chatInputSearchQuery']).get stateId
 
       expect(query).to.be.undefined
 

--- a/client/activity/lib/flux/test/chatinput/chatinputsearchquerystore.coffee
+++ b/client/activity/lib/flux/test/chatinput/chatinputsearchquerystore.coffee
@@ -19,14 +19,15 @@ describe 'ChatInputSearchQueryStore', ->
 
       query1 = 'qwerty'
       query2 = '123456'
+      initiatorId = 'test'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_QUERY, query : query1
-      query = @reactor.evaluate ['chatInputSearchQuery']
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_QUERY, { initiatorId, query : query1 }
+      query = @reactor.evaluate(['chatInputSearchQuery']).get initiatorId
 
       expect(query).to.equal query1
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_QUERY, query: query2
-      query = @reactor.evaluate ['chatInputSearchQuery']
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_QUERY, { initiatorId, query: query2 }
+      query = @reactor.evaluate(['chatInputSearchQuery']).get initiatorId
 
       expect(query).to.equal query2
 
@@ -36,14 +37,15 @@ describe 'ChatInputSearchQueryStore', ->
     it 'clears current query', ->
 
       testQuery = 'qwerty'
+      initiatorId = 'test'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_QUERY, query : testQuery
-      query = @reactor.evaluate ['chatInputSearchQuery']
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_QUERY, { initiatorId, query : testQuery }
+      query = @reactor.evaluate(['chatInputSearchQuery']).get initiatorId
 
       expect(query).to.equal testQuery
 
-      @reactor.dispatch actions.UNSET_CHAT_INPUT_SEARCH_QUERY
-      query = @reactor.evaluate ['chatInputSearchQuery']
+      @reactor.dispatch actions.UNSET_CHAT_INPUT_SEARCH_QUERY, { initiatorId }
+      query = @reactor.evaluate(['chatInputSearchQuery']).get initiatorId
 
-      expect(query).to.be.null
+      expect(query).to.be.undefined
 

--- a/client/activity/lib/flux/test/chatinput/chatinputsearchselectedindexstore.coffee
+++ b/client/activity/lib/flux/test/chatinput/chatinputsearchselectedindexstore.coffee
@@ -18,9 +18,10 @@ describe 'ChatInputSearchSelectedIndexStore', ->
     it 'sets selected index', ->
 
       index = 3
+      initiatorId = 'test'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { index }
-      selectedIndex = @reactor.evaluate ['chatInputSearchSelectedIndex']
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId, index }
+      selectedIndex = @reactor.evaluate(['chatInputSearchSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal index
 
@@ -30,15 +31,16 @@ describe 'ChatInputSearchSelectedIndexStore', ->
   	it 'moves to next index', ->
 
       index = 3
+      initiatorId = 'test'
       nextIndex = index + 1
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { index }
-      selectedIndex = @reactor.evaluate ['chatInputSearchSelectedIndex']
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId, index }
+      selectedIndex = @reactor.evaluate(['chatInputSearchSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal index
       
-      @reactor.dispatch actions.MOVE_TO_NEXT_CHAT_INPUT_SEARCH_INDEX
-      selectedIndex = @reactor.evaluate ['chatInputSearchSelectedIndex']
+      @reactor.dispatch actions.MOVE_TO_NEXT_CHAT_INPUT_SEARCH_INDEX, { initiatorId }
+      selectedIndex = @reactor.evaluate(['chatInputSearchSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal nextIndex
 
@@ -48,15 +50,16 @@ describe 'ChatInputSearchSelectedIndexStore', ->
     it 'moves to prev index', ->
 
       index = 3
+      initiatorId = 'test'
       prevIndex = index - 1
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { index }
-      selectedIndex = @reactor.evaluate ['chatInputSearchSelectedIndex']
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId, index }
+      selectedIndex = @reactor.evaluate(['chatInputSearchSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal index
       
-      @reactor.dispatch actions.MOVE_TO_PREV_CHAT_INPUT_SEARCH_INDEX
-      selectedIndex = @reactor.evaluate ['chatInputSearchSelectedIndex']
+      @reactor.dispatch actions.MOVE_TO_PREV_CHAT_INPUT_SEARCH_INDEX, { initiatorId }
+      selectedIndex = @reactor.evaluate(['chatInputSearchSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal prevIndex
 
@@ -66,14 +69,15 @@ describe 'ChatInputSearchSelectedIndexStore', ->
     it 'resets selected index', ->
 
       index = 3
+      initiatorId = 'test'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { index }
-      selectedIndex = @reactor.evaluate ['chatInputSearchSelectedIndex']
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId, index }
+      selectedIndex = @reactor.evaluate(['chatInputSearchSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal index
 
-      @reactor.dispatch actions.RESET_CHAT_INPUT_SEARCH_SELECTED_INDEX
-      selectedIndex = @reactor.evaluate ['chatInputSearchSelectedIndex']
+      @reactor.dispatch actions.RESET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId }
+      selectedIndex = @reactor.evaluate(['chatInputSearchSelectedIndex']).get initiatorId
 
-      expect(selectedIndex).to.equal 0
+      expect(selectedIndex).to.be.undefined
 

--- a/client/activity/lib/flux/test/chatinput/chatinputsearchselectedindexstore.coffee
+++ b/client/activity/lib/flux/test/chatinput/chatinputsearchselectedindexstore.coffee
@@ -18,10 +18,10 @@ describe 'ChatInputSearchSelectedIndexStore', ->
     it 'sets selected index', ->
 
       index = 3
-      initiatorId = 'test'
+      stateId = 'test'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId, index }
-      selectedIndex = @reactor.evaluate(['chatInputSearchSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { stateId, index }
+      selectedIndex = @reactor.evaluate(['chatInputSearchSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal index
 
@@ -31,16 +31,16 @@ describe 'ChatInputSearchSelectedIndexStore', ->
   	it 'moves to next index', ->
 
       index = 3
-      initiatorId = 'test'
+      stateId = 'test'
       nextIndex = index + 1
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId, index }
-      selectedIndex = @reactor.evaluate(['chatInputSearchSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { stateId, index }
+      selectedIndex = @reactor.evaluate(['chatInputSearchSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal index
       
-      @reactor.dispatch actions.MOVE_TO_NEXT_CHAT_INPUT_SEARCH_INDEX, { initiatorId }
-      selectedIndex = @reactor.evaluate(['chatInputSearchSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.MOVE_TO_NEXT_CHAT_INPUT_SEARCH_INDEX, { stateId }
+      selectedIndex = @reactor.evaluate(['chatInputSearchSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal nextIndex
 
@@ -50,16 +50,16 @@ describe 'ChatInputSearchSelectedIndexStore', ->
     it 'moves to prev index', ->
 
       index = 3
-      initiatorId = 'test'
+      stateId = 'test'
       prevIndex = index - 1
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId, index }
-      selectedIndex = @reactor.evaluate(['chatInputSearchSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { stateId, index }
+      selectedIndex = @reactor.evaluate(['chatInputSearchSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal index
       
-      @reactor.dispatch actions.MOVE_TO_PREV_CHAT_INPUT_SEARCH_INDEX, { initiatorId }
-      selectedIndex = @reactor.evaluate(['chatInputSearchSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.MOVE_TO_PREV_CHAT_INPUT_SEARCH_INDEX, { stateId }
+      selectedIndex = @reactor.evaluate(['chatInputSearchSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal prevIndex
 
@@ -69,15 +69,15 @@ describe 'ChatInputSearchSelectedIndexStore', ->
     it 'resets selected index', ->
 
       index = 3
-      initiatorId = 'test'
+      stateId = 'test'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId, index }
-      selectedIndex = @reactor.evaluate(['chatInputSearchSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { stateId, index }
+      selectedIndex = @reactor.evaluate(['chatInputSearchSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal index
 
-      @reactor.dispatch actions.RESET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { initiatorId }
-      selectedIndex = @reactor.evaluate(['chatInputSearchSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.RESET_CHAT_INPUT_SEARCH_SELECTED_INDEX, { stateId }
+      selectedIndex = @reactor.evaluate(['chatInputSearchSelectedIndex']).get stateId
 
       expect(selectedIndex).to.be.undefined
 

--- a/client/activity/lib/flux/test/chatinput/chatinputsearchstore.coffee
+++ b/client/activity/lib/flux/test/chatinput/chatinputsearchstore.coffee
@@ -24,8 +24,10 @@ describe 'ChatInputSearchStore', ->
         { id : '1', body : message1 }
         { id : '2', body : message2 }
       ]
-      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_SUCCESS, { items }
-      searchItems = @reactor.evaluate ['chatInputSearchItems']
+      initiatorId = '123'
+
+      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_SUCCESS, { initiatorId, items }
+      searchItems = @reactor.evaluate(['chatInputSearchItems']).get initiatorId
 
       expect(searchItems.size).to.equal items.length
       expect(searchItems.get(0).get('body')).to.equal message1
@@ -34,8 +36,8 @@ describe 'ChatInputSearchStore', ->
       items = [
         { id : '3', body : message3 }
       ]
-      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_SUCCESS, { items }
-      searchItems = @reactor.evaluate ['chatInputSearchItems']
+      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_SUCCESS, { initiatorId, items }
+      searchItems = @reactor.evaluate(['chatInputSearchItems']).get initiatorId
 
       expect(searchItems.size).to.equal items.length
       expect(searchItems.get(0).get('body')).to.equal message3
@@ -49,22 +51,23 @@ describe 'ChatInputSearchStore', ->
       { id : '1', body : message1 }
       { id : '2', body : message2 }
     ]
+    initiatorId = '123'
 
     it 'resets store data', ->
 
-      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_SUCCESS, { items }
+      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_SUCCESS, { initiatorId, items }
 
-      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_RESET
-      searchItems = @reactor.evaluate ['chatInputSearchItems']
+      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_RESET, { initiatorId }
+      searchItems = @reactor.evaluate(['chatInputSearchItems']).get initiatorId
 
-      expect(searchItems.size).to.equal 0
+      expect(searchItems).to.be.undefined
 
     it 'handles fetch data failure', ->
 
-      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_SUCCESS, { items }
+      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_SUCCESS, { initiatorId, items }
 
-      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_FAIL
-      searchItems = @reactor.evaluate ['chatInputSearchItems']
+      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_FAIL, { initiatorId }
+      searchItems = @reactor.evaluate(['chatInputSearchItems']).get initiatorId
 
-      expect(searchItems.size).to.equal 0
+      expect(searchItems).to.be.undefined
 

--- a/client/activity/lib/flux/test/chatinput/chatinputsearchstore.coffee
+++ b/client/activity/lib/flux/test/chatinput/chatinputsearchstore.coffee
@@ -24,10 +24,10 @@ describe 'ChatInputSearchStore', ->
         { id : '1', body : message1 }
         { id : '2', body : message2 }
       ]
-      initiatorId = '123'
+      stateId = '123'
 
-      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_SUCCESS, { initiatorId, items }
-      searchItems = @reactor.evaluate(['chatInputSearchItems']).get initiatorId
+      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_SUCCESS, { stateId, items }
+      searchItems = @reactor.evaluate(['chatInputSearchItems']).get stateId
 
       expect(searchItems.size).to.equal items.length
       expect(searchItems.get(0).get('body')).to.equal message1
@@ -36,8 +36,8 @@ describe 'ChatInputSearchStore', ->
       items = [
         { id : '3', body : message3 }
       ]
-      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_SUCCESS, { initiatorId, items }
-      searchItems = @reactor.evaluate(['chatInputSearchItems']).get initiatorId
+      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_SUCCESS, { stateId, items }
+      searchItems = @reactor.evaluate(['chatInputSearchItems']).get stateId
 
       expect(searchItems.size).to.equal items.length
       expect(searchItems.get(0).get('body')).to.equal message3
@@ -51,23 +51,23 @@ describe 'ChatInputSearchStore', ->
       { id : '1', body : message1 }
       { id : '2', body : message2 }
     ]
-    initiatorId = '123'
+    stateId = '123'
 
     it 'resets store data', ->
 
-      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_SUCCESS, { initiatorId, items }
+      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_SUCCESS, { stateId, items }
 
-      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_RESET, { initiatorId }
-      searchItems = @reactor.evaluate(['chatInputSearchItems']).get initiatorId
+      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_RESET, { stateId }
+      searchItems = @reactor.evaluate(['chatInputSearchItems']).get stateId
 
       expect(searchItems).to.be.undefined
 
     it 'handles fetch data failure', ->
 
-      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_SUCCESS, { initiatorId, items }
+      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_SUCCESS, { stateId, items }
 
-      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_FAIL, { initiatorId }
-      searchItems = @reactor.evaluate(['chatInputSearchItems']).get initiatorId
+      @reactor.dispatch actionTypes.CHAT_INPUT_SEARCH_FAIL, { stateId }
+      searchItems = @reactor.evaluate(['chatInputSearchItems']).get stateId
 
       expect(searchItems).to.be.undefined
 

--- a/client/activity/lib/flux/test/chatinput/chatinputsearchvisibilitystore.coffee
+++ b/client/activity/lib/flux/test/chatinput/chatinputsearchvisibilitystore.coffee
@@ -17,13 +17,15 @@ describe 'ChatInputSearchVisibilityStore', ->
 
     it 'sets visibility', ->
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_VISIBILITY, { visible : yes }
-      visible = @reactor.evaluate ['chatInputSearchVisibility']
+      initiatorId = '123'
+
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_VISIBILITY, { initiatorId, visible : yes }
+      visible = @reactor.evaluate(['chatInputSearchVisibility']).get initiatorId
 
       expect(visible).to.be.true
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_VISIBILITY, { visible : no }
-      visible = @reactor.evaluate ['chatInputSearchVisibility']
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_VISIBILITY, { initiatorId, visible : no }
+      visible = @reactor.evaluate(['chatInputSearchVisibility']).get initiatorId
 
       expect(visible).to.be.false
 

--- a/client/activity/lib/flux/test/chatinput/chatinputsearchvisibilitystore.coffee
+++ b/client/activity/lib/flux/test/chatinput/chatinputsearchvisibilitystore.coffee
@@ -17,15 +17,15 @@ describe 'ChatInputSearchVisibilityStore', ->
 
     it 'sets visibility', ->
 
-      initiatorId = '123'
+      stateId = '123'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_VISIBILITY, { initiatorId, visible : yes }
-      visible = @reactor.evaluate(['chatInputSearchVisibility']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_VISIBILITY, { stateId, visible : yes }
+      visible = @reactor.evaluate(['chatInputSearchVisibility']).get stateId
 
       expect(visible).to.be.true
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_VISIBILITY, { initiatorId, visible : no }
-      visible = @reactor.evaluate(['chatInputSearchVisibility']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_SEARCH_VISIBILITY, { stateId, visible : no }
+      visible = @reactor.evaluate(['chatInputSearchVisibility']).get stateId
 
       expect(visible).to.be.false
 

--- a/client/activity/lib/flux/test/chatinput/chatinputusersquerystore.coffee
+++ b/client/activity/lib/flux/test/chatinput/chatinputusersquerystore.coffee
@@ -19,14 +19,15 @@ describe 'ChatInputUsersQueryStore', ->
 
       query1 = 'ben'
       query2 = 'john'
+      initiatorId = '123'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_QUERY, query : query1
-      query = @reactor.evaluate ['chatInputUsersQuery']
+      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_QUERY, { initiatorId, query : query1 }
+      query = @reactor.evaluate(['chatInputUsersQuery']).get initiatorId
 
       expect(query).to.equal query1
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_QUERY, query: query2
-      query = @reactor.evaluate ['chatInputUsersQuery']
+      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_QUERY, { initiatorId, query: query2 }
+      query = @reactor.evaluate(['chatInputUsersQuery']).get initiatorId
 
       expect(query).to.equal query2
 
@@ -36,14 +37,15 @@ describe 'ChatInputUsersQueryStore', ->
     it 'clears current query', ->
 
       testQuery = 'alex'
+      initiatorId = '123'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_QUERY, query : testQuery
-      query = @reactor.evaluate ['chatInputUsersQuery']
+      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_QUERY, { initiatorId, query : testQuery }
+      query = @reactor.evaluate(['chatInputUsersQuery']).get initiatorId
 
       expect(query).to.equal testQuery
 
-      @reactor.dispatch actions.UNSET_CHAT_INPUT_USERS_QUERY
-      query = @reactor.evaluate ['chatInputUsersQuery']
+      @reactor.dispatch actions.UNSET_CHAT_INPUT_USERS_QUERY, { initiatorId }
+      query = @reactor.evaluate(['chatInputUsersQuery']).get initiatorId
 
-      expect(query).to.be.null
+      expect(query).to.be.undefined
 

--- a/client/activity/lib/flux/test/chatinput/chatinputusersquerystore.coffee
+++ b/client/activity/lib/flux/test/chatinput/chatinputusersquerystore.coffee
@@ -19,15 +19,15 @@ describe 'ChatInputUsersQueryStore', ->
 
       query1 = 'ben'
       query2 = 'john'
-      initiatorId = '123'
+      stateId = '123'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_QUERY, { initiatorId, query : query1 }
-      query = @reactor.evaluate(['chatInputUsersQuery']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_QUERY, { stateId, query : query1 }
+      query = @reactor.evaluate(['chatInputUsersQuery']).get stateId
 
       expect(query).to.equal query1
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_QUERY, { initiatorId, query: query2 }
-      query = @reactor.evaluate(['chatInputUsersQuery']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_QUERY, { stateId, query: query2 }
+      query = @reactor.evaluate(['chatInputUsersQuery']).get stateId
 
       expect(query).to.equal query2
 
@@ -37,15 +37,15 @@ describe 'ChatInputUsersQueryStore', ->
     it 'clears current query', ->
 
       testQuery = 'alex'
-      initiatorId = '123'
+      stateId = '123'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_QUERY, { initiatorId, query : testQuery }
-      query = @reactor.evaluate(['chatInputUsersQuery']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_QUERY, { stateId, query : testQuery }
+      query = @reactor.evaluate(['chatInputUsersQuery']).get stateId
 
       expect(query).to.equal testQuery
 
-      @reactor.dispatch actions.UNSET_CHAT_INPUT_USERS_QUERY, { initiatorId }
-      query = @reactor.evaluate(['chatInputUsersQuery']).get initiatorId
+      @reactor.dispatch actions.UNSET_CHAT_INPUT_USERS_QUERY, { stateId }
+      query = @reactor.evaluate(['chatInputUsersQuery']).get stateId
 
       expect(query).to.be.undefined
 

--- a/client/activity/lib/flux/test/chatinput/chatinputusersselectedindexstore.coffee
+++ b/client/activity/lib/flux/test/chatinput/chatinputusersselectedindexstore.coffee
@@ -18,10 +18,10 @@ describe 'ChatInputUsersSelectedIndexStore', ->
     it 'sets selected index', ->
 
       index = 1
-      initiatorId = '123'
+      stateId = '123'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_SELECTED_INDEX, { initiatorId, index }
-      selectedIndex = @reactor.evaluate(['chatInputUsersSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_SELECTED_INDEX, { stateId, index }
+      selectedIndex = @reactor.evaluate(['chatInputUsersSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal index
 
@@ -31,16 +31,16 @@ describe 'ChatInputUsersSelectedIndexStore', ->
   	it 'moves to next index', ->
 
       index = 1
-      initiatorId = '123'
+      stateId = '123'
       nextIndex = index + 1
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_SELECTED_INDEX, { initiatorId, index }
-      selectedIndex = @reactor.evaluate(['chatInputUsersSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_SELECTED_INDEX, { stateId, index }
+      selectedIndex = @reactor.evaluate(['chatInputUsersSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal index
       
-      @reactor.dispatch actions.MOVE_TO_NEXT_CHAT_INPUT_USERS_INDEX, { initiatorId }
-      selectedIndex = @reactor.evaluate(['chatInputUsersSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.MOVE_TO_NEXT_CHAT_INPUT_USERS_INDEX, { stateId }
+      selectedIndex = @reactor.evaluate(['chatInputUsersSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal nextIndex
 
@@ -50,16 +50,16 @@ describe 'ChatInputUsersSelectedIndexStore', ->
     it 'moves to prev index', ->
 
       index = 1
-      initiatorId = '123'
+      stateId = '123'
       prevIndex = index - 1
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_SELECTED_INDEX, { initiatorId, index }
-      selectedIndex = @reactor.evaluate(['chatInputUsersSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_SELECTED_INDEX, { stateId, index }
+      selectedIndex = @reactor.evaluate(['chatInputUsersSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal index
       
-      @reactor.dispatch actions.MOVE_TO_PREV_CHAT_INPUT_USERS_INDEX, { initiatorId }
-      selectedIndex = @reactor.evaluate(['chatInputUsersSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.MOVE_TO_PREV_CHAT_INPUT_USERS_INDEX, { stateId }
+      selectedIndex = @reactor.evaluate(['chatInputUsersSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal prevIndex
 
@@ -69,15 +69,15 @@ describe 'ChatInputUsersSelectedIndexStore', ->
     it 'resets selected index', ->
 
       index = 1
-      initiatorId = '123'
+      stateId = '123'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_SELECTED_INDEX, { initiatorId, index }
-      selectedIndex = @reactor.evaluate(['chatInputUsersSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_SELECTED_INDEX, { stateId, index }
+      selectedIndex = @reactor.evaluate(['chatInputUsersSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal index
 
-      @reactor.dispatch actions.RESET_CHAT_INPUT_USERS_SELECTED_INDEX, { initiatorId }
-      selectedIndex = @reactor.evaluate(['chatInputUsersSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.RESET_CHAT_INPUT_USERS_SELECTED_INDEX, { stateId }
+      selectedIndex = @reactor.evaluate(['chatInputUsersSelectedIndex']).get stateId
 
       expect(selectedIndex).to.be.undefined
 

--- a/client/activity/lib/flux/test/chatinput/chatinputusersselectedindexstore.coffee
+++ b/client/activity/lib/flux/test/chatinput/chatinputusersselectedindexstore.coffee
@@ -18,9 +18,10 @@ describe 'ChatInputUsersSelectedIndexStore', ->
     it 'sets selected index', ->
 
       index = 1
+      initiatorId = '123'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_SELECTED_INDEX, { index }
-      selectedIndex = @reactor.evaluate ['chatInputUsersSelectedIndex']
+      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_SELECTED_INDEX, { initiatorId, index }
+      selectedIndex = @reactor.evaluate(['chatInputUsersSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal index
 
@@ -30,15 +31,16 @@ describe 'ChatInputUsersSelectedIndexStore', ->
   	it 'moves to next index', ->
 
       index = 1
+      initiatorId = '123'
       nextIndex = index + 1
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_SELECTED_INDEX, { index }
-      selectedIndex = @reactor.evaluate ['chatInputUsersSelectedIndex']
+      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_SELECTED_INDEX, { initiatorId, index }
+      selectedIndex = @reactor.evaluate(['chatInputUsersSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal index
       
-      @reactor.dispatch actions.MOVE_TO_NEXT_CHAT_INPUT_USERS_INDEX
-      selectedIndex = @reactor.evaluate ['chatInputUsersSelectedIndex']
+      @reactor.dispatch actions.MOVE_TO_NEXT_CHAT_INPUT_USERS_INDEX, { initiatorId }
+      selectedIndex = @reactor.evaluate(['chatInputUsersSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal nextIndex
 
@@ -48,15 +50,16 @@ describe 'ChatInputUsersSelectedIndexStore', ->
     it 'moves to prev index', ->
 
       index = 1
+      initiatorId = '123'
       prevIndex = index - 1
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_SELECTED_INDEX, { index }
-      selectedIndex = @reactor.evaluate ['chatInputUsersSelectedIndex']
+      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_SELECTED_INDEX, { initiatorId, index }
+      selectedIndex = @reactor.evaluate(['chatInputUsersSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal index
       
-      @reactor.dispatch actions.MOVE_TO_PREV_CHAT_INPUT_USERS_INDEX
-      selectedIndex = @reactor.evaluate ['chatInputUsersSelectedIndex']
+      @reactor.dispatch actions.MOVE_TO_PREV_CHAT_INPUT_USERS_INDEX, { initiatorId }
+      selectedIndex = @reactor.evaluate(['chatInputUsersSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal prevIndex
 
@@ -66,14 +69,15 @@ describe 'ChatInputUsersSelectedIndexStore', ->
     it 'resets selected index', ->
 
       index = 1
+      initiatorId = '123'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_SELECTED_INDEX, { index }
-      selectedIndex = @reactor.evaluate ['chatInputUsersSelectedIndex']
+      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_SELECTED_INDEX, { initiatorId, index }
+      selectedIndex = @reactor.evaluate(['chatInputUsersSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal index
 
-      @reactor.dispatch actions.RESET_CHAT_INPUT_USERS_SELECTED_INDEX
-      selectedIndex = @reactor.evaluate ['chatInputUsersSelectedIndex']
+      @reactor.dispatch actions.RESET_CHAT_INPUT_USERS_SELECTED_INDEX, { initiatorId }
+      selectedIndex = @reactor.evaluate(['chatInputUsersSelectedIndex']).get initiatorId
 
-      expect(selectedIndex).to.equal 0
+      expect(selectedIndex).to.be.undefined
 

--- a/client/activity/lib/flux/test/chatinput/chatinputusersvisibilitystore.coffee
+++ b/client/activity/lib/flux/test/chatinput/chatinputusersvisibilitystore.coffee
@@ -17,15 +17,15 @@ describe 'ChatInputUsersVisibilityStore', ->
 
     it 'sets visibility', ->
 
-      initiatorId = 'test'
+      stateId = 'test'
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_VISIBILITY, { initiatorId, visible : yes }
-      visible = @reactor.evaluate(['chatInputUsersVisibility']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_VISIBILITY, { stateId, visible : yes }
+      visible = @reactor.evaluate(['chatInputUsersVisibility']).get stateId
 
       expect(visible).to.be.true
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_VISIBILITY, { initiatorId, visible : no }
-      visible = @reactor.evaluate(['chatInputUsersVisibility']).get initiatorId
+      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_VISIBILITY, { stateId, visible : no }
+      visible = @reactor.evaluate(['chatInputUsersVisibility']).get stateId
 
       expect(visible).to.be.false
 

--- a/client/activity/lib/flux/test/chatinput/chatinputusersvisibilitystore.coffee
+++ b/client/activity/lib/flux/test/chatinput/chatinputusersvisibilitystore.coffee
@@ -17,13 +17,15 @@ describe 'ChatInputUsersVisibilityStore', ->
 
     it 'sets visibility', ->
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_VISIBILITY, { visible : yes }
-      visible = @reactor.evaluate ['chatInputUsersVisibility']
+      initiatorId = 'test'
+
+      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_VISIBILITY, { initiatorId, visible : yes }
+      visible = @reactor.evaluate(['chatInputUsersVisibility']).get initiatorId
 
       expect(visible).to.be.true
 
-      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_VISIBILITY, { visible : no }
-      visible = @reactor.evaluate ['chatInputUsersVisibility']
+      @reactor.dispatch actions.SET_CHAT_INPUT_USERS_VISIBILITY, { initiatorId, visible : no }
+      visible = @reactor.evaluate(['chatInputUsersVisibility']).get initiatorId
 
       expect(visible).to.be.false
 

--- a/client/activity/lib/flux/test/chatinput/commonemojilistselectedindexstore.coffee
+++ b/client/activity/lib/flux/test/chatinput/commonemojilistselectedindexstore.coffee
@@ -18,9 +18,10 @@ describe 'CommonEmojiListSelectedIndexStore', ->
     it 'sets selected index', ->
 
       index = 5
+      initiatorId = '123'
 
-      @reactor.dispatch actions.SET_COMMON_EMOJI_LIST_SELECTED_INDEX, { index }
-      selectedIndex = @reactor.evaluate ['commonEmojiListSelectedIndex']
+      @reactor.dispatch actions.SET_COMMON_EMOJI_LIST_SELECTED_INDEX, { initiatorId, index }
+      selectedIndex = @reactor.evaluate(['commonEmojiListSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal index
 
@@ -30,14 +31,15 @@ describe 'CommonEmojiListSelectedIndexStore', ->
     it 'resets selected index', ->
 
       index = 5
+      initiatorId = '123'
 
-      @reactor.dispatch actions.SET_COMMON_EMOJI_LIST_SELECTED_INDEX, { index }
-      selectedIndex = @reactor.evaluate ['commonEmojiListSelectedIndex']
+      @reactor.dispatch actions.SET_COMMON_EMOJI_LIST_SELECTED_INDEX, { initiatorId, index }
+      selectedIndex = @reactor.evaluate(['commonEmojiListSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal index
 
-      @reactor.dispatch actions.RESET_COMMON_EMOJI_LIST_SELECTED_INDEX
-      selectedIndex = @reactor.evaluate ['commonEmojiListSelectedIndex']
+      @reactor.dispatch actions.RESET_COMMON_EMOJI_LIST_SELECTED_INDEX, { initiatorId }
+      selectedIndex = @reactor.evaluate(['commonEmojiListSelectedIndex']).get initiatorId
 
-      expect(selectedIndex).to.equal 0
+      expect(selectedIndex).to.be.undefined
 

--- a/client/activity/lib/flux/test/chatinput/commonemojilistselectedindexstore.coffee
+++ b/client/activity/lib/flux/test/chatinput/commonemojilistselectedindexstore.coffee
@@ -18,10 +18,10 @@ describe 'CommonEmojiListSelectedIndexStore', ->
     it 'sets selected index', ->
 
       index = 5
-      initiatorId = '123'
+      stateId = '123'
 
-      @reactor.dispatch actions.SET_COMMON_EMOJI_LIST_SELECTED_INDEX, { initiatorId, index }
-      selectedIndex = @reactor.evaluate(['commonEmojiListSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.SET_COMMON_EMOJI_LIST_SELECTED_INDEX, { stateId, index }
+      selectedIndex = @reactor.evaluate(['commonEmojiListSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal index
 
@@ -31,15 +31,15 @@ describe 'CommonEmojiListSelectedIndexStore', ->
     it 'resets selected index', ->
 
       index = 5
-      initiatorId = '123'
+      stateId = '123'
 
-      @reactor.dispatch actions.SET_COMMON_EMOJI_LIST_SELECTED_INDEX, { initiatorId, index }
-      selectedIndex = @reactor.evaluate(['commonEmojiListSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.SET_COMMON_EMOJI_LIST_SELECTED_INDEX, { stateId, index }
+      selectedIndex = @reactor.evaluate(['commonEmojiListSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal index
 
-      @reactor.dispatch actions.RESET_COMMON_EMOJI_LIST_SELECTED_INDEX, { initiatorId }
-      selectedIndex = @reactor.evaluate(['commonEmojiListSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.RESET_COMMON_EMOJI_LIST_SELECTED_INDEX, { stateId }
+      selectedIndex = @reactor.evaluate(['commonEmojiListSelectedIndex']).get stateId
 
       expect(selectedIndex).to.be.undefined
 

--- a/client/activity/lib/flux/test/chatinput/commonemojilistvisibilitystore.coffee
+++ b/client/activity/lib/flux/test/chatinput/commonemojilistvisibilitystore.coffee
@@ -17,13 +17,15 @@ describe 'CommonEmojiListVisibilityStore', ->
 
     it 'sets visibility', ->
 
-      @reactor.dispatch actions.SET_COMMON_EMOJI_LIST_VISIBILITY, { visible : yes }
-      visible = @reactor.evaluate ['commonEmojiListVisibility']
+      initiatorId = '123'
+
+      @reactor.dispatch actions.SET_COMMON_EMOJI_LIST_VISIBILITY, { initiatorId, visible : yes }
+      visible = @reactor.evaluate(['commonEmojiListVisibility']).get initiatorId
 
       expect(visible).to.be.true
 
-      @reactor.dispatch actions.SET_COMMON_EMOJI_LIST_VISIBILITY, { visible : no }
-      visible = @reactor.evaluate ['commonEmojiListVisibility']
+      @reactor.dispatch actions.SET_COMMON_EMOJI_LIST_VISIBILITY, { initiatorId, visible : no }
+      visible = @reactor.evaluate(['commonEmojiListVisibility']).get initiatorId
 
       expect(visible).to.be.false
 

--- a/client/activity/lib/flux/test/chatinput/commonemojilistvisibilitystore.coffee
+++ b/client/activity/lib/flux/test/chatinput/commonemojilistvisibilitystore.coffee
@@ -17,15 +17,15 @@ describe 'CommonEmojiListVisibilityStore', ->
 
     it 'sets visibility', ->
 
-      initiatorId = '123'
+      stateId = '123'
 
-      @reactor.dispatch actions.SET_COMMON_EMOJI_LIST_VISIBILITY, { initiatorId, visible : yes }
-      visible = @reactor.evaluate(['commonEmojiListVisibility']).get initiatorId
+      @reactor.dispatch actions.SET_COMMON_EMOJI_LIST_VISIBILITY, { stateId, visible : yes }
+      visible = @reactor.evaluate(['commonEmojiListVisibility']).get stateId
 
       expect(visible).to.be.true
 
-      @reactor.dispatch actions.SET_COMMON_EMOJI_LIST_VISIBILITY, { initiatorId, visible : no }
-      visible = @reactor.evaluate(['commonEmojiListVisibility']).get initiatorId
+      @reactor.dispatch actions.SET_COMMON_EMOJI_LIST_VISIBILITY, { stateId, visible : no }
+      visible = @reactor.evaluate(['commonEmojiListVisibility']).get stateId
 
       expect(visible).to.be.false
 

--- a/client/activity/lib/flux/test/chatinput/filteredemojilistquerystore.coffee
+++ b/client/activity/lib/flux/test/chatinput/filteredemojilistquerystore.coffee
@@ -19,14 +19,15 @@ describe 'FilteredEmojiListQueryStore', ->
 
       query1 = 'smile'
       query2 = '+1'
+      initiatorId = 'qwerty'
 
-      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_QUERY, query : query1
-      query = @reactor.evaluate ['filteredEmojiListQuery']
+      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_QUERY, { initiatorId, query : query1 }
+      query = @reactor.evaluate(['filteredEmojiListQuery']).get initiatorId
 
       expect(query).to.equal query1
 
-      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_QUERY, query: query2
-      query = @reactor.evaluate ['filteredEmojiListQuery']
+      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_QUERY, { initiatorId, query: query2 }
+      query = @reactor.evaluate(['filteredEmojiListQuery']).get initiatorId
 
       expect(query).to.equal query2
 
@@ -36,14 +37,15 @@ describe 'FilteredEmojiListQueryStore', ->
     it 'clears current query', ->
 
       testQuery = 'smile'
+      initiatorId = 'qwerty'
 
-      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_QUERY, query : testQuery
-      query = @reactor.evaluate ['filteredEmojiListQuery']
+      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_QUERY, { initiatorId, query : testQuery }
+      query = @reactor.evaluate(['filteredEmojiListQuery']).get initiatorId
 
       expect(query).to.equal testQuery
 
-      @reactor.dispatch actions.UNSET_FILTERED_EMOJI_LIST_QUERY
-      query = @reactor.evaluate ['filteredEmojiListQuery']
+      @reactor.dispatch actions.UNSET_FILTERED_EMOJI_LIST_QUERY, { initiatorId }
+      query = @reactor.evaluate(['filteredEmojiListQuery']).get initiatorId
 
-      expect(query).to.be.null
+      expect(query).to.be.undefined
 

--- a/client/activity/lib/flux/test/chatinput/filteredemojilistquerystore.coffee
+++ b/client/activity/lib/flux/test/chatinput/filteredemojilistquerystore.coffee
@@ -19,15 +19,15 @@ describe 'FilteredEmojiListQueryStore', ->
 
       query1 = 'smile'
       query2 = '+1'
-      initiatorId = 'qwerty'
+      stateId = 'qwerty'
 
-      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_QUERY, { initiatorId, query : query1 }
-      query = @reactor.evaluate(['filteredEmojiListQuery']).get initiatorId
+      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_QUERY, { stateId, query : query1 }
+      query = @reactor.evaluate(['filteredEmojiListQuery']).get stateId
 
       expect(query).to.equal query1
 
-      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_QUERY, { initiatorId, query: query2 }
-      query = @reactor.evaluate(['filteredEmojiListQuery']).get initiatorId
+      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_QUERY, { stateId, query: query2 }
+      query = @reactor.evaluate(['filteredEmojiListQuery']).get stateId
 
       expect(query).to.equal query2
 
@@ -37,15 +37,15 @@ describe 'FilteredEmojiListQueryStore', ->
     it 'clears current query', ->
 
       testQuery = 'smile'
-      initiatorId = 'qwerty'
+      stateId = 'qwerty'
 
-      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_QUERY, { initiatorId, query : testQuery }
-      query = @reactor.evaluate(['filteredEmojiListQuery']).get initiatorId
+      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_QUERY, { stateId, query : testQuery }
+      query = @reactor.evaluate(['filteredEmojiListQuery']).get stateId
 
       expect(query).to.equal testQuery
 
-      @reactor.dispatch actions.UNSET_FILTERED_EMOJI_LIST_QUERY, { initiatorId }
-      query = @reactor.evaluate(['filteredEmojiListQuery']).get initiatorId
+      @reactor.dispatch actions.UNSET_FILTERED_EMOJI_LIST_QUERY, { stateId }
+      query = @reactor.evaluate(['filteredEmojiListQuery']).get stateId
 
       expect(query).to.be.undefined
 

--- a/client/activity/lib/flux/test/chatinput/filteredemojilistselectedindexstore.coffee
+++ b/client/activity/lib/flux/test/chatinput/filteredemojilistselectedindexstore.coffee
@@ -18,10 +18,10 @@ describe 'FilteredEmojiListSelectedIndexStore', ->
     it 'sets selected index', ->
 
       index = 5
-      initiatorId = 'qwerty'
+      stateId = 'qwerty'
 
-      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { initiatorId, index }
-      selectedIndex = @reactor.evaluate(['filteredEmojiListSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { stateId, index }
+      selectedIndex = @reactor.evaluate(['filteredEmojiListSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal index
 
@@ -31,16 +31,16 @@ describe 'FilteredEmojiListSelectedIndexStore', ->
   	it 'moves to next index', ->
 
       index = 5
-      initiatorId = 'qwerty'
+      stateId = 'qwerty'
       nextIndex = index + 1
 
-      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { initiatorId, index }
-      selectedIndex = @reactor.evaluate(['filteredEmojiListSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { stateId, index }
+      selectedIndex = @reactor.evaluate(['filteredEmojiListSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal index
       
-      @reactor.dispatch actions.MOVE_TO_NEXT_FILTERED_EMOJI_LIST_INDEX, { initiatorId }
-      selectedIndex = @reactor.evaluate(['filteredEmojiListSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.MOVE_TO_NEXT_FILTERED_EMOJI_LIST_INDEX, { stateId }
+      selectedIndex = @reactor.evaluate(['filteredEmojiListSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal nextIndex
 
@@ -50,16 +50,16 @@ describe 'FilteredEmojiListSelectedIndexStore', ->
     it 'moves to prev index', ->
 
       index = 5
-      initiatorId = 'qwerty'
+      stateId = 'qwerty'
       prevIndex = index - 1
 
-      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { initiatorId, index }
-      selectedIndex = @reactor.evaluate(['filteredEmojiListSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { stateId, index }
+      selectedIndex = @reactor.evaluate(['filteredEmojiListSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal index
       
-      @reactor.dispatch actions.MOVE_TO_PREV_FILTERED_EMOJI_LIST_INDEX, { initiatorId }
-      selectedIndex = @reactor.evaluate(['filteredEmojiListSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.MOVE_TO_PREV_FILTERED_EMOJI_LIST_INDEX, { stateId }
+      selectedIndex = @reactor.evaluate(['filteredEmojiListSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal prevIndex
 
@@ -69,15 +69,15 @@ describe 'FilteredEmojiListSelectedIndexStore', ->
     it 'resets selected index', ->
 
       index = 5
-      initiatorId = 'qwerty'
+      stateId = 'qwerty'
 
-      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { initiatorId, index }
-      selectedIndex = @reactor.evaluate(['filteredEmojiListSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { stateId, index }
+      selectedIndex = @reactor.evaluate(['filteredEmojiListSelectedIndex']).get stateId
 
       expect(selectedIndex).to.equal index
 
-      @reactor.dispatch actions.RESET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { initiatorId }
-      selectedIndex = @reactor.evaluate(['filteredEmojiListSelectedIndex']).get initiatorId
+      @reactor.dispatch actions.RESET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { stateId }
+      selectedIndex = @reactor.evaluate(['filteredEmojiListSelectedIndex']).get stateId
 
       expect(selectedIndex).to.be.undefined
 

--- a/client/activity/lib/flux/test/chatinput/filteredemojilistselectedindexstore.coffee
+++ b/client/activity/lib/flux/test/chatinput/filteredemojilistselectedindexstore.coffee
@@ -18,9 +18,10 @@ describe 'FilteredEmojiListSelectedIndexStore', ->
     it 'sets selected index', ->
 
       index = 5
+      initiatorId = 'qwerty'
 
-      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { index }
-      selectedIndex = @reactor.evaluate ['filteredEmojiListSelectedIndex']
+      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { initiatorId, index }
+      selectedIndex = @reactor.evaluate(['filteredEmojiListSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal index
 
@@ -30,15 +31,16 @@ describe 'FilteredEmojiListSelectedIndexStore', ->
   	it 'moves to next index', ->
 
       index = 5
+      initiatorId = 'qwerty'
       nextIndex = index + 1
 
-      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { index }
-      selectedIndex = @reactor.evaluate ['filteredEmojiListSelectedIndex']
+      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { initiatorId, index }
+      selectedIndex = @reactor.evaluate(['filteredEmojiListSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal index
       
-      @reactor.dispatch actions.MOVE_TO_NEXT_FILTERED_EMOJI_LIST_INDEX
-      selectedIndex = @reactor.evaluate ['filteredEmojiListSelectedIndex']
+      @reactor.dispatch actions.MOVE_TO_NEXT_FILTERED_EMOJI_LIST_INDEX, { initiatorId }
+      selectedIndex = @reactor.evaluate(['filteredEmojiListSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal nextIndex
 
@@ -48,15 +50,16 @@ describe 'FilteredEmojiListSelectedIndexStore', ->
     it 'moves to prev index', ->
 
       index = 5
+      initiatorId = 'qwerty'
       prevIndex = index - 1
 
-      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { index }
-      selectedIndex = @reactor.evaluate ['filteredEmojiListSelectedIndex']
+      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { initiatorId, index }
+      selectedIndex = @reactor.evaluate(['filteredEmojiListSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal index
       
-      @reactor.dispatch actions.MOVE_TO_PREV_FILTERED_EMOJI_LIST_INDEX
-      selectedIndex = @reactor.evaluate ['filteredEmojiListSelectedIndex']
+      @reactor.dispatch actions.MOVE_TO_PREV_FILTERED_EMOJI_LIST_INDEX, { initiatorId }
+      selectedIndex = @reactor.evaluate(['filteredEmojiListSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal prevIndex
 
@@ -66,14 +69,15 @@ describe 'FilteredEmojiListSelectedIndexStore', ->
     it 'resets selected index', ->
 
       index = 5
+      initiatorId = 'qwerty'
 
-      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { index }
-      selectedIndex = @reactor.evaluate ['filteredEmojiListSelectedIndex']
+      @reactor.dispatch actions.SET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { initiatorId, index }
+      selectedIndex = @reactor.evaluate(['filteredEmojiListSelectedIndex']).get initiatorId
 
       expect(selectedIndex).to.equal index
 
-      @reactor.dispatch actions.RESET_FILTERED_EMOJI_LIST_SELECTED_INDEX
-      selectedIndex = @reactor.evaluate ['filteredEmojiListSelectedIndex']
+      @reactor.dispatch actions.RESET_FILTERED_EMOJI_LIST_SELECTED_INDEX, { initiatorId }
+      selectedIndex = @reactor.evaluate(['filteredEmojiListSelectedIndex']).get initiatorId
 
-      expect(selectedIndex).to.equal 0
+      expect(selectedIndex).to.be.undefined
 

--- a/client/app/lib/flux/reactormixin.coffee
+++ b/client/app/lib/flux/reactormixin.coffee
@@ -9,8 +9,8 @@ module.exports =
 
   getInitialState: ->
 
-    @id = kd.utils.getUniqueId()  unless @id
-    getState kd.singletons.reactor, @getDataBindings(), @id
+    @stateId = kd.utils.getUniqueId()  unless @stateId
+    getState kd.singletons.reactor, @getDataBindings(), @stateId
 
 
   componentDidMount: ->
@@ -19,13 +19,13 @@ module.exports =
     { reactor } = kd.singletons
 
     bindings = component.getDataBindings()
-    id       = component.id
+    stateId  = component.stateId
 
-    state = _.assign component.state, getState(reactor, bindings, id)
+    state = _.assign component.state, getState(reactor, bindings, stateId)
     component.__unwatchFns = []
 
     _.each bindings, (getter, key) ->
-      getter = processGetter getter, id
+      getter = processGetter getter, stateId
       unwatchFn = reactor.observe getter, (val) ->
         newState = {}
         newState[key] = val
@@ -44,13 +44,13 @@ module.exports =
  * Returns a mapping of the getDataBinding keys to
  * the reactor values
 ###
-getState = (reactor, data, id) ->
+getState = (reactor, data, stateId) ->
 
-  return _.mapValues data, (value) -> reactor.evaluate processGetter(value, id)
+  return _.mapValues data, (value) -> reactor.evaluate processGetter(value, stateId)
 
 
-processGetter = (getter, id) ->
+processGetter = (getter, stateId) ->
 
   if typeof getter is 'function'
-    return getter id
+    return getter stateId
   return getter

--- a/client/app/lib/flux/reactormixin.coffee
+++ b/client/app/lib/flux/reactormixin.coffee
@@ -10,7 +10,7 @@ module.exports =
   getInitialState: ->
 
     @stateId = kd.utils.getUniqueId()  unless @stateId
-    getState kd.singletons.reactor, @getDataBindings(), @stateId
+    getState kd.singletons.reactor, @getDataBindings()
 
 
   componentDidMount: ->
@@ -19,13 +19,11 @@ module.exports =
     { reactor } = kd.singletons
 
     bindings = component.getDataBindings()
-    stateId  = component.stateId
 
-    state = _.assign component.state, getState(reactor, bindings, stateId)
+    state = _.assign component.state, getState(reactor, bindings)
     component.__unwatchFns = []
 
     _.each bindings, (getter, key) ->
-      getter = processGetter getter, stateId
       unwatchFn = reactor.observe getter, (val) ->
         newState = {}
         newState[key] = val
@@ -44,13 +42,8 @@ module.exports =
  * Returns a mapping of the getDataBinding keys to
  * the reactor values
 ###
-getState = (reactor, data, stateId) ->
+getState = (reactor, data) ->
 
-  return _.mapValues data, (value) -> reactor.evaluate processGetter(value, stateId)
+  return _.mapValues data, (value) -> reactor.evaluate value
 
 
-processGetter = (getter, stateId) ->
-
-  if typeof getter is 'function'
-    return getter stateId
-  return getter


### PR DESCRIPTION
continuation of #4852 

Original description from @alex-ionochkin:

> @usirin, can you review these changes which make possible to have multiple same components like `ChatInputWidget` on the same page?
> 
> Here is what I do:
> - `ReactorMixin` generates unique `stateId` and passes it to getters if getters are functions
> - Getters attached to multiple components on the page should be converted to functions and accept `stateId` as parameter in order to return value from store using `stateId` as key
> - When component calls an action, it passes `stateId` as parameter to action
> - Store saves a value from action using `stateId` as key. For example, if we have 2 `ChatInputWidget`s on the page, `ChatInputChannelsVisibilityStore` can have 2 separate keys - one for each widget - and 2 values for them accordingly
> 
> Thus, we can put multiple same components on the page and they will work independently
> 
> /cc @sinan 

Main difference between #4852 and this is that this pr doesn't depend on an implicit `processGetter` function, because of the fact that if we go implicity way we wouldn't be able to use `function` type of getters with more than one arguments. This PR, instead, easily pass the `this.stateId` of component to getter itself in `getDataBindings` method. So that if, in the future, we want to pass `stateId` as 2nd argument we can do that, along with other type of arguments, since we basically have access to the `props` inside of `getDataBindings` method.
