### PR TITLE
Readme support for JStackTemplates

### DIFF
--- a/client/admin/lib/styl/app.group.admin.styl
+++ b/client/admin/lib/styl/app.group.admin.styl
@@ -1334,9 +1334,18 @@ Admin main styles
       &.red
         bg                  color, darkred
 
+  .readme
+  .variables
     .editor-view
       height                calc(100% \- 170px)
       rounded               4px 4px 0 0
+
+  .readme
+    .preview-button
+      z-index               13
+      right                 0
+      bottom                0
+      abs()
 
   .message-view
     font-size               14px

--- a/client/admin/lib/styl/app.group.admin.styl
+++ b/client/admin/lib/styl/app.group.admin.styl
@@ -1334,21 +1334,22 @@ Admin main styles
       &.red
         bg                  color, darkred
 
-    .message-view
-      font-size             14px
-      height                50px
-
-      pre
-        display             inline
-        background-color    #eee
-        font-size           12px
-        padding             2px 3px
-        border              1px solid #ddd
-        rounded             2px
-
     .editor-view
       height                calc(100% \- 170px)
       rounded               4px 4px 0 0
+
+  .message-view
+    font-size               14px
+    height                  50px
+
+    pre
+      display               inline
+      background-color      #eee
+      font-size             12px
+      padding               2px 3px
+      border                1px solid #ddd
+      rounded               2px
+
 
   .step-define-stack
 

--- a/client/admin/lib/views/stacks/definestackview.coffee
+++ b/client/admin/lib/views/stacks/definestackview.coffee
@@ -23,6 +23,7 @@ parseTerraformOutput = require './parseterraformoutput'
 OutputView           = require './outputview'
 ProvidersView        = require './providersview'
 VariablesView        = require './variablesview'
+ReadmeView           = require './readmeview'
 StackTemplateView    = require './stacktemplateview'
 
 
@@ -67,6 +68,11 @@ module.exports = class DefineStackView extends KDView
     @tabView.addPane providersPane     = new KDTabPaneView
       name : 'Providers'
       view : @providersView
+
+    @readmeView                        = new ReadmeView { stackTemplate }
+    @tabView.addPane readmePane        = new KDTabPaneView
+      name : 'Readme'
+      view : @readmeView
 
     { @credentials } = @stackTemplateView.credentialStatus or {}
 
@@ -339,6 +345,7 @@ module.exports = class DefineStackView extends KDView
 
     { title }         = @stackTemplateView.inputTitle.getData()
     templateContent   = @stackTemplateView.editorView.getValue()
+    description       = @readmeView.editorView.getValue() # aka readme
 
     # TODO split following into their own helper methods
     # and call them in here ~ GG
@@ -393,8 +400,10 @@ module.exports = class DefineStackView extends KDView
       templateContent = convertedDoc.content
 
 
+    template = templateContent
+
     updateStackTemplate {
-      template: templateContent, templateDetails
+      template, description, templateDetails
       credentials, stackTemplate, title, config
     }, (err, stackTemplate) =>
 

--- a/client/admin/lib/views/stacks/definestackview.coffee
+++ b/client/admin/lib/views/stacks/definestackview.coffee
@@ -93,15 +93,12 @@ module.exports = class DefineStackView extends KDView
       else
         @saveButton.disable()
 
-    variablesPane.on 'PaneDidShow', =>
-      @setFooterVisibility 'show'
-
-    stackTemplatePane.on 'PaneDidShow', =>
-      @setFooterVisibility 'show'
-
-    providersPane.on 'PaneDidShow', =>
-      @outputView.fall()
-      @setFooterVisibility 'hide'
+    @tabView.on 'PaneDidShow', (pane) =>
+      if pane is providersPane
+        @outputView.fall()
+        @setFooterVisibility 'hide'
+      else
+        @setFooterVisibility 'show'
 
 
   setFooterVisibility: (state) ->

--- a/client/admin/lib/views/stacks/editors/basestackeditorview.coffee
+++ b/client/admin/lib/views/stacks/editors/basestackeditorview.coffee
@@ -15,19 +15,12 @@ module.exports = class BaseStackEditorView extends IDEEditorPane
 
     curryIn options, cssClass: 'editor-view'
 
-    if options.content?
-      content = Encoder.htmlDecode options.content or ''
-      { content, contentType, err } = jsonToYaml content
-    else
-      content = """
-        # This is a YAML file which you can define
-        # key-value pairs like;
-        #
-        #   foo: bar
-        #
+    { content, contentType } = options
+    contentType             ?= 'json'
 
-      """
-      contentType = 'yaml'
+    if content and contentType is 'json'
+      content = Encoder.htmlDecode content or ''
+      { content, contentType, err } = jsonToYaml content
 
     options.content     = content
     options.contentType = contentType

--- a/client/admin/lib/views/stacks/editors/markdowneditorview.coffee
+++ b/client/admin/lib/views/stacks/editors/markdowneditorview.coffee
@@ -1,0 +1,32 @@
+kd                  = require 'kd'
+KDModalView         = kd.ModalView
+KDButtonView        = kd.ButtonView
+
+BaseStackEditorView = require './basestackeditorview'
+applyMarkdown       = require 'app/util/applyMarkdown'
+
+
+module.exports = class MarkdownEditorView extends BaseStackEditorView
+
+  viewAppended: ->
+    super
+
+    @addSubView new KDButtonView
+      title    : 'Preview'
+      cssClass : 'solid compact preview-button'
+      callback : @bound 'handlePreview'
+
+
+  handlePreview: ->
+
+    { title } = @getOptions()
+    content   = @getContent()
+
+    new kd.ModalView
+      title          : title or 'Readme Preview'
+      cssClass       : 'has-markdown content-modal'
+      height         : 500
+      overlay        : yes
+      overlayOptions : cssClass : 'second-overlay'
+      content        : applyMarkdown content
+

--- a/client/admin/lib/views/stacks/editors/variableseditorview.coffee
+++ b/client/admin/lib/views/stacks/editors/variableseditorview.coffee
@@ -1,3 +1,18 @@
 BaseStackEditorView = require './basestackeditorview'
 
 module.exports = class VariablesEditorView extends BaseStackEditorView
+
+  constructor: (options = {}, data) ->
+
+    unless options.content
+      options.content = """
+        # This is a YAML file which you can define
+        # key-value pairs like;
+        #
+        #   foo: bar
+        #
+
+      """
+      options.contentType = 'yaml'
+
+    super options, data

--- a/client/admin/lib/views/stacks/readmeview.coffee
+++ b/client/admin/lib/views/stacks/readmeview.coffee
@@ -1,0 +1,31 @@
+kd                 = require 'kd'
+
+KDView             = kd.View
+KDCustomHTMLView   = kd.CustomHTMLView
+
+MarkdownEditorView = require './editors/markdowneditorview'
+
+
+module.exports = class ReadmeView extends KDView
+
+
+  constructor: (options = {}, data) ->
+
+    super options, data
+
+    { stackTemplate } = @getOptions()
+
+    @addSubView new KDCustomHTMLView
+      cssClass   : 'text header'
+      partial    : 'Readme text for this stack template'
+
+    @messageView = @addSubView new KDCustomHTMLView
+      cssClass   : 'message-view'
+      partial    : "You can write down a readme text for new users. This text
+                    will be shown when they wants to use this stack. You can
+                    use markdown with the readme content."
+
+    @editorView   = @addSubView new MarkdownEditorView
+      content     : stackTemplate?.description or ''
+      delegate    : this
+      contentType : 'md'

--- a/client/admin/lib/views/stacks/updatestacktemplate.coffee
+++ b/client/admin/lib/views/stacks/updatestacktemplate.coffee
@@ -3,7 +3,7 @@ remote = require('app/remote').getInstance()
 
 module.exports = updateStackTemplate = (data, callback) ->
 
-  { template, templateDetails, credentials
+  { template, templateDetails, credentials, description
     title, stackTemplate, machines, config } = data
 
   title or= 'Default stack template'
@@ -12,7 +12,8 @@ module.exports = updateStackTemplate = (data, callback) ->
 
     dataToUpdate = if machines \
       then { machines } else {
-        title, template, credentials, templateDetails, config
+        title, template, credentials
+        templateDetails, config, description
       }
 
     stackTemplate.update dataToUpdate, (err) ->
@@ -21,6 +22,7 @@ module.exports = updateStackTemplate = (data, callback) ->
   else
 
     remote.api.JStackTemplate.create {
-      title, template, credentials, templateDetails, config
+      title, template, credentials
+      templateDetails, config, description
     }, callback
 


### PR DESCRIPTION
![](http://take.ms/7NX3u)

We're now using `JStackTemplate.description` field for readme document. Keeping as markdown.
