### PR TITLE
Update Google Maps query [fixes #102151702]

### DIFF
--- a/client/about/lib/aboutappview.coffee
+++ b/client/about/lib/aboutappview.coffee
@@ -57,7 +57,7 @@ module.exports = class AboutAppView extends JView
       <h3>Where we are?</h3>
       <address>358 Brannan Street, San Francisco, CA, 94107</address>
       <div class='map-container'>
-        <iframe width="100%" height="100%" frameborder="0" style="border:0" src="https://www.google.com/maps/embed/v1/place?q=Koding%2C%20Brannan%20Street%2C%20San%20Francisco%2C%20CA%2C%20United%20States&key=#{globals.config.google.apiKey}"></iframe>
+        <iframe width="100%" height="100%" frameborder="0" style="border:0" src="https://www.google.com/maps/embed/v1/place?q=358+Brannan+Street,+San+Francisco,+CA,+United+States&key=#{globals.config.google.apiKey}"></iframe>
       </div>
     </section>
     <section class='assets'>
@@ -86,5 +86,3 @@ module.exports = class AboutAppView extends JView
     </section>
     {{> @footer}}
     """
-
-


### PR DESCRIPTION
[Google map doesn't load on the About page](https://www.pivotaltracker.com/story/show/102151702)

Search query for address is not navigating to Koding HQ anymore. Current query is `Koding, Brannan Street, San Francisco, CA, United States` which is even autocompleted by Google Maps. I'll change query to `358 Brannan Street, San Francisco, CA, United States`.
