### PR TITLE
Skip hash tag matches in block quotes [fixes #103060902]

### DIFF
--- a/client/app/lib/util/transformTags.coffee
+++ b/client/app/lib/util/transformTags.coffee
@@ -1,3 +1,4 @@
+_                     = require 'lodash'
 getGroup              = require './getGroup'
 getBlockquoteRanges   = require './getBlockquoteRanges'
 groupifyLink          = require './groupifyLink'
@@ -13,7 +14,7 @@ module.exports = (text = '') ->
       return yes  if start <= position <= end
     return no
 
-  hashtags = twitter.extractHashtags text
+  hashtags = _.uniq twitter.extractHashtags text
   for hashtag in hashtags
     href = groupifyLink "/Activity/Topic/#{hashtag}", no
     tag = "##{hashtag}"

--- a/client/app/lib/util/transformTags.coffee
+++ b/client/app/lib/util/transformTags.coffee
@@ -16,10 +16,11 @@ module.exports = (text = '') ->
 
   hashtags = _.uniq twitter.extractHashtags text
   for hashtag in hashtags
-    href = groupifyLink "/Activity/Topic/#{hashtag}", no
-    tag = "##{hashtag}"
-    url =  "[#{tag}](#{href})"
+    url  = groupifyLink "/Activity/Topic/#{hashtag}", no
+    tag  = "##{hashtag}"
+    text = text.replace "#{tag}", (match, offset) ->
+      if inSkipRange offset
+      then match
+      else "[#{tag}](#{url})"
 
-    text = text.replace "#{tag}", url
-  
   return text


### PR DESCRIPTION
[Hashtags are rendered as topic link in code snippets](https://www.pivotaltracker.com/story/show/103060902)
