### PR TITLE
social: remove unncessary sending of jwtToken in register event

### DIFF
--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -1462,7 +1462,6 @@ module.exports = class JUser extends jraphical.Module
     user             = null
     error            = null
     newToken         = null
-    jwtToken         = null
     invitation       = null
     foreignAuthType  = null
 
@@ -1559,7 +1558,7 @@ module.exports = class JUser extends jraphical.Module
       ->
         subject             = Tracker.types.START_REGISTER
         { username, email } = user
-        Tracker.track username, { to : email, subject }, { jwtToken, pin }
+        Tracker.track username, { to : email, subject }, { pin }
         queue.next()
 
       ->


### PR DESCRIPTION
Idk why but mailsender doesn't seem to like `jwtToken` as optional properties. It was optional anyway, so I'm removing it.
