### PR TITLE
account: fix for a path of ssh keys file in popup message [fixes #102882924]

### DIFF
--- a/client/account/lib/views/accountsshkeylistcontroller.coffee
+++ b/client/account/lib/views/accountsshkeylistcontroller.coffee
@@ -10,6 +10,7 @@ showError = require 'app/util/showError'
 Machine = require 'app/providers/machine'
 SshKey = require 'app/util/sshkey'
 KDModalView = kd.ModalView
+whoami = require 'app/util/whoami'
 
 
 module.exports = class AccountSshKeyListController extends AccountListViewController
@@ -79,16 +80,18 @@ module.exports = class AccountSshKeyListController extends AccountListViewContro
 
   showDeleteModal: ->
 
+    { nickname } = whoami().profile
+
     modal = new KDModalView
       title          : 'Deleting SSH Key'
-      content        : '''
+      content        : """
         <p>
           Please note that even though the SSH key has been deleted from Account Settings, 
-          it still exists in your <strong>/home/username/.ssh/authorized_keys</strong> file. 
+          it still exists in your <strong>/home/#{nickname}/.ssh/authorized_keys</strong> file.
           Please ensure that you delete the key from that file too. 
           <a href="http://learn.koding.com/guides/ssh-into-your-vm/#deleting-a-key" target="_blank" class="guide-link">This guide</a> shows how to delete a ssh key.
         </p>
-      '''
+      """
       overlay        : yes
       overlayOptions :
         cssClass     : 'delete-ssh-key-overlay'

--- a/client/account/lib/views/accountsshkeylistcontroller.coffee
+++ b/client/account/lib/views/accountsshkeylistcontroller.coffee
@@ -10,7 +10,7 @@ showError = require 'app/util/showError'
 Machine = require 'app/providers/machine'
 SshKey = require 'app/util/sshkey'
 KDModalView = kd.ModalView
-whoami = require 'app/util/whoami'
+nick = require 'app/util/nick'
 
 
 module.exports = class AccountSshKeyListController extends AccountListViewController
@@ -80,9 +80,8 @@ module.exports = class AccountSshKeyListController extends AccountListViewContro
 
   showDeleteModal: ->
 
-    { nickname } = whoami().profile
-
-    modal = new KDModalView
+    nickname = nick()
+    modal    = new KDModalView
       title          : 'Deleting SSH Key'
       content        : """
         <p>


### PR DESCRIPTION
@gokmen, can you please review this small fix?
When user deletes ssh key on `Account Settings` -> `SSH Keys` modal, they see a message:
`Please note that even though the SSH key has been deleted from Account Settings, 
it still exists in your /home/username/.ssh/authorized_keys file. 
Please ensure that you delete the key from that file too.`
I changed `username` in the ssh file path to user's nickname
Here is the ![link](https://www.pivotaltracker.com/story/show/102882924) to the task in Pivotal
