### PR TITLE
reactivity: chat list item: focus on edit input only if edit mode is on [fixes #103352706]

### DIFF
--- a/client/activity/lib/components/chatlistitem/index.coffee
+++ b/client/activity/lib/components/chatlistitem/index.coffee
@@ -64,8 +64,9 @@ module.exports = class ChatListItem extends React.Component
 
   componentDidUpdate: ->
 
-    @setState editMode: @props.message.get '__isEditing'
-    @focusInputOnEdit()
+    isEditing = @props.message.get '__isEditing'
+    @setState editMode: isEditing
+    @focusInputOnEdit()  if isEditing
 
 
   getAccountInfo: ->

--- a/client/activity/lib/components/chatlistitem/index.coffee
+++ b/client/activity/lib/components/chatlistitem/index.coffee
@@ -191,8 +191,7 @@ module.exports = class ChatListItem extends React.Component
 
     domNode = @refs.EditMessageTextarea.getDOMNode()
 
-    kd.utils.wait 100, ->
-      kd.utils.moveCaretToEnd domNode
+    kd.utils.moveCaretToEnd domNode
 
 
   editPost: ->
@@ -200,8 +199,6 @@ module.exports = class ChatListItem extends React.Component
     messageId = @props.message.get '_id'
 
     ActivityFlux.actions.message.setMessageEditMode messageId
-    @focusInputOnEdit()
-
 
 
   showDeletePostPromptModal: ->


### PR DESCRIPTION
@usirin, @gokhansongul, can you guys review this fix? It's for a [bug](https://www.pivotaltracker.com/story/show/103352706) of losing chat input focus after a new message has been submitted or even after hovering chat input items
