### PR TITLE
reactivity: chat list: scroll to bottom once new message is submitted

### DIFF
--- a/client/activity/lib/components/chatpane/index.coffee
+++ b/client/activity/lib/components/chatpane/index.coffee
@@ -10,8 +10,6 @@ ScrollerMixin   = require 'app/components/scroller/scrollermixin'
 
 module.exports = class ChatPane extends React.Component
 
-  @include [ScrollerMixin]
-
   @defaultProps =
     title         : null
     messages      : null
@@ -23,14 +21,11 @@ module.exports = class ChatPane extends React.Component
 
   componentWillUpdate: (nextProps, nextState) ->
 
-    ScrollerMixin.componentWillUpdate.call this, nextProps, nextState
+    return  unless nextProps?.thread
 
-    return  unless nextProps?.messages
-
-    { messages } = nextProps
-    fakeMessages = messages.filter (message) -> message.get 'isFake'
-    hasNewMessage = fakeMessages.size > 0
-    @shouldScrollToBottom = yes  if hasNewMessage
+    { thread } = nextProps
+    isMessageBeingSubmitted = thread.getIn ['flags', 'isMessageBeingSubmitted']
+    @shouldScrollToBottom = yes  if isMessageBeingSubmitted
 
 
   onSubmit: (event) -> @props.onSubmit? event
@@ -86,4 +81,6 @@ module.exports = class ChatPane extends React.Component
       </section>
     </div>
 
+
+React.Component.include.call ChatPane, [ScrollerMixin]
 

--- a/client/activity/lib/components/chatpane/index.coffee
+++ b/client/activity/lib/components/chatpane/index.coffee
@@ -21,6 +21,18 @@ module.exports = class ChatPane extends React.Component
     showItemMenu  : yes
 
 
+  componentWillUpdate: (nextProps, nextState) ->
+
+    ScrollerMixin.componentWillUpdate.call this, nextProps, nextState
+
+    return  unless nextProps?.messages
+
+    { messages } = nextProps
+    fakeMessages = messages.filter (message) -> message.get 'isFake'
+    hasNewMessage = fakeMessages.size > 0
+    @shouldScrollToBottom = yes  if hasNewMessage
+
+
   onSubmit: (event) -> @props.onSubmit? event
 
 

--- a/client/activity/lib/flux/stores/channelflagsstore.coffee
+++ b/client/activity/lib/flux/stores/channelflagsstore.coffee
@@ -15,20 +15,39 @@ module.exports = class ChannelFlagsStore extends KodingFluxStore
 
     @on actions.LOAD_MESSAGES_BEGIN, @handleLoadMessagesBegin
     @on actions.LOAD_MESSAGES_SUCCESS, @handleLoadMessagesSuccess
+    @on actions.CREATE_MESSAGE_BEGIN, @handleCreateMessageBegin
+    @on actions.CREATE_MESSAGE_SUCCESS, @handleCreateMessageEnd
+    @on actions.CREATE_MESSAGE_FAIL, @handleCreateMessageEnd
 
 
   handleLoadMessagesBegin: (channelFlags, { channelId }) ->
 
-    unless channelFlags.has channelId
-      channelFlags = channelFlags.set channelId, immutable.Map()
-
+    channelFlags = @createChannelMapIfNeed channelFlags, channelId
     return channelFlags.setIn [channelId, 'isMessagesLoading'], yes
 
 
   handleLoadMessagesSuccess: (channelFlags, { channelId }) ->
 
-    unless channelFlags.has channelId
-      channelFlags = channelFlags.set channelId, immutable.Map()
-
+    channelFlags = @createChannelMapIfNeed channelFlags, channelId
     return channelFlags.setIn [channelId, 'isMessagesLoading'], no
+
+
+  handleCreateMessageBegin: (channelFlags, { channelId }) ->
+
+    channelFlags = @createChannelMapIfNeed channelFlags, channelId
+    return channelFlags.setIn [channelId, 'isMessageBeingSubmitted'], yes
+
+
+  handleCreateMessageEnd: (channelFlags, { channelId }) ->
+
+    channelFlags = @createChannelMapIfNeed channelFlags, channelId
+    return channelFlags.setIn [channelId, 'isMessageBeingSubmitted'], no
+
+
+  createChannelMapIfNeed: (channelFlags, channelId) ->
+
+    unless channelFlags.has channelId
+      return channelFlags.set channelId, immutable.Map()
+
+    return channelFlags
 

--- a/client/activity/lib/flux/stores/channelflagsstore.coffee
+++ b/client/activity/lib/flux/stores/channelflagsstore.coffee
@@ -22,29 +22,31 @@ module.exports = class ChannelFlagsStore extends KodingFluxStore
 
   handleLoadMessagesBegin: (channelFlags, { channelId }) ->
 
-    channelFlags = @createChannelMapIfNeed channelFlags, channelId
+    channelFlags = helper.ensureChannelMap channelFlags, channelId
     return channelFlags.setIn [channelId, 'isMessagesLoading'], yes
 
 
   handleLoadMessagesSuccess: (channelFlags, { channelId }) ->
 
-    channelFlags = @createChannelMapIfNeed channelFlags, channelId
+    channelFlags = helper.ensureChannelMap channelFlags, channelId
     return channelFlags.setIn [channelId, 'isMessagesLoading'], no
 
 
   handleCreateMessageBegin: (channelFlags, { channelId }) ->
 
-    channelFlags = @createChannelMapIfNeed channelFlags, channelId
+    channelFlags = helper.ensureChannelMap channelFlags, channelId
     return channelFlags.setIn [channelId, 'isMessageBeingSubmitted'], yes
 
 
   handleCreateMessageEnd: (channelFlags, { channelId }) ->
 
-    channelFlags = @createChannelMapIfNeed channelFlags, channelId
+    channelFlags = helper.ensureChannelMap channelFlags, channelId
     return channelFlags.setIn [channelId, 'isMessageBeingSubmitted'], no
 
 
-  createChannelMapIfNeed: (channelFlags, channelId) ->
+helper =
+
+  ensureChannelMap: (channelFlags, channelId) ->
 
     unless channelFlags.has channelId
       return channelFlags.set channelId, immutable.Map()

--- a/client/activity/lib/flux/test/channelflagsstore.coffee
+++ b/client/activity/lib/flux/test/channelflagsstore.coffee
@@ -37,3 +37,52 @@ describe 'ChannelFlagsStore', ->
 
       expect(storeState.mockChannelFlagsForSuccessId.isMessagesLoading).to.eql no
 
+
+  describe 'handleCreateMessageBegin', ->
+
+    it 'sets isMessageBeingSubmitted flag to true when a new message is being submitted in the channel', ->
+
+      @reactor.dispatch actionTypes.CREATE_MESSAGE_BEGIN, {
+        channelId: 'mockChannelFlagsForBeginId'
+      }
+
+      storeState = @reactor.evaluateToJS ['ChannelFlagsStore']
+
+      expect(storeState.mockChannelFlagsForBeginId.isMessageBeingSubmitted).to.eql yes
+
+
+  describe 'handleCreateMessageEnd', ->
+
+    it 'sets isMessageBeingSubmitted flag to false when a new message has been successfully submitted', ->
+
+      @reactor.dispatch actionTypes.CREATE_MESSAGE_BEGIN, {
+        channelId: 'mockChannelFlagsForEndId'
+      }
+
+      storeState = @reactor.evaluateToJS ['ChannelFlagsStore']
+      expect(storeState.mockChannelFlagsForEndId.isMessageBeingSubmitted).to.eql yes
+
+      @reactor.dispatch actionTypes.CREATE_MESSAGE_SUCCESS, {
+        channelId: 'mockChannelFlagsForEndId'
+      }
+
+      storeState = @reactor.evaluateToJS ['ChannelFlagsStore']
+      expect(storeState.mockChannelFlagsForEndId.isMessageBeingSubmitted).to.eql no
+
+
+    it 'sets isMessageBeingSubmitted flag to false when a new message has failed to submit', ->
+
+      @reactor.dispatch actionTypes.CREATE_MESSAGE_BEGIN, {
+        channelId: 'mockChannelFlagsForEndId'
+      }
+
+      storeState = @reactor.evaluateToJS ['ChannelFlagsStore']
+      expect(storeState.mockChannelFlagsForEndId.isMessageBeingSubmitted).to.eql yes
+
+      @reactor.dispatch actionTypes.CREATE_MESSAGE_FAIL, {
+        channelId: 'mockChannelFlagsForEndId'
+      }
+
+      storeState = @reactor.evaluateToJS ['ChannelFlagsStore']
+      expect(storeState.mockChannelFlagsForEndId.isMessageBeingSubmitted).to.eql no
+


### PR DESCRIPTION
@usirin, can you please review this fix? This is to scroll chat list to the bottom when a new message has been submitted
Here is the short video:
![scroll](http://g.recordit.co/6eE4uVJOJG.gif)
