### PR TITLE
reactivity: chat input: search and emoji buttons order [fixes #103474620]

### DIFF
--- a/client/activity/lib/components/chatinputwidget/index.coffee
+++ b/client/activity/lib/components/chatinputwidget/index.coffee
@@ -287,12 +287,12 @@ module.exports = class ChatInputWidget extends React.Component
         ref       = 'textInput'
       />
       <Link
-        className = "ChatInputWidget-emojiButton"
-        onClick   = { @bound 'handleEmojiButtonClick' }
-      />
-      <Link
         className = "ChatInputWidget-searchButton"
         onClick   = { @bound 'handleSearchButtonClick' }
+      />
+      <Link
+        className = "ChatInputWidget-emojiButton"
+        onClick   = { @bound 'handleEmojiButtonClick' }
       />
     </div>
 


### PR DESCRIPTION
@usirin, can you please review this fix? I changed order of search and emoji buttons in markup according to how the appear on UI. So when writing in input pressing tab selects search button instead of emoji button as before. Here is the [task](https://www.pivotaltracker.com/story/show/103474620) in Pivotal
