### PR TITLE
reactivity: emojify most popular message list [fixes #103483098]

### DIFF
--- a/client/activity/lib/components/channelmessageslist/index.coffee
+++ b/client/activity/lib/components/channelmessageslist/index.coffee
@@ -1,8 +1,9 @@
-kd          = require 'kd'
-React       = require 'kd-react'
-Link        = require 'app/components/common/link'
-immutable   = require 'immutable'
+kd            = require 'kd'
+React         = require 'kd-react'
+Link          = require 'app/components/common/link'
+immutable     = require 'immutable'
 formatContent = require 'app/util/formatContent'
+emojify       = require 'emojify.js'
 
 module.exports = class ChannelMessagesList extends React.Component
 
@@ -12,17 +13,18 @@ module.exports = class ChannelMessagesList extends React.Component
     maxCount: 10
 
 
-
   renderBody: ->
+
 
   renderChildren: ->
     return null  unless @props.messages
 
     @props.messages.slice(0, @props.maxCount).map (message) ->
       <li key={message.get 'id'} className="ChannelMessagesList-messageItem">
-        <Link href="/Channels/Public/#{message.get 'slug'}">
-          {helper.renderBody message}
-        </Link>
+        <Link
+          href="/Channels/Public/#{message.get 'slug'}"
+          dangerouslySetInnerHTML={__html: helper.renderBody message}
+        />
       </li>
 
 
@@ -37,5 +39,6 @@ helper =
   renderBody: (message) ->
     e = document.createElement 'div'
     e.innerHTML = formatContent message.get 'body'
-    return e.textContent or e.innerText
+    body = e.textContent or e.innerText
+    body = emojify.replace body
 

--- a/client/activity/lib/components/channelmessageslist/styl/channelmessageslist.styl
+++ b/client/activity/lib/components/channelmessageslist/styl/channelmessageslist.styl
@@ -6,3 +6,8 @@
     color                   #727372
     text-decoration         underline
     font-size               $fs-regular
+
+  .emoji
+    size                    16px 16px
+    vertical-align          bottom
+


### PR DESCRIPTION
@usirin, can you please take a look at these changes? This is a fix for [this bug](https://www.pivotaltracker.com/story/show/103483098)
Here is the screenshot:
![most-active-threads-emojis](https://cloud.githubusercontent.com/assets/492219/9905898/4977a188-5c90-11e5-90d6-30aa90253068.jpg)

It would be nicer to use `emojify.run()` instead of `emojify.replace()` but since message items are links and `<a>` is in the list of emojify ignore tags (https://github.com/koding/koding/blob/master/client/app/lib/maincontroller.coffee#L90), it didn't work
