### PR TITLE
Client: Activity: added ComponentDidUpdate event handler to render emojis after message editing

### DIFF
--- a/client/activity/lib/components/chatlist/index.coffee
+++ b/client/activity/lib/components/chatlist/index.coffee
@@ -10,6 +10,7 @@ module.exports = class ChatList extends React.Component
     messages     : immutable.List()
     showItemMenu : yes
     firstPost    : null
+    channelName  : ''
     isMessagesLoading: no
 
 
@@ -57,6 +58,7 @@ module.exports = class ChatList extends React.Component
         key          : message.get 'id'
         message      : message
         showItemMenu : showItemMenu
+        channelName  : @props.channelName
 
       count          = @calculateRemainingMessageCount()
       firstMessageId = @getFirstMessageId()

--- a/client/activity/lib/components/chatlistitem/index.coffee
+++ b/client/activity/lib/components/chatlistitem/index.coffee
@@ -253,7 +253,7 @@ module.exports = class ChatListItem extends React.Component
 
     ActivityFlux.actions.message.editMessage(
       @props.message.get('id')
-      @state.editInputValue
+      value
       @props.message.get('payload').toJS()
     )
 

--- a/client/activity/lib/components/chatlistitem/index.coffee
+++ b/client/activity/lib/components/chatlistitem/index.coffee
@@ -36,6 +36,7 @@ module.exports = class ChatListItem extends React.Component
     account                       : null
     isDeleting                    : no
     isMenuOpen                    : no
+    channelName                   : ''
     editInputValue                : ''
     isUserMarkedAsTroll           : no
     isBlockUserModalVisible       : no
@@ -241,7 +242,13 @@ module.exports = class ChatListItem extends React.Component
 
   updateMessage: ->
 
+    name  = @props.channelName
+    value = @state.editInputValue
     messageId = @props.message.get '_id'
+
+    unless value.match ///\##{name}///
+      value += " ##{name} "
+
     ActivityFlux.actions.message.unsetMessageEditMode messageId
 
     ActivityFlux.actions.message.editMessage(

--- a/client/activity/lib/components/chatpane/index.coffee
+++ b/client/activity/lib/components/chatpane/index.coffee
@@ -41,6 +41,7 @@ module.exports = class ChatPane extends React.Component
           firstPost={@props.thread.get 'message'}
           messages={@props.messages}
           showItemMenu={@props.showItemMenu}
+          channelName={@props.thread.getIn ['channel', 'name']}
         />
       </Scroller>
     </section>

--- a/client/activity/lib/components/common/messagebody.coffee
+++ b/client/activity/lib/components/common/messagebody.coffee
@@ -13,8 +13,12 @@ module.exports = class MessageBody extends React.Component
 
   contentDidMount: (content) ->
 
-    contentElement = React.findDOMNode content
+    @content       = content
+    contentElement = React.findDOMNode @content
     emojify.run contentElement  if contentElement
+
+
+  componentDidUpdate: -> @contentDidMount(@content)
 
 
   render: ->

--- a/client/activity/lib/components/common/messagebody.coffee
+++ b/client/activity/lib/components/common/messagebody.coffee
@@ -11,14 +11,19 @@ module.exports = class MessageBody extends React.Component
     message: immutable.Map()
 
 
-  contentDidMount: (content) ->
+  renderEmojis: ->
 
-    @content       = content
     contentElement = React.findDOMNode @content
     emojify.run contentElement  if contentElement
 
 
-  componentDidUpdate: -> @contentDidMount(@content)
+  contentDidMount: (content) ->
+
+    @content = content
+    @renderEmojis()
+
+
+  componentDidUpdate: -> @renderEmojis()
 
 
   render: ->


### PR DESCRIPTION
It's fixed but we have another bug about message editing. After message editing, message is deleting. I couldn't understant why. the code is in `realtime/actioncreators.coffee` line 20. I couldn't find where we trigger `MessageRemoved`. 

``` coffee
channel.on 'MessageRemoved', (message) ->
    dispatch actions.REMOVE_MESSAGE_SUCCESS, { messageId: message.id }
```

 @alex-ionochkin and @usirin , do you have any idea? 

you can see below, fixed `emoji rendering after message editing problem` and `deleting message after edit` problem
<img src='http://g.recordit.co/xx9yMSiKQC.gif'/>
