### PR TITLE
reactivity: trim white spaces in the message body to fix emoji rendering problems [fixes #103475676]

### DIFF
--- a/client/activity/lib/components/chatinputwidget/index.coffee
+++ b/client/activity/lib/components/chatinputwidget/index.coffee
@@ -111,7 +111,8 @@ module.exports = class ChatInputWidget extends React.Component
       break
 
     unless isDropboxEnter
-      @props.onSubmit? { value: @state.value }
+      value = @state.value.trim()
+      @props.onSubmit? { value }
       @setState { value: '' }
 
 

--- a/client/activity/lib/flux/getters.coffee
+++ b/client/activity/lib/flux/getters.coffee
@@ -134,7 +134,7 @@ selectedChannelThread = [
       messages.map (msg) ->
         msg.update 'body', (body) ->
           # don't show channel name on post body.
-          body.replace ///\##{channel.get('name')}///, ''
+          body.replace(///\##{channel.get('name')}///, '').trim()
     return thread.set 'channel', channel
 ]
 


### PR DESCRIPTION
@usirin, can you please review this fix? It's for [this bug](https://www.pivotaltracker.com/story/show/103475676)
![fix](http://g.recordit.co/14tXV6y7hW.gif)

/cc @sinan 

The reason why it didn't work is white space at the end of message body after removing channel name from the string. I checked `emojify` logic and found out that it doesn't replace emoji string with image if it's followed by white space. Here is how `emojify` checks if it can replace found emoji name with image - https://github.com/Ranks/emojify.js/blob/master/src/emojify.js#L204-L217

However, the problem is not fixed completely and may happen in some cases. For example, if message body is `foo:+1: test`, `:+1:` won't be replaced with image because it's followed by white space and it's not the end of the string. This is how `emojify` works - I guess it thinks that `:+1:` is the part of word `foo` and doesn't touch it.
I checked how slack does in the same situation and found out that it replaces emoji name in such case. It replaces emoji name even if it is in the middle of the word.

So if this problem is important, maybe it makes sense to find something better than `emojify`?
