### PR TITLE
Fix for machine states when things changed on AWS side but not in Kloud. 

### DIFF
--- a/client/app/lib/kite/kites/kloud.coffee
+++ b/client/app/lib/kite/kites/kloud.coffee
@@ -186,6 +186,20 @@ module.exports = class KodingKite_KloudKite extends require('../kodingkite')
 
           KiteLogger.failed 'kloud', 'info'
 
+        # If kite somehow unregistered from Kontrol and Kloud is failing
+        # to find it in Kontrol registry we are getting this `not found`
+        # at this point we can assume that the machine is Stopped. But on
+        # the other hand, Kloud should also mark this machine as Stopped if
+        # it couldn't find it in Kontrol registry ~ GG FIXME: FA
+        else if err.message is 'not found'
+
+          @resolveRequestingInfos machineId, State: Machine.State.Stopped
+          KiteLogger.failed 'kloud', 'info'
+
+          kd.warn '[kloud:info] failed, Kite not found in Kontrol registry!', err
+
+          return
+
         kd.warn '[kloud:info] failed, sending current state back:', { currentState, err }
         @resolveRequestingInfos machineId, State: currentState
 

--- a/client/app/lib/providers/environmentsmachinestatemodal.coffee
+++ b/client/app/lib/providers/environmentsmachinestatemodal.coffee
@@ -556,7 +556,7 @@ module.exports = class EnvironmentsMachineStateModal extends BaseModalView
         { groupsController } = kd.singletons
         return  unless groupsController.currentGroupHasStack()
 
-    else if not isKoding() and @stack
+    else if not isKoding() and @stack and @state is NotInitialized
       title    = 'Build Stack'
       callback = 'turnOnMachine'
     else


### PR DESCRIPTION
So basically we are marking the machine as `Stopped` when we got `not found` error message from `kloud.info` which is sending back that message when it couldn't find the machine klient in the `Kontrol`'s registry. This needs to be fixed in Kloud itself and it should be marked as `Stopped` in DB by Kloud. But for now this at least prevents to open IDE for not existing instances. cc/ @fatih 
