### PR TITLE
Fix scope level of assignment [fixes #103886448]

### DIFF
--- a/client/app/lib/activity/sidebar/activitysidebar.coffee
+++ b/client/app/lib/activity/sidebar/activitysidebar.coffee
@@ -616,7 +616,8 @@ module.exports = class ActivitySidebar extends KDCustomHTMLView
           environmentMap[machine._id]
 
         @createMachineList 'stack', { title, stack }, stackEnvironment
-        inProgress = no
+
+      inProgress = no
 
 
   redrawMachineList: ->


### PR DESCRIPTION
[VMs are not displaying in real-time in the sidebar after the stack is configured](https://www.pivotaltracker.com/story/show/103886448)
