### PR TITLE
Kloud: generate kite key template variable per resource [fixes #103949762]

### DIFF
--- a/go/src/koding/kites/kloud/kloud/terraformutils.go
+++ b/go/src/koding/kites/kloud/kloud/terraformutils.go
@@ -276,8 +276,10 @@ func injectKodingData(ctx context.Context, template *terraformTemplate, username
 			}
 		}
 
+		kiteKeyName := fmt.Sprintf("kitekeys_%s", resourceName)
+
 		// will be replaced with the kitekeys we create below
-		userCfg.KiteKey = "${lookup(var.kitekeys, count.index)}"
+		userCfg.KiteKey = fmt.Sprintf("${lookup(var.%s, count.index)}", kiteKeyName)
 
 		userdata, err := sess.Userdata.Create(userCfg)
 		if err != nil {
@@ -314,7 +316,7 @@ func injectKodingData(ctx context.Context, template *terraformTemplate, username
 			countKeys[strconv.Itoa(i)] = kiteKey
 		}
 
-		template.Variable["kitekeys"] = map[string]interface{}{
+		template.Variable[kiteKeyName] = map[string]interface{}{
 			"default": countKeys,
 		}
 


### PR DESCRIPTION
In the case of multiple machine resources under terraform template, only the last one was sent to terraformer kite. Since HCL  is using hash map for resources, it was overriding the variable `kitekeys`, now we are able to support multiple resources with and without count directive

fixes #103949762

thanks to @gokmen for the tip
