### PR TITLE
Reactivity chat input value store

### DIFF
--- a/client/activity/lib/components/chatinputwidget/index.coffee
+++ b/client/activity/lib/components/chatinputwidget/index.coffee
@@ -72,7 +72,7 @@ module.exports = class ChatInputWidget extends React.Component
   resetValue: ->
 
     channelId = @props.thread.get 'channelId'
-    ChatInputFlux.actions.value.setValue channelId
+    ChatInputFlux.actions.value.resetValue channelId
 
 
   onChange: (event) ->
@@ -311,7 +311,7 @@ module.exports = class ChatInputWidget extends React.Component
       { @renderUserDropbox() }
       { @renderSearchDropbox() }
       <TextArea
-        value     = { @state.value ? '' }
+        value     = { @state.value }
         onChange  = { @bound 'onChange' }
         onKeyDown = { @bound 'onKeyDown' }
         ref       = 'textInput'

--- a/client/activity/lib/components/chatinputwidget/index.coffee
+++ b/client/activity/lib/components/chatinputwidget/index.coffee
@@ -25,18 +25,13 @@ module.exports = class ChatInputWidget extends React.Component
   @defaultProps =
     enableSearch : no
 
-  constructor: (props) ->
-
-    super props
-
-    @state = { value : '' }
-
 
   getDataBindings: ->
 
     { getters } = ChatInputFlux
 
     return {
+      value                          : getters.currentValue
       filteredEmojiList              : getters.filteredEmojiList @stateId
       filteredEmojiListSelectedIndex : getters.filteredEmojiListSelectedIndex @stateId
       filteredEmojiListSelectedItem  : getters.filteredEmojiListSelectedItem @stateId
@@ -68,10 +63,23 @@ module.exports = class ChatInputWidget extends React.Component
   getDropboxes: -> [ @refs.emojiDropbox, @refs.channelDropbox, @refs.userDropbox, @refs.searchDropbox ]
 
 
+  setValue: (value) ->
+
+    channelId = @props.thread.get 'channelId'
+    ChatInputFlux.actions.value.setValue channelId, value
+
+
+  resetValue: ->
+
+    channelId = @props.thread.get 'channelId'
+    ChatInputFlux.actions.value.setValue channelId
+
+
   onChange: (event) ->
 
     { value } = event.target
-    @setState { value }
+
+    @setValue value
 
     textInput = React.findDOMNode @refs.textInput
     textData  =
@@ -120,7 +128,7 @@ module.exports = class ChatInputWidget extends React.Component
     unless isDropboxEnter
       value = @state.value.trim()
       @props.onSubmit? { value }
-      @setState { value: '' }
+      @resetValue()
 
 
   onEsc: (event) ->
@@ -160,7 +168,7 @@ module.exports = class ChatInputWidget extends React.Component
     textInput = React.findDOMNode @refs.textInput
 
     { value, cursorPosition } = helpers.insertDropboxItem textInput, item
-    @setState { value }
+    @setValue value
 
     kd.utils.defer ->
       helpers.setCursorPosition textInput, cursorPosition
@@ -171,7 +179,7 @@ module.exports = class ChatInputWidget extends React.Component
     { value } = @state
 
     newValue = value + item
-    @setState { value : newValue }
+    @setValue newValue
 
     textInput = React.findDOMNode this.refs.textInput
     textInput.focus()
@@ -196,7 +204,7 @@ module.exports = class ChatInputWidget extends React.Component
 
     if value.indexOf(searchMarker) is -1
       value = searchMarker + value
-      @setState { value }
+      @setValue value
 
     textInput = React.findDOMNode @refs.textInput
     textInput.focus()
@@ -303,7 +311,7 @@ module.exports = class ChatInputWidget extends React.Component
       { @renderUserDropbox() }
       { @renderSearchDropbox() }
       <TextArea
-        value     = { @state.value }
+        value     = { @state.value ? '' }
         onChange  = { @bound 'onChange' }
         onKeyDown = { @bound 'onKeyDown' }
         ref       = 'textInput'

--- a/client/activity/lib/components/privatechatpane/index.coffee
+++ b/client/activity/lib/components/privatechatpane/index.coffee
@@ -42,8 +42,9 @@ module.exports = class PrivateChatPane extends React.Component
     >
       <footer className="PrivateChatPane-footer">
         <ChatInputWidget
-          onSubmit        = { @bound 'onSubmit' }
-          enableSearch    = no
+          onSubmit     = { @bound 'onSubmit' }
+          enableSearch = no
+          thread       = { @props.thread }
         />
       </footer>
     </ChatPane>

--- a/client/activity/lib/components/publicchatpane/index.coffee
+++ b/client/activity/lib/components/publicchatpane/index.coffee
@@ -60,8 +60,10 @@ module.exports = class PublicChatPane extends React.Component
 
     return null  unless @props.messages
 
+    { thread } = @props
+
     footerInnerComponent = if @channel 'isParticipant'
-    then <ChatInputWidget onSubmit={@bound 'onSubmit'} />
+    then <ChatInputWidget onSubmit={@bound 'onSubmit'} thread={thread}  />
     else @renderFollowChannel()
 
     <footer className="PublicChatPane-footer">

--- a/client/activity/lib/flux/chatinput/actions/actiontypes.coffee
+++ b/client/activity/lib/flux/chatinput/actions/actiontypes.coffee
@@ -40,5 +40,6 @@ module.exports = {
 
   'SET_LAST_MESSAGE_EDIT_MODE'
 
+  'SET_CHAT_INPUT_VALUE'
 }
 

--- a/client/activity/lib/flux/chatinput/actions/value.coffee
+++ b/client/activity/lib/flux/chatinput/actions/value.coffee
@@ -4,12 +4,24 @@ actionTypes = require './actiontypes'
 dispatch = (args...) -> kd.singletons.reactor.dispatch args...
 
 
+###*
+ * Action to set chat input value for the specified channel.
+ *
+ * @param {string} channelId
+ * @param {string} value
+###
 setValue = (channelId, value) ->
 
   { SET_CHAT_INPUT_VALUE } = actionTypes
   dispatch SET_CHAT_INPUT_VALUE, { channelId, value }
 
 
+###*
+ * Action to reset chat input value for the specified channel.
+ * It sets chat input value to empty string
+ *
+ * @param {string} channelId
+###
 resetValue = (channelId) ->
 
   setValue channelId, ''
@@ -19,3 +31,4 @@ module.exports = {
   setValue
   resetValue
 }
+

--- a/client/activity/lib/flux/chatinput/actions/value.coffee
+++ b/client/activity/lib/flux/chatinput/actions/value.coffee
@@ -1,0 +1,21 @@
+kd          = require 'kd'
+actionTypes = require './actiontypes'
+
+dispatch = (args...) -> kd.singletons.reactor.dispatch args...
+
+
+setValue = (channelId, value) ->
+
+  { SET_CHAT_INPUT_VALUE } = actionTypes
+  dispatch SET_CHAT_INPUT_VALUE, { channelId, value }
+
+
+resetValue = (channelId) ->
+
+  setValue channelId, ''
+
+
+module.exports = {
+  setValue
+  resetValue
+}

--- a/client/activity/lib/flux/chatinput/getters.coffee
+++ b/client/activity/lib/flux/chatinput/getters.coffee
@@ -1,3 +1,4 @@
+kd                         = require 'kd'
 immutable                  = require 'immutable'
 ActivityFluxGetters        = require 'activity/flux/getters'
 calculateListSelectedIndex = require 'activity/util/calculateListSelectedIndex'
@@ -23,6 +24,7 @@ SearchQueryStore                    = [['ChatInputSearchQueryStore'], withEmptyM
 SearchSelectedIndexStore            = [['ChatInputSearchSelectedIndexStore'], withEmptyMap]
 SearchVisibilityStore               = [['ChatInputSearchVisibilityStore'], withEmptyMap]
 SearchStore                         = [['ChatInputSearchStore'], withEmptyMap]
+ValueStore                          = [['ChatInputValueStore'], withEmptyMap]
 
 
 filteredEmojiListQuery = (stateId) -> [
@@ -220,6 +222,13 @@ searchVisibility = (stateId) -> [
 ]
 
 
+currentValue = [
+  ValueStore
+  ActivityFluxGetters.selectedChannelThreadId
+  (values, channelId) -> values.get channelId
+]
+
+
 module.exports = {
   filteredEmojiList
   filteredEmojiListQuery
@@ -250,5 +259,7 @@ module.exports = {
   searchSelectedIndex
   searchSelectedItem
   searchVisibility
+
+  currentValue
 }
 

--- a/client/activity/lib/flux/chatinput/getters.coffee
+++ b/client/activity/lib/flux/chatinput/getters.coffee
@@ -225,7 +225,7 @@ searchVisibility = (stateId) -> [
 currentValue = [
   ValueStore
   ActivityFluxGetters.selectedChannelThreadId
-  (values, channelId) -> values.get channelId
+  (values, channelId) -> values.get channelId, ''
 ]
 
 

--- a/client/activity/lib/flux/chatinput/index.coffee
+++ b/client/activity/lib/flux/chatinput/index.coffee
@@ -7,6 +7,7 @@ module.exports = {
     user    : require './actions/user'
     search  : require './actions/search'
     message : require './actions/message'
+    value   : require './actions/value'
 
   stores  : [
     require './stores/emoji/emojisstore'
@@ -24,6 +25,7 @@ module.exports = {
     require './stores/search/querystore'
     require './stores/search/visibilitystore'
     require './stores/search/searchstore'
+    require './stores/valuestore'
   ]
 }
 

--- a/client/activity/lib/flux/chatinput/stores/valuestore.coffee
+++ b/client/activity/lib/flux/chatinput/stores/valuestore.coffee
@@ -1,0 +1,33 @@
+actions         = require 'activity/flux/chatinput/actions/actiontypes'
+KodingFluxStore = require 'app/flux/store'
+immutable       = require 'immutable'
+
+###*
+ * Store to handle current chat input value
+###
+module.exports = class ChatInputValueStore extends KodingFluxStore
+
+  @getterPath = 'ChatInputValueStore'
+
+
+  getInitialState: -> immutable.Map()
+
+
+  initialize: ->
+
+    @on actions.SET_CHAT_INPUT_VALUE, @setValue
+
+
+  ###*
+   * It updates value for a given stateId
+   *
+   * @param {immutable.Map} currentState
+   * @param {object} payload
+   * @param {string} payload.channelId
+   * @param {string} payload.value
+   * @return {immutable.Map} nextState
+  ###
+  setValue: (currentState, { channelId, value }) ->
+
+    currentState.set channelId, value
+

--- a/client/activity/lib/flux/chatinput/tests/index.coffee
+++ b/client/activity/lib/flux/chatinput/tests/index.coffee
@@ -14,4 +14,6 @@ require './search/selectedindexstore'
 require './search/visibilitystore'
 require './search/searchstore'
 require './search/getters'
+require './value/valuestore'
+require './value/valuegetter'
 

--- a/client/activity/lib/flux/chatinput/tests/value/valuegetter.coffee
+++ b/client/activity/lib/flux/chatinput/tests/value/valuegetter.coffee
@@ -25,7 +25,7 @@ describe 'ChatInputValueGetter', ->
     value1       = '12345'
     value2       = 'qwerty'
     emptyChannel = 'channel3'
-    { getters } = ChatInputFlux
+    { getters }  = ChatInputFlux
 
     it 'gets value depending on the current channel id', ->
 

--- a/client/activity/lib/flux/chatinput/tests/value/valuegetter.coffee
+++ b/client/activity/lib/flux/chatinput/tests/value/valuegetter.coffee
@@ -1,0 +1,43 @@
+{ expect } = require 'chai'
+
+Reactor = require 'app/flux/reactor'
+ChatInputValueStore = require 'activity/flux/chatinput/stores/valuestore'
+SelectedChannelThreadIdStore = require 'activity/flux/stores/selectedchannelthreadidstore'
+ChatInputFlux = require 'activity/flux/chatinput'
+ActivityActions = require 'activity/flux/actions/actiontypes'
+ChatInputActions = require 'activity/flux/chatinput/actions/actiontypes'
+
+describe 'ChatInputValueGetter', ->
+
+  beforeEach ->
+
+    @reactor = new Reactor()
+    stores = {}
+    stores[ChatInputValueStore.getterPath] = ChatInputValueStore
+    stores[SelectedChannelThreadIdStore.getterPath] = SelectedChannelThreadIdStore
+    @reactor.registerStores stores
+
+
+  describe '#currentValue', ->
+
+    channelId1  = 'channel1'
+    channelId2  = 'channel2'
+    value1      = '12345'
+    value2      = 'qwerty'
+    { getters } = ChatInputFlux
+
+    it 'gets value depending on the current channel id', ->
+
+      @reactor.dispatch ChatInputActions.SET_CHAT_INPUT_VALUE, { channelId : channelId1, value : value1 }
+      @reactor.dispatch ChatInputActions.SET_CHAT_INPUT_VALUE, { channelId : channelId2, value : value2 }
+
+      @reactor.dispatch ActivityActions.SET_SELECTED_CHANNEL_THREAD, { channelId : channelId1 }
+
+      value = @reactor.evaluate getters.currentValue
+      expect(value).to.equal value1
+
+      @reactor.dispatch ActivityActions.SET_SELECTED_CHANNEL_THREAD, { channelId : channelId2 }
+
+      value = @reactor.evaluate getters.currentValue
+      expect(value).to.equal value2
+

--- a/client/activity/lib/flux/chatinput/tests/value/valuegetter.coffee
+++ b/client/activity/lib/flux/chatinput/tests/value/valuegetter.coffee
@@ -20,10 +20,11 @@ describe 'ChatInputValueGetter', ->
 
   describe '#currentValue', ->
 
-    channelId1  = 'channel1'
-    channelId2  = 'channel2'
-    value1      = '12345'
-    value2      = 'qwerty'
+    channelId1   = 'channel1'
+    channelId2   = 'channel2'
+    value1       = '12345'
+    value2       = 'qwerty'
+    emptyChannel = 'channel3'
     { getters } = ChatInputFlux
 
     it 'gets value depending on the current channel id', ->
@@ -40,4 +41,9 @@ describe 'ChatInputValueGetter', ->
 
       value = @reactor.evaluate getters.currentValue
       expect(value).to.equal value2
+
+      @reactor.dispatch ActivityActions.SET_SELECTED_CHANNEL_THREAD, { channelId : emptyChannel }
+
+      value = @reactor.evaluate getters.currentValue
+      expect(value).to.equal ''
 

--- a/client/activity/lib/flux/chatinput/tests/value/valuestore.coffee
+++ b/client/activity/lib/flux/chatinput/tests/value/valuestore.coffee
@@ -1,0 +1,33 @@
+{ expect } = require 'chai'
+
+Reactor = require 'app/flux/reactor'
+
+ChatInputValueStore = require 'activity/flux/chatinput/stores/valuestore'
+actions = require 'activity/flux/chatinput/actions/actiontypes'
+
+describe 'ChatInputValueStore', ->
+
+  beforeEach ->
+
+    @reactor = new Reactor
+    @reactor.registerStores chatInputValue : ChatInputValueStore
+
+
+  describe '#setValue', ->
+
+    it 'sets value depending on channel', ->
+
+      channelId  = 'test'
+      testValue1 = 'qwerty'
+      testValue2 = 'whoa!'
+
+      @reactor.dispatch actions.SET_CHAT_INPUT_VALUE, { channelId, value : testValue1 }
+      value = @reactor.evaluate(['chatInputValue']).get channelId
+
+      expect(value).to.equal testValue1
+
+      @reactor.dispatch actions.SET_CHAT_INPUT_VALUE, { channelId, value : testValue2 }
+      value = @reactor.evaluate(['chatInputValue']).get channelId
+
+      expect(value).to.equal testValue2
+


### PR DESCRIPTION
@usirin, can you review these changes? They save current value of chat input to store depending on the current channel and restore value from store when user changes channel.
Here is the short video:
![chat input value](http://g.recordit.co/1q9eoPZrq0.gif)
