### PR TITLE
reactivity: fix for broken channel urls [fixes #103661226]

### DIFF
--- a/client/activity/lib/components/chatinputwidget/index.coffee
+++ b/client/activity/lib/components/chatinputwidget/index.coffee
@@ -14,7 +14,6 @@ KeyboardKeys         = require 'app/util/keyboardKeys'
 Link                 = require 'app/components/common/link'
 whoami               = require 'app/util/whoami'
 helpers              = require './helpers'
-groupifyLink         = require 'app/util/groupifyLink'
 focusOnGlobalKeyDown = require 'activity/util/focusOnGlobalKeyDown'
 
 
@@ -181,7 +180,7 @@ module.exports = class ChatInputWidget extends React.Component
 
     { initialChannelId, slug } = message
     ActivityFlux.actions.channel.loadChannelById(initialChannelId).then ({ channel }) ->
-      kd.singletons.router.handleRoute groupifyLink "/Channels/#{channel.name}/#{slug}"
+      kd.singletons.router.handleRoute "/Channels/#{channel.name}/#{slug}"
 
 
   handleEmojiButtonClick: (event) ->

--- a/client/app/lib/util/transformReactivityTags.coffee
+++ b/client/app/lib/util/transformReactivityTags.coffee
@@ -1,8 +1,7 @@
-_                     = require 'lodash'
-getGroup              = require './getGroup'
-getBlockquoteRanges   = require './getBlockquoteRanges'
-groupifyLink          = require './groupifyLink'
-twitter               = require 'twitter-text'
+_                   = require 'lodash'
+getGroup            = require './getGroup'
+getBlockquoteRanges = require './getBlockquoteRanges'
+twitter             = require 'twitter-text'
 
 module.exports = (text = '') ->
 
@@ -16,7 +15,7 @@ module.exports = (text = '') ->
 
   hashtags = _.uniq twitter.extractHashtags text
   for hashtag in hashtags
-    url  = groupifyLink "/Channels/#{hashtag}", no
+    url  = "/Channels/#{hashtag}"
     tag  = "##{hashtag}"
     text = text.replace "#{tag}", (match, offset) ->
       if inSkipRange offset


### PR DESCRIPTION
@usirin, can you please review the fix for [this bug](https://www.pivotaltracker.com/story/show/103661226)? It remove usage of `groupifyLink` util when building channel urls since it breaks urls and there is no need to use it
