### PR TITLE
reactivity: fix for exception when switching to private channel

### DIFF
--- a/client/activity/lib/util/getParticipantOrigins.coffee
+++ b/client/activity/lib/util/getParticipantOrigins.coffee
@@ -5,12 +5,14 @@ module.exports = getParticipantOrigins = (channel) ->
 
   { lastMessage, participantsPreview, participantCount } = channel.toJS()
 
-  lastMessageOwner = lastMessage.account
+  lastMessageOwner = lastMessage?.account
 
-  origins = if isMyPost lastMessage then [] else [lastMessageOwner]
+  origins = if lastMessageOwner and not isMyPost(lastMessage) then [lastMessageOwner] else []
+  owners  = [whoami()._id]
+  owners.push lastMessageOwner._id  if lastMessageOwner
 
   filtered = participantsPreview.filter (p) ->
-    return not (p._id in [whoami()._id, lastMessageOwner._id])
+    return not (p._id in owners)
 
   origins = (origins.concat filtered).slice 0, 3
 


### PR DESCRIPTION
@usirin, can you review this fix? Exception occurs when user switches from empty public channel to private messages. This change fixes this error
