### PR TITLE
reactivity: hightlight urls even if they do not have a protocol [#103779584]

### DIFF
--- a/client/activity/lib/components/common/messagebody.coffee
+++ b/client/activity/lib/components/common/messagebody.coffee
@@ -3,8 +3,6 @@ React         = require 'kd-react'
 emojify       = require 'emojify.js'
 formatContent = require 'app/util/formatReactivityContent'
 immutable     = require 'immutable'
-urlGrabber    = require 'app/util/urlGrabber'
-regexps       = require 'app/util/regexps'
 
 
 module.exports = class MessageBody extends React.Component
@@ -30,37 +28,11 @@ module.exports = class MessageBody extends React.Component
 
   render: ->
 
-    body    = @props.message.get 'body'
-    body    = helper.markdownUrls body
-    content = formatContent body
+    content = formatContent @props.message.get 'body'
 
     return \
       <article
         className="MessageBody"
         ref={@bound 'contentDidMount'}
         dangerouslySetInnerHTML={__html: content} />
-
-
-  helper =
-
-    markdownUrls: (body) ->
-
-      urls          = urlGrabber body
-      processedUrls = {}
-
-      for url in urls
-        continue  if processedUrls[url]
-
-        urlWithProtocol = unless regexps.hasProtocol.test url
-        then "http://#{url}"
-        else url
-
-        urlMarkdown = "[#{url}](#{urlWithProtocol})"
-
-        urlRegExp = new RegExp "(\\s|^)(#{url})(\\s|$)", 'g'
-        body      = body.replace urlRegExp, (match, p1, p2, p3) -> p1 + urlMarkdown + p3
-
-        processedUrls[url] = yes
-
-      return body
 

--- a/client/app/lib/util/formatReactivityContent.coffee
+++ b/client/app/lib/util/formatReactivityContent.coffee
@@ -5,6 +5,7 @@ formatQuotes = require './formatQuotes'
 formatBlockquotes = require './formatBlockquotes'
 applyMarkdown = require './applyMarkdown'
 expandUsernames = require './expandUsernames'
+markdownUrls = require './markdownUrls'
 
 module.exports = (body = '', markdownOptions = {}) ->
 
@@ -14,6 +15,7 @@ module.exports = (body = '', markdownOptions = {}) ->
     transformEmails
     formatQuotes
     formatBlockquotes
+    markdownUrls
   ]
 
   body = fn body for fn in fns
@@ -21,3 +23,4 @@ module.exports = (body = '', markdownOptions = {}) ->
   body = expandUsernames body, 'code, a'
 
   return body
+

--- a/client/app/lib/util/markdownUrls.coffee
+++ b/client/app/lib/util/markdownUrls.coffee
@@ -1,0 +1,48 @@
+urlGrabber = require 'app/util/urlGrabber'
+regexps    = require 'app/util/regexps'
+
+
+formatUrls = (text) ->
+
+  urls          = urlGrabber text
+  processedUrls = {}
+
+  for url in urls
+    continue  if processedUrls[url]
+
+    urlWithProtocol = unless regexps.hasProtocol.test url
+    then "http://#{url}"
+    else url
+
+    urlMarkdown = "[#{url}](#{urlWithProtocol})"
+
+    urlRegExp = new RegExp "(\\s|^)(#{url})(\\s|$)", 'g'
+    text      = text.replace urlRegExp, (match, p1, p2, p3) -> p1 + urlMarkdown + p3
+
+    processedUrls[url] = yes
+
+  return text
+
+
+formatUrlsByPosition = (text, startIndex, endIndex) ->
+
+  text = text.substring startIndex, endIndex
+  return formatUrls text
+
+
+module.exports = markdownUrls = (body) ->
+
+  regExp    = new RegExp '(`|```)([^`]+)\\1', 'g'
+  prevIndex = 0
+  result    = ''
+
+  while match = regExp.exec body
+    formattedText   = formatUrlsByPosition body, prevIndex, match.index
+    result         += formattedText
+    result         += match[0]
+    prevIndex       = regExp.lastIndex
+
+  result += formatUrlsByPosition body, prevIndex
+
+  return result
+


### PR DESCRIPTION
@usirin, can you please review this change? It fixes the problem that if message contains url without protocol (for example, google.com), such url is not highlighted in the message.
Since normal urls (like http://google.com) are highlighted with markdown util, I was not able to find a better way to fix the problem than converting urls to markdown markup, i.e. google.com -> `[google.com](http://google.com)`.
To extract urls from the message body `urlGrabber` is used. It splits the body into the words and checks every word if the word is url. So once I have urls extracted by `urlGrabber`, I replace them with markdown markup using the same approach as `urlGrabber`, i.e. replace only those urls which are separate words

/cc @sinan 
