### PR TITLE
reactivity: scroll chat to the bottom when user submits a new message

### DIFF
--- a/client/activity/lib/components/chatpane/index.coffee
+++ b/client/activity/lib/components/chatpane/index.coffee
@@ -21,7 +21,8 @@ module.exports = class ChatPane extends React.Component
     return  unless nextProps?.thread
 
     { thread } = nextProps
-    @isMessageBeingSubmitted = thread.getIn ['flags', 'isMessageBeingSubmitted']
+    isMessageBeingSubmitted = thread.getIn ['flags', 'isMessageBeingSubmitted']
+    @shouldScrollToBottom   = yes  if isMessageBeingSubmitted
 
 
   onTopThresholdReached: -> @props.onLoadMore()

--- a/client/app/lib/components/scroller/scrollermixin.coffee
+++ b/client/app/lib/components/scroller/scrollermixin.coffee
@@ -21,7 +21,7 @@ module.exports = ScrollerMixin =
 
     element = React.findDOMNode @refs.scrollContainer
 
-    if @shouldScrollToBottom and @isMessageBeingSubmitted
+    if @shouldScrollToBottom
       element.scrollTop = element.scrollHeight
     else
       element.scrollTop = @scrollTop + (element.scrollHeight - @scrollHeight)


### PR DESCRIPTION
@usirin, can review this fix? It makes scrolling chat to the bottom working again after a new message is being submitted
