### PR TITLE
reactivity: fix to remove current channel name in message body carefully [fixes #103901232]

### DIFF
--- a/client/activity/lib/flux/getters.coffee
+++ b/client/activity/lib/flux/getters.coffee
@@ -139,7 +139,7 @@ selectedChannelThread = [
       messages.map (msg) ->
         msg.update 'body', (body) ->
           # don't show channel name on post body.
-          body.replace(///\##{channel.get('name')}///, '').trim()
+          body.replace(///\##{channel.get('name')}($|\s)///, '').trim()
     return thread.set 'channel', channel
 ]
 


### PR DESCRIPTION
@usirin, can you please review this change? It removes current channel name in message body only if channel name is a separate word
