### PR TITLE
reactivity: set focus to the end only when message has been just opened to edit [fixes #104224338]

### DIFF
--- a/client/activity/lib/components/chatlistitem/index.coffee
+++ b/client/activity/lib/components/chatlistitem/index.coffee
@@ -65,9 +65,12 @@ module.exports = class ChatListItem extends React.Component
     @getAccountInfo()
 
 
-  componentDidUpdate: ->
+  componentDidUpdate: (prevProps, prevState) ->
 
-    @focusInputOnEdit()  if @props.message.get '__isEditing'
+    isEditing  = @props.message.get '__isEditing'
+    wasEditing = prevProps.message.get '__isEditing'
+
+    @focusInputOnEdit()  if isEditing and not wasEditing
 
 
   getAccountInfo: ->


### PR DESCRIPTION
@usirin,ca you please review this fix? It for [this bug](https://www.pivotaltracker.com/story/show/104224338)
