### PR TITLE
Updated sidebar list item links texts to fix `Topic title is cut off incorrectly and can be overlapped with unread jevels` [fixes #98595548]

### DIFF
--- a/client/app/lib/components/sidebarlist/sidebarlistitem.coffee
+++ b/client/app/lib/components/sidebarlist/sidebarlistitem.coffee
@@ -25,7 +25,7 @@ module.exports = class SidebarListItem extends React.Component
   render: ->
     <div className={@getClassName()} onClick={@props.onClick}>
       <cite className="SidebarListItem-icon" />
-      <Link className="SidebarListItem-link" href={@props.href}>
+      <Link className="SidebarListItem-link" title={@props.title} href={@props.href}>
         {@props.title}
       </Link>
       {@renderUnreadCount()}

--- a/client/app/lib/components/sidebarlist/styl/sidebarlistitem.styl
+++ b/client/app/lib/components/sidebarlist/styl/sidebarlistitem.styl
@@ -23,7 +23,8 @@
   color                     $gray-14
   text-decoration           none
   font-weight               $fw-regular
-  width                     100%
+  width                     75%
+  ellipsis()
 
 .SidebarListItem-unreadCount
   position                  absolute


### PR DESCRIPTION
<img src='http://g.recordit.co/eFqxTAeO8H.gif' />
