### PR TITLE
Check existence of `config` property of compute stack instance [fixes #104165312]

### DIFF
--- a/client/app/lib/activity/sidebar/sidebarmachinebox.coffee
+++ b/client/app/lib/activity/sidebar/sidebarmachinebox.coffee
@@ -43,7 +43,7 @@ module.exports = class SidebarMachineBox extends KDView
     computeController.on "stateChanged-#{@machine._id}", @bound 'handleStateChanged'
 
     if stack = computeController.findStackFromMachineId @machine._id
-      visibility = stack.config.sidebar?[@machine.uid]?.visibility
+      visibility = stack.config?.sidebar?[@machine.uid]?.visibility
 
     @setVisibility visibility ? on
 

--- a/client/app/lib/environment/machineslistitem.coffee
+++ b/client/app/lib/environment/machineslistitem.coffee
@@ -58,7 +58,7 @@ module.exports = class MachinesListItem extends kd.ListItemView
     { computeController } = kd.singletons
 
     stack = computeController.findStackFromMachineId machine._id
-    defaultValue = stack.config.sidebar?[machine.uid]?.visibility
+    defaultValue = stack.config?.sidebar?[machine.uid]?.visibility
     defaultValue ?= on
 
     @sidebarToggle  = new KodingSwitch
@@ -95,7 +95,7 @@ module.exports = class MachinesListItem extends kd.ListItemView
 
     stack = computeController.findStackFromMachineId machine._id
 
-    { config } = stack
+    { config } = stack.config ?= {}
 
     config.sidebar ?= {}
     config.sidebar[machine.uid] = { visibility: state }


### PR DESCRIPTION
Managed VM stacks don't have a `config` propert by default.

[Managed VM can't be added correctly](https://www.pivotaltracker.com/story/show/104165312)
