### PR TITLE
reactivity: increase preview count from 5 to 20 on chat sidebar participants [#104286792]

### DIFF
--- a/client/activity/lib/components/channelparticipantavatars/index.coffee
+++ b/client/activity/lib/components/channelparticipantavatars/index.coffee
@@ -16,7 +16,7 @@ module.exports = class ChannelParticipantAvatars extends React.Component
   @include [DropboxInputMixin]
 
   PREVIEW_COUNT     = 0
-  MAX_PREVIEW_COUNT = 4
+  MAX_PREVIEW_COUNT = 19
 
   @defaultProps =
     channelThread : null

--- a/client/activity/lib/components/channelparticipantavatars/styl/channelparticipantavatars.styl
+++ b/client/activity/lib/components/channelparticipantavatars/styl/channelparticipantavatars.styl
@@ -10,7 +10,7 @@
   margin                  5px 0 0 10px
   line-height             28px
 
-  &:first-child
+  &:nth-child(5n+1)
     margin-left           0
 
 .ChannelParticipantAvatars-newParticipantBox


### PR DESCRIPTION
@usirin, can you please review this change? It increases a number of participants on chat sidebar.
Here is a [task](https://www.pivotaltracker.com/story/show/104286792) in pivotal
Here is a short video:
![participants](http://g.recordit.co/5H3ILofz2D.gif)
