### PR TITLE
Reactivity dropboxes redesign [fixes #104203988, #104203956, #104203516]

### DIFF
--- a/client/activity/lib/components/channeldropbox/index.coffee
+++ b/client/activity/lib/components/channeldropbox/index.coffee
@@ -108,15 +108,9 @@ module.exports = class ChannelDropbox extends React.Component
       visible      = { @isActive() }
       onOuterClick = { @bound 'close' }
       direction    = 'up'
+      title        = 'Channels'
       ref          = 'dropbox'
     >
-      <div className="Dropbox-innerContainer">
-        <div className="Dropbox-header">
-          Channels
-        </div>
-        <div className="ChannelDropbox-list">
-          {@renderList()}
-        </div>
-      </div>
+      {@renderList()}
     </Dropbox>
 

--- a/client/activity/lib/components/channeldropbox/styl/channeldropbox.styl
+++ b/client/activity/lib/components/channeldropbox/styl/channeldropbox.styl
@@ -1,3 +1,0 @@
-.ChannelDropbox-list
-  padding-bottom            5px
-

--- a/client/activity/lib/components/channeldropboxitem/index.coffee
+++ b/client/activity/lib/components/channeldropboxitem/index.coffee
@@ -15,7 +15,7 @@ module.exports = class ChannelDropboxItem extends React.Component
   render: ->
 
     { item } = @props
-    <DropboxItem {...@props} className="ChannelDropboxItem">
+    <DropboxItem {...@props} className="DropboxItem-separated ChannelDropboxItem">
       <span className="ChannelDropboxItem-hash"># </span>
       {item.get 'name'}
     </DropboxItem>

--- a/client/activity/lib/components/channeldropboxitem/styl/channeldropboxitem.styl
+++ b/client/activity/lib/components/channeldropboxitem/styl/channeldropboxitem.styl
@@ -1,11 +1,3 @@
 .ChannelDropboxItem
-  color                     #716f6d !important
-  padding                   5px 16px
-  margin                    1px 0px
-
-.ChannelDropboxItem:first-child
-  margin-top                0px
-
-.ChannelDropboxItem-hash
-  color                     #9c9a9a
+  padding                   7px 16px 8px 16px
 

--- a/client/activity/lib/components/channeldropboxitem/styl/channeldropboxitem.styl
+++ b/client/activity/lib/components/channeldropboxitem/styl/channeldropboxitem.styl
@@ -1,3 +1,4 @@
 .ChannelDropboxItem
-  padding                   7px 16px 8px 16px
+  padding-top               8px
+  height                    34px
 

--- a/client/activity/lib/components/dropbox/dropboxwrappermixin.coffee
+++ b/client/activity/lib/components/dropbox/dropboxwrappermixin.coffee
@@ -27,7 +27,7 @@ module.exports = DropboxWrapperMixin =
 
     return  if prevProps.selectedItem is selectedItem or not selectedItem
 
-    containerElement = @refs.dropbox.getMainElement()
+    containerElement = @refs.dropbox.getContentElement()
     itemElement      = React.findDOMNode @refs[@getItemKey selectedItem]
 
     scrollToTarget containerElement, itemElement

--- a/client/activity/lib/components/dropbox/index.coffee
+++ b/client/activity/lib/components/dropbox/index.coffee
@@ -27,11 +27,11 @@ module.exports = class Dropbox extends React.Component
     return  unless @props.visible
     return  unless @props.direction is 'up'
 
-    element = $ @getMainElement()
+    element = $ React.findDOMNode @refs.dropbox
     element.css top : -element.outerHeight()
 
 
-  getMainElement: -> React.findDOMNode @refs.dropbox
+  getContentElement: -> React.findDOMNode @refs.content
 
 
   handleMouseClick: (event) ->
@@ -57,13 +57,37 @@ module.exports = class Dropbox extends React.Component
     return classnames classes
 
 
+  renderSubtitle: ->
+
+    { subtitle } = @props
+    return  unless subtitle
+
+    <span className="Dropbox-subtitle">{ subtitle }</span>
+
+
+  renderHeader: ->
+
+    { title } = @props
+    return unless title
+
+    <div className='Dropbox-header'>
+      { title }
+      { @renderSubtitle() }
+    </div>
+
+
   render: ->
 
     className = @getClassName()
 
     <div className={className}>
-      <div className="Dropbox" ref="dropbox">
-        {@props.children}
+      <div className='Dropbox' ref='dropbox'>
+        { @renderHeader() }
+        <div className='Dropbox-scrollable' ref='content'>
+          <div className='Dropbox-content'>
+            { @props.children }
+          </div>
+        </div>
       </div>
     </div>
 

--- a/client/activity/lib/components/dropbox/styl/dropbox.styl
+++ b/client/activity/lib/components/dropbox/styl/dropbox.styl
@@ -6,11 +6,11 @@
   abs()
   overflow                  auto
   width                     100%
-  max-height                300px
-  border                    1px solid #dcdcdc
-  shadow                    0 5px 15px rgba(0,0,0,0.2)
+  max-height                307px
+  border                    1px solid #dfdfdf
   bg                        color, #fff
   borderBox()
+  rounded                   5px 5px 0 0
 
 .Dropbox-innerContainer
   rel()
@@ -19,5 +19,5 @@
   color                     #b5adad
   text-transform            uppercase
   font-size                 11px
-  padding                   9px 16px
+  padding                   8px 16px 7px 16px
 

--- a/client/activity/lib/components/dropbox/styl/dropbox.styl
+++ b/client/activity/lib/components/dropbox/styl/dropbox.styl
@@ -6,7 +6,8 @@
   abs()
   width                     100%
   border                    1px solid #dfdfdf
-  bg                        color, #fff
+  border-bottom             0px
+  bg                        color, #fcfcfc
   borderBox()
   rounded                   5px 5px 0 0
 

--- a/client/activity/lib/components/dropbox/styl/dropbox.styl
+++ b/client/activity/lib/components/dropbox/styl/dropbox.styl
@@ -4,20 +4,29 @@
 
 .Dropbox
   abs()
-  overflow                  auto
   width                     100%
-  max-height                307px
   border                    1px solid #dfdfdf
   bg                        color, #fff
   borderBox()
   rounded                   5px 5px 0 0
 
-.Dropbox-innerContainer
+.Dropbox-scrollable
+  overflow                  auto
+  max-height                271px
+
+.Dropbox-content
   rel()
 
 .Dropbox-header
   color                     #b5adad
   text-transform            uppercase
-  font-size                 11px
-  padding                   8px 16px 7px 16px
+  font-size                 12px
+  padding                   8px 12px
+  border-bottom             1px solid #dfdfdf
+
+.Dropbox-subtitle
+  font-weight               bold
+  color                     #4f4f4f
+  text-transform            none
+  padding-left              3px
 

--- a/client/activity/lib/components/dropboxitem/styl/dropboxitem.styl
+++ b/client/activity/lib/components/dropboxitem/styl/dropboxitem.styl
@@ -1,6 +1,8 @@
 .DropboxItem
   font-size                 14px
   pointer()
+  border-top                1px solid #dfdfdf
+  color                     #4e4d4e
 
 .DropboxItem-selected
   bg                        color, #ffeb9c

--- a/client/activity/lib/components/dropboxitem/styl/dropboxitem.styl
+++ b/client/activity/lib/components/dropboxitem/styl/dropboxitem.styl
@@ -1,9 +1,16 @@
 .DropboxItem
   font-size                 14px
   pointer()
-  border-top                1px solid #dfdfdf
   color                     #4e4d4e
 
 .DropboxItem-selected
   bg                        color, #ffeb9c
+
+.DropboxItem-separated
+  padding-left              12px
+  borderBox()
+  border-top                1px solid #dfdfdf
+
+.DropboxItem-separated:first-child
+  border-top                0px
 

--- a/client/activity/lib/components/emojidropbox/index.coffee
+++ b/client/activity/lib/components/emojidropbox/index.coffee
@@ -109,16 +109,11 @@ module.exports = class EmojiDropbox extends React.Component
       visible      = { @isActive() }
       onOuterClick = { @bound 'close' }
       direction    = 'up'
+      title        = 'Emojis matching '
+      subtitle     = { ":#{query}" }
       ref          = 'dropbox'
     >
-      <div className="Dropbox-innerContainer">
-        <div className="Dropbox-header">
-          Emojis matching <strong>:{query}</strong>
-        </div>
-        <div className="EmojiDropbox-list">
-          {@renderList()}
-          <div className="clearfix" />
-        </div>
-      </div>
+      {@renderList()}
+      <div className="clearfix" />
     </Dropbox>
 

--- a/client/activity/lib/components/emojidropbox/styl/emojidropbox.styl
+++ b/client/activity/lib/components/emojidropbox/styl/emojidropbox.styl
@@ -1,16 +1,7 @@
 .EmojiDropbox
-  .Dropbox
-    max-height              298px
+  .Dropbox-scrollable
+    max-height              268px
 
-  .Dropbox-header
-    padding-bottom          8px
-
-    strong
-      color                 #4f4f4f
-      text-transform        none
-      padding-left          3px
-
-.EmojiDropbox-list
-  padding                   12px
-  padding-top               0px
+  .Dropbox-content
+    padding                 4px 12px 8px 12px
 

--- a/client/activity/lib/components/emojidropboxitem/styl/emojidropboxitem.styl
+++ b/client/activity/lib/components/emojidropboxitem/styl/emojidropboxitem.styl
@@ -4,7 +4,6 @@
   rounded                   12px
   padding                   3px 12px 5px 7px
   margin                    1px 0 2px 0
-  border                    none
 
   .emoji
     size                    16px 16px

--- a/client/activity/lib/components/emojidropboxitem/styl/emojidropboxitem.styl
+++ b/client/activity/lib/components/emojidropboxitem/styl/emojidropboxitem.styl
@@ -4,6 +4,7 @@
   rounded                   12px
   padding                   3px 12px 5px 7px
   margin                    1px 0 2px 0
+  border                    none
 
   .emoji
     size                    16px 16px

--- a/client/activity/lib/components/emojiselector/styl/emojiselector.styl
+++ b/client/activity/lib/components/emojiselector/styl/emojiselector.styl
@@ -3,6 +3,8 @@
     right                   0px
     rounded                 3px
     width                   auto
+
+  .Dropbox-scrollable
     max-height              none
 
 .EmojiSelector-list

--- a/client/activity/lib/components/publicchatpane/styl/publicchatpane.styl
+++ b/client/activity/lib/components/publicchatpane/styl/publicchatpane.styl
@@ -13,7 +13,7 @@
     padding-left            44px
     size                    100%, 42px
     min-height              0
-    border                  1px solid #F2F2F2
+    border                  1px solid #dfdfdf
 
 .PublicChatPane-subscribeContainer
   borderBox()

--- a/client/activity/lib/components/searchdropbox/index.coffee
+++ b/client/activity/lib/components/searchdropbox/index.coffee
@@ -104,10 +104,9 @@ module.exports = class SearchDropbox extends React.Component
       visible        = { @isActive() }
       onOuterClick   = { @bound 'close' }
       direction      = 'up'
+      title          = 'Search'
       ref            = 'dropbox'
     >
-      <div className="Dropbox-innerContainer">
-        {@renderList()}
-      </div>
+      {@renderList()}
     </Dropbox>
 

--- a/client/activity/lib/components/searchdropboxitem/index.coffee
+++ b/client/activity/lib/components/searchdropboxitem/index.coffee
@@ -26,7 +26,7 @@ module.exports = class SearchDropboxItem extends React.Component
 
     { renderProfileLink, renderLikesCount, renderCommentsCount } = helper
 
-    <DropboxItem {...@props} className="SearchDropboxItem">
+    <DropboxItem {...@props} className="DropboxItem-separated SearchDropboxItem">
       <SearchItemBody source={messageBody} />
       <div>
         <span className="SearchDropboxItem-info SearchDropboxItem-profileLink">

--- a/client/activity/lib/components/searchdropboxitem/styl/searchdropboxitem.styl
+++ b/client/activity/lib/components/searchdropboxitem/styl/searchdropboxitem.styl
@@ -1,7 +1,6 @@
 .SearchDropboxItem
-  padding                   8px 20px 15px 20px
+  padding                   8px 12px 15px 12px
   color                     #605f63
-  border-bottom             1px solid #f3f3f3
   font-size                 16px
 
   &:last-child

--- a/client/activity/lib/components/userdropbox/index.coffee
+++ b/client/activity/lib/components/userdropbox/index.coffee
@@ -108,15 +108,9 @@ module.exports = class UserDropbox extends React.Component
       visible        = { @isActive() }
       onOuterClick   = { @bound 'close' }
       direction      = 'up'
+      title          = 'People'
       ref            = 'dropbox'
     >
-      <div className="Dropbox-innerContainer">
-        <div className="Dropbox-header">
-          People
-        </div>
-        <div className="UserDropbox-list">
-          {@renderList()}
-        </div>
-      </div>
+      {@renderList()}
     </Dropbox>
 

--- a/client/activity/lib/components/userdropbox/styl/userdropbox.styl
+++ b/client/activity/lib/components/userdropbox/styl/userdropbox.styl
@@ -1,7 +1,0 @@
-.UserDropbox
-  .Dropbox
-    max-height              294px
-
-.UserDropbox-list
-  padding-bottom            5px
-

--- a/client/activity/lib/components/userdropboxitem/index.coffee
+++ b/client/activity/lib/components/userdropboxitem/index.coffee
@@ -24,7 +24,7 @@ module.exports = class UserDropboxItem extends React.Component
       'UserDropboxItem-fullName' : yes
       'hidden'                  : not (profile.firstName and profile.lastName)
 
-    <DropboxItem {...@props} className="UserDropboxItem">
+    <DropboxItem {...@props} className="DropboxItem-separated UserDropboxItem">
       <Avatar width='25' height='25' account={account} />
       <div className='UserDropboxItem-names'>
         <span className='UserDropboxItem-nickname'>

--- a/client/activity/lib/components/userdropboxitem/styl/userdropboxitem.styl
+++ b/client/activity/lib/components/userdropboxitem/styl/userdropboxitem.styl
@@ -1,5 +1,6 @@
 .UserDropboxItem
-  padding                   4px 16px
+  padding-top               4px
+  height                    34px
 
   .ProfilePicture
     rounded                 3px

--- a/client/activity/lib/components/userdropboxitem/styl/userdropboxitem.styl
+++ b/client/activity/lib/components/userdropboxitem/styl/userdropboxitem.styl
@@ -1,10 +1,5 @@
 .UserDropboxItem
-  color                     #716f6d !important
-  padding                   3px 16px
-  margin                    1px 0px
-
-  &:first-child
-    margin-top              0px
+  padding                   4px 16px
 
   .ProfilePicture
     rounded                 3px
@@ -15,11 +10,7 @@
 .UserDropboxItem-names
   padding-top               3px
 
-.UserDropboxItem-fullName:before
-  content                   ""
-  size                      3px 3px
-  rounded                   50%
-  bg                        color, #b1b1b1
-  margin                    0 6px
-  blockMid()
+.UserDropboxItem-fullName
+  color                     #aaa8aa
+  padding-left              7px
 


### PR DESCRIPTION
@usirin, can you review these changes? Pivotal tasks are [users dropbox redesign](https://www.pivotaltracker.com/story/show/104203988), [channels dropbox redesign](https://www.pivotaltracker.com/story/show/104203956), [search dropbox redesign](https://www.pivotaltracker.com/story/show/104203516).
Besides redesign, I made dropbox header fixed so when user scrolls dropbox content header stays on the top
Also, I made refactoring of `Dropbox` component - I removed header and scroll container markup from specific dropboxes and put them into `Dropbox` component.

Here is how it looks now:
Users dropbox
![users](http://g.recordit.co/q74ZQtmVyy.gif)

Channels dropbox
![channels](http://g.recordit.co/A6jjx1e3gp.gif)

Search dropbox
![search](http://g.recordit.co/r8iA5nf5zt.gif)

Also, please note that since dropbox header has been fixed, I've added a border line under it to separate header from the rest content when user scrolls the content. Here is how it looks on emoji dropbox:
![emoji](http://g.recordit.co/46C7cqoQue.gif)

/cc @sinan 
