### PR TITLE
Fixed button styling on Your Stacks modal [ fixes #104429184 ]

### DIFF
--- a/client/app/lib/stacks/stacksmodal.coffee
+++ b/client/app/lib/stacks/stacksmodal.coffee
@@ -7,7 +7,7 @@ module.exports = class StacksModal extends kd.ModalView
 
   constructor: (options = {}, data) ->
 
-    options.cssClass = kd.utils.curry 'stacks-modal', options.cssClass
+    options.cssClass = kd.utils.curry 'stacks-modal your-stacks', options.cssClass
     options.width    = 742
     options.title    = 'Your Stacks'
     options.overlay  = yes
@@ -27,7 +27,7 @@ module.exports = class StacksModal extends kd.ModalView
 
     createButton = new kd.ButtonView
       title      : 'Create New Stack'
-      cssClass   : 'solid compact green'
+      cssClass   : 'solid compact green create-stack'
       callback   : ->
         new kd.NotificationView title: 'Coming soon.'
 

--- a/client/app/lib/styl/computeproviders.styl
+++ b/client/app/lib/styl/computeproviders.styl
@@ -925,6 +925,17 @@ computeproviders.styl
     abs                     15px, 25px
 
 
+  &.your-stacks
+    .create-stack
+      right                 35px
+
+    .close-icon
+      top                   19px !important
+
+    .stacktemplate-item .buttons
+      right                 10px
+
+
 .kdmodal.stack-template-content
 
   .kdmodal-title


### PR DESCRIPTION
Button is overlapped with Close icon on the Advanced stack info overlay #104429184
