### PR TITLE
Map name to purpose to description for privatemessage channels

### DIFF
--- a/client/activity/lib/flux/createchannel/actions/channel.coffee
+++ b/client/activity/lib/flux/createchannel/actions/channel.coffee
@@ -48,7 +48,7 @@ removeAllParticipants = ->
  * @param {string} payload.purpose
  * @param {array} payload.recipients
 ###
-createPublicChannel = (options={}) ->
+createPublicChannel = (options = {}) ->
 
   { CREATE_PUBLIC_CHANNEL
     CREATE_PUBLIC_CHANNEL_FAIL
@@ -75,7 +75,7 @@ createPublicChannel = (options={}) ->
  * @param {string} payload.purpose
  * @param {array}  payload.recipients
 ###
-createPrivateChannel = (options={}) ->
+createPrivateChannel = (options = {}) ->
 
   { CREATE_PRIVATE_CHANNEL
     CREATE_PRIVATE_CHANNEL_FAIL

--- a/client/activity/lib/flux/createchannel/actions/channel.coffee
+++ b/client/activity/lib/flux/createchannel/actions/channel.coffee
@@ -1,3 +1,4 @@
+_                       = require 'lodash'
 kd                      = require 'kd'
 actionTypes             = require './actiontypes'
 showErrorNotification   = require 'app/util/showErrorNotification'
@@ -83,7 +84,9 @@ createPrivateChannel = (options = {}) ->
 
   dispatch CREATE_PRIVATE_CHANNEL, options
 
-  kd.singletons.socialapi.channel.createChannelWithParticipants options, (err, channels) ->
+  _options = _mapPrivateChannelOptions options
+
+  kd.singletons.socialapi.channel.createChannelWithParticipants _options, (err, channels) ->
     if err
       dispatch CREATE_PRIVATE_CHANNEL_FAIL, { err }
       showErrorNotification err, userMessage: err.message
@@ -91,6 +94,19 @@ createPrivateChannel = (options = {}) ->
 
     [channel] = channels
     dispatch CREATE_PRIVATE_CHANNEL_SUCCESS, { channel }
+
+
+_mapPrivateChannelOptions = (options) ->
+
+  # don't modify arg
+  _options = _.assign {}, options
+
+  _options['payload'] or= {}
+  _options['payload']['description'] = options.purpose
+  _options['purpose'] = options.name
+  _options['name'] = ''
+
+  return _options
 
 
 module.exports = {

--- a/client/activity/lib/util/prepareThreadTitle.coffee
+++ b/client/activity/lib/util/prepareThreadTitle.coffee
@@ -6,10 +6,10 @@ makeProfileText       = require 'activity/util/makeProfileText'
 module.exports = prepareThreadTitle = (thread) ->
 
   channel = thread.get 'channel'
-  purpose = channel.get 'purpose'
+  name = channel.get 'name'
 
-  if purpose
-    return <span className="purpose">{purpose}</span>
+  if name
+    return <span className="Thread-name">{name}</span>
 
   preview = channel.get 'participantsPreview'
   count   = channel.get 'participantCount'

--- a/client/app/lib/socialapicontroller.coffee
+++ b/client/app/lib/socialapicontroller.coffee
@@ -259,8 +259,14 @@ module.exports = class SocialApiController extends KDController
     item.accountOldId        = channel.accountOldId
     # we only allow name, purpose and payload to be updated
     item.payload             = data.payload
-    item.name                = data.name
-    item.purpose             = data.purpose
+
+    if item.typeConstant is 'privatemessage'
+      item.name = data.purpose
+      item.purpose = item.payload?.description or ''
+    else
+      item.name = data.name
+      item.purpose = data.purpose
+
     item.participantCount    = channel.participantCount
     item.participantsPreview = mapAccounts channel.participantsPreview
     item.unreadCount         = channel.unreadCount

--- a/client/app/lib/socialapicontroller.coffee
+++ b/client/app/lib/socialapicontroller.coffee
@@ -7,6 +7,7 @@ remote = require('./remote').getInstance()
 checkFlag = require './util/checkFlag'
 whoami = require './util/whoami'
 kd = require 'kd'
+isKoding = require './util/isKoding'
 KDController = kd.Controller
 MessageEventManager = require './messageeventmanager'
 
@@ -260,7 +261,7 @@ module.exports = class SocialApiController extends KDController
     # we only allow name, purpose and payload to be updated
     item.payload             = data.payload
 
-    if item.typeConstant is 'privatemessage'
+    if not isKoding() and item.typeConstant is 'privatemessage'
       item.name = data.purpose
       item.purpose = item.payload?.description or ''
     else


### PR DESCRIPTION
- [x] map `name to purpose`, `purpose to payload's description` field when creating a private channel in teams context.
- [x] map `payload's description to purpose` and `purpose to name` field when reading a private channel in teams context.

/cc @cihangir @mehmetalisavas 
