### PR TITLE
StacksInitialView: don't allow more than 1 stack template [completes #104714314]

### DIFF
--- a/client/admin/lib/views/stacks/initialview.coffee
+++ b/client/admin/lib/views/stacks/initialview.coffee
@@ -13,22 +13,51 @@ module.exports = class InitialView extends kd.View
 
     super options, data
 
+    @_stackTemplatesLength = 0
+
     @createStackButton = new kd.ButtonView
       title    : 'Create new Stack'
-      cssClass : 'solid compact green action'
-      callback : => @emit 'CreateNewStack', skipOnboarding: yes
+      cssClass : 'solid compact green action hidden'
+      callback : (event) =>
+        console.log @_stackTemplatesLength
+        if @_stackTemplatesLength >= 1 and not event?.shiftKey
+          @showWarning "Multiple Stack Template support will be
+                        provided soon. You still can modify your
+                        existing stack templates."
+        else
+          @emit 'CreateNewStack', skipOnboarding: yes
 
     @stackTemplateList = new StackTemplateListView
 
     @stackTemplateList.listView.on 'ItemSelected', (stackTemplate) =>
       @emit 'EditStack', stackTemplate
 
+    @stackTemplateList.listView.on 'ItemDeleted', =>
+      @_stackTemplatesLength = @stackTemplateList.listView.items.length - 1
+
     @stackTemplateList.listController.on 'ItemsLoaded', (stackTemplates) =>
       @emit 'NoTemplatesFound'  if stackTemplates.length is 0
+      @_stackTemplatesLength = stackTemplates.length
+      @createStackButton.show()
 
 
   reload: ->
     @stackTemplateList.listController.loadItems()
+
+
+  showWarning: (content) ->
+    modal = new kd.ModalView
+      title          : ''
+      content        : content
+      overlay        : yes
+      overlayOptions :
+        cssClass     : 'second-overlay'
+        overlayClick : yes
+      buttons        :
+        close        :
+          title      : 'Close'
+          cssClass   : 'solid medium gray'
+          callback   : -> modal.destroy()
 
 
   pistachio: ->


### PR DESCRIPTION
This is a soft block, which you can bypass it by holding on `Shift` while clicking to Create new Stack button. This will be reverted once we have a better ux for this flow.

![](http://g.recordit.co/FAeKo8W0T4.gif)

cc/ @devrim 
