### PR TITLE
Sidebar: Set white color to sidebar tag when it is activated

### DIFF
--- a/client/app/lib/styl/resurrection.sidebar.styl
+++ b/client/app/lib/styl/resurrection.sidebar.styl
@@ -486,10 +486,14 @@ sidebarTextShadow()
     //   sidebarTextShadow()
 
     &.selected
-      color           sidebarActive
+      color                 sidebarActive
 
       .ttag:before
-        color         #fff
+        color               sidebarActive
+
+      .ttag
+        color               sidebarActive
+
 
     borderBox()
     &:hover


### PR DESCRIPTION
/cc @fatihacet 
##### Before

<img width="258" alt="screen shot 2015-10-02 at 6 28 33 pm" src="https://cloud.githubusercontent.com/assets/728733/10250556/28ce008e-6934-11e5-9ec3-1f4fb63ae2ff.png">
##### After

<img width="260" alt="screen shot 2015-10-02 at 6 28 51 pm" src="https://cloud.githubusercontent.com/assets/728733/10250562/2ebef430-6934-11e5-9d76-91094903283c.png">
