### PR TITLE
kloud: Increased the CheckBuild WaitiState from 12m to 15m

### DIFF
--- a/go/src/koding/kites/kloud/api/amazon/instance.go
+++ b/go/src/koding/kites/kloud/api/amazon/instance.go
@@ -70,7 +70,7 @@ func (a *Amazon) CheckBuild(ctx context.Context, instanceId string, start, finis
 	}
 
 	ws := waitstate.WaitState{
-		Timeout:      12 * time.Minute,
+		Timeout:      15 * time.Minute,
 		StateFunc:    stateFunc,
 		DesiredState: machinestate.Running,
 		Start:        start,


### PR DESCRIPTION
A small increase in timeout, to help give AWS a chance to complete the
task we have asked of them _(build & start machine)_.

assigned: @cihangir 
cc @fatih 
