### PR TITLE
kloud: Reduced "klient missing" timeout to 20m from 50m

### DIFF
--- a/go/src/koding/kites/kloud/provider/koding/machine.go
+++ b/go/src/koding/kites/kloud/provider/koding/machine.go
@@ -280,7 +280,7 @@ func (m *Machine) stopIfKlientIsMissing(ctx context.Context) error {
 	}
 
 	// If the klient has been missing less than X minutes, don't stop
-	if time.Since(m.Assignee.KlientMissingAt) < time.Minute*50 {
+	if time.Since(m.Assignee.KlientMissingAt) < time.Minute*20 {
 		return nil
 	}
 


### PR DESCRIPTION
To reduce the amount of time klient stays missing, and thus how much we
are billed for actions by the user during that time, the missing timeout
has been reduced to 20m.

assigned: @cihangir 
cc @fatih
