### PR TITLE
Speed up coffee watch

### DIFF
--- a/client/builder/lib/index.coffee
+++ b/client/builder/lib/index.coffee
@@ -30,6 +30,7 @@ throttle      = require 'throttleit'
 child_process = require 'child_process'
 collapse      = require 'bundle-collapser/plugin'
 convert       = require 'convert-source-map'
+globby        = require 'globby'
 
 
 JS_OUTFILE                  = 'bundle.js'
@@ -468,11 +469,14 @@ class Haydar extends events.EventEmitter
 
       styl manifest, globs
 
+      files = globs.reduce (acc, glob) ->
+        acc.concat globby.sync glob
+      , []
 
       if opts.watchCss and not watchedGlobs[globs.join()]
         watchedGlobs[globs.join()] = yes
         console.log "watching #{globs}"
-        w = chokidar.watch globs, persistent: yes
+        w = chokidar.watch files, persistent: yes
         w.on 'ready', -> w.on 'raw', onRaw
 
 

--- a/client/builder/lib/index.coffee
+++ b/client/builder/lib/index.coffee
@@ -326,7 +326,7 @@ class Haydar extends events.EventEmitter
 
             s.once 'finish', ->
               secs = ((Date.now() - start)/1000).toFixed 2
-              msg = "written #{outfile} (#{secs})"
+              msg = "written #{outfile} (#{secs} secs)"
               console.log msg
               console.log "extracted source maps to #{opts.jsSourcemapsOutfile}"
               if not opts.watchJs
@@ -461,7 +461,7 @@ class Haydar extends events.EventEmitter
         return  unless file
 
         if e in ['change','modified','deleted']
-          console.log "updated #{globs}"
+          console.log "New '#{e}' event on #{file}"
           start = Date.now()
           styl manifest, globs
 
@@ -475,7 +475,7 @@ class Haydar extends events.EventEmitter
 
       if opts.watchCss and not watchedGlobs[globs.join()]
         watchedGlobs[globs.join()] = yes
-        console.log "watching #{globs}"
+        globs.forEach (glob) -> console.log "watching #{glob}"
         w = chokidar.watch files, persistent: yes
         w.on 'ready', -> w.on 'raw', onRaw
 

--- a/client/builder/package.json
+++ b/client/builder/package.json
@@ -15,6 +15,7 @@
     "coffeeify": "1.0.0",
     "defined": "0.0.0",
     "exorcist": "0.1.6",
+    "globby": "3.0.1",
     "gulp-concat": "2.5.2",
     "gulp-stylus": "2.0.1",
     "gulp.spritesmith": "2.5.1",


### PR DESCRIPTION
This PR removes triggering stylus compilation when a coffee file inside a given glob changes. It achieves it by:
- [x] Resolving filenames with `globby` package before passing to chokidar.
- [x] Since `globby.sync` returns an array, and `chokidar.watch` accepts file list array, it just passes the result to `globby.watch`

This doesn't improve stylus compilation speed, but it removes the unnecessary compilations of stylus when a coffee file changes because of `chokidar.watch` resolves globs in a way that i don't understand. So the coffee file compilation watch process at its fastest right now.
