### PR TITLE
reactivity: emoji matching improvements [fixes #104402730]

### DIFF
--- a/client/activity/lib/components/emojidropbox/index.coffee
+++ b/client/activity/lib/components/emojidropbox/index.coffee
@@ -21,6 +21,7 @@ module.exports = class EmojiDropbox extends React.Component
     items          : immutable.List()
     selectedIndex  : 0
     selectedItem   : null
+    query          : ''
 
 
   formatSelectedValue: -> formatEmojiName @props.selectedItem
@@ -84,7 +85,7 @@ module.exports = class EmojiDropbox extends React.Component
 
   renderList: ->
 
-    { items, selectedIndex } = @props
+    { items, selectedIndex, query } = @props
 
     items.map (item, index) =>
       isSelected = index is selectedIndex
@@ -93,6 +94,7 @@ module.exports = class EmojiDropbox extends React.Component
         isSelected  = { isSelected }
         index       = { index }
         item        = { item }
+        query       = { query }
         onSelected  = { @bound 'onItemSelected' }
         onConfirmed = { @bound 'confirmSelectedItem' }
         key         = { @getItemKey item }

--- a/client/activity/lib/components/emojidropboxitem/index.coffee
+++ b/client/activity/lib/components/emojidropboxitem/index.coffee
@@ -12,9 +12,25 @@ module.exports = class EmojiDropboxItem extends React.Component
     item       : immutable.Map()
     isSelected : no
     index      : 0
+    query      : ''
 
 
   componentDidMount: -> emojify.run React.findDOMNode @refs.icon
+
+
+  renderEmojiName: ->
+
+    { item, query } = @props
+
+    index = item.indexOf query
+    if index is 0
+      formatEmojiName item
+    else
+      <span>
+        :{item.substring 0, index}
+        <strong>{query}</strong>
+        {item.substring index + query.length}:
+      </span>
 
 
   render: ->
@@ -22,6 +38,6 @@ module.exports = class EmojiDropboxItem extends React.Component
     { item } = @props
     <DropboxItem {...@props} className="EmojiDropboxItem">
       <span ref='icon'>{formatEmojiName item}</span>
-      {formatEmojiName item}
+      {@renderEmojiName()}
     </DropboxItem>
 

--- a/client/activity/lib/components/emojidropboxitem/styl/emojidropboxitem.styl
+++ b/client/activity/lib/components/emojidropboxitem/styl/emojidropboxitem.styl
@@ -13,3 +13,7 @@
   &.DropboxItem-selected
     bg                      color, rgba(249,204,13,0.4)
 
+  strong
+    font-weight             bold
+    color                   #4e4d4e
+

--- a/client/activity/lib/flux/chatinput/getters.coffee
+++ b/client/activity/lib/flux/chatinput/getters.coffee
@@ -45,7 +45,11 @@ filteredEmojiList = (stateId) -> [
   filteredEmojiListQuery stateId
   (emojis, query) ->
     return immutable.List()  unless query
-    emojis.filter (emoji) -> emoji.indexOf(query) is 0
+
+    isBeginningMatch = query.length < 3
+    emojis.filter (emoji) ->
+      index = emoji.indexOf(query)
+      if isBeginningMatch then index is 0 else index > -1
 ]
 
 

--- a/client/activity/lib/flux/chatinput/getters.coffee
+++ b/client/activity/lib/flux/chatinput/getters.coffee
@@ -47,9 +47,14 @@ filteredEmojiList = (stateId) -> [
     return immutable.List()  unless query
 
     isBeginningMatch = query.length < 3
-    emojis.filter (emoji) ->
-      index = emoji.indexOf(query)
-      if isBeginningMatch then index is 0 else index > -1
+    emojis
+      .filter (emoji) ->
+        index = emoji.indexOf(query)
+        if isBeginningMatch then index is 0 else index > -1
+      .sort (emoji1, emoji2) ->
+        return -1  if emoji1.indexOf(query) is 0
+        return 1  if emoji2.indexOf(query) is 0
+        return 0
 ]
 
 


### PR DESCRIPTION
@usirin, can you review it? Emoji matching and highlighting rules are:
- if user entered < 3 characters, search for emojis which start with entered query
- if user entered >=3 characters, search for emojis which include query at any place of the word
- highlight query only if it's not at the beginning of the word
  /cc @sinan 

![emojis](http://g.recordit.co/6nBN8RLnvB.gif)
