### PR TITLE
WebtermMessagePane: handle session invalid errors correctly so we can see click here to open a new tab message instead of an unknown error occurred for invalid sessions

### DIFF
--- a/client/app/lib/terminal/webtermmessagepane.coffee
+++ b/client/app/lib/terminal/webtermmessagepane.coffee
@@ -64,7 +64,7 @@ module.exports = class WebTermMessagePane extends KDCustomScrollView
     kd.utils.killRepeat @loader.repeater
     @loader.hide()
 
-    if err.message is "ErrNoSession"
+    if err.message in ["ErrNoSession", "session doesn't exists"]
 
       @setMessage \
         "This session is not valid anymore,


### PR DESCRIPTION
We need to handle this error as well for invalid sessions ![](http://take.ms/3QV8Y)
