### PR TITLE
VM Settings: Resize VM: Don't show resize vm link for non-koding groups [fixes #104983522]

### DIFF
--- a/client/app/lib/providers/machinesettingsdiskusageview.coffee
+++ b/client/app/lib/providers/machinesettingsdiskusageview.coffee
@@ -1,6 +1,7 @@
 kd                  = require 'kd'
 KDView              = kd.View
 showError           = require 'app/util/showError'
+isKoding            = require 'app/util/isKoding'
 KDCustomHTMLView    = kd.CustomHTMLView
 ComputeResizeModal  = require './computeresizemodal'
 CircularProgressBar = require 'app/commonviews/circularprogressbar'
@@ -53,10 +54,14 @@ module.exports = class MachineSettingsDiskUsageView extends KDView
         <span>#{format usage} of #{format total}</span>
       """
 
-    unless @getData().isManaged()
+    if not @getData().isManaged() and isKoding()
       @addSubView new KDCustomHTMLView
         cssClass : 'footline'
-        partial  : "If you have a paid plan or storage through referrals, you can <a href='#' class='resize'>resize your VM</a>.<br>Share Koding and <a href='#' class='share'>get more storage for free</a>!"
+        partial  : """
+          If you have a paid plan or storage through referrals, you can
+          <a href='#' class='resize'>resize your VM</a>.<br>Share Koding and
+          <a href='#' class='share'>get more storage for free</a>!
+        """
         click    : (e) =>
           if e.target.tagName is 'A'
 

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -1878,7 +1878,7 @@ paymentGrayLighter  = #f8f8f8
     font-size               42px
 
   .usage-info
-    width                   260px
+    width                   270px
     border                  1px solid #F0F0F0
     padding                 15px
     text-align              right
@@ -1889,8 +1889,7 @@ paymentGrayLighter  = #f8f8f8
       display               inline
       font-size             16px
       font-weight           400
-      position              relative
-      left                  -50px
+      float                 left
 
     span
       display               inline


### PR DESCRIPTION
/cc @fatihacet @szkl @gokmen 
##### For Team

<img width="931" alt="team-vm" src="https://cloud.githubusercontent.com/assets/728733/10325345/653906be-6c99-11e5-96ec-3570299a2db3.png">
##### For Koding

<img width="1161" alt="koding-vm" src="https://cloud.githubusercontent.com/assets/728733/10325349/6bc9bcc6-6c99-11e5-9085-910b389e5565.png">
##### For Managed VM

<img width="1162" alt="managed-vm" src="https://cloud.githubusercontent.com/assets/728733/10325354/72e6b662-6c99-11e5-81f6-80d2b3d3d041.png">
