### PR TITLE
Teams: Sidebar: Fix broken styles on Safari [fixes #105089982]

### DIFF
--- a/client/app/lib/components/sidebarchannelssection/styl/sidebarchannelssection.styl
+++ b/client/app/lib/components/sidebarchannelssection/styl/sidebarchannelssection.styl
@@ -3,12 +3,13 @@ $lh-channels = 20px
 .SidebarChannelsSection .SidebarListItem
   line-height               $lh-channels
   margin                    4px 0
+  min-height                24px
 
 .SidebarChannelsSection .SidebarListItem-icon
   display                   inline-block
   margin-right              7px
   rel()
-  top                       -2px
+  float                     left
 
   &:before
     display                 block

--- a/client/app/lib/components/sidebarmessagessection/styl/sidebarmessagessection.styl
+++ b/client/app/lib/components/sidebarmessagessection/styl/sidebarmessagessection.styl
@@ -6,5 +6,5 @@
   border-radius             100%
   margin                    0 8px 0 2px
   rel()
-  top                       -5px
-
+  top                       4px
+  float                     left

--- a/client/app/lib/styl/resurrection.sidebar.styl
+++ b/client/app/lib/styl/resurrection.sidebar.styl
@@ -633,7 +633,7 @@ sidebarTextShadow()
           size          10px, 10px
           bg            color, #808080
           border-radius 100%
-          abs           3px 0 0 -14px
+          abs           2px 0 0 -14px
 
       .avatarview
         size            24px 24px


### PR DESCRIPTION
/cc @sinan 

BEFORE
![before](https://cloud.githubusercontent.com/assets/728733/10335777/15601bb0-6cfc-11e5-9237-0dd33ee57f32.png)

AFTER

![ss2](https://cloud.githubusercontent.com/assets/728733/10335772/070b89aa-6cfc-11e5-9d60-f42acd5ab718.png)
