### PR TITLE
Client: NPM: Packages: Upgrade Validator [fixes #104867994]

### DIFF
--- a/client/activity/lib/styl/activity.listitem.styl
+++ b/client/activity/lib/styl/activity.listitem.styl
@@ -613,7 +613,7 @@ activity.listitem.styl
     size                    0 0
     border                  10px solid transparent
     border-bottom-color     #fff
-    abs                     0 114px 100% 0
+    abs                     0 90px 100% 0
     margin-bottom           -2px
 
   &:before
@@ -621,7 +621,7 @@ activity.listitem.styl
     size                    0 0
     border                  10px solid transparent
     border-bottom-color     #cfcfcf
-    abs                     0 114px 100% 0
+    abs                     0 90px 100% 0
 
   .activity-content-wrapper
     padding-bottom          15px

--- a/client/package.json
+++ b/client/package.json
@@ -54,7 +54,7 @@
     "timeago": "0.2.0",
     "twitter-text": "1.12.0",
     "uniq": "1.0.1",
-    "validator": "3.33.0"
+    "validator": "4.1.0"
   },
   "scripts": {
     "preinstall": "./npm-preinstall.sh",


### PR DESCRIPTION
I had need to upgrade this module because `validator.isEmail` method fails when it called with that value `$url = "http://cdn.sstatic.net/stackoverflow/img/sprites.png` ( etc. ). 
##### Use cases:
- `$url = "http://cdn.sstatic.net/stackoverflow/img/sprites.png` => fail
- `$url = "http://cdn.sstatic.net/stackoverflow/img/sprites.png"` => fail
- `$url = " http://cdn.sstatic.net/stackoverflow/img/sprites.png` => success

But we can handle all of them cases with `4.1.0` version now.

/cc @koding/frontend 
