### PR TITLE
Display stack machine list regardless of hid machine boxes [fixes #104983886]

### DIFF
--- a/client/app/lib/activity/sidebar/sidebarmachinelist.coffee
+++ b/client/app/lib/activity/sidebar/sidebarmachinelist.coffee
@@ -18,14 +18,11 @@ module.exports = class SidebarMachineList extends KDCustomHTMLView
 
     super options, data
 
-    @hide()
-
     @machineBoxes = []
     @machineBoxesByMachineUId = {}
 
     @createHeader()
     @addMachineBoxes()
-    @updateVisibility()
 
 
   createHeader: ->
@@ -54,8 +51,6 @@ module.exports = class SidebarMachineList extends KDCustomHTMLView
     data = boxes or @getData()
     data.forEach @bound 'addMachineBox'
 
-    @updateVisibility()
-
 
   addMachineBox: (machineAndWorkspaceData) ->
 
@@ -65,7 +60,6 @@ module.exports = class SidebarMachineList extends KDCustomHTMLView
 
     box = new SidebarMachineBox {}, machineAndWorkspaceData
 
-    box.on 'SetVisibility', @bound 'updateVisibility'
     box.once 'KDObjectWillBeDestroyed', @lazyBound 'handleMachineBoxDestroy', box
 
     @forwardEvent box, 'ListStateChanged'


### PR DESCRIPTION
[Stack is permanently hidden in sidebar when all machines are hid](https://www.pivotaltracker.com/story/show/104983886)
