### PR TITLE
Detect changes in symlinked paths

### DIFF
--- a/servers/models
+++ b/servers/models
@@ -1,0 +1,1 @@
+../workers/social/lib/social/models

--- a/watch-node
+++ b/watch-node
@@ -15,13 +15,13 @@ command="node $path"
 $command &
 pid=$!
 while [[ true ]]; do
-    
+
     if [[ `uname` == "Darwin" ]]; then
-      files=`find $watchfolder -type f -mtime -2s`
+      files=`find -L $watchfolder -type f -mtime -2s`
     else
-      files=`find $watchfolder -type f -mmin $(echo 2/60 | bc -l)`
+      files=`find -L $watchfolder -type f -mmin $(echo 2/60 | bc -l)`
     fi
-    
+
     if [[ $files != "" ]]
     then
         echo [watch-node $$] files changed [$files] killing $pid $command


### PR DESCRIPTION
`models` directory is relatively symlinked into `servers` directory.
`find` command in `watch-node` script is passed `-L` option which makes it deference symlinks. Therefore changes in symlinked directory are also taken into account which basically makes `watch-node` script to restart webserver when you change a model physically under social worker directory.
