### PR TITLE
IDE: Sidebar: Don't open environments modal when SHARED VMS title is clicked. [fixes #105203998]

### DIFF
--- a/client/app/lib/activity/sidebar/sidebarsharedmachineslist.coffee
+++ b/client/app/lib/activity/sidebar/sidebarsharedmachineslist.coffee
@@ -16,3 +16,7 @@ module.exports = class SidebarSharedMachinesList extends SidebarMachineList
 
     @on 'MachineBoxDestroyed', =>
       @hide()  if @machineBoxes.length is 0
+
+
+  # Don't anything when sidebar title is clicked.
+  headerClickHandler: ->

--- a/client/app/lib/styl/resurrection.sidebar.styl
+++ b/client/app/lib/styl/resurrection.sidebar.styl
@@ -1148,6 +1148,10 @@ h3.sidebar-title
 
 
 .shared-machines
+
+  h3.sidebar-title
+    cursor                  default
+
   .workspaces-link
     cursor          default
     &:hover


### PR DESCRIPTION
/cc @fatihacet @szkl 
