### PR TITLE
kloud: Do not stop alwayson machines after info decision

### DIFF
--- a/go/src/koding/kites/kloud/provider/koding/info.go
+++ b/go/src/koding/kites/kloud/provider/koding/info.go
@@ -50,6 +50,13 @@ func (m *Machine) Info(ctx context.Context) (map[string]string, error) {
 		// This ensures that the machine will never store Stopped in the
 		// database, while still running on the provider.
 		if resultState == machinestate.Stopped {
+			if m.Meta.AlwaysOn {
+				m.Log.Info("Info decision was to stop the machine, but it is an AlwaysOn machine. Ignoring decision. (username: %s, instanceId: %s, region: %s)",
+					m.Username, m.Meta.InstanceId, m.Meta.Region,
+				)
+				return
+			}
+
 			m.Log.Info("======> STOP started (inconsistent state)<======")
 
 			// Note that this Stop() call is done in a goroutine so that it


### PR DESCRIPTION
Note that we're chosing to still attempt the info decision (rather than
always returning on), because this helps us log the issue and keep stats
on it. Ideally, always-on machines should never return an info decision
of stopped, so it's worth while to log the issue, and be aware of
potential problematic patterns.

cc @sent-hil 

This is mainly just a patch, to mitigate the current Klient issues and stopping of always-on vms. We believe that the whole method needs some refactoring, as it has a lot of edge case logic, but for now this puts an easy to understand stop on the whole problem - and provides meaningful logs.
