### PR TITLE
Add content-display to full size apps list [fixes #105736950]

### DIFF
--- a/client/activity/lib/views/activityactionsview.coffee
+++ b/client/activity/lib/views/activityactionsview.coffee
@@ -1,12 +1,12 @@
-kd = require 'kd'
-KDContextMenu = kd.ContextMenu
-KDLoaderView = kd.LoaderView
-ActivityCommentCount = require './comments/activitycommentcount'
-ActivityLikeView = require './activitylikeview'
-ActivitySharePopup = require './activitysharepopup'
-groupifyLink = require 'app/util/groupifyLink'
-JView = require 'app/jview'
-CustomLinkView = require 'app/customlinkview'
+kd                    = require 'kd'
+KDContextMenu         = kd.ContextMenu
+KDLoaderView          = kd.LoaderView
+ActivityCommentCount  = require './comments/activitycommentcount'
+ActivityLikeView      = require './activitylikeview'
+ActivitySharePopup    = require './activitysharepopup'
+groupifyLink          = require 'app/util/groupifyLink'
+JView                 = require 'app/jview'
+CustomLinkView        = require 'app/customlinkview'
 
 
 module.exports = class ActivityActionsView extends JView
@@ -52,8 +52,10 @@ module.exports = class ActivityActionsView extends JView
           lazyLoad    : yes
         , customView  : new ActivitySharePopup delegate: this, url: shareUrl
 
-        pane = kd.singletons.appManager.frontApp.getView().tabs.getActivePane()
+        { frontApp } = kd.singletons.appManager
+        return  if frontApp.options.name isnt 'Activity'
 
+        pane = frontApp.getView().tabs.getActivePane()
         pane.scrollView.wrapper.once 'scroll', @sharePopup.bound 'destroy'
 
     @likeView = new ActivityLikeView {}, data

--- a/client/app/lib/mainviewcontroller.coffee
+++ b/client/app/lib/mainviewcontroller.coffee
@@ -82,23 +82,16 @@ module.exports = class MainViewController extends KDViewController
 
   setViewState: (options = {}) ->
 
-    {behavior, name} = options
+    { behavior, name } = options
 
     html     = global.document.documentElement
     mainView = @getView()
 
-    fullSizeApps    = [ 'Login', 'Pricing', 'Activity', 'Teams', 'Welcome' ]
     appsWithSidebar = [
       'Activity', 'Members', 'content-display', 'Apps', 'Dashboard', 'Account'
       'Environments', 'Bugs', 'Welcome'
     ]
 
-    if (isApp = behavior is 'application') or (name in fullSizeApps)
-    then KDView.setElementClass html, 'add', 'app'
-    else KDView.setElementClass html, 'remove', 'app'
-
-    if isApp or name in appsWithSidebar
+    if behavior is 'application' or name in appsWithSidebar
     then mainView.setClass 'with-sidebar'
     else mainView.unsetClass 'with-sidebar'
-
-

--- a/client/app/lib/styl/resurrection.commons.styl
+++ b/client/app/lib/styl/resurrection.commons.styl
@@ -10,7 +10,6 @@ body.apps
 body.environments
   bg                    color #e4e4e4
 
-html.app
 body.activity
 body.dashboard
 body.account

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -7,31 +7,26 @@ resurrection.styl
 */
 }
 
-// When app class is added to html tag
-// layout becomes 100% width and height
-// so that apps can control their own
-// scrollviews and add their chrome frames
-html.app
-  height            100%
+html
+  height                    100%
+
   body
-    height          100%
-    overflow        hidden  // this is to avoid rubber-band/elastic scroll on macs
+    font-family             openSansFamily
+    font-weight             400
+    -webkit-font-smoothing  subpixel-antialiased
+    height                  100%
+    overflow                hidden  // this is to avoid rubber-band/elastic scroll on macs
 
-body
-  font-family             openSansFamily
-  font-weight             400
-  -webkit-font-smoothing  subpixel-antialiased
+    &.noscroll
+      overflow              hidden
 
-  &.noscroll
-    overflow        hidden
+    &.logged-in
+      #main-header
+        nav
+          hidden()
 
-  &.logged-in
-    #main-header
-      nav
-        hidden()
-
-  > .invisible
-    abs             -1000% 0 0 -1000%
+    > .invisible
+      abs                   -1000% 0 0 -1000%
 
 input
 textarea

--- a/client/pricing/lib/styl/pricing.styl
+++ b/client/pricing/lib/styl/pricing.styl
@@ -10,8 +10,6 @@ pricing.styl
 
 body.pricing
 
-  height                100%
-
   #main-header
     .inner-container
       -webkit-font-smoothing  antialiased


### PR DESCRIPTION
For this story: https://www.pivotaltracker.com/n/projects/1217662/stories/105736950
By this fix all `<html>` and `<body>` element will have `100% height`.

/cc @fatihacet @usirin @sinan @gokmen @szkl 

<img width="1056" alt="screen shot 2015-10-19 at 2 58 51 pm" src="https://cloud.githubusercontent.com/assets/728733/10577263/55f0a562-7672-11e5-8c01-20e943047966.png">
