### PR TITLE
IDE: Collaboration: Chat: Set 12px font size to inputs when edit mode is activated. [fixes #105997334]

### DIFF
--- a/client/activity/lib/styl/activity.pm.styl
+++ b/client/activity/lib/styl/activity.pm.styl
@@ -629,9 +629,24 @@ headsListSelectedBgColor   = #7a7a7a
 
 .collaboration .chat-heads
 .collaboration .kdlistview-collaboration
+
+  .reply-input-widget
+  &.padded
+    width                   100%
+
   .avatarview
     cite.staff
       border-color  #f8f8f8
+
+  .privatemessage.editing
+    .edit-widget-wrapper
+
+      .edit-widget
+        margin-bottom       2px
+
+      .kdbutton .button-title
+      .edit-widget .input-view
+        font-size           12px
 
 #kdmaincontainer.collapsed .reply-input-widget
   kalc                width, 100% \- 131px


### PR DESCRIPTION
/cc @fatihacet @szkl @usirin @gokmen 
##### Before

![6sip2](https://cloud.githubusercontent.com/assets/728733/10579591/9c427fc2-7681-11e5-802c-b96a348af162.jpg)
##### After

<img width="364" alt="screen shot 2015-10-19 at 4 47 29 pm" src="https://cloud.githubusercontent.com/assets/728733/10579584/9282c1b8-7681-11e5-875c-65e0fd51409c.png">
