### PR TITLE
cleaner: Disabling Tag related processes, during the aws workaround fix

### DIFF
--- a/go/src/koding/kites/kloud/cleaners/cmd/cleaner/main.go
+++ b/go/src/koding/kites/kloud/cleaners/cmd/cleaner/main.go
@@ -133,10 +133,10 @@ func (c *Cleaner) collectAndProcess() error {
 	}
 
 	c.process(
-		&TagInstances{
-			Instances: artifacts.Instances,
-			Machines:  artifacts.MongodbUsers,
-		},
+		//&TagInstances{
+		//	Instances: artifacts.Instances,
+		//	Machines:  artifacts.MongodbUsers,
+		//},
 		&TestVMS{
 			Instances: artifacts.Instances,
 		},
@@ -157,10 +157,10 @@ func (c *Cleaner) collectAndProcess() error {
 			Instances: artifacts.Instances,
 			Cleaner:   c,
 		},
-		&GhostVMs{
-			Instances: artifacts.Instances,
-			Ids:       artifacts.MongodbUsers,
-		},
+		//&GhostVMs{
+		//	Instances: artifacts.Instances,
+		//	Ids:       artifacts.MongodbUsers,
+		//},
 		&MultipleVMs{
 			Instances:     artifacts.Instances,
 			UsersMultiple: artifacts.UsersMultiple,


### PR DESCRIPTION
The following PR temporarily disables the processes which are affected by the AWS Tag weirdness _(aws is not returning tags)_. We will re-enable them once they're fixed _(hopefully tomorrow)_.

cc @sent-hil 
