### PR TITLE
reactivity: private messages sidebar notification fixes [fixes #104634520, #106509514]

### DIFF
--- a/client/activity/lib/components/chatlist/index.coffee
+++ b/client/activity/lib/components/chatlist/index.coffee
@@ -34,6 +34,7 @@ module.exports = class ChatList extends React.Component
     super props
 
     @state = { selectedMessageId: @props.selectedMessageId }
+    kd.singletons.windowController.addFocusListener @bound 'handleFocus'
 
 
   getDataBindings: ->
@@ -56,6 +57,11 @@ module.exports = class ChatList extends React.Component
 
     if kd.singletons.windowController.isFocused()
       ActivityFlux.actions.channel.glance @props.channelId
+
+
+  handleFocus: (focused) ->
+
+    @glance()  if focused and @props.unreadCount
 
 
   onGlancerEnter: -> @glance()

--- a/client/activity/lib/flux/actions/realtime/actioncreators.coffee
+++ b/client/activity/lib/flux/actions/realtime/actioncreators.coffee
@@ -68,7 +68,7 @@ bindNotificationEvents = ->
 
   kd.singletons.notificationController
     .on 'MessageAddedToChannel', (payload) ->
-      { channel, channelMessage } = payload
+      { channel : { id }, channelMessage, unreadCount } = payload
 
       # TODO: FIXME
       # The reason we are doing these extra fetches is that right now backend
@@ -78,26 +78,23 @@ bindNotificationEvents = ->
       # everything is in place before doing anything. This will be fixed once
       # instance events of `SocialChannel` instances for private messages are
       # fixed. ~Umut
-      socialapi.channel.byId { id: channel.id }, (err, _channel) ->
+      socialapi.channel.byId { id }, (err, channel) ->
         return  if err
 
-        bindChannelEvents _channel
+        bindChannelEvents channel
 
-        actionType = if isPublicChannel _channel
+        actionType = if isPublicChannel channel
         then actions.LOAD_FOLLOWED_PUBLIC_CHANNEL_SUCCESS
         else actions.LOAD_FOLLOWED_PRIVATE_CHANNEL_SUCCESS
 
-        dispatch actionType, { channel : _channel, channelId: _channel.id }
+        dispatch actionType, { channel, channelId: channel.id }
 
-        { unreadCount } = data
-        _dispatchFn { unreadCount, channel : _channel }
-
-        socialapi.message.byId { id: channelMessage.id }, (err, _message) ->
+        socialapi.message.byId { id: channelMessage.id }, (err, message) ->
           return  if err
 
-          bindMessageEvents _message
-          _loadMessageFn { channel, channelMessage: _message }
-          _dispatchFn { unreadCount: payload.unreadCount, channel }
+          bindMessageEvents message
+          _loadMessageFn { channel, channelMessage: message }
+          _dispatchFn { unreadCount, channel }
 
     .on 'MessageRemovedFromChannel', _dispatchFn
     .on 'RemovedFromChannel', _dispatchFn

--- a/client/activity/lib/flux/actions/realtime/actioncreators.coffee
+++ b/client/activity/lib/flux/actions/realtime/actioncreators.coffee
@@ -1,5 +1,6 @@
 kd = require 'kd'
 actions = require '../actiontypes'
+isPublicChannel = require 'app/util/isPublicChannel'
 
 dispatch = (args...) -> kd.singletons.reactor.dispatch args...
 
@@ -81,6 +82,16 @@ bindNotificationEvents = ->
         return  if err
 
         bindChannelEvents _channel
+
+        actionType = if isPublicChannel _channel
+        then actions.LOAD_FOLLOWED_PUBLIC_CHANNEL_SUCCESS
+        else actions.LOAD_FOLLOWED_PRIVATE_CHANNEL_SUCCESS
+
+        dispatch actionType, { channel : _channel, channelId: _channel.id }
+
+        { unreadCount } = data
+        _dispatchFn { unreadCount, channel : _channel }
+
         socialapi.message.byId { id: channelMessage.id }, (err, _message) ->
           return  if err
 

--- a/client/activity/lib/flux/actions/realtime/actioncreators.coffee
+++ b/client/activity/lib/flux/actions/realtime/actioncreators.coffee
@@ -88,13 +88,13 @@ bindNotificationEvents = ->
         else actions.LOAD_FOLLOWED_PRIVATE_CHANNEL_SUCCESS
 
         dispatch actionType, { channel, channelId: channel.id }
+        _dispatchFn { unreadCount, channel }
 
         socialapi.message.byId { id: channelMessage.id }, (err, message) ->
           return  if err
 
           bindMessageEvents message
           _loadMessageFn { channel, channelMessage: message }
-          _dispatchFn { unreadCount, channel }
 
     .on 'MessageRemovedFromChannel', _dispatchFn
     .on 'RemovedFromChannel', _dispatchFn

--- a/client/activity/lib/flux/stores/channelsstore.coffee
+++ b/client/activity/lib/flux/stores/channelsstore.coffee
@@ -39,6 +39,11 @@ module.exports = class ChannelsStore extends KodingFluxStore
 
   handleLoadChannelSuccess: (channels, { channel }) ->
 
+    # if channel comes from backend without unreadCount data,
+    # we use it from the store if it exists
+    if channels.has(channel.id) and not channel.unreadCount
+      channel.unreadCount = channels.getIn [channel.id, 'unreadCount']
+
     return channels.set channel.id, toImmutable channel
 
 

--- a/client/activity/lib/flux/stores/channelsstore.coffee
+++ b/client/activity/lib/flux/stores/channelsstore.coffee
@@ -39,11 +39,6 @@ module.exports = class ChannelsStore extends KodingFluxStore
 
   handleLoadChannelSuccess: (channels, { channel }) ->
 
-    # if channel comes from backend without unreadCount data,
-    # we use it from the store if it exists
-    if channels.has(channel.id) and not channel.unreadCount
-      channel.unreadCount = channels.getIn [channel.id, 'unreadCount']
-
     return channels.set channel.id, toImmutable channel
 
 

--- a/client/app/lib/components/scroller/scrollermixin.coffee
+++ b/client/app/lib/components/scroller/scrollermixin.coffee
@@ -31,7 +31,8 @@ module.exports = ScrollerMixin =
       element.scrollTop = element.scrollHeight
     else if @isThresholdReached
       element.scrollTop = @scrollTop + (element.scrollHeight - @scrollHeight)
-      @isThresholdReached = no
+
+    @isThresholdReached = no
 
     @afterScrollDidUpdate?()
 


### PR DESCRIPTION
@usirin, can you please review these changes? They fix the next bugs:
- sidebar notification doesn't appear when user is invited to a private channel
- channel unread counter sometimes is not reset when user opens a channel (it happened from time to time; when it happened it worked like this - a new message comes -> counter is increased and shows 1 -> user opens a channel, counter disappears -> user goes to another channel -> another new message comes -> counter incorrectly shows 2 instead of 1)
- channel unread counter doesn't disappear when a new message comes to open channel and user sets focus to the document
