### PR TITLE
Providers: Managed VM: Re-open managed vm modal when plan is upgraded. [fixes #105566938]

### DIFF
--- a/client/app/lib/providers/managed/addmanagedmachinemodal.coffee
+++ b/client/app/lib/providers/managed/addmanagedmachinemodal.coffee
@@ -139,18 +139,24 @@ module.exports = class AddManagedMachineModal extends kd.ModalView
         Free Koding accounts are limited to adding one external machine and
         you already have one connected. Paid accounts are allowed to add unlimited external machines.
       </p>
-      <p>Please <a href="/Pricing">upgrade</a> to be able to add more.</p>
     """
 
+    @content.addSubView new kd.CustomHTMLView
+      tagName : 'p'
+      partial : 'Please <a href="/Pricing">upgrade</a> to be able to add more.'
+      click   : (event) =>
+        return  unless event.target.tagName is 'A'
+
+        # Don't require 'ComputeHelpers' on top. If you do that,
+        # you will get a circular dependency error from browserify.
+        ComputeHelpers  = require '../computehelpers'
+
+        kd.singletons.paymentController.once 'PaymentWorkflowFinishedSuccessfully', ->
+          ComputeHelpers.handleNewMachineRequest provider: 'managed'
+
+        @destroy()
+
     @setClass 'error'
-    @content.$('a').on 'click', =>
-
-      ComputeHelpers  = require '../computehelpers'
-
-      kd.singletons.paymentController.once 'PaymentWorkflowFinishedSuccessfully', ->
-        ComputeHelpers.handleNewMachineRequest provider: 'managed'
-
-      @destroy()
 
 
   destroy: ->

--- a/client/app/lib/providers/managed/addmanagedmachinemodal.coffee
+++ b/client/app/lib/providers/managed/addmanagedmachinemodal.coffee
@@ -143,6 +143,14 @@ module.exports = class AddManagedMachineModal extends kd.ModalView
     """
 
     @setClass 'error'
+    @content.$('a').on 'click', =>
+
+      ComputeHelpers  = require '../computehelpers'
+
+      kd.singletons.paymentController.once 'PaymentWorkflowFinishedSuccessfully', ->
+        ComputeHelpers.handleNewMachineRequest provider: 'managed'
+
+      @destroy()
 
 
   destroy: ->

--- a/client/pricing/lib/pricingappview.coffee
+++ b/client/pricing/lib/pricingappview.coffee
@@ -281,6 +281,8 @@ module.exports = class PricingAppView extends KDView
         @plans.setState @state
 
         kd.singletons.router.handleRoute '/'
+        kd.utils.defer ->
+          kd.singletons.paymentController.emit 'PaymentWorkflowFinishedSuccessfully'
 
 
   continueFrom: (planTitle, planInterval) ->


### PR DESCRIPTION
The use case:
- User has free plan and already connected 1 managed vm.
- User wants to add a new managed vm.
- User sees that modal:

<img width="683" alt="screen shot 2015-10-20 at 4 51 43 pm" src="https://cloud.githubusercontent.com/assets/728733/10609136/dfc5359a-774a-11e5-9f16-ac639b2b84b6.png">
- After that, user clicks `upgrade` link.

Here's the screencast:
![1ukkdmbmgk](https://cloud.githubusercontent.com/assets/728733/10609194/23f4acaa-774b-11e5-989e-13ccee3a8276.gif)

/cc @fatihacet @szkl @gokmen @sinan 
