### PR TITLE
Notification: Set cursor pointer property to "Couldn't connect to backend" notification. [fixes #98208774]

### DIFF
--- a/client/app/lib/maincontroller.coffee
+++ b/client/app/lib/maincontroller.coffee
@@ -361,6 +361,7 @@ module.exports           = class MainController extends KDController
 
       notification = new KDNotificationView
         title         : "Couldn't connect to backend!"
+        cssClass      : 'disconnection'
         type          : "tray"
         closeManually : no
         content       : """We don't know why, but your browser couldn't reach our server.

--- a/client/app/lib/providers/managed/addmanagedmachinemodal.coffee
+++ b/client/app/lib/providers/managed/addmanagedmachinemodal.coffee
@@ -143,6 +143,14 @@ module.exports = class AddManagedMachineModal extends kd.ModalView
     """
 
     @setClass 'error'
+    @content.$('a').on 'click', =>
+
+      ComputeHelpers  = require '../computehelpers'
+
+      kd.singletons.paymentController.once 'PaymentWorkflowFinishedSuccessfully', ->
+        ComputeHelpers.handleNewMachineRequest provider: 'managed'
+
+      @destroy()
 
 
   destroy: ->

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -2406,3 +2406,7 @@ paymentGrayLighter  = #f8f8f8
         bg                  color, transparent !important
         a
           color             #575757
+
+.kdnotification.tray.disconnection
+  pointer()
+

--- a/client/pricing/lib/pricingappview.coffee
+++ b/client/pricing/lib/pricingappview.coffee
@@ -281,6 +281,8 @@ module.exports = class PricingAppView extends KDView
         @plans.setState @state
 
         kd.singletons.router.handleRoute '/'
+        kd.utils.defer ->
+          kd.singletons.paymentController.emit 'PaymentWorkflowFinishedSuccessfully'
 
 
   continueFrom: (planTitle, planInterval) ->


### PR DESCRIPTION
Change cursor default icon to pointer while mouse is over on notification. By this means users can detect it is clickable.

/cc @fatihacet @szkl @sinan @gokmen 
