### PR TITLE
Notification: Set cursor pointer property to "Couldn't connect to backend" notification. [fixes #98208774]

### DIFF
--- a/client/app/lib/maincontroller.coffee
+++ b/client/app/lib/maincontroller.coffee
@@ -361,6 +361,7 @@ module.exports           = class MainController extends KDController
 
       notification = new KDNotificationView
         title         : "Couldn't connect to backend!"
+        cssClass      : 'disconnection'
         type          : "tray"
         closeManually : no
         content       : """We don't know why, but your browser couldn't reach our server.

--- a/client/app/lib/maincontroller.coffee
+++ b/client/app/lib/maincontroller.coffee
@@ -361,7 +361,7 @@ module.exports           = class MainController extends KDController
 
       notification = new KDNotificationView
         title         : "Couldn't connect to backend!"
-        cssClass      : 'disconnection'
+        cssClass      : 'disconnected'
         type          : "tray"
         closeManually : no
         content       : """We don't know why, but your browser couldn't reach our server.

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -2407,6 +2407,6 @@ paymentGrayLighter  = #f8f8f8
         a
           color             #575757
 
-.kdnotification.tray.disconnection
+.kdnotification.tray.disconnected
   pointer()
 

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -2406,3 +2406,7 @@ paymentGrayLighter  = #f8f8f8
         bg                  color, transparent !important
         a
           color             #575757
+
+.kdnotification.tray.disconnection
+  pointer()
+


### PR DESCRIPTION
Change cursor default icon to pointer while mouse is over on notification. By this means users can detect it is clickable.

/cc @fatihacet @szkl @sinan @gokmen 
