### PR TITLE
Check analytics.user getter function

### DIFF
--- a/client/app/lib/util/trackInitialTurnOn.coffee
+++ b/client/app/lib/util/trackInitialTurnOn.coffee
@@ -7,6 +7,7 @@ Tracker = require 'app/util/tracker'
 module.exports = (machine) ->
 
   return  unless analytics
+  return  unless typeof analytics.user is 'function'
 
   { initialTurnOn } = analytics.user().traits()
   return  if initialTurnOn


### PR DESCRIPTION
ublock extension prevents analytics.js loading up its full version. `analytics.user` property is missed as a result.
