### PR TITLE
reactivity: portal dropbox exception fix [fixes #106203812]

### DIFF
--- a/client/activity/lib/components/dropbox/dropboxbody.coffee
+++ b/client/activity/lib/components/dropbox/dropboxbody.coffee
@@ -1,53 +1,16 @@
-$            = require 'jquery'
 kd           = require 'kd'
 React        = require 'kd-react'
 classnames   = require 'classnames'
 ActivityFlux = require 'activity/flux'
-KeyboardKeys = require 'app/util/keyboardKeys'
 
 module.exports = class DropboxBody extends React.Component
 
   @defaultProps =
-    visible   : no
     className : ''
     type      : 'dropdown'
 
 
-  componentDidMount: ->
-
-    document.addEventListener 'mousedown', @bound 'handleMouseClick'
-    document.addEventListener 'keydown', @bound 'handleKeyDown'
-
-
-  componentWillUnmount: ->
-
-    document.removeEventListener 'mousedown', @bound 'handleMouseClick'
-    document.removeEventListener 'keydown', @bound 'handleKeyDown'
-
-
   getContentElement: -> React.findDOMNode @refs.content
-
-
-  handleMouseClick: (event) ->
-
-    { visible, onClose } = @props
-
-    return  unless visible
-
-    { target } = event
-    dropbox    = React.findDOMNode this
-    innerClick = $.contains dropbox, target
-
-    onClose?()  unless innerClick
-
-
-  handleKeyDown: (event) ->
-
-    { visible, onClose } = @props
-
-    return  unless @props.visible
-
-    onClose?()  if event.which is KeyboardKeys.ESC
 
 
   getContainerClassName: ->
@@ -95,8 +58,6 @@ module.exports = class DropboxBody extends React.Component
 
 
   render: ->
-
-    { visible } = @props
 
     containerClassName = @getContainerClassName()
     contentClassName   = @getContentClassName()

--- a/client/activity/lib/components/dropbox/portaldropbox.coffee
+++ b/client/activity/lib/components/dropbox/portaldropbox.coffee
@@ -89,11 +89,16 @@ module.exports = class PortalDropbox extends React.Component
 
     { visible, resize } = @props
 
-    <Portal isOpened={visible} className='PortalDropbox'>
-      <Dropbox {...@props}
-        contentClassName={if resize is 'content' then 'Dropbox-resizable'}
-        ref='dropbox'>
-          { @props.children }
-      </Dropbox>
+    <Portal
+      isOpened            = { visible }
+      className           = 'PortalDropbox'
+      closeOnEsc          = yes
+      onClose             = { @props.onClose }
+      closeOnOutsideClick = yes>
+        <Dropbox {...@props}
+          contentClassName={if resize is 'content' then 'Dropbox-resizable'}
+          ref='dropbox'>
+            { @props.children }
+        </Dropbox>
     </Portal>
 

--- a/client/activity/lib/components/dropbox/relativedropbox.coffee
+++ b/client/activity/lib/components/dropbox/relativedropbox.coffee
@@ -1,10 +1,23 @@
-$          = require 'jquery'
-kd         = require 'kd'
-React      = require 'kd-react'
-classnames = require 'classnames'
-Dropbox    = require './dropboxbody'
+$            = require 'jquery'
+kd           = require 'kd'
+React        = require 'kd-react'
+classnames   = require 'classnames'
+Dropbox      = require './dropboxbody'
+KeyboardKeys = require 'app/util/keyboardKeys'
 
 module.exports = class RelativeDropbox extends React.Component
+
+  componentDidMount: ->
+
+    document.addEventListener 'mousedown', @bound 'handleMouseClick'
+    document.addEventListener 'keydown', @bound 'handleKeyDown'
+
+
+  componentWillUnmount: ->
+
+    document.removeEventListener 'mousedown', @bound 'handleMouseClick'
+    document.removeEventListener 'keydown', @bound 'handleKeyDown'
+
 
   componentDidUpdate: ->
 
@@ -16,6 +29,28 @@ module.exports = class RelativeDropbox extends React.Component
 
 
   getContentElement: -> @refs.dropbox.getContentElement()
+
+
+  handleMouseClick: (event) ->
+
+    { visible, onClose } = @props
+
+    return  unless visible
+
+    { target } = event
+    dropbox    = React.findDOMNode this
+    innerClick = $.contains dropbox, target
+
+    onClose?()  unless innerClick
+
+
+  handleKeyDown: (event) ->
+
+    { visible, onClose } = @props
+
+    return  unless @props.visible
+
+    onClose?()  if event.which is KeyboardKeys.ESC
 
 
   render: ->


### PR DESCRIPTION
@usirin, can you please review the fix for [this bug](https://www.pivotaltracker.com/story/show/106203812)?
The reason of problem is that when `Portal` is closed (`isOpened=no`), it removes its children from DOM. In this case `componentWillUnmount` is not called in `DropboxBody` and its document listeners of `mousedown` and `keydown` events are still alive. So once user clicks on any place in document after portal dropbox is closed, `handleMouseClick` handler is called and `React.findDOMNode this` throws error since it doesn't find its element in DOM.
To avoid this issue, I use `closeOnEsc` and `closeOnOutsideClick` Portal props in `PortalDropbox` to handle dropbox close event with standard Portal functionality and moved handling of `mousedown` and `keydown` document events to `RelativeDropbox` where it's really needed
