### PR TITLE
Cacheable returns a single instance of JStackTemplate

### DIFF
--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -970,9 +970,8 @@ module.exports = class ComputeController extends KDController
 
     { baseStackId } = stack
 
-    remote.cacheable 'JStackTemplate', baseStackId, (err, templates) ->
+    remote.cacheable 'JStackTemplate', baseStackId, (err, template) ->
       return callback err  if err
-      [ template ] = templates
       return callback null, template or {}
 
 


### PR DESCRIPTION
Fixes `Uncaught TypeError: Cannot read property 'details' of undefined` error in environments modal which is occurring after a stack template is updated.
