### PR TITLE
kloud: Assign Elastic IP before machine has started [fixes #106291760]

### DIFF
--- a/go/src/koding/kites/kloud/provider/koding/machine.go
+++ b/go/src/koding/kites/kloud/provider/koding/machine.go
@@ -167,7 +167,6 @@ func (m *Machine) MarkAsStoppedWithReason(reason string) error {
 		return c.UpdateId(
 			m.Id,
 			bson.M{"$set": bson.M{
-				"ipAddress":         "",
 				"status.state":      machinestate.Stopped.String(),
 				"status.modifiedAt": time.Now().UTC(),
 				"status.reason":     reason,
@@ -179,7 +178,6 @@ func (m *Machine) MarkAsStoppedWithReason(reason string) error {
 
 	// so any State() method returns the correct status
 	m.Status.State = machinestate.Stopped.String()
-	m.IpAddress = ""
 	return nil
 }
 

--- a/go/src/koding/kites/kloud/provider/koding/start.go
+++ b/go/src/koding/kites/kloud/provider/koding/start.go
@@ -109,6 +109,36 @@ func (m *Machine) Start(ctx context.Context) (err error) {
 			time.Sleep(time.Second * 20)
 		}
 
+		// Assign a Elastic IP for a paying customer if it doesn't have any
+		// assigned yet (Elastic IP's are assigned only during the Build). We
+		// lookup the IP from the Elastic IPs, if it's not available (returns an
+		// error) we proceed and create it.
+		if m.Payment.Plan != "free" { // check this first to avoid an additional AWS call
+			m.Log.Debug("Checking if IP is an Elastic IP for paying user: (ip: %s)", m.IpAddress)
+
+			_, err = m.Session.AWSClient.Client.Addresses([]string{m.IpAddress}, nil, ec2.NewFilter())
+			if isAddressNotFoundError(err) {
+				oldIp := m.IpAddress
+				elasticIp, err := m.Session.AWSClient.AllocateAndAssociateIP(m.Meta.InstanceId)
+
+				m.Log.Info(
+					"Paying user without Elastic IP detected. Assigning IP. (username: %s, instanceId: %s, region: %s, oldIp: %s, newIp: %s)",
+					m.Credential, m.Meta.InstanceId, m.Meta.Region, oldIp, elasticIp,
+				)
+
+				if err != nil {
+					m.Log.Error("couldn't not create elastic IP: %s", err)
+				} else {
+					m.IpAddress = elasticIp
+				}
+			} else if err != nil {
+				m.Log.Error(
+					"Failed to retrieve Elastic IP information: %s (username: %s, instanceId: %s, region: %s, ip: %s)",
+					err.Error(), m.Credential, m.Meta.InstanceId, m.Meta.Region, m.IpAddress,
+				)
+			}
+		}
+
 		startFunc := func() error {
 			instance, err := m.Session.AWSClient.Start(ctx)
 			if err == nil {
@@ -159,28 +189,6 @@ func (m *Machine) Start(ctx context.Context) (err error) {
 		// go go go!
 		if err := startFunc(); err != nil {
 			return err
-		}
-	}
-
-	// Assign a Elastic IP for a paying customer if it doesn't have any
-	// assigned yet (Elastic IP's are assigned only during the Build). We
-	// lookup the IP from the Elastic IPs, if it's not available (returns an
-	// error) we proceed and create it.
-	if m.Payment.Plan != "free" { // check this first to avoid an additional AWS call
-		_, err = m.Session.AWSClient.Client.Addresses([]string{m.IpAddress}, nil, ec2.NewFilter())
-		if isAddressNotFoundError(err) {
-			oldIp := m.IpAddress
-			elasticIp, err := m.Session.AWSClient.AllocateAndAssociateIP(m.Meta.InstanceId)
-			if err != nil {
-				m.Log.Warning("couldn't not create elastic IP: %s", err)
-			} else {
-				m.IpAddress = elasticIp
-			}
-
-			m.Log.Info(
-				"Paying user without Elastic IP detected. Assigning IP. (username: %s, instanceId: %s, region: %s, oldIp: %s, newIp: %s)",
-				m.Credential, m.Meta.InstanceId, m.Meta.Region, oldIp, elasticIp,
-			)
 		}
 	}
 


### PR DESCRIPTION
The old method of assigning an elastic ip after the machine has started
can cause a race condition for Klient, where the machine's IP changes
moments after it is first brought up.

To resolve this, the elastic IP is assigned _before_ the machine is
started (when it is in the Stopping or Stopped state).

In addition to this, the IP of the machine is no longer removed on
machine Stop. This allows the Start method to know the previous IP,
and check if it was an elastic IP or not, allocating a new one as
needed.

cc @cihangir @fatih 
