### PR TITLE
reactivity: adjust chat pane scroll position if chat input does not fit the screen [fixes #105857360]

### DIFF
--- a/client/activity/lib/components/chatinputwidget/index.coffee
+++ b/client/activity/lib/components/chatinputwidget/index.coffee
@@ -26,6 +26,7 @@ module.exports = class ChatInputWidget extends React.Component
 
   @defaultProps =
     disabledFeatures : []
+    onReady          : kd.noop
 
 
   getDataBindings: ->
@@ -79,11 +80,21 @@ module.exports = class ChatInputWidget extends React.Component
     scrollContainer = $(textInput).closest '.Scrollable'
     scrollContainer.on 'scroll', @bound 'closeDropboxes'
 
+    # Mark as ready if no value is provided in props.
+    # Otherwise, we need to wait till value prop is set to state
+    @ready()  unless value
+
 
   componentDidUpdate: (oldProps, oldState) ->
 
-    @focus()  if oldState.value isnt @state.value
+    isValueChanged = oldState.value isnt @state.value
+    @focus()  if isValueChanged
     @updateDropboxPositions()
+
+    # This line actually is needed for the case
+    # when value prop is set to state.
+    # In other cases ready() does nothing
+    @ready()  if isValueChanged
 
 
   componentWillUnmount: ->
@@ -93,6 +104,14 @@ module.exports = class ChatInputWidget extends React.Component
     textInput = React.findDOMNode this.refs.textInput
     scrollContainer = $(textInput).closest '.Scrollable'
     scrollContainer.off 'scroll', @bound 'closeDropboxes'
+
+
+  ready: ->
+
+    return  if @isReady
+
+    @isReady = yes
+    @props.onReady?()
 
 
   updateDropboxPositions: ->

--- a/client/activity/lib/components/chatlist/index.coffee
+++ b/client/activity/lib/components/chatlist/index.coffee
@@ -27,6 +27,7 @@ module.exports = class ChatList extends React.Component
     unreadCount       : 0
     isMessagesLoading : no
     selectedMessageId : null
+    onItemEditStarted : kd.noop
 
   constructor: (props) ->
 
@@ -127,7 +128,7 @@ module.exports = class ChatList extends React.Component
 
   renderChildren: ->
 
-    { messages, showItemMenu, channelName, channelId } = @props
+    { messages, showItemMenu, channelName, channelId, onItemEditStarted } = @props
     { selectedMessageId } = @state
 
     lastDifferentOwnerId = null
@@ -136,11 +137,12 @@ module.exports = class ChatList extends React.Component
     children = messages.toList().reduce (children, message, i) =>
 
       itemProps =
-        key          : message.get 'id'
-        message      : message
-        showItemMenu : showItemMenu
-        channelName  : channelName
-        channelId    : channelId
+        key           : message.get 'id'
+        message       : message
+        showItemMenu  : showItemMenu
+        channelName   : channelName
+        channelId     : channelId
+        onEditStarted : onItemEditStarted
 
       if selectedMessageId is message.get 'id'
         itemProps['isSelected'] = yes

--- a/client/activity/lib/components/chatlistitem/index.coffee
+++ b/client/activity/lib/components/chatlistitem/index.coffee
@@ -45,6 +45,7 @@ module.exports = class ChatListItem extends React.Component
     showItemMenu                  : yes
     isSelected                    : no
     channelId                     : ''
+    onEditStarted                 : kd.noop
 
   constructor: (props) ->
 
@@ -265,6 +266,12 @@ module.exports = class ChatListItem extends React.Component
     ActivityFlux.actions.message.unsetMessageEditMode messageId
 
 
+  onEditStarted: ->
+
+    element = React.findDOMNode this
+    @props.onEditStarted? element
+
+
   getEditModeClassNames: -> classnames
     'ChatItem-updateMessageForm': yes
     'hidden' : not @props.message.get '__isEditing'
@@ -304,6 +311,7 @@ module.exports = class ChatListItem extends React.Component
         onEsc            = { @bound 'cancelEdit' }
         ref              = 'editInput'
         disabledFeatures = { ['commands'] }
+        onReady          = { @bound 'onEditStarted' }
       />
       <div className='clearfix'></div>
     </div>

--- a/client/activity/lib/components/chatpane/index.coffee
+++ b/client/activity/lib/components/chatpane/index.coffee
@@ -108,7 +108,7 @@ module.exports = class ChatPane extends React.Component
     else scrollContainer.classList.remove 'padded'
 
 
-  onItemEditStarted: (itemElement)->
+  onItemEditStarted: (itemElement) ->
 
     return  unless itemElement
 

--- a/client/activity/lib/components/chatpane/index.coffee
+++ b/client/activity/lib/components/chatpane/index.coffee
@@ -5,6 +5,7 @@ ActivityFlux         = require 'activity/flux'
 Scroller             = require 'app/components/scroller'
 ScrollerMixin        = require 'app/components/scroller/scrollermixin'
 ChannelInfoContainer = require 'activity/components/channelinfocontainer'
+scrollToTarget       = require 'app/util/scrollToTarget'
 
 
 module.exports = class ChatPane extends React.Component
@@ -107,6 +108,17 @@ module.exports = class ChatPane extends React.Component
     else scrollContainer.classList.remove 'padded'
 
 
+  onItemEditStarted: (itemElement)->
+
+    return  unless itemElement
+
+    # this delay is a time needed to chat input
+    # in order to resize its textarea
+    kd.utils.wait 50, =>
+      scrollContainer = React.findDOMNode @refs.scrollContainer
+      scrollToTarget scrollContainer, itemElement
+
+
   renderBody: ->
 
     return null  unless @props.thread
@@ -123,6 +135,7 @@ module.exports = class ChatPane extends React.Component
         channelId={@channel 'id'}
         channelName={@channel 'name'}
         unreadCount={@channel 'unreadCount'}
+        onItemEditStarted={@bound 'onItemEditStarted'}
       />
     </Scroller>
 

--- a/client/activity/lib/components/dropbox/styl/dropbox.styl
+++ b/client/activity/lib/components/dropbox/styl/dropbox.styl
@@ -24,8 +24,6 @@
 .Dropbox-scrollable
   overflow                  auto
   max-height                271px
-
-.Dropbox-content
   rel()
 
 .Dropbox-header

--- a/client/app/lib/util/scrollToTarget.coffee
+++ b/client/app/lib/util/scrollToTarget.coffee
@@ -29,7 +29,7 @@ module.exports = (container, target) ->
   targetPosition        = target.position()
   return  unless targetPosition
 
-  targetTop             = targetPosition.top
+  targetTop             = targetPosition.top + containerScrollTop
   targetHeight          = target.outerHeight yes
   targetBottom          = targetTop + targetHeight
 
@@ -49,3 +49,4 @@ module.exports = (container, target) ->
     hasPrevSibling = target.prev().length > 0
     scrollTop = if hasPrevSibling then targetTop else 0
     container.scrollTop scrollTop
+


### PR DESCRIPTION
@usirin, can you please review this fix? It's for [this bug](https://www.pivotaltracker.com/story/show/105857360)
I added a logic to scroll chat pane to the bottom border of chat list item if it doesn't
fit the screen. If editing item is in the middle of the screen, it does nothing.
Also, it automatically scrolls to the last item when user starts editing it by pressing up arrow in chat input on the bottom of the page

/cc @sinan 
