### PR TITLE
Activity: Content between triple backticks can be displayed differently [fixes #93871312]

### DIFF
--- a/client/app/lib/util/applyMarkdown.coffee
+++ b/client/app/lib/util/applyMarkdown.coffee
@@ -5,7 +5,7 @@ module.exports = (text, options = {})->
 
   return null unless text
 
-  text = text.replace '/\\/', '\\\\'
+  text = text.replace /\\/g, '\\'
 
   options.gfm       ?= true
   options.pedantic  ?= false

--- a/client/app/lib/util/applyMarkdown.coffee
+++ b/client/app/lib/util/applyMarkdown.coffee
@@ -5,7 +5,7 @@ module.exports = (text, options = {})->
 
   return null unless text
 
-  text = text.replace '\\', '\\\\'
+  text = text.replace '/\\/', '\\\\'
 
   options.gfm       ?= true
   options.pedantic  ?= false


### PR DESCRIPTION
Initial issue
![image](https://cloud.githubusercontent.com/assets/1278794/10706034/8fbcede2-79eb-11e5-8476-726a942b97a9.png)

This markdown
![screenshot at 01-07-42](https://cloud.githubusercontent.com/assets/1278794/10706049/b35ac846-79eb-11e5-9ab9-6a8c3c5ca4be.png)

Results in this
![screenshot at 01-07-54](https://cloud.githubusercontent.com/assets/1278794/10706050/b35badec-79eb-11e5-8d0e-5e86d3711eb9.png)

**The story:** https://www.pivotaltracker.com/story/show/93871312

**Notes:** When parsing the text and applying markdown the replace was using a string instead of a regex. Changed that to regex and it now performs as expected. It doesn't insert an extra `\`

cc. @sinan  
