### PR TITLE
reactivity: chat input fixes [fixes #106477572, #106621526, #106526672, #106481952]

### DIFF
--- a/client/activity/lib/components/dropbox/portaldropbox.coffee
+++ b/client/activity/lib/components/dropbox/portaldropbox.coffee
@@ -85,6 +85,14 @@ module.exports = class PortalDropbox extends React.Component
     resizable.css { height : resizeHeight }
 
 
+  onClose: ->
+
+    { visible, onClose } = @props
+
+    return  unless visible
+    @props.onClose?()
+
+
   render: ->
 
     { visible, resize } = @props
@@ -93,7 +101,7 @@ module.exports = class PortalDropbox extends React.Component
       isOpened            = { visible }
       className           = 'PortalDropbox'
       closeOnEsc          = yes
-      onClose             = { @props.onClose }
+      onClose             = { @bound 'onClose' }
       closeOnOutsideClick = yes>
         <Dropbox {...@props}
           contentClassName={if resize is 'content' then 'Dropbox-resizable'}

--- a/client/activity/lib/components/privatechatpane/styl/privatechatpane.styl
+++ b/client/activity/lib/components/privatechatpane/styl/privatechatpane.styl
@@ -15,6 +15,3 @@
     min-height              0
     border                  1px solid #dfdfdf
 
-.PrivateChatPane-footer
-  height                    70px
-

--- a/client/activity/lib/components/publicchatpane/styl/publicchatpane.styl
+++ b/client/activity/lib/components/publicchatpane/styl/publicchatpane.styl
@@ -19,7 +19,7 @@
   borderBox()
   color                     $gray-2
   bg                        color, $gray-19
-  margin                    0 40px
+  margin                    0 40px 10px 40px
   height                    60px
   padding                   15px 0 0
   font-size                 14px
@@ -34,5 +34,3 @@
     bg                      color, $indigo-blue
     text-transform          uppercase
 
-.PublicChatPane-footer
-  height                    70px


### PR DESCRIPTION
@usirin, can you please review fixes for these bugs - https://www.pivotaltracker.com/story/show/106477572, https://www.pivotaltracker.com/story/show/106621526, https://www.pivotaltracker.com/story/show/106526672, https://www.pivotaltracker.com/story/show/106481952?
In short, these changes fix:
- a problem with chat input not expanding to above when it has a multi-line text
- a bug that user can't leave a channel with `/leave` command
- a bug that user can't delete a message removing its text while editing

/cc @sinan
