### PR TITLE
reactivity: hide "Add new participant" button if current user is not a channel participant [fixes #105318350]

### DIFF
--- a/client/activity/lib/components/channelparticipantavatars/index.coffee
+++ b/client/activity/lib/components/channelparticipantavatars/index.coffee
@@ -185,15 +185,23 @@ module.exports = class ChannelParticipantAvatars extends React.Component
     </div>
 
 
-  getAddNewParticipantButtonClassNames: -> classnames
-    'ChannelParticipantAvatars-newParticipantBox': yes
-    'cross': @state.addNewParticipantMode
+  getAddNewParticipantButtonClassNames: ->
+
+    isParticipant = @props.channelThread.getIn ['channel', 'isParticipant']
+
+    return classnames
+      'ChannelParticipantAvatars-newParticipantBox': yes
+      'cross': @state.addNewParticipantMode
+      'hidden': not isParticipant
 
 
   renderNewParticipantButton: ->
 
-    <div className='ChannelParticipantAvatars-singleBox' onClick={@bound 'onNewParticipantButtonClick'}>
-      <div className={@getAddNewParticipantButtonClassNames()}></div>
+    <div className='ChannelParticipantAvatars-singleBox'>
+      <div
+        className={@getAddNewParticipantButtonClassNames()}
+        onClick={@bound 'onNewParticipantButtonClick'}
+       />
     </div>
 
 


### PR DESCRIPTION
@usirin, can you please review the fix of [this bug](https://www.pivotaltracker.com/story/show/105318350)?

![button](http://g.recordit.co/tlmabcbipY.gif)

/cc @sinan 
