### PR TITLE
reactivity: fix for removing private message in realtime [fixes #106528034]

### DIFF
--- a/client/activity/lib/flux/actions/realtime/actioncreators.coffee
+++ b/client/activity/lib/flux/actions/realtime/actioncreators.coffee
@@ -88,7 +88,11 @@ bindNotificationEvents = ->
           _loadMessageFn { channel, channelMessage: _message }
           _dispatchFn { unreadCount: payload.unreadCount, channel }
 
-    .on 'MessageRemovedFromChannel', _dispatchFn
+    .on 'MessageRemovedFromChannel', (payload) ->
+      { channel, channelMessage, unreadCount } = payload
+      dispatch actions.REMOVE_MESSAGE_SUCCESS, { messageId: channelMessage.id }
+      _dispatchFn { unreadCount, channel }
+
     .on 'RemovedFromChannel', _dispatchFn
     .on 'ReplyAdded', _dispatchFn
     .on 'ParticipantUpdated', _dispatchFn


### PR DESCRIPTION
@usirin, can you please review the fix for [this bug](https://www.pivotaltracker.com/story/show/106528034)?

/cc @sinan 

![removing_message](http://g.recordit.co/i7E23MlCki.gif)
