### PR TITLE
Teams: Make MSM bigger if there is readme content. [ fixes #106507704 ]

### DIFF
--- a/client/app/lib/providers/environmentsmachinestatemodal.coffee
+++ b/client/app/lib/providers/environmentsmachinestatemodal.coffee
@@ -842,6 +842,8 @@ module.exports = class EnvironmentsMachineStateModal extends BaseModalView
       @readmeView.wrapper.addSubView readmeContent
       @readmeView.show()
       @readmeView.getDomElement().find('a').attr('target', '_blank')
+      @setClass 'has-readme'
+      @setWidth 540
 
 
   showErrorDetails: (errorMessage) ->

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -1310,6 +1310,9 @@ paymentGrayLighter  = #f8f8f8
   left                      50% !important
   margin-left               -91px
 
+  &.has-readme
+    margin-left             -141px
+
   .kdmodal-content
     overflow                visible
 
@@ -1332,7 +1335,7 @@ paymentGrayLighter  = #f8f8f8
     .has-markdown
       padding               0 20px
       font-size             14px
-      max-height            200px
+      max-height            240px
 
 
   .content-container


### PR DESCRIPTION
100px wider and 40px taller for readme content.
