### PR TITLE
Prevent credential delete if it's inuse by a stack template [completes #106280122]

### DIFF
--- a/client/account/lib/accountcredentiallist.coffee
+++ b/client/account/lib/accountcredentiallist.coffee
@@ -26,6 +26,12 @@ module.exports = class AccountCredentialList extends KDListView
   deleteItem: (item) ->
 
     credential = item.getData()
+
+    if credential.inuse
+      new kd.NotificationView
+        title: 'This credential is currently in-use'
+      return
+
     credential.isBootstrapped (err, bootstrapped) =>
 
       kd.warn "Bootstrap check failed:", { credential, err }  if err
@@ -42,7 +48,17 @@ module.exports = class AccountCredentialList extends KDListView
         **WARNING!** destroying resources includes **ALL RESOURCES**; your
         team member's instances, volumes, keypairs and **everything else we've
         created on your account**.
-      " else "Do you want to remove **#{credential.title}** ?"
+        \n\n
+        **WARNING!** removing a credential can cause your stacks or instances
+        to stop working properly, please make sure that you don't have any
+        stacktemplates relying on this credential.
+      " else "
+        **WARNING!** removing a credential can cause your stacks or instances
+        to stop working properly, please make sure that you don't have any
+        stacktemplates relying on this credential.
+        \n\n
+        Do you want to remove **#{credential.title}** ?
+      "
 
       removeCredential = =>
         credential.delete (err) =>

--- a/client/account/lib/accountcredentiallist.coffee
+++ b/client/account/lib/accountcredentiallist.coffee
@@ -37,25 +37,25 @@ module.exports = class AccountCredentialList extends KDListView
       kd.warn "Bootstrap check failed:", { credential, err }  if err
 
       description = applyMarkdown if bootstrapped then "
-        This **#{credential.title}** credential is bootstrapped before which
+        This **#{credential.title}** credential is bootstrapped before. It
         means that you have modified data on your **#{credential.provider}**
         account.
         \n\n
-        You can remove this credential from Koding and manually cleanup
-        the resources created on your provider or you can **destroy** all
-        bootstrapped data and resources along with credential.
+        You can remove this credential here and manually cleanup the resources
+        which are created on your provider. Or you can **destroy** all
+        bootstrapped data and resources along with this credential.
         \n\n
-        **WARNING!** destroying resources includes **ALL RESOURCES**; your
-        team member's instances, volumes, keypairs and **everything else we've
-        created on your account**.
+        **WARNING!** by destroying resources you'd destroy **ALL RESOURCES**;
+        your team members' instances, volumes, keypairs, and **everything else
+        we've created on their accounts**.
         \n\n
         **WARNING!** removing a credential can cause your stacks or instances
         to stop working properly, please make sure that you don't have any
-        stacktemplates relying on this credential.
+        stack or stack templates that depend on this credential.
       " else "
         **WARNING!** removing a credential can cause your stacks or instances
         to stop working properly, please make sure that you don't have any
-        stacktemplates relying on this credential.
+        stack or stack templates that depend on this credential.
         \n\n
         Do you want to remove **#{credential.title}** ?
       "

--- a/client/app/lib/stacks/credentiallistitem.coffee
+++ b/client/app/lib/stacks/credentiallistitem.coffee
@@ -12,7 +12,7 @@ module.exports = class CredentialListItem extends kd.ListItemView
     super options, data
 
     delegate = @getDelegate()
-    { identifier, owner, title, verified } = @getData()
+    { identifier, owner, title, verified } = credential = @getData()
 
     @deleteButton = new kd.ButtonView
       cssClass : 'solid compact outline red secondary'
@@ -45,6 +45,7 @@ module.exports = class CredentialListItem extends kd.ListItemView
     credentials = credentials.concat (selectedCredentials or [])
 
     if identifier in credentials
+      credential.inuse = yes
       @inuseView.show()
 
     @warningView = new kd.CustomHTMLView


### PR DESCRIPTION
This happens if already in-use credential requested to remove
![](http://g.recordit.co/Moer6SvWNH.gif)

And this extended warning modal is shown if it's requested from Account settings
![](http://take.ms/tjyYd)

In future we can make this check in backend and prevent it from there but to be able do that we need to fetch all machines, stacks and stack templates which using this credential. And this is a heavy process for both implementation and the executing so for now leaving this responsibility to team admin with a detailed warning description here.
