### PR TITLE
reactivity: channel loading refactoring

### DIFF
--- a/client/activity/lib/components/channelthreadpane/index.coffee
+++ b/client/activity/lib/components/channelthreadpane/index.coffee
@@ -141,7 +141,7 @@ reset = (props, state) ->
     channel = ActivityFlux.getters.channelByName channelName
     thread.changeSelectedThread channel.id  if channel
 
-    channelActions.loadChannel('public', channelName).then ({ channel }) ->
+    channelActions.loadChannelByName(channelName).then ({ channel }) ->
       thread.changeSelectedThread channel.id
       channelActions.loadParticipants channel.id
 

--- a/client/activity/lib/components/chatinputwidget/index.coffee
+++ b/client/activity/lib/components/chatinputwidget/index.coffee
@@ -272,7 +272,7 @@ module.exports = class ChatInputWidget extends React.Component
   onSearchItemConfirmed: (message) ->
 
     { initialChannelId, id } = message
-    ActivityFlux.actions.channel.loadChannelById(initialChannelId).then ({ channel }) ->
+    ActivityFlux.actions.channel.loadChannel(initialChannelId).then ({ channel }) ->
       kd.singletons.router.handleRoute "/Channels/#{channel.name}/#{id}"
 
 

--- a/client/activity/lib/components/privatemessagethreadpane/index.coffee
+++ b/client/activity/lib/components/privatemessagethreadpane/index.coffee
@@ -139,7 +139,7 @@ reset = (props, state) ->
       privateChannelId = botChannel.id
 
   if privateChannelId
-    channelActions.loadChannel('private', privateChannelId).then ({ channel }) ->
+    channelActions.loadChannel(privateChannelId).then ({ channel }) ->
       threadActions.changeSelectedThread channel.id
       channelActions.loadParticipants channel.id, channel.participantsPreview
   else if not channelThread

--- a/client/activity/lib/flux/actions/channel.coffee
+++ b/client/activity/lib/flux/actions/channel.coffee
@@ -29,7 +29,7 @@ dispatch = (args...) -> kd.singletons.reactor.dispatch args...
  * @param {object} params - func parameters
  * @return {Promise}
 ###
-loadChannelWithFunc = (func, params) ->
+loadChannelWithFn = (func, params) ->
 
   { LOAD_CHANNEL_BEGIN
     LOAD_CHANNEL_FAIL
@@ -114,7 +114,7 @@ loadChannel = (id) ->
   func   = kd.singletons.socialapi.channel.byId
   params = { id }
 
-  loadChannelWithFunc func, params
+  loadChannelWithFn func, params
 
 
 ###*
@@ -130,7 +130,7 @@ loadChannelByName = (name) ->
   params = { name, type }
   func   = kd.singletons.socialapi.channel.byName
 
-  loadChannelWithFunc func, params
+  loadChannelWithFn func, params
 
 
 ###*
@@ -277,7 +277,7 @@ loadChannelsByQuery = (query, options = {}) ->
 
   options.name = query
   func = kd.singletons.socialapi.channel.searchTopics
-  loadChannelsWithFunc func, options
+  loadChannelsWithFn func, options
 
 
 ###*
@@ -288,10 +288,10 @@ loadChannelsByQuery = (query, options = {}) ->
 loadChannels = (options = {}) ->
 
   func = kd.singletons.socialapi.channel.list
-  loadChannelsWithFunc func, options
+  loadChannelsWithFn func, options
 
 
-loadChannelsWithFunc = (func, options) ->
+loadChannelsWithFn = (func, options) ->
 
   { LOAD_CHANNELS_BEGIN
     LOAD_CHANNELS_SUCCESS

--- a/client/activity/lib/flux/actions/channel.coffee
+++ b/client/activity/lib/flux/actions/channel.coffee
@@ -25,11 +25,11 @@ dispatch = (args...) -> kd.singletons.reactor.dispatch args...
  * After channel is loaded it binds to channel events,
  * emits LOAD_CHANNEL_SUCCESS event and load channel messages
  *
- * @param {function} func - function which loads a channel
- * @param {object} params - func parameters
+ * @param {function} fn - function which loads a channel
+ * @param {object} params - fn parameters
  * @return {Promise}
 ###
-loadChannelWithFn = (func, params) ->
+loadChannelWithFn = (fn, params) ->
 
   { LOAD_CHANNEL_BEGIN
     LOAD_CHANNEL_FAIL
@@ -39,7 +39,7 @@ loadChannelWithFn = (func, params) ->
 
     dispatch LOAD_CHANNEL_BEGIN, params
 
-    func params, (err, channel) ->
+    fn params, (err, channel) ->
       if err
         dispatch LOAD_CHANNEL_FAIL, { err }
         reject err
@@ -111,10 +111,10 @@ sanitizeTypeAndId = (type, id) ->
 ###
 loadChannel = (id) ->
 
-  func   = kd.singletons.socialapi.channel.byId
+  fn     = kd.singletons.socialapi.channel.byId
   params = { id }
 
-  loadChannelWithFn func, params
+  loadChannelWithFn fn, params
 
 
 ###*
@@ -128,9 +128,9 @@ loadChannelByName = (name) ->
   name   = name.toLowerCase()
   type   = getChannelTypeByName name
   params = { name, type }
-  func   = kd.singletons.socialapi.channel.byName
+  fn     = kd.singletons.socialapi.channel.byName
 
-  loadChannelWithFn func, params
+  loadChannelWithFn fn, params
 
 
 ###*
@@ -276,8 +276,8 @@ loadPopularChannels = (options = {}) ->
 loadChannelsByQuery = (query, options = {}) ->
 
   options.name = query
-  func = kd.singletons.socialapi.channel.searchTopics
-  loadChannelsWithFn func, options
+  fn = kd.singletons.socialapi.channel.searchTopics
+  loadChannelsWithFn fn, options
 
 
 ###*
@@ -287,11 +287,11 @@ loadChannelsByQuery = (query, options = {}) ->
 ###
 loadChannels = (options = {}) ->
 
-  func = kd.singletons.socialapi.channel.list
-  loadChannelsWithFn func, options
+  fn = kd.singletons.socialapi.channel.list
+  loadChannelsWithFn fn, options
 
 
-loadChannelsWithFn = (func, options) ->
+loadChannelsWithFn = (fn, options) ->
 
   { LOAD_CHANNELS_BEGIN
     LOAD_CHANNELS_SUCCESS
@@ -301,7 +301,7 @@ loadChannelsWithFn = (func, options) ->
   dispatch LOAD_CHANNELS_BEGIN
 
   new Promise (resolve, reject) ->
-    func options, (err, channels) ->
+    fn options, (err, channels) ->
       if err
         dispatch LOAD_CHANNELS_FAIL, { err }
         return reject err


### PR DESCRIPTION
@usirin, can you please review this refactoring for loading channels? These are refactoring changes which were mentioned in https://github.com/koding/koding/pull/5450

Initially I was going to have only one generic method `loadChannel()` but there is a case when this method doesn't work fine - https://github.com/koding/koding/blob/master/client/activity/lib/components/chatinputwidget/index.coffee#L275. In this case I need to pass type = `private` to specify that the second param is id. It confuses since I load public channel in this place.
That's why I decided to have 2 separate methods:
- `loadChannel` - generic method to load any channel by id
- `loadChannelByName` - method to load public channels by name

Please let me know if you have a better idea how to organize this code

/cc @sinan 
