### PR TITLE
Teams: Team Settings: Change position of close icon [fixes #106484264]

### DIFF
--- a/client/admin/lib/styl/app.group.admin.styl
+++ b/client/admin/lib/styl/app.group.admin.styl
@@ -2153,6 +2153,10 @@ Admin main styles
     .kdmodal-content
        margin-top           -40px !important
 
+    .kdmodal-inner
+      > .close-icon
+        right               20px
+
   .kdmodal-content
     height                  100% !important
 


### PR DESCRIPTION
/cc @fatihacet @gokmen @szkl 
#### Before

<img width="264" alt="before" src="https://cloud.githubusercontent.com/assets/728733/10797063/87a08f4e-7da9-11e5-9c10-d29796757bb1.png">
#### After

<img width="248" alt="after" src="https://cloud.githubusercontent.com/assets/728733/10797068/8cf349be-7da9-11e5-9a47-feca789406ce.png">
