### PR TITLE
reactivity: emoji prerendering [fixes #106527212]

### DIFF
--- a/client/activity/lib/components/chatlistitem/styl/chatitem.styl
+++ b/client/activity/lib/components/chatlistitem/styl/chatitem.styl
@@ -62,8 +62,7 @@
       .Tooltip-wrapper
         visible()
 
-  .emoji
-    size                    20px 20px
+  .emojiIconWrapper
     vertical-align          text-bottom
 
   .SettingsMenuWrapper

--- a/client/activity/lib/components/chatlistitem/styl/chatitem.styl
+++ b/client/activity/lib/components/chatlistitem/styl/chatitem.styl
@@ -62,7 +62,7 @@
       .Tooltip-wrapper
         visible()
 
-  .emojiIconWrapper
+  .emoji-wrapper
     vertical-align          text-bottom
 
   .SettingsMenuWrapper

--- a/client/activity/lib/components/chatpane/index.coffee
+++ b/client/activity/lib/components/chatpane/index.coffee
@@ -6,6 +6,7 @@ Scroller             = require 'app/components/scroller'
 ScrollerMixin        = require 'app/components/scroller/scrollermixin'
 ChannelInfoContainer = require 'activity/components/channelinfocontainer'
 scrollToTarget       = require 'app/util/scrollToTarget'
+classnames           = require 'classnames'
 
 
 module.exports = class ChatPane extends React.Component
@@ -45,6 +46,18 @@ module.exports = class ChatPane extends React.Component
 
 
   channel: (key) -> @props.thread.getIn ['channel', key]
+
+
+  getClassName: ->
+
+    { className } = @props
+
+    classes =
+      'ChatPane'             : yes
+      'emojiSpritePreloader' : yes
+    classes[className]       = yes  if className
+
+    return classnames classes
 
 
   renderChannelInfoContainer: ->
@@ -97,7 +110,8 @@ module.exports = class ChatPane extends React.Component
 
 
   render: ->
-    <div className={kd.utils.curry 'ChatPane', @props.className}>
+
+    <div className={@getClassName()}>
       <section className="ChatPane-contentWrapper">
         <section className="ChatPane-body" ref="ChatPaneBody">
           {@renderBody()}

--- a/client/activity/lib/components/chatpane/index.coffee
+++ b/client/activity/lib/components/chatpane/index.coffee
@@ -53,8 +53,8 @@ module.exports = class ChatPane extends React.Component
     { className } = @props
 
     classes =
-      'ChatPane'             : yes
-      'emojiSpritePreloader' : yes
+      'ChatPane'               : yes
+      'emoji-sprite-preloader' : yes
     classes[className]       = yes  if className
 
     return classnames classes

--- a/client/activity/lib/components/chatpane/index.coffee
+++ b/client/activity/lib/components/chatpane/index.coffee
@@ -4,6 +4,7 @@ ChatList             = require 'activity/components/chatlist'
 ActivityFlux         = require 'activity/flux'
 Scroller             = require 'app/components/scroller'
 ScrollerMixin        = require 'app/components/scroller/scrollermixin'
+EmojiPreloaderMixin  = require 'activity/components/emojipreloadermixin'
 ChannelInfoContainer = require 'activity/components/channelinfocontainer'
 scrollToTarget       = require 'app/util/scrollToTarget'
 classnames           = require 'classnames'
@@ -52,10 +53,8 @@ module.exports = class ChatPane extends React.Component
 
     { className } = @props
 
-    classes =
-      'ChatPane'               : yes
-      'emoji-sprite-preloader' : yes
-    classes[className]       = yes  if className
+    classes = { 'ChatPane' : yes }
+    classes[className] = yes  if className
 
     return classnames classes
 
@@ -121,5 +120,5 @@ module.exports = class ChatPane extends React.Component
     </div>
 
 
-React.Component.include.call ChatPane, [ScrollerMixin]
+React.Component.include.call ChatPane, [ScrollerMixin, EmojiPreloaderMixin]
 

--- a/client/activity/lib/components/common/messagebody.coffee
+++ b/client/activity/lib/components/common/messagebody.coffee
@@ -1,11 +1,12 @@
-$                    = require 'jquery'
-React                = require 'kd-react'
-emojify              = require 'emojify.js'
-formatContent        = require 'app/util/formatReactivityContent'
-immutable            = require 'immutable'
-classnames           = require 'classnames'
-transformTags        = require 'app/util/transformReactivityTags'
-ImmutableRenderMixin = require 'react-immutable-render-mixin'
+$                     = require 'jquery'
+React                 = require 'kd-react'
+emojify               = require 'emojify.js'
+formatContent         = require 'app/util/formatReactivityContent'
+immutable             = require 'immutable'
+classnames            = require 'classnames'
+transformTags         = require 'app/util/transformReactivityTags'
+ImmutableRenderMixin  = require 'react-immutable-render-mixin'
+renderEmojiSpriteIcon = require 'activity/util/renderEmojiSpriteIcon'
 
 
 module.exports = class MessageBody extends React.Component
@@ -49,7 +50,7 @@ module.exports = class MessageBody extends React.Component
   renderEmojis: ->
 
     contentElement = React.findDOMNode @content
-    emojify.run contentElement  if contentElement
+    emojify.run contentElement, renderEmojiSpriteIcon  if contentElement
 
 
   transformChannelHashtags: (message) ->

--- a/client/activity/lib/components/common/messagebody.coffee
+++ b/client/activity/lib/components/common/messagebody.coffee
@@ -1,12 +1,11 @@
-$                     = require 'jquery'
-React                 = require 'kd-react'
-emojify               = require 'emojify.js'
-formatContent         = require 'app/util/formatReactivityContent'
-immutable             = require 'immutable'
-classnames            = require 'classnames'
-transformTags         = require 'app/util/transformReactivityTags'
-ImmutableRenderMixin  = require 'react-immutable-render-mixin'
-renderEmojiSpriteIcon = require 'activity/util/renderEmojiSpriteIcon'
+$                    = require 'jquery'
+React                = require 'kd-react'
+formatContent        = require 'app/util/formatReactivityContent'
+immutable            = require 'immutable'
+classnames           = require 'classnames'
+transformTags        = require 'app/util/transformReactivityTags'
+ImmutableRenderMixin = require 'react-immutable-render-mixin'
+renderEmojis         = require 'activity/util/renderEmojis'
 
 
 module.exports = class MessageBody extends React.Component
@@ -50,7 +49,7 @@ module.exports = class MessageBody extends React.Component
   renderEmojis: ->
 
     contentElement = React.findDOMNode @content
-    emojify.run contentElement, renderEmojiSpriteIcon  if contentElement
+    renderEmojis contentElement  if contentElement
 
 
   transformChannelHashtags: (message) ->

--- a/client/activity/lib/components/emojidropboxitem/index.coffee
+++ b/client/activity/lib/components/emojidropboxitem/index.coffee
@@ -1,9 +1,10 @@
-kd              = require 'kd'
-React           = require 'kd-react'
-immutable       = require 'immutable'
-formatEmojiName = require 'activity/util/formatEmojiName'
-DropboxItem     = require 'activity/components/dropboxitem'
-emojify         = require 'emojify.js'
+kd                    = require 'kd'
+React                 = require 'kd-react'
+immutable             = require 'immutable'
+formatEmojiName       = require 'activity/util/formatEmojiName'
+DropboxItem           = require 'activity/components/dropboxitem'
+emojify               = require 'emojify.js'
+renderEmojiSpriteIcon = require 'activity/util/renderEmojiSpriteIcon'
 
 
 module.exports = class EmojiDropboxItem extends React.Component
@@ -15,7 +16,10 @@ module.exports = class EmojiDropboxItem extends React.Component
     query      : ''
 
 
-  componentDidMount: -> emojify.run React.findDOMNode @refs.icon
+  componentDidMount: ->
+
+    icon = React.findDOMNode @refs.icon
+    emojify.run icon, renderEmojiSpriteIcon
 
 
   renderEmojiName: ->
@@ -37,7 +41,9 @@ module.exports = class EmojiDropboxItem extends React.Component
 
     { item } = @props
     <DropboxItem {...@props} className="EmojiDropboxItem">
-      <span ref='icon'>{formatEmojiName item}</span>
+      <span className='emojiSpriteIconWrapper'>
+        <span ref='icon'>{formatEmojiName item}</span>
+      </span>
       {@renderEmojiName()}
     </DropboxItem>
 

--- a/client/activity/lib/components/emojidropboxitem/index.coffee
+++ b/client/activity/lib/components/emojidropboxitem/index.coffee
@@ -4,8 +4,6 @@ immutable             = require 'immutable'
 formatEmojiName       = require 'activity/util/formatEmojiName'
 DropboxItem           = require 'activity/components/dropboxitem'
 EmojiIcon             = require 'activity/components/emojiicon'
-emojify               = require 'emojify.js'
-renderEmojiSpriteIcon = require 'activity/util/renderEmojiSpriteIcon'
 
 
 module.exports = class EmojiDropboxItem extends React.Component

--- a/client/activity/lib/components/emojidropboxitem/index.coffee
+++ b/client/activity/lib/components/emojidropboxitem/index.coffee
@@ -3,6 +3,7 @@ React                 = require 'kd-react'
 immutable             = require 'immutable'
 formatEmojiName       = require 'activity/util/formatEmojiName'
 DropboxItem           = require 'activity/components/dropboxitem'
+EmojiIcon             = require 'activity/components/emojiicon'
 emojify               = require 'emojify.js'
 renderEmojiSpriteIcon = require 'activity/util/renderEmojiSpriteIcon'
 
@@ -10,16 +11,10 @@ renderEmojiSpriteIcon = require 'activity/util/renderEmojiSpriteIcon'
 module.exports = class EmojiDropboxItem extends React.Component
 
   @defaultProps =
-    item       : immutable.Map()
+    item       : ''
     isSelected : no
     index      : 0
     query      : ''
-
-
-  componentDidMount: ->
-
-    icon = React.findDOMNode @refs.icon
-    emojify.run icon, renderEmojiSpriteIcon
 
 
   renderEmojiName: ->
@@ -41,9 +36,7 @@ module.exports = class EmojiDropboxItem extends React.Component
 
     { item } = @props
     <DropboxItem {...@props} className="EmojiDropboxItem">
-      <span className='emojiSpriteIconWrapper'>
-        <span ref='icon'>{formatEmojiName item}</span>
-      </span>
+      <EmojiIcon emoji={item} />
       {@renderEmojiName()}
     </DropboxItem>
 

--- a/client/activity/lib/components/emojidropboxitem/styl/emojidropboxitem.styl
+++ b/client/activity/lib/components/emojidropboxitem/styl/emojidropboxitem.styl
@@ -11,13 +11,13 @@
     margin-right            5px
     display                 inline-block
 
-  .emojiSpriteIcon
-    top                     -8px
-    left                    -8px
-    transform               scale(0.5, 0.5)
+    .emojiSpriteIcon
+      top                   -8px
+      left                  -8px
+      transform             scale(0.5, 0.5)
 
-  .emojiIcon
-    size                    16px 16px
+    .emojiIcon
+      size                  16px 16px
 
   &.DropboxItem-selected
     bg                      color, rgba(249,204,13,0.4)

--- a/client/activity/lib/components/emojidropboxitem/styl/emojidropboxitem.styl
+++ b/client/activity/lib/components/emojidropboxitem/styl/emojidropboxitem.styl
@@ -5,19 +5,19 @@
   padding                   3px 12px 5px 7px
   margin                    1px 0 2px 0
 
-  .emojiSpriteIconWrapper
-    rel()
+  .emojiIconWrapper
     size                    16px 16px
     vertical-align          bottom
     margin-right            5px
     display                 inline-block
 
   .emojiSpriteIcon
-    abs()
     top                     -8px
     left                    -8px
     transform               scale(0.5, 0.5)
-    size                    32px 32px
+
+  .emojiIcon
+    size                    16px 16px
 
   &.DropboxItem-selected
     bg                      color, rgba(249,204,13,0.4)

--- a/client/activity/lib/components/emojidropboxitem/styl/emojidropboxitem.styl
+++ b/client/activity/lib/components/emojidropboxitem/styl/emojidropboxitem.styl
@@ -5,18 +5,18 @@
   padding                   3px 12px 5px 7px
   margin                    1px 0 2px 0
 
-  .emojiIconWrapper
+  .emoji-wrapper
     size                    16px 16px
     vertical-align          bottom
     margin-right            5px
     display                 inline-block
 
-    .emojiSpriteIcon
+    .emoji-sprite
       top                   -8px
       left                  -8px
       transform             scale(0.5, 0.5)
 
-    .emojiIcon
+    .emoji
       size                  16px 16px
 
   &.DropboxItem-selected

--- a/client/activity/lib/components/emojidropboxitem/styl/emojidropboxitem.styl
+++ b/client/activity/lib/components/emojidropboxitem/styl/emojidropboxitem.styl
@@ -5,10 +5,19 @@
   padding                   3px 12px 5px 7px
   margin                    1px 0 2px 0
 
-  .emoji
+  .emojiSpriteIconWrapper
+    rel()
     size                    16px 16px
     vertical-align          bottom
     margin-right            5px
+    display                 inline-block
+
+  .emojiSpriteIcon
+    abs()
+    top                     -8px
+    left                    -8px
+    transform               scale(0.5, 0.5)
+    size                    32px 32px
 
   &.DropboxItem-selected
     bg                      color, rgba(249,204,13,0.4)

--- a/client/activity/lib/components/emojiicon/index.coffee
+++ b/client/activity/lib/components/emojiicon/index.coffee
@@ -1,11 +1,10 @@
-kd                    = require 'kd'
-React                 = require 'kd-react'
-immutable             = require 'immutable'
-classnames            = require 'classnames'
-formatEmojiName       = require 'activity/util/formatEmojiName'
-ImmutableRenderMixin  = require 'react-immutable-render-mixin'
-emojify               = require 'emojify.js'
-renderEmojiSpriteIcon = require 'activity/util/renderEmojiSpriteIcon'
+kd                   = require 'kd'
+React                = require 'kd-react'
+immutable            = require 'immutable'
+classnames           = require 'classnames'
+formatEmojiName      = require 'activity/util/formatEmojiName'
+ImmutableRenderMixin = require 'react-immutable-render-mixin'
+renderEmojis         = require 'activity/util/renderEmojis'
 
 module.exports = class EmojiIcon extends React.Component
 
@@ -15,16 +14,16 @@ module.exports = class EmojiIcon extends React.Component
     emoji : ''
 
 
-  runEmojify: ->
+  emojifyIcon: ->
 
     icon = React.findDOMNode @refs.icon
-    emojify.run icon, renderEmojiSpriteIcon
+    renderEmojis icon
 
 
-  componentDidMount: -> @runEmojify()
+  componentDidMount: -> @emojifyIcon()
 
 
-  componentDidUpdate: -> @runEmojify()
+  componentDidUpdate: -> @emojifyIcon()
 
 
   render: ->

--- a/client/activity/lib/components/emojiicon/index.coffee
+++ b/client/activity/lib/components/emojiicon/index.coffee
@@ -1,0 +1,37 @@
+kd                    = require 'kd'
+React                 = require 'kd-react'
+immutable             = require 'immutable'
+classnames            = require 'classnames'
+formatEmojiName       = require 'activity/util/formatEmojiName'
+ImmutableRenderMixin  = require 'react-immutable-render-mixin'
+emojify               = require 'emojify.js'
+renderEmojiSpriteIcon = require 'activity/util/renderEmojiSpriteIcon'
+
+module.exports = class EmojiIcon extends React.Component
+
+  @include [ ImmutableRenderMixin ]
+
+  @defaultProps =
+    emoji : ''
+
+
+  runEmojify: ->
+
+    icon = React.findDOMNode @refs.icon
+    emojify.run icon, renderEmojiSpriteIcon
+
+
+  componentDidMount: -> @runEmojify()
+
+
+  componentDidUpdate: -> @runEmojify()
+
+
+  render: ->
+
+    { emoji } = @props
+
+    <span className='emojiIconWrapper' ref='icon'>
+      {formatEmojiName emoji}
+    </span>
+

--- a/client/activity/lib/components/emojiicon/index.coffee
+++ b/client/activity/lib/components/emojiicon/index.coffee
@@ -31,7 +31,7 @@ module.exports = class EmojiIcon extends React.Component
 
     { emoji } = @props
 
-    <span className='emojiIconWrapper' ref='icon'>
+    <span ref='icon'>
       {formatEmojiName emoji}
     </span>
 

--- a/client/activity/lib/components/emojiicon/styl/emojiicon.styl
+++ b/client/activity/lib/components/emojiicon/styl/emojiicon.styl
@@ -1,8 +1,15 @@
 .emojiIconWrapper
   rel()
-  dBlock()
+  dIBlock()
+  size                      20px 20px
 
   .emojiSpriteIcon
     abs()
     size                    32px 32px
+    left                    -6px
+    top                     -6px
+    transform               scale(0.625, 0.625)
+
+  .emojiIcon
+    size                    20px 20px
 

--- a/client/activity/lib/components/emojiicon/styl/emojiicon.styl
+++ b/client/activity/lib/components/emojiicon/styl/emojiicon.styl
@@ -1,15 +1,15 @@
-.emojiIconWrapper
+.emoji-wrapper
   rel()
   dIBlock()
   size                      20px 20px
 
-  .emojiSpriteIcon
+  .emoji-sprite
     abs()
     size                    32px 32px
     left                    -6px
     top                     -6px
     transform               scale(0.625, 0.625)
 
-  .emojiIcon
+  .emoji
     size                    20px 20px
 

--- a/client/activity/lib/components/emojiicon/styl/emojiicon.styl
+++ b/client/activity/lib/components/emojiicon/styl/emojiicon.styl
@@ -1,0 +1,8 @@
+.emojiIconWrapper
+  rel()
+  dBlock()
+
+  .emojiSpriteIcon
+    abs()
+    size                    32px 32px
+

--- a/client/activity/lib/components/emojipreloadermixin/index.coffee
+++ b/client/activity/lib/components/emojipreloadermixin/index.coffee
@@ -1,0 +1,9 @@
+React = require 'kd-react'
+
+module.exports = EmojiPreloaderMixin =
+
+  componentDidMount: ->
+
+    element = React.findDOMNode this
+    element.classList.add 'emoji-sprite-preloader'
+

--- a/client/activity/lib/components/emojiselector/index.coffee
+++ b/client/activity/lib/components/emojiselector/index.coffee
@@ -3,14 +3,12 @@ kd                    = require 'kd'
 React                 = require 'kd-react'
 classnames            = require 'classnames'
 immutable             = require 'immutable'
-emojify               = require 'emojify.js'
 formatEmojiName       = require 'activity/util/formatEmojiName'
 ChatInputFlux         = require 'activity/flux/chatinput'
 Dropbox               = require 'activity/components/dropbox/portaldropbox'
 EmojiSelectorItem     = require 'activity/components/emojiselectoritem'
 EmojiIcon             = require 'activity/components/emojiicon'
 ImmutableRenderMixin  = require 'react-immutable-render-mixin'
-renderEmojiSpriteIcon = require 'activity/util/renderEmojiSpriteIcon'
 
 
 module.exports = class EmojiSelector extends React.Component

--- a/client/activity/lib/components/emojiselector/index.coffee
+++ b/client/activity/lib/components/emojiselector/index.coffee
@@ -8,6 +8,7 @@ formatEmojiName       = require 'activity/util/formatEmojiName'
 ChatInputFlux         = require 'activity/flux/chatinput'
 Dropbox               = require 'activity/components/dropbox/portaldropbox'
 EmojiSelectorItem     = require 'activity/components/emojiselectoritem'
+EmojiIcon             = require 'activity/components/emojiicon'
 ImmutableRenderMixin  = require 'react-immutable-render-mixin'
 renderEmojiSpriteIcon = require 'activity/util/renderEmojiSpriteIcon'
 
@@ -21,15 +22,6 @@ module.exports = class EmojiSelector extends React.Component
     items        : immutable.List()
     visible      : no
     selectedItem : ''
-
-
-  componentDidUpdate: (prevProps, prevState) ->
-
-    { visible } = @props
-    return  unless visible
-
-    list = React.findDOMNode this.refs.list
-    emojify.run list, renderEmojiSpriteIcon
 
 
   updatePosition: (inputDimensions) -> @refs.dropbox.setInputDimensions inputDimensions
@@ -59,7 +51,7 @@ module.exports = class EmojiSelector extends React.Component
     { items, selectedItem } = @props
 
     items.map (item, index) =>
-      isSelected   = selectedItem is item
+      isSelected = selectedItem is item
 
       <EmojiSelectorItem
         item         = { item }
@@ -69,13 +61,6 @@ module.exports = class EmojiSelector extends React.Component
         onConfirmed  = { @bound 'onItemConfirmed' }
         key          = { item }
       />
-
-
-  renderSelectedItemIcon: ->
-
-    { selectedItem } = @props
-    icon = "<span class='emojiSpriteIcon emoji-#{selectedItem or 'cow'}' />"
-    <div className="EmojiSelector-selectedItemIcon" dangerouslySetInnerHTML={__html: icon} />
 
 
   render: ->
@@ -91,12 +76,14 @@ module.exports = class EmojiSelector extends React.Component
       ref       = 'dropbox'
       resize    = 'custom'
     >
-      <div className="EmojiSelector-list Dropbox-resizable" ref="list">
+      <div className="EmojiSelector-list Dropbox-resizable">
         {@renderList()}
         <div className='clearfix'></div>
       </div>
       <div className="EmojiSelector-footer">
-        {@renderSelectedItemIcon()}
+        <span className="EmojiSelector-selectedItemIcon">
+          <EmojiIcon emoji={selectedItem or 'cow'} />
+        </span>
         <div className="EmojiSelector-selectedItemName">
           {if selectedItem then formatEmojiName selectedItem else 'Choose your emoji!'}
         </div>

--- a/client/activity/lib/components/emojiselector/styl/emojiselector.styl
+++ b/client/activity/lib/components/emojiselector/styl/emojiselector.styl
@@ -27,6 +27,8 @@
 
   .emojiSpriteIcon
     size                    32px 32px
+    sta()
+    transform                none
 
   .emojiIcon
     size                    32px 32px

--- a/client/activity/lib/components/emojiselector/styl/emojiselector.styl
+++ b/client/activity/lib/components/emojiselector/styl/emojiselector.styl
@@ -10,7 +10,7 @@
     max-height              none
 
 .EmojiSelector-list
-  max-height                298px
+  max-height                306px
   width                     327px
   overflow                  auto
   padding                   18px 0 18px 18px
@@ -24,6 +24,12 @@
   fl()
   margin-right              15px
   size                      36px 36px
+
+  .emojiSpriteIcon
+    size                    32px 32px
+
+  .emojiIcon
+    size                    32px 32px
 
 .EmojiSelector-selectedItemName
   color                     #646565

--- a/client/activity/lib/components/emojiselector/styl/emojiselector.styl
+++ b/client/activity/lib/components/emojiselector/styl/emojiselector.styl
@@ -25,13 +25,16 @@
   margin-right              15px
   size                      36px 36px
 
-  .emojiSpriteIcon
+  .emoji-wrapper
     size                    32px 32px
-    sta()
-    transform                none
 
-  .emojiIcon
-    size                    32px 32px
+    .emoji-sprite
+      size                  32px 32px
+      sta()
+      transform             none
+
+    .emoji
+      size                  32px 32px
 
 .EmojiSelector-selectedItemName
   color                     #646565

--- a/client/activity/lib/components/emojiselectoritem/index.coffee
+++ b/client/activity/lib/components/emojiselectoritem/index.coffee
@@ -1,9 +1,7 @@
 kd                   = require 'kd'
 React                = require 'kd-react'
-immutable            = require 'immutable'
-classnames           = require 'classnames'
-formatEmojiName      = require 'activity/util/formatEmojiName'
 DropboxItem          = require 'activity/components/dropboxitem'
+EmojiIcon            = require 'activity/components/emojiicon'
 ImmutableRenderMixin = require 'react-immutable-render-mixin'
 
 module.exports = class EmojiSelectorItem extends React.Component
@@ -11,7 +9,7 @@ module.exports = class EmojiSelectorItem extends React.Component
   @include [ ImmutableRenderMixin ]
 
   @defaultProps =
-    item         : immutable.Map()
+    item         : ''
     isSelected   : no
     index        : 0
 
@@ -19,10 +17,8 @@ module.exports = class EmojiSelectorItem extends React.Component
   render: ->
 
     { item } = @props
-    className = classnames
-      'EmojiSelectorItem'            : yes
 
-    <DropboxItem {...@props} className={className}>
-      {formatEmojiName item}
+    <DropboxItem {...@props} className='EmojiSelectorItem'>
+      <EmojiIcon emoji={item} />
     </DropboxItem>
 

--- a/client/activity/lib/components/emojiselectoritem/styl/emojiselectoritem.styl
+++ b/client/activity/lib/components/emojiselectoritem/styl/emojiselectoritem.styl
@@ -1,12 +1,18 @@
 .EmojiSelectorItem
   fl()
-  padding                   2px
+  padding                   8px
   rounded                   4px
 
   &.DropboxItem-selected
     bg                      color, #FEEC99
 
-  .emojiSpriteIcon
-    transform               scale(0.625, 0.625)
-    size                    32px 32px
+  .emojiIconWrapper
+    size                    20px 20px
 
+    .emojiSpriteIcon
+      left                  -6px
+      top                   -6px
+      transform             scale(0.625, 0.625)
+
+    .emojiIcon
+      size                  20px 20px

--- a/client/activity/lib/components/emojiselectoritem/styl/emojiselectoritem.styl
+++ b/client/activity/lib/components/emojiselectoritem/styl/emojiselectoritem.styl
@@ -6,13 +6,3 @@
   &.DropboxItem-selected
     bg                      color, #FEEC99
 
-  .emojiIconWrapper
-    size                    20px 20px
-
-    .emojiSpriteIcon
-      left                  -6px
-      top                   -6px
-      transform             scale(0.625, 0.625)
-
-    .emojiIcon
-      size                  20px 20px

--- a/client/activity/lib/index.coffee
+++ b/client/activity/lib/index.coffee
@@ -160,6 +160,6 @@ helper =
 
     options =
       identifier : 'emojis'
-      url        : '/a/static/emojify/emojify.css'
+      url        : '/a/static/emojify/emojify.css?v=1'
 
     KodingAppsController.appendHeadElement 'style', options

--- a/client/activity/lib/util/renderEmojiSpriteIcon.coffee
+++ b/client/activity/lib/util/renderEmojiSpriteIcon.coffee
@@ -1,5 +1,35 @@
+IMAGE_EMOJIS = [
+  'broken_heart'
+  'confounded'
+  'flushed'
+  'flowning'
+  'grinning'
+  'heart'
+  'kissing_heart'
+  'mask'
+  'pensive'
+  'relaxed'
+  'rage'
+  'smirk'
+  'sob'
+  'smile'
+  'stuck_out_tongue_closed_eyes'
+  'stuck_out_tongue_winking_eye'
+  'scream'
+  'wink'
+]
+
 module.exports = renderEmojiSpriteIcon = (emoji, emojiName) ->
-  span = document.createElement 'span'
-  span.className = "emojiSpriteIcon emoji-#{emojiName}"
-  return span
+
+  if emojiName in IMAGE_EMOJIS
+    emojiElement = document.createElement 'img'
+    emojiElement.className = 'emojiIcon'
+    emojiElement.setAttribute 'src', "https://s3.amazonaws.com/koding-cdn/emojis/#{emojiName}.png"
+  else
+    emojiElement = document.createElement 'span'
+    emojiElement.className = "emojiSpriteIcon emoji-#{emojiName}"
+
+  emojiElement.setAttribute 'title', emoji
+
+  return emojiElement
 

--- a/client/activity/lib/util/renderEmojiSpriteIcon.coffee
+++ b/client/activity/lib/util/renderEmojiSpriteIcon.coffee
@@ -21,15 +21,14 @@ IMAGE_EMOJIS = [
 
 module.exports = renderEmojiSpriteIcon = (emoji, emojiName) ->
 
+  element = document.createElement 'span'
+  element.className = 'emojiIconWrapper'
+
   if emojiName in IMAGE_EMOJIS
-    emojiElement = document.createElement 'img'
-    emojiElement.className = 'emojiIcon'
-    emojiElement.setAttribute 'src', "https://s3.amazonaws.com/koding-cdn/emojis/#{emojiName}.png"
+    imagePath = 'https://s3.amazonaws.com/koding-cdn/emojis/'
+    element.innerHTML = "<img src='#{imagePath}#{emojiName}.png' class='emojiIcon' title='#{emoji}' />"
   else
-    emojiElement = document.createElement 'span'
-    emojiElement.className = "emojiSpriteIcon emoji-#{emojiName}"
+    element.innerHTML = "<span class='emojiSpriteIcon emoji-#{emojiName}' title='#{emoji}' />"
 
-  emojiElement.setAttribute 'title', emoji
-
-  return emojiElement
+  return element
 

--- a/client/activity/lib/util/renderEmojis.coffee
+++ b/client/activity/lib/util/renderEmojis.coffee
@@ -1,3 +1,5 @@
+emojify = require 'emojify.js'
+
 IMAGE_EMOJIS = [
   'broken_heart'
   'confounded'
@@ -19,16 +21,19 @@ IMAGE_EMOJIS = [
   'wink'
 ]
 
-module.exports = renderEmojiSpriteIcon = (emoji, emojiName) ->
+renderEmojiIcon = (emoji, emojiName) ->
 
   element = document.createElement 'span'
-  element.className = 'emojiIconWrapper'
+  element.className = 'emoji-wrapper'
 
   if emojiName in IMAGE_EMOJIS
     imagePath = 'https://s3.amazonaws.com/koding-cdn/emojis/'
-    element.innerHTML = "<img src='#{imagePath}#{emojiName}.png' class='emojiIcon' title='#{emoji}' />"
+    element.innerHTML = "<img src='#{imagePath}#{emojiName}.png' class='emoji' title='#{emoji}' />"
   else
-    element.innerHTML = "<span class='emojiSpriteIcon emoji-#{emojiName}' title='#{emoji}' />"
+    element.innerHTML = "<span class='emoji-sprite emoji-#{emojiName}' title='#{emoji}' />"
 
   return element
+
+
+module.exports = renderEmojis = (element) -> emojify.run element, renderEmojiIcon
 

--- a/website/a/static/emojify/emojify.css
+++ b/website/a/static/emojify/emojify.css
@@ -1,4 +1,4 @@
-    .emojiSpriteIcon {
+    .emoji-sprite {
         background-image: url('/a/static/emojify/emojify.png');
         display: inline-block;
     }
@@ -7,18 +7,18 @@
       Add this class to container element in which emojis can be rendered.
       It will preload emoji sprite and emojis will appear without any delay
     */
-    .emojiSpritePreloader:after {
+    .emoji-sprite-preloader:after {
         background-image: url('/a/static/emojify/emojify.png');
         content: '';
     }
 
     @media (min--moz-device-pixel-ratio: 1.5), (-o-min-device-pixel-ratio: 3/2), (-webkit-min-device-pixel-ratio: 1.5), (min-device-pixel-ratio: 1.5), (min-resolution: 1.5dppx) {
-        .emojiSpriteIcon {
+        .emoji-sprite {
             background-image: url('/a/static/emojify/emojify@2x.png');
             background-size: 1091px 1049px;
         }
 
-       .emojiSpritePreloader:after {
+       .emoji-sprite-preloader:after {
             background-image: url('/a/static/emojify/emojify@2x.png');
             content: '';
         }

--- a/website/a/static/emojify/emojify.css
+++ b/website/a/static/emojify/emojify.css
@@ -3,10 +3,24 @@
         display: inline-block;
     }
 
+    /*
+      Add this class to container element in which emojis can be rendered.
+      It will preload emoji sprite and emojis will appear without any delay
+    */
+    .emojiSpritePreloader:after {
+        background-image: url('/a/static/emojify/emojify.png');
+        content: '';
+    }
+
     @media (min--moz-device-pixel-ratio: 1.5), (-o-min-device-pixel-ratio: 3/2), (-webkit-min-device-pixel-ratio: 1.5), (min-device-pixel-ratio: 1.5), (min-resolution: 1.5dppx) {
         .emojiSpriteIcon {
             background-image: url('/a/static/emojify/emojify@2x.png');
             background-size: 1091px 1049px;
+        }
+
+       .emojiSpritePreloader:after {
+            background-image: url('/a/static/emojify/emojify@2x.png');
+            content: '';
         }
     }
 


### PR DESCRIPTION
@usirin, can you please review these changes? They are for [this task](https://www.pivotaltracker.com/story/show/106527212)

Here is some technical details on the changes:
- emojis in chat list messages, chat input emoji dropbox and emoji selector are rendered with emoji sprite
- I found out that sprite doesn't contain several emojis which can be rendered by images (18 items). If we need to show such emoji, I render them as images. In 98% of cases user didn't notice any delay in rendering emojis since image emojis are only 18 items while the total number of emojis is 900+.
- Emoji sprite is preloaded when user opens a chat first time. I add `emoji-sprite-preloader` class to `ChatInput` element for that purpose
  Also I did some minor refactoring and improvements like `EmojiIcon` component and `renderEmojis` util

Here is the short video - http://recordit.co/woGG307AAJ

/cc @sinan 
