### PR TITLE
Integrations Improvement Package [ fixes #104398472 ] [ completes #106897328 ]

### DIFF
--- a/client/admin/lib/styl/app.group.admin.styl
+++ b/client/admin/lib/styl/app.group.admin.styl
@@ -1459,6 +1459,16 @@ Admin main styles
         .edit
           visible()
 
+      .tag
+        font-size           10px
+        display             inline-block
+        margin-left         6px
+        line-height         10px
+        padding             3px 6px
+        color               #FFF
+        background          #434343
+        border-radius       2px
+
       .by
         fl()
         color               #8d8d8d

--- a/client/admin/lib/views/integrations/adminconfiguredintegrationitemview.coffee
+++ b/client/admin/lib/views/integrations/adminconfiguredintegrationitemview.coffee
@@ -57,19 +57,25 @@ module.exports = class AdminConfiguredIntegrationItemView extends AdminIntegrati
 
   createSubItem: (data, account) ->
 
+    { id, createdAt, isDisabled } = data.channelIntegration
+
+    disabledMarkup = ''
+
+    if isDisabled
+      disabledMarkup = '<span class="tag">DISABLED</span>'
+
     @listView.addSubView subview = new KDCustomHTMLView
       cssClass : 'integration'
       partial  : """
-        <p>posts to ##{data.channel.name} channel</p>
+        <p>posts to ##{data.channel.name} channel#{disabledMarkup}</p>
         <p class="by">added by #{account.profile.nickname}</p>
       """
 
-    subview.addSubView new KDTimeAgoView {}, data.channelIntegration.createdAt
+    subview.addSubView new KDTimeAgoView {}, createdAt
     subview.addSubView new KDCustomHTMLView
       cssClass : 'edit'
       partial  : 'Customize <span></span>'
-      click    : =>
-        { id } = data.channelIntegration
+      click    : ->
         kd.singletons.router.handleRoute "/Admin/Integrations/Configure/#{id}"
 
 

--- a/client/admin/lib/views/integrations/adminintegrationdetailsview.coffee
+++ b/client/admin/lib/views/integrations/adminintegrationdetailsview.coffee
@@ -179,7 +179,7 @@ module.exports = class AdminIntegrationDetailsView extends JView
       return kd.warn err  if err
       @settingsForm.buttons.Save.hideLoader()
       new kd.NotificationView title : 'Integration is successfully saved!'
-      kd.singletons.router.handleRoute '/Admin/Integrations'
+      kd.singletons.router.handleRoute '/Admin/Integrations/Configured'
 
 
   regenerateToken: ->

--- a/client/admin/lib/views/integrations/adminintegrationdetailsview.coffee
+++ b/client/admin/lib/views/integrations/adminintegrationdetailsview.coffee
@@ -180,6 +180,7 @@ module.exports = class AdminIntegrationDetailsView extends JView
       @settingsForm.buttons.Save.hideLoader()
       new kd.NotificationView title : 'Integration is successfully saved!'
       kd.singletons.router.handleRoute '/Admin/Integrations/Configured'
+      @emit 'IntegrationUpdated'
 
 
   regenerateToken: ->
@@ -218,6 +219,8 @@ module.exports = class AdminIntegrationDetailsView extends JView
 
       return showError  if err
 
+      @emit 'IntegrationUpdated'
+
       @getData().isDisabled = newState
       { status } = @settingsForm.inputs
 
@@ -238,7 +241,7 @@ module.exports = class AdminIntegrationDetailsView extends JView
 
       if response.status
         kd.singletons.router.handleRoute '/Admin/Integrations/Configured'
-        @emit 'IntegrationRemoved'
+        @emit 'IntegrationUpdated'
 
 
   getFormOptions: ->

--- a/client/admin/lib/views/integrations/adminintegrationdetailsview.coffee
+++ b/client/admin/lib/views/integrations/adminintegrationdetailsview.coffee
@@ -231,6 +231,16 @@ module.exports = class AdminIntegrationDetailsView extends JView
         status.updatePartial 'Disable Integration'
 
 
+  removeIntegration: ->
+
+    integrationHelpers.remove @getData().id, (err, response) =>
+      return showError err  if err
+
+      if response.status
+        kd.singletons.router.handleRoute '/Admin/Integrations/Configured'
+        @emit 'IntegrationRemoved'
+
+
   getFormOptions: ->
 
     data            = @getData()
@@ -301,19 +311,26 @@ module.exports = class AdminIntegrationDetailsView extends JView
     { integrationType, isDisabled } = @getData()
 
     if integrationType isnt 'new'
-      cssClass = 'disable status'
-      title    = 'Disable Integration'
+      cssClass     = 'disable status'
+      disableTitle = 'Disable Integration'
 
       if isDisabled
-        cssClass = 'enable status'
-        title    = 'Enable Integration'
+        cssClass     = 'enable status'
+        disableTitle = 'Enable Integration'
 
       formOptions.fields.status =
         label     : '<p>Integration Status</p><span>You can enable/disable your integration here.</span>'
-        itemClass : KDCustomHTMLView
-        partial   : title
+        itemClass : kd.CustomHTMLView
+        partial   : disableTitle
         cssClass  : cssClass
         click     : @bound 'handleStatusChange'
+
+      formOptions.fields.remove =
+        label     : '<p>Remove Integration</p><span>You can remove your integration here. Please note that, this action cannot be undone.</span>'
+        itemClass : kd.CustomHTMLView
+        partial   : 'REMOVE INTEGRATION'
+        cssClass  : 'disable status'
+        click     : @bound 'removeIntegration'
 
     return formOptions
 

--- a/client/admin/lib/views/integrations/adminintegrationdetailsview.coffee
+++ b/client/admin/lib/views/integrations/adminintegrationdetailsview.coffee
@@ -1,17 +1,12 @@
 kd                   = require 'kd'
 JView                = require 'app/jview'
+whoami               = require 'app/util/whoami'
 remote               = require('app/remote').getInstance()
 globals              = require 'globals'
 showError            = require 'app/util/showError'
-KDInputView          = kd.InputView
-KDLabelView          = kd.LabelView
-KDButtonView         = kd.ButtonView
 applyMarkdown        = require 'app/util/applyMarkdown'
 CustomLinkView       = require 'app/customlinkview'
-KDCustomHTMLView     = kd.CustomHTMLView
 integrationHelpers   = require 'app/helpers/integration'
-KDFormViewWithFields = kd.FormViewWithFields
-whoami               = require 'app/util/whoami'
 
 
 module.exports = class AdminIntegrationDetailsView extends JView
@@ -26,7 +21,7 @@ module.exports = class AdminIntegrationDetailsView extends JView
 
     @createInstructionsView()
 
-    @settingsForm = new KDFormViewWithFields @getFormOptions()
+    @settingsForm = new kd.FormViewWithFields @getFormOptions()
 
     @createEventCheckboxes()
 
@@ -40,7 +35,7 @@ module.exports = class AdminIntegrationDetailsView extends JView
     { instructions } = integration
 
     if instructions
-      @instructionsView = new KDCustomHTMLView
+      @instructionsView = new kd.CustomHTMLView
         tagName  : 'section'
         cssClass : 'has-markdown instructions container'
         partial  : """
@@ -48,10 +43,10 @@ module.exports = class AdminIntegrationDetailsView extends JView
           <p class='subtitle'>Here are the steps necessary to add the #{integration.title} integration.</p>
           <hr />
         """
-      @instructionsView.addSubView new KDCustomHTMLView
+      @instructionsView.addSubView new kd.CustomHTMLView
         partial  : applyMarkdown instructions
     else
-      @instructionsView = new KDCustomHTMLView cssClass: 'hidden'
+      @instructionsView = new kd.CustomHTMLView cssClass: 'hidden'
 
 
   createAuthView: ->
@@ -59,12 +54,12 @@ module.exports = class AdminIntegrationDetailsView extends JView
     { authorizable, isAuthorized } = @getData()
 
     unless authorizable
-      @authView = new KDCustomHTMLView cssClass: 'hidden'
+      @authView = new kd.CustomHTMLView cssClass: 'hidden'
       return
 
     @setClass 'authorizable'
 
-    @authView = new KDCustomHTMLView
+    @authView = new kd.CustomHTMLView
       tagName  : 'section'
       cssClass : 'auth container'
       partial  : """
@@ -80,7 +75,7 @@ module.exports = class AdminIntegrationDetailsView extends JView
       buttonTitle = 'Remove your authorization'
       buttonClass = 'red'
 
-    @authButton = new KDButtonView
+    @authButton = new kd.ButtonView
       title     : buttonTitle
       cssClass  : "solid compact #{buttonClass}"
       loader    : yes
@@ -126,16 +121,16 @@ module.exports = class AdminIntegrationDetailsView extends JView
   createEventCheckboxes: ->
 
     selectedEvents = @getData().selectedEvents or []
-    mainWrapper    = new KDCustomHTMLView cssClass: 'event-cbes'
+    mainWrapper    = new kd.CustomHTMLView cssClass: 'event-cbes'
 
     return  unless @data.settings?.events
 
     for item in @data.settings.events
 
       { name } = item
-      wrapper  = new KDCustomHTMLView cssClass: 'event-cb'
-      label    = new KDLabelView title: item.description
-      checkbox = new KDInputView
+      wrapper  = new kd.CustomHTMLView cssClass: 'event-cb'
+      label    = new kd.LabelView title: item.description
+      checkbox = new kd.InputView
         type         : 'checkbox'
         name         : name
         label        : label
@@ -270,7 +265,7 @@ module.exports = class AdminIntegrationDetailsView extends JView
           click         : -> @selectAll()
           nextElement   :
             regenerate  :
-              itemClass : KDCustomHTMLView
+              itemClass : kd.CustomHTMLView
               partial   : 'Regenerate'
               cssClass  : 'link'
               click     : @bound 'regenerateToken'

--- a/client/admin/lib/views/integrations/adminintegrationdetailsview.coffee
+++ b/client/admin/lib/views/integrations/adminintegrationdetailsview.coffee
@@ -304,7 +304,7 @@ module.exports = class AdminIntegrationDetailsView extends JView
         Cancel          :
           title         : 'Cancel'
           cssClass      : 'solid green medium red'
-          callback      : -> kd.singletons.router.handleRoute '/Admin/Integrations/Configure'
+          callback      : -> kd.singletons.router.handleRoute '/Admin/Integrations/Configured'
 
     delete formOptions.fields.repository  unless repositories.length
 

--- a/client/admin/lib/views/integrations/adminintegrationparentview.coffee
+++ b/client/admin/lib/views/integrations/adminintegrationparentview.coffee
@@ -52,8 +52,14 @@ module.exports = class AdminIntegrationParentView extends JView
     integrationHelpers.fetchConfigureData options, (err, data) =>
       return @handleError err  if err
 
-      @addSubView @mainView = new AdminIntegrationDetailsView {}, data
       @loader?.destroy()
+      @addSubView @mainView = new AdminIntegrationDetailsView {}, data
+
+      @mainView.on 'IntegrationRemoved', =>
+        adminTabView           = @getDelegate()
+        { configuredListView } = adminTabView.getPaneByName('Integrations').mainView
+
+        configuredListView.refresh()
 
 
   handleError: (err) ->

--- a/client/admin/lib/views/integrations/adminintegrationparentview.coffee
+++ b/client/admin/lib/views/integrations/adminintegrationparentview.coffee
@@ -55,7 +55,7 @@ module.exports = class AdminIntegrationParentView extends JView
       @loader?.destroy()
       @addSubView @mainView = new AdminIntegrationDetailsView {}, data
 
-      @mainView.on 'IntegrationRemoved', =>
+      @mainView.on 'IntegrationUpdated', =>
         adminTabView           = @getDelegate()
         { configuredListView } = adminTabView.getPaneByName('Integrations').mainView
 

--- a/client/admin/lib/views/integrations/adminintegrationslistview.coffee
+++ b/client/admin/lib/views/integrations/adminintegrationslistview.coffee
@@ -1,15 +1,10 @@
-kd                          = require 'kd'
-KDView                      = kd.View
-remote                      = require('app/remote').getInstance()
-KDCustomHTMLView            = kd.CustomHTMLView
-KDCustomScrollView          = kd.CustomScrollView
-KDListViewController        = kd.ListViewController
-AdminIntegrationItemView    = require './adminintegrationitemview'
-AdminIntegrationDetailsView = require './adminintegrationdetailsview'
-integrationHelpers          = require 'app/helpers/integration'
+kd                       = require 'kd'
+remote                   = require('app/remote').getInstance()
+integrationHelpers       = require 'app/helpers/integration'
+AdminIntegrationItemView = require './adminintegrationitemview'
 
 
-module.exports = class AdminIntegrationsListView extends KDView
+module.exports = class AdminIntegrationsListView extends kd.View
 
   constructor: (options = {}, data) ->
 
@@ -24,17 +19,17 @@ module.exports = class AdminIntegrationsListView extends KDView
     @createListController()
     @fetchIntegrations()
 
-    @addSubView @subContentView = new KDCustomScrollView
+    @addSubView @subContentView = new kd.CustomScrollView
 
 
   createListController: ->
 
-    @listController       = new KDListViewController
+    @listController       = new kd.ListViewController
       viewOptions         :
         wrapper           : yes
         itemClass         : @getOptions().listItemClass
       useCustomScrollView : yes
-      noItemFoundWidget   : new KDCustomHTMLView
+      noItemFoundWidget   : new kd.CustomHTMLView
         cssClass          : 'hidden no-item-found'
         partial           : 'No integration available.'
       startWithLazyLoader : yes

--- a/client/admin/lib/views/integrations/adminintegrationsview.coffee
+++ b/client/admin/lib/views/integrations/adminintegrationsview.coffee
@@ -1,13 +1,10 @@
 kd            = require 'kd'
-KDView        = kd.View
-KDTabView     = kd.TabView
-KDTabPaneView = kd.TabPaneView
 
 AdminIntegrationsListView           = require './adminintegrationslistview'
 AdminConfiguredIntegrationsListView = require './adminconfiguredintegrationslistview'
 
 
-module.exports = class AdminMembersView extends KDView
+module.exports = class AdminMembersView extends kd.View
 
   constructor: (options = {}, data) ->
 
@@ -20,10 +17,10 @@ module.exports = class AdminMembersView extends KDView
 
   createTabView: ->
 
-    @addSubView tabView = @tabView = new KDTabView hideHandleCloseIcons: yes
+    @addSubView tabView = @tabView = new kd.TabView hideHandleCloseIcons: yes
 
-    tabView.addPane all        = new KDTabPaneView name: 'All Services'
-    tabView.addPane configured = new KDTabPaneView name: 'Configured Integrations'
+    tabView.addPane all        = new kd.TabPaneView name: 'All Services'
+    tabView.addPane configured = new kd.TabPaneView name: 'Configured Integrations'
 
     @allListView        = new AdminIntegrationsListView           integrationType: 'new'
     @configuredListView = new AdminConfiguredIntegrationsListView integrationType: 'configured'

--- a/client/admin/lib/views/integrations/adminintegrationsview.coffee
+++ b/client/admin/lib/views/integrations/adminintegrationsview.coffee
@@ -37,5 +37,5 @@ module.exports = class AdminMembersView extends kd.View
 
   handleAction: (action) ->
 
-    index = if action is 'Configure' then 1 else 0
+    index = if action is 'Configured' then 1 else 0
     @tabView.showPaneByIndex index


### PR DESCRIPTION
- [x] Integrations can not be deleted  - there is no way to delete an integration
- [x] Fix showing Configured Integrations tab via URL with routing.
- [x] there is no way to visually understand an integration is disabled or not. expect going to its details view.
- [x] when a new integration added, switch to configured integrations tab. right now we are showing all integrations tab again.
- [x] switch back to configured integrations list when cancel button is clicked on integration customization view.
