### PR TITLE
reactivity: remove user profile links [fixes #106527260]

### DIFF
--- a/client/activity/lib/components/searchdropboxitem/index.coffee
+++ b/client/activity/lib/components/searchdropboxitem/index.coffee
@@ -3,6 +3,7 @@ React                = require 'kd-react'
 immutable            = require 'immutable'
 classnames           = require 'classnames'
 formatPlural         = kd.utils.formatPlural
+formatContent        = require 'app/util/formatReactivityContent'
 DropboxItem          = require 'activity/components/dropboxitem'
 SearchItemBody       = require 'activity/components/searchitembody'
 ProfileText          = require 'app/components/profile/profiletext'
@@ -27,7 +28,7 @@ module.exports = class SearchDropboxItem extends React.Component
     { renderProfileLink, renderLikesCount, renderCommentsCount } = helper
 
     <DropboxItem {...@props} className="DropboxItem-separated SearchDropboxItem">
-      <SearchItemBody source={messageBody} />
+      <SearchItemBody source={messageBody} formatContentFn={formatContent} />
       <div>
         <span className="SearchDropboxItem-info SearchDropboxItem-profileLink">
           by { renderProfileLink message }

--- a/client/activity/lib/components/searchdropboxitem/index.coffee
+++ b/client/activity/lib/components/searchdropboxitem/index.coffee
@@ -28,7 +28,7 @@ module.exports = class SearchDropboxItem extends React.Component
     { renderProfileLink, renderLikesCount, renderCommentsCount } = helper
 
     <DropboxItem {...@props} className="DropboxItem-separated SearchDropboxItem">
-      <SearchItemBody source={messageBody} formatContentFn={formatContent} />
+      <SearchItemBody source={messageBody} contentFormatter={formatContent} />
       <div>
         <span className="SearchDropboxItem-info SearchDropboxItem-profileLink">
           by { renderProfileLink message }

--- a/client/activity/lib/components/searchitembody/index.coffee
+++ b/client/activity/lib/components/searchitembody/index.coffee
@@ -1,7 +1,6 @@
 $             = require 'jquery'
 React         = require 'kd-react'
 Constants     = require 'activity/flux/actions/searchconstants'
-formatContent = require 'app/util/formatContent'
 emojify       = require 'emojify.js'
 
 module.exports = class SearchItemBody extends React.Component
@@ -31,7 +30,11 @@ module.exports = class SearchItemBody extends React.Component
     startTag = '<span class="SearchItemBody-matchedWord">'
     endTag   = '</span>'
 
-    content = formatContent @props.source, { highlight : no }
+    { source, formatContentFn } = @props
+
+    content = source
+
+    content = formatContentFn content, { highlight : no }  if @props.formatContentFn
 
     content = helper.cleanUselessMarkers content
     content = helper.replaceMarkers content, startTag, endTag

--- a/client/activity/lib/components/searchitembody/index.coffee
+++ b/client/activity/lib/components/searchitembody/index.coffee
@@ -1,9 +1,14 @@
-$             = require 'jquery'
-React         = require 'kd-react'
-Constants     = require 'activity/flux/actions/searchconstants'
-emojify       = require 'emojify.js'
+kd        = require 'kd'
+$         = require 'jquery'
+React     = require 'kd-react'
+Constants = require 'activity/flux/actions/searchconstants'
+emojify   = require 'emojify.js'
 
 module.exports = class SearchItemBody extends React.Component
+
+  @defaultProps =
+    contentFormatter : kd.noop
+
 
   ###*
    * Renders search item body
@@ -30,11 +35,11 @@ module.exports = class SearchItemBody extends React.Component
     startTag = '<span class="SearchItemBody-matchedWord">'
     endTag   = '</span>'
 
-    { source, formatContentFn } = @props
+    { source, contentFormatter } = @props
 
     content = source
 
-    content = formatContentFn content, { highlight : no }  if @props.formatContentFn
+    content = contentFormatter content, { highlight : no }
 
     content = helper.cleanUselessMarkers content
     content = helper.replaceMarkers content, startTag, endTag

--- a/client/activity/lib/components/suggestionitem/index.coffee
+++ b/client/activity/lib/components/suggestionitem/index.coffee
@@ -35,7 +35,7 @@ module.exports = class SuggestionItem extends React.Component
         {makeAvatar message.get('account')}
       </div>
       <div className="ActivitySuggestionItem-messageBody">
-        <SearchItemBody source={messageBody} formatContentFn={formatContent} />
+        <SearchItemBody source={messageBody} contentFormatter={formatContent} />
       </div>
       <div>
         <span className="ActivitySuggestionItem-info ActivitySuggestionItem-profileLink">

--- a/client/activity/lib/components/suggestionitem/index.coffee
+++ b/client/activity/lib/components/suggestionitem/index.coffee
@@ -7,6 +7,7 @@ ProfileText           = require 'app/components/profile/profiletext'
 ProfileLinkContainer  = require 'app/components/profile/profilelinkcontainer'
 formatPlural          = kd.utils.formatPlural
 classnames            = require 'classnames'
+formatContent         = require 'app/util/formatContent'
 
 module.exports = class SuggestionItem extends React.Component
 
@@ -34,7 +35,7 @@ module.exports = class SuggestionItem extends React.Component
         {makeAvatar message.get('account')}
       </div>
       <div className="ActivitySuggestionItem-messageBody">
-        <SearchItemBody source={messageBody} />
+        <SearchItemBody source={messageBody} formatContentFn={formatContent} />
       </div>
       <div>
         <span className="ActivitySuggestionItem-info ActivitySuggestionItem-profileLink">

--- a/client/app/lib/components/profile/profilelink.coffee
+++ b/client/app/lib/components/profile/profilelink.coffee
@@ -12,7 +12,7 @@ module.exports = class ProfileLink extends React.Component
   getHref: ->
     if @props.account.isIntegration
     then "/Admin/Integrations/Configure/#{@props.account.id}"
-    else "/#{@props.account.profile.nickname}"
+    else ''
 
 
   render: ->

--- a/client/app/lib/components/profile/profilelink.coffee
+++ b/client/app/lib/components/profile/profilelink.coffee
@@ -12,7 +12,7 @@ module.exports = class ProfileLink extends React.Component
   getHref: ->
     if @props.account.isIntegration
     then "/Admin/Integrations/Configure/#{@props.account.id}"
-    else ''
+    else '#'
 
 
   render: ->

--- a/client/app/lib/util/expandReactivityUsernames.coffee
+++ b/client/app/lib/util/expandReactivityUsernames.coffee
@@ -1,0 +1,52 @@
+$ = require 'jquery'
+
+module.exports = (text, excludeSelector) ->
+  # excludeSelector is a jQuery selector
+
+  # as a jQuery selector, e.g. "pre"
+  # means that all @s in <pre> tags will not be expanded
+
+  return null  unless text
+
+  replaceFunc = (text, isProfile) ->
+    text.replace /\B\@([\w\-]+)/gim, (u) ->
+      username = u.replace "@", ""
+      return "<a href='#' class='profile-link'>#{u}</a>"  if isProfile
+      return u.link "#"
+
+  # default case for regular text
+  if not excludeSelector
+    replaceFunc text, yes
+
+  # context-sensitive expansion
+  else
+    result = ""
+    $(text).each (i, element) ->
+      $element = $(element)
+      elementCheck = $element.not excludeSelector
+      parentCheck = $element.parents(excludeSelector).length is 0
+      if elementCheck and parentCheck and $element.html()?
+        ###
+        we need to skip child nodes that meet to excludeSelector
+        but we should not forget that @s may be found in a simple text
+        ###
+        $element.contents().each (j, child) ->
+          $child = $(child)
+          return  if $child.is excludeSelector
+
+          isTextNode   = child.nodeType is Node.TEXT_NODE
+          childContent = if isTextNode then $child.text() else $child.html()
+          return  unless childContent
+
+          replacedText = replaceFunc childContent, no
+
+          if replacedText isnt childContent
+            if isTextNode
+              $child.wrap '<span>'
+              $child.parent().html replacedText
+            else
+              $child.html replacedText
+
+      result += $element.get(0).outerHTML or "" # in case there is a text-only element
+    result
+

--- a/client/app/lib/util/formatReactivityContent.coffee
+++ b/client/app/lib/util/formatReactivityContent.coffee
@@ -3,7 +3,7 @@ transformEmails = require './transformEmails'
 formatQuotes = require './formatQuotes'
 formatBlockquotes = require './formatBlockquotes'
 applyMarkdown = require './applyMarkdown'
-expandUsernames = require './expandUsernames'
+expandUsernames = require './expandReactivityUsernames'
 markdownUrls = require './markdownUrls'
 
 module.exports = (body = '', markdownOptions = {}) ->
@@ -18,6 +18,7 @@ module.exports = (body = '', markdownOptions = {}) ->
 
   body = fn body for fn in fns
   body = applyMarkdown body, markdownOptions
+  body = expandUsernames body, 'code, a'
 
   return body
 

--- a/client/app/lib/util/formatReactivityContent.coffee
+++ b/client/app/lib/util/formatReactivityContent.coffee
@@ -18,7 +18,6 @@ module.exports = (body = '', markdownOptions = {}) ->
 
   body = fn body for fn in fns
   body = applyMarkdown body, markdownOptions
-  body = expandUsernames body, 'code, a'
 
   return body
 


### PR DESCRIPTION
@usirin, can you please review these changes?
/cc @sinan 

Here is how a chat looks after removing profile links:
![profile-links-removing](https://cloud.githubusercontent.com/assets/492219/10815474/6813c2c4-7e3d-11e5-9ffe-7a50eef8dca9.jpg)

Links in messages are regular text, message owner links are still blue but not clickable. Do we need to make them the same color as text?
