### PR TITLE
Social: bodyParser to increase request limit to 2mb from 100kb [fixes #106279222]

### DIFF
--- a/workers/social/lib/social/main.coffee
+++ b/workers/social/lib/social/main.coffee
@@ -146,7 +146,8 @@ do ->
   bodyParser = require 'body-parser'
 
   app.use compression()
-  app.use bodyParser.json()
+  app.use bodyParser.json { limit: '2mb' }
+
   helmet.defaults app
   app.use cors()
 


### PR DESCRIPTION
Currently social handlers not using a limit for `bodyParser` which is `100kb` by default https://github.com/expressjs/body-parser/blob/master/lib/types/json.js#L54
and this was causing to reject the save request

```
Error: request entity too large
  at makeError (/Users/gokmen/Code/koding/node_modules/body-parser/node_modules/raw-body/index.js:184:15)
  at module.exports (/Users/gokmen/Code/koding/node_modules/body-parser/node_modules/raw-body/index.js:40:15)
  at read (/Users/gokmen/Code/koding/node_modules/body-parser/lib/read.js:64:3)
  at jsonParser (/Users/gokmen/Code/koding/node_modules/body-parser/lib/types/json.js:116:5)
```

I set it as `2mb` for now, probably would be enough for most of our requirements. Here is an example stack template with 3k lines in it (~100kb) https://slack-files.com/T024KH59A-F0DDVFN8L-280814a323 for tests.
