### PR TITLE
Account Settings: Fix style inconsistency [fixes #106846142]

### DIFF
--- a/client/account/lib/styl/account.styl
+++ b/client/account/lib/styl/account.styl
@@ -29,6 +29,15 @@ app.settings.styl
   .kdmodal-content
     overflow                hidden !important
 
+    .AppModal-nav
+      .AppModal-navItem
+        color               #a1a1a1
+        text-decoration     none
+
+        &.selected
+        &.active
+          color             #52a840
+
   .AppModal-navItem:before
     content                 ''
     display                 inline-block


### PR DESCRIPTION
/cc @fatihacet @gokmen @szkl @sinan 
#### Before

![before2](https://cloud.githubusercontent.com/assets/728733/10818037/dfb15518-7e46-11e5-9e40-50591b2a2e46.png)
#### After

<img width="864" alt="screen shot 2015-10-29 at 2 15 21 pm" src="https://cloud.githubusercontent.com/assets/728733/10818105/9127bac6-7e47-11e5-9ce1-cd33b73408e6.png">
<img width="1026" alt="screen shot 2015-10-29 at 2 15 32 pm" src="https://cloud.githubusercontent.com/assets/728733/10818106/912ec2f8-7e47-11e5-886f-83abc2a54356.png">
