### PR TITLE
Kloud admin interface

### DIFF
--- a/client/app/lib/kite/kites/kloud.coffee
+++ b/client/app/lib/kite/kites/kloud.coffee
@@ -22,12 +22,10 @@ module.exports = class KodingKite_KloudKite extends require('../kodingkite')
   @createMethod = (ctx, { method, rpcMethod }) ->
     ctx[method] = (payload) ->
 
-      if payload?.machineId?
-
-        provider = getProvider payload.machineId
+      if payload?.machineId? and provider = getProvider payload.machineId
 
         if provider not in SUPPORTED_PROVIDERS
-          # machine provider is not supported by kloud #{payload.machineId}
+          # machine provider is not supported by kloud #{ payload.machineId }
           return Promise.reject
             name    : 'NotSupported'
             message : 'Operation is not supported for this VM'
@@ -52,6 +50,10 @@ module.exports = class KodingKite_KloudKite extends require('../kodingkite')
     resize          : 'resize'
     restart         : 'restart'
     destroy         : 'destroy'
+
+    # Admin helpers
+    addAdmin        : 'admin.add'
+    removeAdmin     : 'admin.remove'
 
     # Domain managament
     setDomain       : 'domain.set'

--- a/go/src/koding/db/mongodb/modelhelper/machine.go
+++ b/go/src/koding/db/mongodb/modelhelper/machine.go
@@ -2,6 +2,7 @@ package modelhelper
 
 import (
 	"errors"
+	"fmt"
 	"koding/db/models"
 	"time"
 
@@ -24,6 +25,22 @@ var (
 	MachinesColl           = "jMachines"
 	MachineConstructorName = "JMachine"
 )
+
+func GetMachine(id string) (*models.Machine, error) {
+	if !bson.IsObjectIdHex(id) {
+		return nil, fmt.Errorf("Invalid machine id: %q", id)
+	}
+
+	machine := &models.Machine{}
+	err := Mongo.Run(MachinesColl, func(c *mgo.Collection) error {
+		return c.FindId(bson.ObjectIdHex(id)).One(&machine)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return machine, nil
+}
 
 func GetMachines(userId bson.ObjectId) ([]*MachineContainer, error) {
 	machines := []*models.Machine{}

--- a/go/src/koding/db/mongodb/modelhelper/roles.go
+++ b/go/src/koding/db/mongodb/modelhelper/roles.go
@@ -37,12 +37,12 @@ func FetchAdminAccounts(groupName string) ([]models.Account, error) {
 func IsAdmin(username, groupName string) (bool, error) {
 	group, err := GetGroup(groupName)
 	if err != nil {
-		return false, fmt.Errorf("getGroup err: %s", err)
+		return false, fmt.Errorf("getGroup(%s) err: %s", groupName, err)
 	}
 
 	account, err := GetAccount(username)
 	if err != nil {
-		return false, fmt.Errorf("getAccount err: %s", err)
+		return false, fmt.Errorf("getAccount(%s) err: %s", username, err)
 	}
 
 	selector := Selector{

--- a/go/src/koding/db/mongodb/modelhelper/roles.go
+++ b/go/src/koding/db/mongodb/modelhelper/roles.go
@@ -1,6 +1,7 @@
 package modelhelper
 
 import (
+	"fmt"
 	"koding/db/models"
 
 	"labix.org/v2/mgo/bson"
@@ -36,25 +37,25 @@ func FetchAdminAccounts(groupName string) ([]models.Account, error) {
 func IsAdmin(username, groupName string) (bool, error) {
 	group, err := GetGroup(groupName)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("getGroup err: %s", err)
 	}
 
 	account, err := GetAccount(username)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("getAccount err: %s", err)
 	}
 
 	selector := Selector{
 		"sourceId":   group.Id,
 		"sourceName": "JGroup",
 		"targetId":   account.Id,
-		"targetName": "JAdmin",
+		"targetName": "JAccount",
 		"as":         "admin",
 	}
 
 	count, err := RelationshipCount(selector)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("checkAdminRelationship err: %s", err)
 	}
 
 	return count == 1, nil

--- a/go/src/koding/db/mongodb/modelhelper/roles.go
+++ b/go/src/koding/db/mongodb/modelhelper/roles.go
@@ -31,3 +31,31 @@ func FetchAdminAccounts(groupName string) ([]models.Account, error) {
 
 	return GetAccountsByIds(ids)
 }
+
+// IsAdmin checks if the given username is an admin of the given groupName
+func IsAdmin(username, groupName string) (bool, error) {
+	group, err := GetGroup(groupName)
+	if err != nil {
+		return false, err
+	}
+
+	account, err := GetAccount(username)
+	if err != nil {
+		return false, err
+	}
+
+	selector := Selector{
+		"sourceId":   group.Id,
+		"sourceName": "JGroup",
+		"targetId":   account.Id,
+		"targetName": "JAdmin",
+		"as":         "admin",
+	}
+
+	count, err := RelationshipCount(selector)
+	if err != nil {
+		return false, err
+	}
+
+	return count == 1, nil
+}

--- a/go/src/koding/kites/kloud/klient/klient.go
+++ b/go/src/koding/kites/kloud/klient/klient.go
@@ -35,6 +35,11 @@ type Klient struct {
 	Username string
 }
 
+// ShareRequest is used for klient's klient.share,klient.unshare methods.
+type ShareRequest struct {
+	Username string
+}
+
 func NewPool(k *kite.Kite) *KlientPool {
 	return &KlientPool{
 		kite:    k,
@@ -190,6 +195,46 @@ func (k *Klient) Ping() error {
 	}
 
 	if out == "pong" {
+		return nil
+	}
+
+	return fmt.Errorf("wrong response %s", out)
+}
+
+// AddUser adds the given username to the klient's permission list. Once added
+// the user is able to make requests to Klient
+func (k *Klient) AddUser(username string) error {
+	resp, err := k.Client.Tell("klient.share", &ShareRequest{username})
+	if err != nil {
+		return err
+	}
+
+	out, err := resp.String()
+	if err != nil {
+		return err
+	}
+
+	if out == "shared" {
+		return nil
+	}
+
+	return fmt.Errorf("wrong response %s", out)
+}
+
+// RemoveUser removes the given username from the klient's permission list.
+// Once removed the user is not able to make requests to Klient anymore.
+func (k *Klient) RemoveUser(username string) error {
+	resp, err := k.Client.Tell("klient.unshare", &ShareRequest{username})
+	if err != nil {
+		return err
+	}
+
+	out, err := resp.String()
+	if err != nil {
+		return err
+	}
+
+	if out == "unshared" {
 		return nil
 	}
 

--- a/go/src/koding/kites/kloud/kloud/admin.go
+++ b/go/src/koding/kites/kloud/kloud/admin.go
@@ -4,6 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"koding/db/mongodb/modelhelper"
+	"koding/kites/kloud/contexthelper/request"
+	"koding/kites/kloud/contexthelper/session"
+	"koding/kites/kloud/klient"
+	"time"
+
+	"golang.org/x/net/context"
 
 	"github.com/koding/kite"
 )
@@ -66,10 +72,25 @@ func (k *Kloud) AdminAdd(r *kite.Request) (interface{}, error) {
 	if !isGroupMember {
 		return nil, fmt.Errorf("Group '%s' is not a member of machine '%s'", args.GroupName, args.MachineId)
 	}
-
 	// Now we are ready to go
-	return nil, errors.New("not implemented yet")
 
+	ctx := request.NewContext(context.Background(), r)
+	ctx = k.ContextCreator(ctx)
+	sess, ok := session.FromContext(ctx)
+	if !ok {
+		return nil, errors.New("session context is not passed")
+	}
+
+	kl, err := klient.NewWithTimeout(sess.Kite, machine.QueryString, time.Second*10)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := kl.AddUser(r.Username); err != nil {
+		return nil, err
+	}
+
+	return true, nil
 }
 
 // func (k *Kloud) AdminRemove(r *kite.Request) (interface{}, error) {

--- a/go/src/koding/kites/kloud/kloud/admin.go
+++ b/go/src/koding/kites/kloud/kloud/admin.go
@@ -74,6 +74,8 @@ func (k *Kloud) authorizedKlient(r *kite.Request) (*klient.Klient, error) {
 		return nil, fmt.Errorf("User '%s' is not an admin of group '%s'", r.Username, args.GroupName)
 	}
 
+	k.Log.Debug("User '%s' is an admin. Checking for machine permission", r.Username)
+
 	machine, err := modelhelper.GetMachine(args.MachineId)
 	if err != nil {
 		return nil, fmt.Errorf("getMachine err: %s", err)
@@ -95,6 +97,8 @@ func (k *Kloud) authorizedKlient(r *kite.Request) (*klient.Klient, error) {
 			args.MachineId, args.GroupName)
 	}
 
+	k.Log.Debug("Incoming user is authorized, setting up DB and Klient connection")
+
 	// Now we are ready to go.
 	ctx := request.NewContext(context.Background(), r)
 	ctx = k.ContextCreator(ctx)
@@ -103,5 +107,6 @@ func (k *Kloud) authorizedKlient(r *kite.Request) (*klient.Klient, error) {
 		return nil, errors.New("internal server error (err: session context is not available)")
 	}
 
+	k.Log.Debug("Calling Klient method: %s", r.Method)
 	return klient.NewWithTimeout(sess.Kite, machine.QueryString, time.Second*10)
 }

--- a/go/src/koding/kites/kloud/kloud/admin.go
+++ b/go/src/koding/kites/kloud/kloud/admin.go
@@ -1,0 +1,92 @@
+package kloud
+
+import (
+	"errors"
+	"fmt"
+	"koding/db/mongodb/modelhelper"
+
+	"github.com/koding/kite"
+)
+
+type AdminRequest struct {
+	MachineId string `json:"machineId"`
+	GroupName string `json:"groupName"`
+}
+
+func (k *Kloud) AdminAdd(r *kite.Request) (interface{}, error) {
+	if r.Args == nil {
+		return nil, NewError(ErrNoArguments)
+	}
+
+	var args *AdminRequest
+	if err := r.Args.One().Unmarshal(&args); err != nil {
+		return nil, err
+	}
+
+	if args.MachineId == "" {
+		return nil, errors.New("machineId is not passed")
+	}
+
+	if args.GroupName == "" {
+		return nil, errors.New("group name is not passed")
+	}
+
+	admins, err := modelhelper.FetchAdminAccounts(args.GroupName)
+	if err != nil {
+		return nil, err
+	}
+
+	isAdmin := false
+	for _, admin := range admins {
+		if admin.Profile.Nickname == r.Username {
+			isAdmin = true
+		}
+	}
+	if !isAdmin {
+		return nil, fmt.Errorf("User '%s' is not an admin of group '%s'", r.Username, args.GroupName)
+	}
+
+	machine, err := modelhelper.GetMachine(args.MachineId)
+	if err != nil {
+		return nil, err
+	}
+
+	// fetch jGroup from group slug name
+	g, err := modelhelper.GetGroup(args.GroupName)
+	if err != nil {
+		return nil, err
+	}
+
+	isGroupMember := false
+	for _, group := range machine.Groups {
+		if group.Id.Hex() == g.Id.Hex() {
+			isGroupMember = true
+		}
+	}
+	if !isGroupMember {
+		return nil, fmt.Errorf("Group '%s' is not a member of machine '%s'", args.GroupName, args.MachineId)
+	}
+
+	// Now we are ready to go
+	return nil, errors.New("not implemented yet")
+
+}
+
+// func (k *Kloud) AdminRemove(r *kite.Request) (interface{}, error) {
+// 	if r.Args == nil {
+// 		return nil, NewError(ErrNoArguments)
+// 	}
+//
+// 	var args *AdminRequest
+// 	if err := r.Args.One().Unmarshal(&args); err != nil {
+// 		return nil, err
+// 	}
+//
+// 	if args.MachineId == "" {
+// 		return nil, errors.New("machineId is not passed")
+// 	}
+//
+// 	if args.GroupName == "" {
+// 		return nil, errors.New("group name is not passed")
+// 	}
+// }

--- a/go/src/koding/kites/kloud/kloud/admin.go
+++ b/go/src/koding/kites/kloud/kloud/admin.go
@@ -76,7 +76,7 @@ func (k *Kloud) authorizedKlient(r *kite.Request) (*klient.Klient, error) {
 
 	machine, err := modelhelper.GetMachine(args.MachineId)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getMachine err: %s", err)
 	}
 
 	g, err := modelhelper.GetGroup(args.GroupName)

--- a/go/src/koding/kites/kloud/kloud/admin.go
+++ b/go/src/koding/kites/kloud/kloud/admin.go
@@ -65,7 +65,7 @@ func (k *Kloud) authorizedKlient(r *kite.Request) (*klient.Klient, error) {
 
 	k.Log.Debug("Got arguments %+v for method: %s", args, r.Method)
 
-	isAdmin, err := modelhelper.IsAdmin(args.GroupName, r.Username)
+	isAdmin, err := modelhelper.IsAdmin(r.Username, args.GroupName)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (k *Kloud) authorizedKlient(r *kite.Request) (*klient.Klient, error) {
 
 	machine, err := modelhelper.GetMachine(args.MachineId)
 	if err != nil {
-		return nil, fmt.Errorf("getMachine err: %s", err)
+		return nil, fmt.Errorf("getMachine(%s) err: %s", args.MachineId, err)
 	}
 
 	g, err := modelhelper.GetGroup(args.GroupName)

--- a/go/src/koding/kites/kloud/main.go
+++ b/go/src/koding/kites/kloud/main.go
@@ -301,13 +301,14 @@ func newKite(conf *Config) *kite.Kite {
 		panic(err)
 	}
 
-	// Machine handling methods
+	// Teams/stack handling methods
 	k.HandleFunc("plan", kld.Plan)
 	k.HandleFunc("apply", kld.Apply)
 	k.HandleFunc("describeStack", kld.Status)
 	k.HandleFunc("authenticate", kld.Authenticate)
 	k.HandleFunc("bootstrap", kld.Bootstrap)
 
+	// Single machine handling
 	k.HandleFunc("build", kld.Build)
 	k.HandleFunc("destroy", kld.Destroy)
 	k.HandleFunc("stop", kld.Stop)
@@ -327,6 +328,10 @@ func newKite(conf *Config) *kite.Kite {
 	k.HandleFunc("domain.unset", kld.DomainUnset)
 	k.HandleFunc("domain.add", kld.DomainAdd)
 	k.HandleFunc("domain.remove", kld.DomainRemove)
+
+	// Klient proxy methods
+	k.HandleFunc("admin.add", kld.AdminAdd)
+	k.HandleFunc("admin.remove", kld.AdminRemove)
 
 	k.HandleHTTPFunc("/healthCheck", artifact.HealthCheckHandler(Name))
 	k.HandleHTTPFunc("/version", artifact.VersionHandler())


### PR DESCRIPTION
This introduces two need methods:
- `admin.add`: to add a username which is allowed to make requests to a given klient
- `admin.remove`: to remove a username to permit to make requests to a given klient

The methods require arguments in the form of:

```
type AdminRequest struct {
    MachineId string `json:"machineId"`
    GroupName string `json:"groupName"`
}
```

The username is based on the incoming requesters username.
