### PR TITLE
webserver: do not start listening before bongo is ready [fixes #106944594]

### DIFF
--- a/servers/lib/server/index.coffee
+++ b/servers/lib/server/index.coffee
@@ -134,22 +134,25 @@ app.all  '/:name/:section?/:slug?'               , require './handlers/main.coff
 app.get  '/'                                     , require './handlers/root.coffee'
 app.get  '*'                                     , require './handlers/rest.coffee'
 
-# start webserver
-app.listen webPort
-console.log '[WEBSERVER] running', "http://localhost:#{webPort} pid:#{process.pid}"
+# once bongo is ready we can start listening
+koding.once 'dbClientReady', ->
 
-# start user tracking
-usertracker.start()
+  # start webserver
+  app.listen webPort
+  console.log '[WEBSERVER] running', "http://localhost:#{webPort} pid:#{process.pid}"
 
-# init rabbitmq client for Email to use to queue emails
-mqClient = require './amqp'
-Tracker    = require '../../../workers/social/lib/social/models/tracker.coffee'
-Tracker.setMqClient mqClient
+  # start user tracking
+  usertracker.start()
 
-# NOTE: in the event of errors, send 500 to the client rather
-#       than the stack trace.
-app.use (err, req, res, next) ->
-  console.error 'request error'
-  console.error err
-  console.error err.stack
-  res.status(500).send error_500()
+  # init rabbitmq client for Email to use to queue emails
+  mqClient = require './amqp'
+  Tracker    = require '../../../workers/social/lib/social/models/tracker.coffee'
+  Tracker.setMqClient mqClient
+
+  # NOTE: in the event of errors, send 500 to the client rather
+  #       than the stack trace.
+  app.use (err, req, res, next) ->
+    console.error 'request error'
+    console.error err
+    console.error err.stack
+    res.status(500).send error_500()


### PR DESCRIPTION
We shouldn't let webserver to listen before `bongo` is ready, this is the main reason behind following issue;

```
Error: You must set the database client for this constructor, or failing that, you must set a generic client for Model.
  at Function.module.exports.Model.getCollection (/Users/gokmen/Code/koding/node_modules_koding/bongo/lib/model/index.coffee:158:17)
  at Function.module.exports.one (/Users/gokmen/Code/koding/node_modules_koding/bongo/lib/model/find.coffee:39:29)
```

I don't know any side-effects of this change except webserver won't start to listen until db/bongo is ready. It seems logical to me wait for healthy db connection before making webserver ready.

Any thoughts? cc/ @sinan @mulvad @szkl @sent-hil 
