### PR TITLE
KD Token UI

### DIFF
--- a/client/activity/lib/components/threadsidebar/index.coffee
+++ b/client/activity/lib/components/threadsidebar/index.coffee
@@ -5,7 +5,7 @@ ThreadSidebarContentBox   = require 'activity/components/threadsidebarcontentbox
 ChannelParticipantAvatars = require 'activity/components/channelparticipantavatars'
 ChannelMessagesList       = require 'activity/components/channelmessageslist'
 Link                      = require 'app/components/common/link'
-GenerateNewTokenModal     = require 'app/providers/managed/generatenewtokenmodal'
+InstallKdModal            = require 'app/providers/managed/installkdmodal'
 isGroupChannel            = require 'app/util/isgroupchannel'
 
 
@@ -17,7 +17,7 @@ module.exports = class ThreadSidebar extends React.Component
     channelParticipants: immutable.Map()
 
 
-  showKdModal: -> new GenerateNewTokenModal
+  showKdModal: -> new InstallKdModal
 
 
   renderInviteSection: ->

--- a/client/activity/lib/components/threadsidebar/index.coffee
+++ b/client/activity/lib/components/threadsidebar/index.coffee
@@ -41,7 +41,7 @@ module.exports = class ThreadSidebar extends React.Component
 
   renderKdSection: ->
     <Link className='show-kd-modal' onClick={@bound 'showKdModal'}>
-      <span>New! Use your local IDEs with Koding VMs</span>
+      <span>New! Use your local IDE with your Koding VMs</span>
     </Link>
 
 

--- a/client/activity/lib/components/threadsidebar/index.coffee
+++ b/client/activity/lib/components/threadsidebar/index.coffee
@@ -40,8 +40,6 @@ module.exports = class ThreadSidebar extends React.Component
 
 
   renderKdSection: ->
-    #TODO: Figure out if this onClick should be a prop or not,
-    #and if so, where does it come from?
     <Link className='show-kd-modal' onClick={@showKdModal}>
       <span>New! Use your local IDEs with Koding VMs</span>
     </Link>

--- a/client/activity/lib/components/threadsidebar/index.coffee
+++ b/client/activity/lib/components/threadsidebar/index.coffee
@@ -41,7 +41,7 @@ module.exports = class ThreadSidebar extends React.Component
 
   renderKdSection: ->
     <Link className='show-kd-modal' onClick={@bound 'showKdModal'}>
-      <span>New! Use your local IDE with your Koding VMs</span>
+      <span className="new">New!</span> <span>Use your local IDE with your Koding VMs</span>
     </Link>
 
 

--- a/client/activity/lib/components/threadsidebar/index.coffee
+++ b/client/activity/lib/components/threadsidebar/index.coffee
@@ -4,6 +4,8 @@ immutable                 = require 'immutable'
 ThreadSidebarContentBox   = require 'activity/components/threadsidebarcontentbox'
 ChannelParticipantAvatars = require 'activity/components/channelparticipantavatars'
 ChannelMessagesList       = require 'activity/components/channelmessageslist'
+Link                      = require 'app/components/common/link'
+GenerateNewTokenModal     = require 'app/providers/managed/generatenewtokenmodal'
 isGroupChannel            = require 'app/util/isgroupchannel'
 
 
@@ -13,6 +15,9 @@ module.exports = class ThreadSidebar extends React.Component
     channelThread: immutable.Map()
     messageThread: immutable.Map()
     channelParticipants: immutable.Map()
+
+
+  showKdModal: -> new GenerateNewTokenModal
 
 
   renderInviteSection: ->
@@ -34,6 +39,14 @@ module.exports = class ThreadSidebar extends React.Component
     </p>
 
 
+  renderKdSection: ->
+    #TODO: Figure out if this onClick should be a prop or not,
+    #and if so, where does it come from?
+    <Link className='show-kd-modal' onClick={@showKdModal}>
+      <span>New! Use your local IDEs with Koding VMs</span>
+    </Link>
+
+
   render: ->
     <div className="ThreadSidebar">
       <ThreadSidebarContentBox title="PARTICIPANTS">
@@ -43,8 +56,12 @@ module.exports = class ThreadSidebar extends React.Component
         <p className="ThreadSidebarContentBox-info">Drag a VM to share it with your teammates</p>
         <p className="ThreadSidebarContentBox-info">Drag a Workspace to collaborate</p>
       </ThreadSidebarContentBox>
+
+      <ThreadSidebarContentBox className="kd" title="TOOLS">
+        {@renderKdSection()}
+      </ThreadSidebarContentBox>
+
       <ThreadSidebarContentBox className="help-support" title="HELP & SUPPORT">
-        <a href="http://learn.koding.com/guides/kdfs">New! Use your own IDEs with KDFS</a>
         <a href="http://learn.koding.com/guides/collaboration/">Using collaboration</a>
         <a href="http://learn.koding.com/categories/ssh/">How to ssh into your VMs?</a>
         <a href="http://learn.koding.com"><i>See more...</i></a>

--- a/client/activity/lib/components/threadsidebar/index.coffee
+++ b/client/activity/lib/components/threadsidebar/index.coffee
@@ -40,7 +40,7 @@ module.exports = class ThreadSidebar extends React.Component
 
 
   renderKdSection: ->
-    <Link className='show-kd-modal' onClick={@showKdModal}>
+    <Link className='show-kd-modal' onClick={@bound 'showKdModal'}>
       <span>New! Use your local IDEs with Koding VMs</span>
     </Link>
 

--- a/client/activity/lib/components/threadsidebarcontentbox/styl/threadsidebarcontentbox.styl
+++ b/client/activity/lib/components/threadsidebarcontentbox/styl/threadsidebarcontentbox.styl
@@ -6,6 +6,7 @@
     border                  1px dashed #D3D3D3
     rounded                 2px
 
+  &.kd           .ThreadSidebarContentBox-content,
   &.help-support .ThreadSidebarContentBox-content
     a
       display               block

--- a/client/activity/lib/components/threadsidebarcontentbox/styl/threadsidebarcontentbox.styl
+++ b/client/activity/lib/components/threadsidebarcontentbox/styl/threadsidebarcontentbox.styl
@@ -6,7 +6,7 @@
     border                  1px dashed #D3D3D3
     rounded                 2px
 
-  &.kd           .ThreadSidebarContentBox-content,
+  &.kd           .ThreadSidebarContentBox-content
   &.help-support .ThreadSidebarContentBox-content
     a
       display               block

--- a/client/activity/lib/components/threadsidebarcontentbox/styl/threadsidebarcontentbox.styl
+++ b/client/activity/lib/components/threadsidebarcontentbox/styl/threadsidebarcontentbox.styl
@@ -21,6 +21,10 @@
       i
         font-style          italic
 
+  &.kd .ThreadSidebarContentBox-content .new
+    color                   #00b057
+
+
 
 .ThreadSidebarContentBox-header
   font-family               $ff-title

--- a/client/app/lib/providers/managed/generatenewtokenmodal.coffee
+++ b/client/app/lib/providers/managed/generatenewtokenmodal.coffee
@@ -1,6 +1,6 @@
-kd        = require 'kd'
-globals   = require 'globals'
-whoami    = require 'app/util/whoami'
+kd            = require 'kd'
+globals       = require 'globals'
+whoami        = require 'app/util/whoami'
 
 
 module.exports = class GenerateNewTokenModal extends kd.ModalView
@@ -28,7 +28,7 @@ module.exports = class GenerateNewTokenModal extends kd.ModalView
     @addSubView @content = new kd.CustomHTMLView
       tagName: 'section'
       partial: """
-        <p>kd is a command line program that lets you use your local IDEs with your VMs. Copy and paste the command below in a terminal. Please note:</p>
+        <p>kd is a command line program that lets you use your local IDEs with your VMs. Copy and paste the command below in your PC's terminal. Please note:</p>
         <p class='middle'>1. sudo permission required.</p>
         <p class='middle'>2. Works only on OSX and Linux.</p>
         <p class='middle'>3. kd is currently in beta.</p>

--- a/client/app/lib/providers/managed/generatenewtokenmodal.coffee
+++ b/client/app/lib/providers/managed/generatenewtokenmodal.coffee
@@ -7,8 +7,6 @@ module.exports = class GenerateNewTokenModal extends kd.ModalView
 
   constructor: (options = {}, data) ->
 
-    kd.warn 'Constructing new token modal'
-
     options.cssClass = 'generate-new-token'
     options.title    = 'Install kd'
     options.width    = 690

--- a/client/app/lib/providers/managed/generatenewtokenmodal.coffee
+++ b/client/app/lib/providers/managed/generatenewtokenmodal.coffee
@@ -27,8 +27,9 @@ module.exports = class GenerateNewTokenModal extends kd.ModalView
 
     @addSubView @content = new kd.CustomHTMLView
       tagName: 'section'
+      cssClass: 'has-markdown'
       partial: """
-        <p>kd is a command line program that lets you use your local IDEs with your VMs. Copy and paste the command below in your PC's terminal. Please note:</p>
+        <p><code>kd</code> is a command line program that lets you use your local IDEs with your VMs. Copy and paste the command below in your PC's terminal. Please note:</p>
         <p class='middle'>1. sudo permission required.</p>
         <p class='middle'>2. Works only on OSX and Linux.</p>
         <p class='middle'>3. kd is currently in beta.</p>

--- a/client/app/lib/providers/managed/generatenewtokenmodal.coffee
+++ b/client/app/lib/providers/managed/generatenewtokenmodal.coffee
@@ -33,11 +33,11 @@ module.exports = class GenerateNewTokenModal extends kd.ModalView
         <p class='middle'>1. sudo permission required.</p>
         <p class='middle'>2. Works only on OSX and Linux.</p>
         <p class='middle'>3. kd is currently in beta.</p>
-
-        <span>
-          <a href="http://learn.koding.com/guides/kd" target="_blank">Learn more about this feature.</a>
-        </span>
       """
+    # Commenting out learn, until the article is ready.
+    #<span>
+    #  <a href="http://learn.koding.com/guides/kd" target="_blank">Learn more about this feature.</a>
+    #</span>
 
     @addSubView @code = new kd.CustomHTMLView
       tagName  : 'div'

--- a/client/app/lib/providers/managed/generatenewtokenmodal.coffee
+++ b/client/app/lib/providers/managed/generatenewtokenmodal.coffee
@@ -30,9 +30,9 @@ module.exports = class GenerateNewTokenModal extends kd.ModalView
       cssClass: 'has-markdown'
       partial: """
         <p><code>kd</code> is a command line program that lets you use your local IDEs with your VMs. Copy and paste the command below in your PC's terminal. Please note:</p>
-        <p class='middle'>1. sudo permission required.</p>
+        <p class='middle'>1. <code>sudo</code> permission required.</p>
         <p class='middle'>2. Works only on OSX and Linux.</p>
-        <p class='middle'>3. kd is currently in beta.</p>
+        <p class='middle'>3. <code>kd</code> is currently in beta.</p>
       """
     # Commenting out learn, until the article is ready.
     #<span>

--- a/client/app/lib/providers/managed/generatenewtokenmodal.coffee
+++ b/client/app/lib/providers/managed/generatenewtokenmodal.coffee
@@ -1,0 +1,112 @@
+kd        = require 'kd'
+globals   = require 'globals'
+whoami    = require 'app/util/whoami'
+
+
+module.exports = class GenerateNewTokenModal extends kd.ModalView
+
+  constructor: (options = {}, data) ->
+
+    kd.warn 'Constructing new token modal'
+
+    options.cssClass = 'generate-new-token'
+    options.title    = 'Install kd'
+    options.width    = 690
+    options.height   = 310
+    options.overlay  = yes
+
+    super options, data
+
+    @createElements()
+    @generateCode()
+
+
+  createElements: ->
+
+    @addSubView new kd.CustomHTMLView
+      cssClass: 'bg'
+      partial : '<div class="extra"></div>'
+
+    @addSubView @content = new kd.CustomHTMLView
+      tagName: 'section'
+      partial: """
+        <p>kd is a command line program that lets you use your local IDEs with your VMs. Copy and paste the command below in a terminal. Please note:</p>
+        <p class='middle'>1. sudo permission required.</p>
+        <p class='middle'>2. Works only on OSX and Linux.</p>
+        <p class='middle'>3. kd is currently in beta.</p>
+
+        <span>
+          <a href="http://learn.koding.com/guides/kd" target="_blank">Learn more about this feature.</a>
+        </span>
+      """
+
+    @addSubView @code = new kd.CustomHTMLView
+      tagName  : 'div'
+      cssClass : 'code'
+
+    @code.addSubView @loader = new kd.LoaderView
+      size: width : 16
+      showLoader  : yes
+
+
+  generateCode: ->
+
+    whoami().fetchOtaToken (err, token) =>
+      return @handleError err  if err
+
+      @updateContentViews token
+
+
+  updateContentViews: (token) ->
+
+    kontrolUrl = if globals.config.environment in ['dev', 'sandbox']
+    then "export KONTROLURL=#{globals.config.newkontrol.url}; "
+    else ''
+
+    cmd = "#{kontrolUrl}curl -sL https://kodi.ng/d/kd | bash -s #{token}"
+
+    @loader.destroy()
+    @code.addSubView @input = new kd.InputView
+      defaultValue : cmd
+      click        : =>
+        @showTooltip()
+        @input.selectAll()
+
+    @code.addSubView @selectButton = new kd.CustomHTMLView
+      cssClass : 'select-all'
+      partial  : '<span></span>SELECT'
+      click    : =>
+        @showTooltip()
+        @input.selectAll()
+
+
+  showTooltip: ->
+
+    shortcut = 'Ctrl+C'
+
+    if navigator.userAgent.indexOf('Mac OS X') > -1
+      shortcut = 'Cmd+C'
+
+    @input.setTooltip title: "Press #{shortcut} to copy", placement: 'above'
+    @input.tooltip.show()
+
+    kd.singletons.windowController.addLayer @input
+    @input.on 'ReceivedClickElsewhere', =>
+      @input.unsetTooltip()
+
+
+  handleError: (err) ->
+
+    console.warn "Couldn't fetch otatoken:", err  if err
+
+    @loader.destroy()
+    return @code.updatePartial 'Failed to fetch one time access token.'
+
+
+  destroy: ->
+
+    @input?.unsetTooltip()
+
+    super
+
+

--- a/client/app/lib/providers/managed/installkdmodal.coffee
+++ b/client/app/lib/providers/managed/installkdmodal.coffee
@@ -3,11 +3,11 @@ globals       = require 'globals'
 whoami        = require 'app/util/whoami'
 
 
-module.exports = class GenerateNewTokenModal extends kd.ModalView
+module.exports = class InstallKdModal extends kd.ModalView
 
   constructor: (options = {}, data) ->
 
-    options.cssClass = 'generate-new-token'
+    options.cssClass = 'install-kd-modal'
     options.title    = 'Install kd'
     options.width    = 690
     options.height   = 310

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -2389,7 +2389,7 @@ paymentGrayLighter  = #f8f8f8
       padding               1px 4px
 
   .code .select-all
-    bottom                  43px
+    bottom                  41px
 
 
 .kdmodal.delete-files-modal

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -2268,6 +2268,7 @@ paymentGrayLighter  = #f8f8f8
 
 
 
+.generate-new-token
 .add-managed-vm
 
   .kdmodal-content
@@ -2377,6 +2378,11 @@ paymentGrayLighter  = #f8f8f8
 
     .kdloader
       margin                13px 0 0 165px
+
+
+.generate-new-token
+  .code .select-all
+    bottom                  44px
 
 
 .kdmodal.delete-files-modal

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -2381,8 +2381,15 @@ paymentGrayLighter  = #f8f8f8
 
 
 .generate-new-token
+  .has-markdown
+    p
+      padding               0px
+
+    code
+      padding               1px 4px
+
   .code .select-all
-    bottom                  44px
+    bottom                  43px
 
 
 .kdmodal.delete-files-modal

--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -2268,7 +2268,7 @@ paymentGrayLighter  = #f8f8f8
 
 
 
-.generate-new-token
+.install-kd-modal
 .add-managed-vm
 
   .kdmodal-content
@@ -2380,7 +2380,7 @@ paymentGrayLighter  = #f8f8f8
       margin                13px 0 0 165px
 
 
-.generate-new-token
+.install-kd-modal
   .has-markdown
     p
       padding               0px


### PR DESCRIPTION
In order for KD installations to use a token instead of user/pass for authentication, a UI has to be added to Koding. To do this, the UI from the Managed VM modal was copied/repurposed into a token generation modal. This modal opens up from the Teams sidebar.

Video: http://take.ms/1gNNO _(Tried a few times to show the spinner.. it loaded too fast, heh)_

Sidebar:

![image](https://cloud.githubusercontent.com/assets/47556/10829323/74c3ae50-7e36-11e5-8c1f-dd88d532e0ec.png)

Modal:

![image](https://cloud.githubusercontent.com/assets/47556/10829348/a0c1b614-7e36-11e5-8d62-7806d78a1cbb.png)

Full UI:

![image](https://cloud.githubusercontent.com/assets/47556/10829357/af56db00-7e36-11e5-8b47-4d19a3a4afd6.png)

cc @sinan @usirin 
