### PR TITLE
Display stack template editor in content modal [fixes #106617712]

### DIFF
--- a/client/admin/lib/views/stacks/editors/stacktemplateeditorview.coffee
+++ b/client/admin/lib/views/stacks/editors/stacktemplateeditorview.coffee
@@ -11,21 +11,21 @@ module.exports = class StackTemplateEditorView extends BaseStackEditorView
 
     super options, data
 
+    if options.showHelpContent
+      @once 'EditorReady', @bound 'insertHelpText'
+
+
+  insertHelpText: ->
+
+    position = row: 0, column: 0
+    content  = """
+      # Here is your stack preview
+      # You can make advanced changes like modifying your VM,
+      # installing packages, and running shell commands.
+
+
+    """
+
     ace = @getAce()
-
-    @once 'EditorReady', =>
-
-      unless options.showHelpContent
-        return ace.contentChanged = no
-
-      position = row: 0, column: 0
-      content  = """
-        # Here is your stack preview
-        # You can make advanced changes like modifying your VM,
-        # installing packages, and running shell commands.
-
-
-      """
-
-      ace.editor.session.insert position, content
-      ace.contentChanged = no
+    ace.editor.session.insert position, content
+    ace.contentChanged = no

--- a/client/app/lib/stacks/stacktemplatecontentmodal.coffee
+++ b/client/app/lib/stacks/stacktemplatecontentmodal.coffee
@@ -1,15 +1,16 @@
 kd = require 'kd'
 
-hljs    = require 'highlight.js'
 Encoder = require 'htmlencode'
 
-{ jsonToYaml } = require 'admin/views/stacks/yamlutils'
+StackTemplateEditorView = require 'admin/views/stacks/editors/stacktemplateeditorview'
 
 module.exports = class StackTemplateContentModal extends kd.ModalView
 
   constructor: (options = {}, data) ->
 
     options.cssClass = 'stack-template-content has-markdown'
+
+    options.width    = 800
 
     options.title    = data.title
     options.subtitle = data.modifiedAt
@@ -20,21 +21,21 @@ module.exports = class StackTemplateContentModal extends kd.ModalView
     super
 
 
-  getContent: ->
+  getEditor: ->
 
-    { template: { content } } = @getData()
+    { template: { rawContent } } = @getData()
 
-    json = Encoder.htmlDecode content
-    yaml = jsonToYaml(json).content
-
-    return hljs.highlight('coffee', yaml).value
+    return new StackTemplateEditorView
+      delegate    : this
+      content     : Encoder.htmlDecode rawContent
+      contentType : 'yaml'
+      readOnly    : yes
+      showHelpContent : no
 
 
   viewAppended: ->
 
-    scrollView = new kd.CustomScrollView tagName: 'pre'
-    scrollView.wrapper.addSubView new kd.CustomHTMLView
-      tagName: 'code'
-      partial: @getContent()
+    @addSubView @tabView = new kd.TabView hideHandleContainer: yes
 
-    @addSubView scrollView
+    editorPane = new kd.TabPaneView view: @getEditor()
+    @tabView.addPane editorPane, yes

--- a/client/app/lib/styl/computeproviders.styl
+++ b/client/app/lib/styl/computeproviders.styl
@@ -1022,6 +1022,9 @@ computeproviders.styl
 
   styleScrollBars           rgba(0, 0, 0, .15)
 
+  .kdtabview
+    height                  416px
+
   pre
     padding                 0
     border                  1px solid #eaeaea


### PR DESCRIPTION
[Make stack details modal horizontally scrollable as well](https://www.pivotaltracker.com/story/show/106617712)
