### PR TITLE
reactivity: do not add channel name as a postfix to message body when updating message

### DIFF
--- a/client/activity/lib/components/chatlistitem/index.coffee
+++ b/client/activity/lib/components/chatlistitem/index.coffee
@@ -233,9 +233,6 @@ module.exports = class ChatListItem extends React.Component
     name  = @props.channelName
     messageId = @props.message.get '_id'
 
-    unless value.match ///\##{name}///
-      value += " ##{name} "
-
     ActivityFlux.actions.message.unsetMessageEditMode messageId
 
     ActivityFlux.actions.message.editMessage(

--- a/client/activity/lib/components/chatlistitem/index.coffee
+++ b/client/activity/lib/components/chatlistitem/index.coffee
@@ -230,7 +230,6 @@ module.exports = class ChatListItem extends React.Component
     value = @refs.editInput.getValue().trim()
     return @setState isDeleting: yes  unless value
 
-    name  = @props.channelName
     messageId = @props.message.get '_id'
 
     ActivityFlux.actions.message.unsetMessageEditMode messageId


### PR DESCRIPTION
@usirin, can you please review this?
Since we stopped adding channel name to message body when creating message, it makes sense remove that logic from the code that updates message
