### PR TITLE
Socialapi: fix algolia account related operation handlers

### DIFF
--- a/go/src/socialapi/models/account_test.go
+++ b/go/src/socialapi/models/account_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"socialapi/workers/common/tests"
 	"strings"
 	"testing"
 
@@ -40,416 +41,373 @@ func TestAccountGetId(t *testing.T) {
 }
 
 func TestAccountFetchOrCreate(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while fetching or creating account", t, func() {
-		Convey("it should have old id", func() {
-			a := NewAccount()
-			err := a.FetchOrCreate()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrOldIdIsNotSet)
+		Convey("while fetching or creating account", t, func() {
+			Convey("it should have old id", func() {
+				a := NewAccount()
+				err := a.FetchOrCreate()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrOldIdIsNotSet)
+			})
+
+			Convey("it should have error if nick contains guest-", func() {
+				a := NewAccount()
+				a.OldId = "oldestId"
+				a.Nick = "guest-test"
+				err := a.FetchOrCreate()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrGuestsAreNotAllowed)
+			})
+
+			Convey("it should not have error if required fields are exist", func() {
+				a := NewAccount()
+				a.OldId = "oldIdOfAccount"
+				a.Nick = "WhatANick"
+				err := a.FetchOrCreate()
+				So(err, ShouldBeNil)
+			})
+
 		})
-
-		Convey("it should have error if nick contains guest-", func() {
-			a := NewAccount()
-			a.OldId = "oldestId"
-			a.Nick = "guest-test"
-			err := a.FetchOrCreate()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrGuestsAreNotAllowed)
-		})
-
-		Convey("it should not have error if required fields are exist", func() {
-			a := NewAccount()
-			a.OldId = "oldIdOfAccount"
-			a.Nick = "WhatANick"
-			err := a.FetchOrCreate()
-			So(err, ShouldBeNil)
-		})
-
 	})
 }
 
 func TestAccountFetchAccountById(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while fetching an account by id", t, func() {
-		Convey("it should not have error while fething", func() {
-			// create account
-			acc := CreateAccountWithTest()
-			So(acc.Create(), ShouldBeNil)
+		Convey("while fetching an account by id", t, func() {
+			Convey("it should not have error while fething", func() {
+				// create account
+				acc := CreateAccountWithTest()
+				So(acc.Create(), ShouldBeNil)
 
-			// fetch the account by id of account
-			fa, err := FetchAccountById(acc.Id)
-			// error should be nil
-			// means that fetching is done successfully
-			So(err, ShouldBeNil)
-			// account in the db should equal to fetched account
-			So(fa.Id, ShouldEqual, acc.Id)
-			So(fa.OldId, ShouldEqual, acc.OldId)
-			So(fa.Nick, ShouldEqual, acc.Nick)
+				// fetch the account by id of account
+				fa, err := FetchAccountById(acc.Id)
+				// error should be nil
+				// means that fetching is done successfully
+				So(err, ShouldBeNil)
+				// account in the db should equal to fetched account
+				So(fa.Id, ShouldEqual, acc.Id)
+				So(fa.OldId, ShouldEqual, acc.OldId)
+				So(fa.Nick, ShouldEqual, acc.Nick)
+			})
+
+			Convey("it should have error if record is not found", func() {
+				// init account
+				a := NewAccount()
+				a.Id = 12345
+				a.OldId = "oldIdOfAccount"
+				a.Nick = "WhatANick"
+
+				// this account id is not exist
+				_, err := FetchAccountById(a.Id)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, bongo.RecordNotFound)
+
+			})
 		})
-
-		Convey("it should have error if record is not found", func() {
-			// init account
-			a := NewAccount()
-			a.Id = 12345
-			a.OldId = "oldIdOfAccount"
-			a.Nick = "WhatANick"
-
-			// this account id is not exist
-			_, err := FetchAccountById(a.Id)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, bongo.RecordNotFound)
-
-		})
-
 	})
 }
 
 func TestAccountByNick(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while fetching an account by nick", t, func() {
-		Convey("it should not have error while fething", func() {
-			// create account
-			acc := CreateAccountWithTest()
-			So(acc.Create(), ShouldBeNil)
+		Convey("while fetching an account by nick", t, func() {
+			Convey("it should not have error while fething", func() {
+				// create account
+				acc := CreateAccountWithTest()
+				So(acc.Create(), ShouldBeNil)
 
-			fa := NewAccount()
+				fa := NewAccount()
 
-			// fetch the account by nick of account
-			err := fa.ByNick(acc.Nick)
-			// error should be nil
-			// means that fetching is done successfully
-			So(err, ShouldBeNil)
-			// account in the db should be equal to fetched account
-			So(fa.Id, ShouldEqual, acc.Id)
-			So(fa.OldId, ShouldEqual, acc.OldId)
-			So(fa.Nick, ShouldEqual, acc.Nick)
+				// fetch the account by nick of account
+				err := fa.ByNick(acc.Nick)
+				// error should be nil
+				// means that fetching is done successfully
+				So(err, ShouldBeNil)
+				// account in the db should be equal to fetched account
+				So(fa.Id, ShouldEqual, acc.Id)
+				So(fa.OldId, ShouldEqual, acc.OldId)
+				So(fa.Nick, ShouldEqual, acc.Nick)
+			})
+
+			Convey("it should have error if nick is not set", func() {
+				fa := NewAccount()
+				err := fa.ByNick("")
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrNickIsNotSet)
+			})
+
+			Convey("it should have error if record is not found", func() {
+				fa := NewAccount()
+				err := fa.ByNick("foobarzaa")
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, bongo.RecordNotFound)
+			})
 		})
-
-		Convey("it should have error if nick is not set", func() {
-			fa := NewAccount()
-			err := fa.ByNick("")
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrNickIsNotSet)
-		})
-
-		Convey("it should have error if record is not found", func() {
-			fa := NewAccount()
-			err := fa.ByNick("foobarzaa")
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, bongo.RecordNotFound)
-		})
-
 	})
 }
 
 func TestAccountFetchOldIdsByAccountIds(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while fetching Old Ids by account ids", t, func() {
-		Convey("it should have account id (ids of length) more than zero", func() {
-			acc := []int64{}
-			foi, err := FetchOldIdsByAccountIds(acc)
-			So(err, ShouldBeNil)
-			So(foi, ShouldBeEmpty)
+		Convey("while fetching Old Ids by account ids", t, func() {
+			Convey("it should have account id (ids of length) more than zero", func() {
+				acc := []int64{}
+				foi, err := FetchOldIdsByAccountIds(acc)
+				So(err, ShouldBeNil)
+				So(foi, ShouldBeEmpty)
+			})
+
+			Convey("it should not have error if account is exist in db", func() {
+				// create account
+				acc := CreateAccountWithTest()
+				So(acc.Create(), ShouldBeNil)
+				// we created slice to send to FetchOldIdsByAccountIds as argument
+				idd := []int64{acc.Id}
+
+				// FetchOldIdsByAccountIds returns as slice
+				foi, err := FetchOldIdsByAccountIds(idd)
+				So(err, ShouldBeNil)
+				// used shouldcontain because foi is a slice
+				So(foi, ShouldContain, acc.OldId)
+
+			})
+
+			Convey("it should append successfully", func() {
+				acc1 := NewAccount()
+				acc1.OldId = bson.NewObjectId().Hex()
+				acc1.Nick = bson.NewObjectId().Hex()
+				So(acc1.Create(), ShouldBeNil)
+
+				acc2 := NewAccount()
+				acc2.OldId = bson.NewObjectId().Hex()
+				acc2.Nick = bson.NewObjectId().Hex()
+				So(acc2.Create(), ShouldBeNil)
+
+				idd := []int64{acc1.Id, acc2.Id}
+				old := []string{acc1.OldId, acc2.OldId}
+
+				foi, err := FetchOldIdsByAccountIds(idd)
+				So(err, ShouldBeNil)
+				So(foi[1], ShouldEqual, old[1])
+
+			})
 		})
-
-		Convey("it should not have error if account is exist in db", func() {
-			// create account
-			acc := CreateAccountWithTest()
-			So(acc.Create(), ShouldBeNil)
-			// we created slice to send to FetchOldIdsByAccountIds as argument
-			idd := []int64{acc.Id}
-
-			// FetchOldIdsByAccountIds returns as slice
-			foi, err := FetchOldIdsByAccountIds(idd)
-			So(err, ShouldBeNil)
-			// used shouldcontain because foi is a slice
-			So(foi, ShouldContain, acc.OldId)
-
-		})
-
-		Convey("it should append successfully", func() {
-			acc1 := NewAccount()
-			acc1.OldId = bson.NewObjectId().Hex()
-			acc1.Nick = bson.NewObjectId().Hex()
-			So(acc1.Create(), ShouldBeNil)
-
-			acc2 := NewAccount()
-			acc2.OldId = bson.NewObjectId().Hex()
-			acc2.Nick = bson.NewObjectId().Hex()
-			So(acc2.Create(), ShouldBeNil)
-
-			idd := []int64{acc1.Id, acc2.Id}
-			old := []string{acc1.OldId, acc2.OldId}
-
-			foi, err := FetchOldIdsByAccountIds(idd)
-			So(err, ShouldBeNil)
-			So(foi[1], ShouldEqual, old[1])
-
-		})
-
 	})
 }
 
 func TestAccountCreateFollowingFeedChannel(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while creating feed channel", t, func() {
-		Convey("it should have account id", func() {
-			// create account
-			acc := NewAccount()
+		Convey("while creating feed channel", t, func() {
+			Convey("it should have account id", func() {
+				// create account
+				acc := NewAccount()
 
-			_, err := acc.CreateFollowingFeedChannel()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrAccountIdIsNotSet)
+				_, err := acc.CreateFollowingFeedChannel()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrAccountIdIsNotSet)
+			})
+
+			Convey("it should have creator id as account id", func() {
+				// create account
+				acc := CreateAccountWithTest()
+				So(acc.Create(), ShouldBeNil)
+
+				cff, err := acc.CreateFollowingFeedChannel()
+				So(err, ShouldBeNil)
+				So(cff.CreatorId, ShouldEqual, acc.Id)
+			})
+
+			Convey("it should have channel name as required", func() {
+				// create account
+				acc := NewAccount()
+				acc.OldId = bson.NewObjectId().Hex()
+				acc.Nick = bson.NewObjectId().Hex()
+				So(acc.Create(), ShouldBeNil)
+
+				cff, err := acc.CreateFollowingFeedChannel()
+				So(err, ShouldBeNil)
+				So(strings.HasSuffix(cff.Name, "-FollowingFeedChannel"), ShouldBeTrue)
+			})
+
+			Convey("it should have group name as Channel_KODING_NAME", func() {
+				// create account
+				acc := CreateAccountWithTest()
+				So(acc.Create(), ShouldBeNil)
+
+				cff, err := acc.CreateFollowingFeedChannel()
+				So(err, ShouldBeNil)
+				So(cff.GroupName, ShouldEqual, Channel_KODING_NAME)
+			})
+
+			Convey("it should have purpose as Following Feed for me", func() {
+				// create account
+				acc := CreateAccountWithTest()
+				So(acc.Create(), ShouldBeNil)
+
+				cff, err := acc.CreateFollowingFeedChannel()
+				So(err, ShouldBeNil)
+				So(cff.Purpose, ShouldEqual, "Following Feed for Me")
+			})
+
+			Convey("it should have type constant as Channel_TYPE_FOLLOWERS", func() {
+				// create account
+				acc := CreateAccountWithTest()
+				So(acc.Create(), ShouldBeNil)
+
+				cff, err := acc.CreateFollowingFeedChannel()
+				So(err, ShouldBeNil)
+				So(cff.TypeConstant, ShouldEqual, Channel_TYPE_FOLLOWERS)
+			})
 		})
-
-		Convey("it should have creator id as account id", func() {
-			// create account
-			acc := CreateAccountWithTest()
-			So(acc.Create(), ShouldBeNil)
-
-			cff, err := acc.CreateFollowingFeedChannel()
-			So(err, ShouldBeNil)
-			So(cff.CreatorId, ShouldEqual, acc.Id)
-		})
-
-		Convey("it should have channel name as required", func() {
-			// create account
-			acc := NewAccount()
-			acc.OldId = bson.NewObjectId().Hex()
-			acc.Nick = bson.NewObjectId().Hex()
-			So(acc.Create(), ShouldBeNil)
-
-			cff, err := acc.CreateFollowingFeedChannel()
-			So(err, ShouldBeNil)
-			So(strings.HasSuffix(cff.Name, "-FollowingFeedChannel"), ShouldBeTrue)
-		})
-
-		Convey("it should have group name as Channel_KODING_NAME", func() {
-			// create account
-			acc := CreateAccountWithTest()
-			So(acc.Create(), ShouldBeNil)
-
-			cff, err := acc.CreateFollowingFeedChannel()
-			So(err, ShouldBeNil)
-			So(cff.GroupName, ShouldEqual, Channel_KODING_NAME)
-		})
-
-		Convey("it should have purpose as Following Feed for me", func() {
-			// create account
-			acc := CreateAccountWithTest()
-			So(acc.Create(), ShouldBeNil)
-
-			cff, err := acc.CreateFollowingFeedChannel()
-			So(err, ShouldBeNil)
-			So(cff.Purpose, ShouldEqual, "Following Feed for Me")
-		})
-
-		Convey("it should have type constant as Channel_TYPE_FOLLOWERS", func() {
-			// create account
-			acc := CreateAccountWithTest()
-			So(acc.Create(), ShouldBeNil)
-
-			cff, err := acc.CreateFollowingFeedChannel()
-			So(err, ShouldBeNil)
-			So(cff.TypeConstant, ShouldEqual, Channel_TYPE_FOLLOWERS)
-		})
-
 	})
 }
 
 func TestAccountUnMarkAsTroll(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while unmarking as troll", t, func() {
-		Convey("it should have account id", func() {
-			acc := NewAccount()
+		Convey("while unmarking as troll", t, func() {
+			Convey("it should have account id", func() {
+				acc := NewAccount()
 
-			err := acc.UnMarkAsTroll()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrAccountIdIsNotSet)
-		})
+				err := acc.UnMarkAsTroll()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrAccountIdIsNotSet)
+			})
 
-		Convey("it should have account in db", func() {
-			acc := NewAccount()
-			acc.Id = rand.Int63()
-			err := acc.UnMarkAsTroll()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, bongo.RecordNotFound)
-		})
+			Convey("it should have account in db", func() {
+				acc := NewAccount()
+				acc.Id = rand.Int63()
+				err := acc.UnMarkAsTroll()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, bongo.RecordNotFound)
+			})
 
-		// Convey("it should have error if not troll", func() {
-		// 	// create account
-		// 	acc := CreateAccountWithTest()
-		// 	So(acc.Create(), ShouldBeNil)
+			// Convey("it should have error if not troll", func() {
+			// 	// create account
+			// 	acc := CreateAccountWithTest()
+			// 	So(acc.Create(), ShouldBeNil)
 
-		// 	err := acc.UnMarkAsTroll()
-		// 	So(err, ShouldNotBeNil)
-		// 	So(err.Error(), ShouldContainSubstring, "account is not a troll")
-		// })
+			// 	err := acc.UnMarkAsTroll()
+			// 	So(err, ShouldNotBeNil)
+			// 	So(err.Error(), ShouldContainSubstring, "account is not a troll")
+			// })
 
-		Convey("it should not have error if troll is mark as not a troll", func() {
-			// create account
-			acc := CreateAccountWithTest()
-			acc.IsTroll = true
-			So(acc.Create(), ShouldBeNil)
+			Convey("it should not have error if troll is mark as not a troll", func() {
+				// create account
+				acc := CreateAccountWithTest()
+				acc.IsTroll = true
+				So(acc.Create(), ShouldBeNil)
 
-			err := acc.UnMarkAsTroll()
-			So(err, ShouldBeNil)
+				err := acc.UnMarkAsTroll()
+				So(err, ShouldBeNil)
+			})
 		})
 	})
 }
 
 func TestAccountMarkAsTroll(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("while marking account as troll", t, func() {
+			Convey("it should have account id", func() {
+				acc := NewAccount()
 
-	Convey("while marking account as troll", t, func() {
-		Convey("it should have account id", func() {
-			acc := NewAccount()
+				err := acc.MarkAsTroll()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrAccountIdIsNotSet)
+			})
 
-			err := acc.MarkAsTroll()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrAccountIdIsNotSet)
+			Convey("it should have account in db", func() {
+				acc := NewAccount()
+				acc.Id = 1122312
+
+				err := acc.MarkAsTroll()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, bongo.RecordNotFound)
+			})
+
+			// Convey("it should have error if account is already troll", func() {
+			// 	// create account
+			// 	acc := CreateAccountWithTest()
+			// 	acc.IsTroll = true
+			// 	So(acc.Create(), ShouldBeNil)
+
+			// 	err := acc.MarkAsTroll()
+			// 	So(err, ShouldNotBeNil)
+			// 	So(err.Error(), ShouldContainSubstring, "account is already a troll")
+			// })
+
+			Convey("it should not have error if non-troll account is marked as troll", func() {
+				// create account
+				acc := CreateAccountWithTest()
+				acc.IsTroll = false
+				So(acc.Create(), ShouldBeNil)
+
+				err := acc.MarkAsTroll()
+				So(err, ShouldBeNil)
+				So(acc.IsTroll, ShouldEqual, true)
+			})
 		})
-
-		Convey("it should have account in db", func() {
-			acc := NewAccount()
-			acc.Id = 1122312
-
-			err := acc.MarkAsTroll()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, bongo.RecordNotFound)
-		})
-
-		// Convey("it should have error if account is already troll", func() {
-		// 	// create account
-		// 	acc := CreateAccountWithTest()
-		// 	acc.IsTroll = true
-		// 	So(acc.Create(), ShouldBeNil)
-
-		// 	err := acc.MarkAsTroll()
-		// 	So(err, ShouldNotBeNil)
-		// 	So(err.Error(), ShouldContainSubstring, "account is already a troll")
-		// })
-
-		Convey("it should not have error if non-troll account is marked as troll", func() {
-			// create account
-			acc := CreateAccountWithTest()
-			acc.IsTroll = false
-			So(acc.Create(), ShouldBeNil)
-
-			err := acc.MarkAsTroll()
-			So(err, ShouldBeNil)
-			So(acc.IsTroll, ShouldEqual, true)
-		})
-
 	})
 }
 
 func TestAccountFetchChannel(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while fetching channel", t, func() {
-		Convey("it should have account id", func() {
-			acc := NewAccount()
+		Convey("while fetching channel", t, func() {
+			Convey("it should have account id", func() {
+				acc := NewAccount()
 
-			_, err := acc.FetchChannel("ChannelType")
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrAccountIdIsNotSet)
+				_, err := acc.FetchChannel("ChannelType")
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrAccountIdIsNotSet)
+			})
+
+			Convey("it should have error if channel is not exist", func() {
+				acc := NewAccount()
+				acc.Id = 35135
+
+				_, err := acc.FetchChannel(Channel_TYPE_GROUP)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, bongo.RecordNotFound)
+			})
+
+			Convey("it should not have error if channel type is exist", func() {
+				acc := CreateAccountWithTest()
+				c := CreateTypedChannelWithTest(acc.Id, Channel_TYPE_TOPIC)
+
+				cha, err := acc.FetchChannel(Channel_TYPE_TOPIC)
+				So(err, ShouldBeNil)
+				So(cha.TypeConstant, ShouldEqual, c.TypeConstant)
+			})
 		})
-
-		Convey("it should have error if channel is not exist", func() {
-			acc := NewAccount()
-			acc.Id = 35135
-
-			_, err := acc.FetchChannel(Channel_TYPE_GROUP)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, bongo.RecordNotFound)
-		})
-
-		Convey("it should not have error if channel type is exist", func() {
-
-			// create account
-			acc := CreateAccountWithTest()
-			So(acc.Create(), ShouldBeNil)
-
-			// create channel
-			c := createNewChannelWithTest()
-			c.CreatorId = acc.Id
-			c.TypeConstant = Channel_TYPE_TOPIC
-			So(c.Create(), ShouldBeNil)
-
-			cha, err := acc.FetchChannel(Channel_TYPE_TOPIC)
-			So(err, ShouldBeNil)
-			So(cha.TypeConstant, ShouldEqual, c.TypeConstant)
-		})
-
 	})
 }
 
 func TestAccountsByNick(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while fetching account ids by nicknames", t, func() {
-		Convey("it should not fetch any accounts when nicknames are empty", func() {
-			nicknames := make([]string, 0)
+		Convey("while fetching account ids by nicknames", t, func() {
+			Convey("it should not fetch any accounts when nicknames are empty", func() {
+				nicknames := make([]string, 0)
 
-			accounts, err := FetchAccountsByNicks(nicknames)
-			So(err, ShouldBeNil)
-			So(len(accounts), ShouldEqual, 0)
-		})
+				accounts, err := FetchAccountsByNicks(nicknames)
+				So(err, ShouldBeNil)
+				So(len(accounts), ShouldEqual, 0)
+			})
 
-		Convey("it should fetch accounts by nicknames", func() {
-			acc1 := CreateAccountWithTest()
-			acc2 := CreateAccountWithTest()
-			nicknames := make([]string, 0)
-			nicknames = append(nicknames, acc1.Nick, acc2.Nick)
-			accounts, err := FetchAccountsByNicks(nicknames)
-			So(err, ShouldBeNil)
-			So(accounts, ShouldNotBeNil)
-			So(len(accounts), ShouldEqual, 2)
+			Convey("it should fetch accounts by nicknames", func() {
+				acc1 := CreateAccountWithTest()
+				acc2 := CreateAccountWithTest()
+				nicknames := make([]string, 0)
+				nicknames = append(nicknames, acc1.Nick, acc2.Nick)
+				accounts, err := FetchAccountsByNicks(nicknames)
+				So(err, ShouldBeNil)
+				So(accounts, ShouldNotBeNil)
+				So(len(accounts), ShouldEqual, 2)
+			})
 		})
 	})
-
 }

--- a/go/src/socialapi/models/channel.go
+++ b/go/src/socialapi/models/channel.go
@@ -388,7 +388,12 @@ func (c *Channel) EnsureMessage(cm *ChannelMessage, force bool) (*ChannelMessage
 	err := bongo.B.DB.Model(cml).Unscoped().Where("channel_id = ? and message_id = ?", c.Id, cm.Id).First(cml).Error
 
 	if err == bongo.RecordNotFound {
-		return c.AddMessage(cm)
+		_, err := c.AddMessage(cm)
+		if err == ErrMessageAlreadyInTheChannel {
+			return c.FetchMessageList(cm.Id)
+		}
+
+		return nil, err
 	}
 
 	if err != nil {

--- a/go/src/socialapi/models/channel_test.go
+++ b/go/src/socialapi/models/channel_test.go
@@ -4,6 +4,7 @@ import (
 	"koding/db/mongodb/modelhelper"
 	"socialapi/config"
 	"socialapi/request"
+	"socialapi/workers/common/tests"
 	"testing"
 
 	"github.com/koding/bongo"
@@ -12,332 +13,299 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-// createNewChannelWithTest creates a new account
-// And inits a channel
-func createNewChannelWithTest() *Channel {
-	// init account
-	creator := CreateAccountWithTest()
-
-	// init channel
-	c := NewChannel()
-	// set Creator id
-	c.CreatorId = creator.Id
-	return c
-}
-
 func TestChannelNewChannel(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	c := NewChannel()
+		c := NewChannel()
 
-	Convey("given a NewChannel", t, func() {
+		Convey("given a NewChannel", t, func() {
 
-		Convey("it should have Name as set", func() {
-			So(c.Name, ShouldNotBeBlank)
-		})
+			Convey("it should have Name as set", func() {
+				So(c.Name, ShouldNotBeBlank)
+			})
 
-		Convey("it should have GroupName as set", func() {
-			So(c.GroupName, ShouldNotBeBlank)
-		})
+			Convey("it should have GroupName as set", func() {
+				So(c.GroupName, ShouldNotBeBlank)
+			})
 
-		Convey("it should have TypeConstant as set", func() {
-			So(c.TypeConstant, ShouldEqual, Channel_TYPE_DEFAULT)
-		})
+			Convey("it should have TypeConstant as set", func() {
+				So(c.TypeConstant, ShouldEqual, Channel_TYPE_DEFAULT)
+			})
 
-		Convey("it should have PrivacyConstant as set", func() {
-			So(c.PrivacyConstant, ShouldEqual, Channel_PRIVACY_PRIVATE)
+			Convey("it should have PrivacyConstant as set", func() {
+				So(c.PrivacyConstant, ShouldEqual, Channel_PRIVACY_PRIVATE)
+			})
 		})
 	})
 }
 
 func TestChannelSearch(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	c := NewChannel()
+		c := NewChannel()
 
-	Convey("moderation needed channels", t, func() {
-		account := CreateAccountWithTest()
-		groupChannel := CreateTypedPublicChannelWithTest(
-			account.Id,
-			Channel_TYPE_GROUP,
-		)
+		Convey("moderation needed channels", t, func() {
+			account := CreateAccountWithTest()
+			groupChannel := CreateTypedPublicChannelWithTest(
+				account.Id,
+				Channel_TYPE_GROUP,
+			)
 
-		c.CreatorId = account.Id
-		c.GroupName = groupChannel.GroupName
-		c.TypeConstant = Channel_TYPE_TOPIC
-		c.PrivacyConstant = Channel_PRIVACY_PUBLIC
-		c.MetaBits.Mark(NeedsModeration)
+			c.CreatorId = account.Id
+			c.GroupName = groupChannel.GroupName
+			c.TypeConstant = Channel_TYPE_TOPIC
+			c.PrivacyConstant = Channel_PRIVACY_PUBLIC
+			c.MetaBits.Mark(NeedsModeration)
 
-		So(c.Create(), ShouldBeNil)
-		Convey("should not be in search results", func() {
-			channels, err := NewChannel().Search(&request.Query{
-				Name:      c.Name,
-				GroupName: groupChannel.GroupName,
-				AccountId: account.Id,
-			})
-			So(err, ShouldBeNil)
-			So(len(channels), ShouldEqual, 0)
-		})
-
-		Convey("after removing needs moderation flag", func() {
-			// byname doesnt filter
-			channel, err := NewChannel().ByName(&request.Query{
-				Name:      c.Name,
-				GroupName: groupChannel.GroupName,
-				AccountId: account.Id,
-			})
-			So(err, ShouldBeNil)
-			So(channel, ShouldNotBeNil)
-
-			channel.MetaBits.UnMark(NeedsModeration)
-
-			So(channel.Update(), ShouldBeNil)
-
-			Convey("we should be able to search them", func() {
+			So(c.Create(), ShouldBeNil)
+			Convey("should not be in search results", func() {
 				channels, err := NewChannel().Search(&request.Query{
 					Name:      c.Name,
 					GroupName: groupChannel.GroupName,
 					AccountId: account.Id,
-					Privacy:   channel.PrivacyConstant,
 				})
 				So(err, ShouldBeNil)
-				So(len(channels), ShouldEqual, 1)
-				So(channels[0].Id, ShouldEqual, channel.Id)
+				So(len(channels), ShouldEqual, 0)
+			})
+
+			Convey("after removing needs moderation flag", func() {
+				// byname doesnt filter
+				channel, err := NewChannel().ByName(&request.Query{
+					Name:      c.Name,
+					GroupName: groupChannel.GroupName,
+					AccountId: account.Id,
+				})
+				So(err, ShouldBeNil)
+				So(channel, ShouldNotBeNil)
+
+				channel.MetaBits.UnMark(NeedsModeration)
+
+				So(channel.Update(), ShouldBeNil)
+
+				Convey("we should be able to search them", func() {
+					channels, err := NewChannel().Search(&request.Query{
+						Name:      c.Name,
+						GroupName: groupChannel.GroupName,
+						AccountId: account.Id,
+						Privacy:   channel.PrivacyConstant,
+					})
+					So(err, ShouldBeNil)
+					So(len(channels), ShouldEqual, 1)
+					So(channels[0].Id, ShouldEqual, channel.Id)
+				})
 			})
 		})
 	})
 }
 
 func TestChannelNewCollaborationChannel(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	var creatorId int64 = 123
-	groupName := "testGroup"
-	c := NewPrivateChannel(creatorId, groupName, Channel_TYPE_DEFAULT)
+		var creatorId int64 = 123
+		groupName := "testGroup"
+		c := NewPrivateChannel(creatorId, groupName, Channel_TYPE_DEFAULT)
 
-	Convey("given a NewPrivateMessageChannel", t, func() {
-		Convey("it should have group name", func() {
-			So(c.GroupName, ShouldEqual, groupName)
-		})
+		Convey("given a NewPrivateMessageChannel", t, func() {
+			Convey("it should have group name", func() {
+				So(c.GroupName, ShouldEqual, groupName)
+			})
 
-		Convey("it should have creator id", func() {
-			So(c.CreatorId, ShouldEqual, creatorId)
-		})
+			Convey("it should have creator id", func() {
+				So(c.CreatorId, ShouldEqual, creatorId)
+			})
 
-		Convey("it should have a name", func() {
-			So(c.Name, ShouldNotBeBlank)
-		})
+			Convey("it should have a name", func() {
+				So(c.Name, ShouldNotBeBlank)
+			})
 
-		Convey("it should have the give type constant", func() {
-			So(c.TypeConstant, ShouldEqual, Channel_TYPE_DEFAULT)
-		})
+			Convey("it should have the give type constant", func() {
+				So(c.TypeConstant, ShouldEqual, Channel_TYPE_DEFAULT)
+			})
 
-		Convey("it should have privacy constant", func() {
-			So(c.PrivacyConstant, ShouldEqual, Channel_PRIVACY_PRIVATE)
-		})
+			Convey("it should have privacy constant", func() {
+				So(c.PrivacyConstant, ShouldEqual, Channel_PRIVACY_PRIVATE)
+			})
 
-		Convey("it should not have purpose", func() {
-			So(c.Purpose, ShouldBeBlank)
+			Convey("it should not have purpose", func() {
+				So(c.Purpose, ShouldBeBlank)
+			})
 		})
 	})
 }
 
 func TestChannelNewPrivateChannel(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	var creatorId int64 = 123
-	groupName := "testGroup"
-	c := NewCollaborationChannel(creatorId, groupName)
+		var creatorId int64 = 123
+		groupName := "testGroup"
+		c := NewCollaborationChannel(creatorId, groupName)
 
-	Convey("given a NewPrivateMessageChannel", t, func() {
-		Convey("it should have group name", func() {
-			So(c.GroupName, ShouldEqual, groupName)
+		Convey("given a NewPrivateMessageChannel", t, func() {
+			Convey("it should have group name", func() {
+				So(c.GroupName, ShouldEqual, groupName)
+			})
+
+			Convey("it should have creator id", func() {
+				So(c.CreatorId, ShouldEqual, creatorId)
+			})
+
+			Convey("it should have a name", func() {
+				So(c.Name, ShouldNotBeBlank)
+			})
+
+			Convey("it should have type constant", func() {
+				So(c.TypeConstant, ShouldEqual, Channel_TYPE_COLLABORATION)
+			})
+
+			Convey("it should have privacy constant", func() {
+				So(c.PrivacyConstant, ShouldEqual, Channel_PRIVACY_PRIVATE)
+			})
+
+			Convey("it should have purpose", func() {
+				So(c.Purpose, ShouldBeBlank)
+			})
 		})
-
-		Convey("it should have creator id", func() {
-			So(c.CreatorId, ShouldEqual, creatorId)
-		})
-
-		Convey("it should have a name", func() {
-			So(c.Name, ShouldNotBeBlank)
-		})
-
-		Convey("it should have type constant", func() {
-			So(c.TypeConstant, ShouldEqual, Channel_TYPE_COLLABORATION)
-		})
-
-		Convey("it should have privacy constant", func() {
-			So(c.PrivacyConstant, ShouldEqual, Channel_PRIVACY_PRIVATE)
-		})
-
-		Convey("it should have purpose", func() {
-			So(c.Purpose, ShouldBeBlank)
-		})
-
 	})
 }
 
 func TestChannelNewPrivateMessageChannel(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	// read config once
-	config.MustRead(r.Conf.Path)
+		// read config once
+		config.MustRead(r.Conf.Path)
 
-	var creatorId int64 = 123
-	groupName := "testGroup"
-	c := NewPrivateMessageChannel(creatorId, groupName)
+		var creatorId int64 = 123
+		groupName := "testGroup"
+		c := NewPrivateMessageChannel(creatorId, groupName)
 
-	Convey("given a NewPrivateMessageChannel", t, func() {
-		Convey("it should have group name", func() {
-			So(c.GroupName, ShouldEqual, groupName)
+		Convey("given a NewPrivateMessageChannel", t, func() {
+			Convey("it should have group name", func() {
+				So(c.GroupName, ShouldEqual, groupName)
+			})
+
+			Convey("it should have creator id", func() {
+				So(c.CreatorId, ShouldEqual, creatorId)
+			})
+
+			Convey("it should have a name", func() {
+				So(c.Name, ShouldNotBeBlank)
+			})
+
+			Convey("it should have type constant", func() {
+				So(c.TypeConstant, ShouldEqual, Channel_TYPE_PRIVATE_MESSAGE)
+			})
+
+			Convey("it should have privacy constant", func() {
+				So(c.PrivacyConstant, ShouldEqual, Channel_PRIVACY_PRIVATE)
+			})
+
+			Convey("it should have purpose", func() {
+				So(c.Purpose, ShouldBeBlank)
+			})
 		})
-
-		Convey("it should have creator id", func() {
-			So(c.CreatorId, ShouldEqual, creatorId)
-		})
-
-		Convey("it should have a name", func() {
-			So(c.Name, ShouldNotBeBlank)
-		})
-
-		Convey("it should have type constant", func() {
-			So(c.TypeConstant, ShouldEqual, Channel_TYPE_PRIVATE_MESSAGE)
-		})
-
-		Convey("it should have privacy constant", func() {
-			So(c.PrivacyConstant, ShouldEqual, Channel_PRIVACY_PRIVATE)
-		})
-
-		Convey("it should have purpose", func() {
-			So(c.Purpose, ShouldBeBlank)
-		})
-
 	})
 }
 
 // func createAccount()
 func TestChannelCreate(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while creating channel", t, func() {
-		Convey("channel name should not be empty", func() {
-			// NewChannel sets the default values for channel
-			c := NewChannel()
-			c.Name = ""
-			So(c.Create().Error(), ShouldContainSubstring, "Validation failed")
-		})
+		Convey("while creating channel", t, func() {
+			Convey("channel name should not be empty", func() {
+				// NewChannel sets the default values for channel
+				c := NewChannel()
+				c.Name = ""
+				So(c.Create().Error(), ShouldContainSubstring, "Validation failed")
+			})
 
-		Convey("channel groupName should not be empty", func() {
-			// NewChannel sets the default values for channel
-			c := NewChannel()
-			c.GroupName = ""
-			So(c.Create().Error(), ShouldContainSubstring, "Validation failed")
-		})
+			Convey("channel groupName should not be empty", func() {
+				// NewChannel sets the default values for channel
+				c := NewChannel()
+				c.GroupName = ""
+				So(c.Create().Error(), ShouldContainSubstring, "Validation failed")
+			})
 
-		Convey("channel typeConstant should not be empty", func() {
-			// NewChannel sets the default values for channel
-			c := NewChannel()
-			c.TypeConstant = ""
-			So(c.Create().Error(), ShouldContainSubstring, "Validation failed")
-		})
+			Convey("channel typeConstant should not be empty", func() {
+				// NewChannel sets the default values for channel
+				c := NewChannel()
+				c.TypeConstant = ""
+				So(c.Create().Error(), ShouldContainSubstring, "Validation failed")
+			})
 
-		Convey("channel should have creator id", func() {
-			// NewChannel sets the default values for channel
-			c := NewChannel()
-			c.CreatorId = 0
-			So(c.Create().Error(), ShouldContainSubstring, "Validation failed")
-		})
+			Convey("channel should have creator id", func() {
+				// NewChannel sets the default values for channel
+				c := NewChannel()
+				c.CreatorId = 0
+				So(c.Create().Error(), ShouldContainSubstring, "Validation failed")
+			})
 
-		Convey("channel name should not contain whitespace in the middle", func() {
-			c := NewChannel()
-			c.CreatorId = 1
-			c.Name = "name channel"
+			Convey("channel name should not contain whitespace in the middle", func() {
+				c := NewChannel()
+				c.CreatorId = 1
+				c.Name = "name channel"
 
-			So(c.Create().Error(), ShouldContainSubstring, "has empty space")
-		})
+				So(c.Create().Error(), ShouldContainSubstring, "has empty space")
+			})
 
-		Convey("channel name should not contain leading whitespace", func() {
-			c := NewChannel()
-			c.CreatorId = 1
-			c.Name = " namechannel"
-			So(c.Create().Error(), ShouldContainSubstring, "has empty space")
-		})
+			Convey("channel name should not contain leading whitespace", func() {
+				c := NewChannel()
+				c.CreatorId = 1
+				c.Name = " namechannel"
+				So(c.Create().Error(), ShouldContainSubstring, "has empty space")
+			})
 
-		Convey("channel name should not contain trailing whitespace", func() {
-			c := NewChannel()
-			c.CreatorId = 1
-			c.Name = "namechannel "
-			So(c.Create().Error(), ShouldContainSubstring, "has empty space")
-		})
+			Convey("channel name should not contain trailing whitespace", func() {
+				c := NewChannel()
+				c.CreatorId = 1
+				c.Name = "namechannel "
+				So(c.Create().Error(), ShouldContainSubstring, "has empty space")
+			})
 
-		Convey("calling group channel create twice should not return error", func() {
-			c := NewChannel()
-			c.GroupName = "malitest"
-			c.TypeConstant = Channel_TYPE_GROUP
-			account := CreateAccountWithTest()
-			c.CreatorId = account.Id
-			So(c.Create(), ShouldBeNil)
-			c.Id = 0
-			So(c.Create(), ShouldBeNil)
-		})
+			Convey("calling group channel create twice should not return error", func() {
+				c := NewChannel()
+				c.GroupName = "malitest"
+				c.TypeConstant = Channel_TYPE_GROUP
+				account := CreateAccountWithTest()
+				c.CreatorId = account.Id
+				So(c.Create(), ShouldBeNil)
+				c.Id = 0
+				So(c.Create(), ShouldBeNil)
+			})
 
-		Convey("calling group channel create twice should return same channel", func() {
-			c := NewChannel()
-			c.GroupName = "malitest2"
-			c.TypeConstant = Channel_TYPE_GROUP
-			account := CreateAccountWithTest()
-			c.CreatorId = account.Id
-			So(c.Create(), ShouldBeNil)
-			firstChannel := c.Id
-			c.Id = 0
-			So(c.Create(), ShouldBeNil)
-			So(firstChannel, ShouldEqual, c.Id)
-		})
+			Convey("calling group channel create twice should return same channel", func() {
+				c := NewChannel()
+				c.GroupName = "malitest2"
+				c.TypeConstant = Channel_TYPE_GROUP
+				account := CreateAccountWithTest()
+				c.CreatorId = account.Id
+				So(c.Create(), ShouldBeNil)
+				firstChannel := c.Id
+				c.Id = 0
+				So(c.Create(), ShouldBeNil)
+				So(firstChannel, ShouldEqual, c.Id)
+			})
 
-		Convey("calling followers channel create twice should not return error", func() {
-			c := NewChannel()
-			c.TypeConstant = Channel_TYPE_FOLLOWERS
-			account := CreateAccountWithTest()
-			c.CreatorId = account.Id
-			So(c.Create(), ShouldBeNil)
-			c.Id = 0
-			So(c.Create(), ShouldBeNil)
-		})
+			Convey("calling followers channel create twice should not return error", func() {
+				c := NewChannel()
+				c.TypeConstant = Channel_TYPE_FOLLOWERS
+				account := CreateAccountWithTest()
+				c.CreatorId = account.Id
+				So(c.Create(), ShouldBeNil)
+				c.Id = 0
+				So(c.Create(), ShouldBeNil)
+			})
 
-		Convey("calling followers channel create twice should return same channel", func() {
-			c := NewChannel()
-			c.TypeConstant = Channel_TYPE_FOLLOWERS
-			account := CreateAccountWithTest()
-			c.CreatorId = account.Id
-			So(c.Create(), ShouldBeNil)
-			firstChannel := c.Id
-			c.Id = 0
-			So(c.Create(), ShouldBeNil)
-			So(firstChannel, ShouldEqual, c.Id)
+			Convey("calling followers channel create twice should return same channel", func() {
+				c := NewChannel()
+				c.TypeConstant = Channel_TYPE_FOLLOWERS
+				account := CreateAccountWithTest()
+				c.CreatorId = account.Id
+				So(c.Create(), ShouldBeNil)
+				firstChannel := c.Id
+				c.Id = 0
+				So(c.Create(), ShouldBeNil)
+				So(firstChannel, ShouldEqual, c.Id)
+			})
 		})
 	})
 }
@@ -349,1350 +317,1114 @@ func TestChannelBongoName(t *testing.T) {
 }
 
 func TestChannelCanOpen(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while testing channel permissions", t, func() {
-		Convey("can not open uninitialized channel", func() {
-			c := NewChannel()
-			canOpen, err := c.CanOpen(1231)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrChannelIdIsNotSet)
-			So(canOpen, ShouldBeFalse)
-		})
+		Convey("while testing channel permissions", t, func() {
+			Convey("can not open uninitialized channel", func() {
+				c := NewChannel()
+				canOpen, err := c.CanOpen(1231)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrChannelIdIsNotSet)
+				So(canOpen, ShouldBeFalse)
+			})
 
-		Convey("channel should have creator id while testing CanOpen channel", func() {
-			c := NewChannel()
-			c.Id = 123
-			canOpen, err := c.CanOpen(0)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrCreatorIdIsNotSet)
-			So(canOpen, ShouldBeFalse)
-		})
+			Convey("channel should have creator id while testing CanOpen channel", func() {
+				c := NewChannel()
+				c.Id = 123
+				canOpen, err := c.CanOpen(0)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrCreatorIdIsNotSet)
+				So(canOpen, ShouldBeFalse)
+			})
 
-		Convey("uninitialized account can open koding's group channel", func() {
-			c := NewChannel()
-			c.Id = 123
-			c.CreatorId = 312
-			c.TypeConstant = Channel_TYPE_GROUP
-			c.GroupName = Channel_KODING_NAME
-			canOpen, err := c.CanOpen(0)
-			So(err, ShouldBeNil)
-			So(canOpen, ShouldBeTrue)
-		})
+			Convey("uninitialized account can open koding's group channel", func() {
+				c := NewChannel()
+				c.Id = 123
+				c.CreatorId = 312
+				c.TypeConstant = Channel_TYPE_GROUP
+				c.GroupName = Channel_KODING_NAME
+				canOpen, err := c.CanOpen(0)
+				So(err, ShouldBeNil)
+				So(canOpen, ShouldBeTrue)
+			})
 
-		Convey("uninitialized account can open koding's announcement channel", func() {
-			c := NewChannel()
-			c.Id = 123
-			c.CreatorId = 312
-			c.TypeConstant = Channel_TYPE_ANNOUNCEMENT
-			canOpen, err := c.CanOpen(0)
-			So(err, ShouldBeNil)
-			So(canOpen, ShouldBeTrue)
-		})
+			Convey("uninitialized account can open koding's announcement channel", func() {
+				c := NewChannel()
+				c.Id = 123
+				c.CreatorId = 312
+				c.TypeConstant = Channel_TYPE_ANNOUNCEMENT
+				canOpen, err := c.CanOpen(0)
+				So(err, ShouldBeNil)
+				So(canOpen, ShouldBeTrue)
+			})
 
-		Convey("participants can open group channel", func() {
-			c := createNewChannelWithTest()
-			c.TypeConstant = Channel_TYPE_GROUP
+			Convey("participants can open group channel", func() {
+				acc := CreateAccountWithTest()
+				c := CreateTypedChannelWithTest(acc.Id, Channel_TYPE_GROUP)
 
-			So(c.Create(), ShouldBeNil)
+				AddParticipantsWithTest(c.Id, acc.Id)
 
-			// create a new account
-			account := CreateAccountWithTest()
+				canOpen, err := c.CanOpen(acc.Id)
+				So(err, ShouldBeNil)
+				So(canOpen, ShouldBeTrue)
+			})
 
-			cp, err := c.AddParticipant(account.Id)
-			So(err, ShouldBeNil)
-			So(cp, ShouldNotBeNil)
+			Convey("participants can open topic channel", func() {
+				acc := CreateAccountWithTest()
+				c := CreateTypedChannelWithTest(acc.Id, Channel_TYPE_TOPIC)
 
-			canOpen, err := c.CanOpen(account.Id)
-			So(err, ShouldBeNil)
-			So(canOpen, ShouldBeTrue)
-		})
+				AddParticipantsWithTest(c.Id, acc.Id)
 
-		Convey("participants can open topic channel", func() {
-			c := createNewChannelWithTest()
-			c.TypeConstant = Channel_TYPE_TOPIC
+				canOpen, err := c.CanOpen(acc.Id)
+				So(err, ShouldBeNil)
+				So(canOpen, ShouldBeTrue)
+			})
 
-			So(c.Create(), ShouldBeNil)
+			// pinned activity channel can only be opened by the creator
+			Convey("participants can open pinned activity channel", func() {
+				acc := CreateAccountWithTest()
+				c := CreateTypedChannelWithTest(acc.Id, Channel_TYPE_PINNED_ACTIVITY)
 
-			account := CreateAccountWithTest()
+				AddParticipantsWithTest(c.Id, acc.Id)
 
-			cp, err := c.AddParticipant(account.Id)
-			So(err, ShouldBeNil)
-			So(cp, ShouldNotBeNil)
+				canOpen, err := c.CanOpen(acc.Id)
+				So(err, ShouldBeNil)
+				So(canOpen, ShouldBeTrue)
+			})
 
-			canOpen, err := c.CanOpen(account.Id)
-			So(err, ShouldBeNil)
-			So(canOpen, ShouldBeTrue)
-		})
+			Convey("participants can open private message channel", func() {
+				acc := CreateAccountWithTest()
+				c := CreateTypedChannelWithTest(acc.Id, Channel_TYPE_PRIVATE_MESSAGE)
 
-		// pinned activity channel can only be opened by the creator
-		Convey("participants can open pinned activity channel", func() {
-			c := createNewChannelWithTest()
-			c.TypeConstant = Channel_TYPE_PINNED_ACTIVITY
+				AddParticipantsWithTest(c.Id, acc.Id)
 
-			So(c.Create(), ShouldBeNil)
+				canOpen, err := c.CanOpen(acc.Id)
+				So(err, ShouldBeNil)
+				So(canOpen, ShouldBeTrue)
+			})
 
-			cp, err := c.AddParticipant(c.CreatorId)
-			So(err, ShouldBeNil)
-			So(cp, ShouldNotBeNil)
+			//
+			// NON participant tests
+			//
+			Convey("everyone can open koding group channel", func() {
+				acc := CreateAccountWithTest()
+				c := CreateTypedGroupedChannelWithTest(acc.Id, Channel_TYPE_TOPIC, Channel_KODING_NAME)
 
-			canOpen, err := c.CanOpen(c.CreatorId)
-			So(err, ShouldBeNil)
-			So(canOpen, ShouldBeTrue)
-		})
+				// even if it is not a member of koding, because of guests
+				// AddParticipantsWithTest(c.Id, acc.Id)
 
-		Convey("participants can open private message channel", func() {
-			c := createNewChannelWithTest()
-			c.TypeConstant = Channel_TYPE_PRIVATE_MESSAGE
+				canOpen, err := c.CanOpen(acc.Id)
+				So(err, ShouldBeNil)
+				So(canOpen, ShouldBeTrue)
+			})
 
-			So(c.Create(), ShouldBeNil)
+			Convey("everyone can open koding's topic channel", func() {
+				acc := CreateAccountWithTest()
 
-			account := CreateAccountWithTest()
-			// add participant to the channel
-			cp, err := c.AddParticipant(account.Id)
-			So(err, ShouldBeNil)
-			So(cp, ShouldNotBeNil)
+				c := CreateTypedGroupedChannelWithTest(acc.Id, Channel_TYPE_TOPIC, Channel_KODING_NAME)
 
-			canOpen, err := c.CanOpen(account.Id)
-			So(err, ShouldBeNil)
-			So(canOpen, ShouldBeTrue)
-		})
+				acc2 := CreateAccountWithTest()
+				canOpen, err := c.CanOpen(acc2.Id)
+				So(err, ShouldBeNil)
+				So(canOpen, ShouldBeTrue)
+			})
 
-		//
-		// NON participant tests
-		//
-		Convey("everyone can open koding group channel", func() {
-			c := createNewChannelWithTest()
-			// set required constant to open chanel
-			c.TypeConstant = Channel_TYPE_GROUP
+			Convey("non - participants can not open pinned activity channel", func() {
+				acc := CreateAccountWithTest()
+				c := CreateTypedChannelWithTest(acc.Id, Channel_TYPE_PINNED_ACTIVITY)
 
-			So(c.Create(), ShouldBeNil)
+				account := CreateAccountWithTest()
+				canOpen, err := c.CanOpen(account.Id)
+				So(err, ShouldBeNil)
+				So(canOpen, ShouldBeFalse)
+			})
 
-			account := CreateAccountWithTest()
-			canOpen, err := c.CanOpen(account.Id)
-			So(err, ShouldBeNil)
-			So(canOpen, ShouldBeTrue)
-		})
+			Convey("non-participants can not open private message channel", func() {
+				acc := CreateAccountWithTest()
+				c := CreateTypedChannelWithTest(acc.Id, Channel_TYPE_PRIVATE_MESSAGE)
 
-		Convey("everyone can open koding's topic channel", func() {
-			c := createNewChannelWithTest()
-			c.TypeConstant = Channel_TYPE_TOPIC
-			c.GroupName = Channel_KODING_NAME
-			So(c.Create(), ShouldBeNil)
-
-			account := CreateAccountWithTest()
-			canOpen, err := c.CanOpen(account.Id)
-			So(err, ShouldBeNil)
-			So(canOpen, ShouldBeTrue)
-		})
-
-		Convey("non - participants can not open pinned activity channel", func() {
-			c := createNewChannelWithTest()
-			c.TypeConstant = Channel_TYPE_PINNED_ACTIVITY
-
-			So(c.Create(), ShouldBeNil)
-
-			account := CreateAccountWithTest()
-			canOpen, err := c.CanOpen(account.Id)
-			So(err, ShouldBeNil)
-			So(canOpen, ShouldBeFalse)
-		})
-
-		Convey("non-participants can not open private message channel", func() {
-			c := createNewChannelWithTest()
-			c.TypeConstant = Channel_TYPE_PRIVATE_MESSAGE
-
-			So(c.Create(), ShouldBeNil)
-
-			account := CreateAccountWithTest()
-			canOpen, err := c.CanOpen(account.Id)
-			So(err, ShouldBeNil)
-			So(canOpen, ShouldBeFalse)
+				account := CreateAccountWithTest()
+				canOpen, err := c.CanOpen(account.Id)
+				So(err, ShouldBeNil)
+				So(canOpen, ShouldBeFalse)
+			})
 		})
 	})
 }
 
 func TestChannelCanOpenNonKoding(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while testing channel permissions for non koding groups", t, func() {
-		Convey("uninitialized account can open other group channel", func() {
-			c := NewChannel()
-			c.Id = 123
-			c.CreatorId = 312
-			c.TypeConstant = Channel_TYPE_GROUP
-			c.GroupName = RandomGroupName()
+		Convey("while testing channel permissions for non koding groups", t, func() {
+			Convey("uninitialized account can open other group channel", func() {
+				c := NewChannel()
+				c.Id = 123
+				c.CreatorId = 312
+				c.TypeConstant = Channel_TYPE_GROUP
+				c.GroupName = RandomGroupName()
 
-			canOpen, _ := c.CanOpen(0)
-			So(canOpen, ShouldBeFalse)
-		})
+				canOpen, _ := c.CanOpen(0)
+				So(canOpen, ShouldBeFalse)
+			})
 
-		Convey("uninitialized account can not open other group's announcement channel", func() {
-			c := NewChannel()
-			c.Id = 123
-			c.CreatorId = 312
-			c.TypeConstant = Channel_TYPE_ANNOUNCEMENT
-			c.GroupName = RandomGroupName()
+			Convey("uninitialized account can not open other group's announcement channel", func() {
+				c := NewChannel()
+				c.Id = 123
+				c.CreatorId = 312
+				c.TypeConstant = Channel_TYPE_ANNOUNCEMENT
+				c.GroupName = RandomGroupName()
 
-			canOpen, _ := c.CanOpen(0)
-			So(canOpen, ShouldBeFalse)
-		})
+				canOpen, _ := c.CanOpen(0)
+				So(canOpen, ShouldBeFalse)
+			})
 
-		Convey("non participants can not open other group's group channel", func() {
-			// create a new account
-			owner := CreateAccountWithTest()
-			account := CreateAccountWithTest()
+			Convey("non participants can not open other group's group channel", func() {
+				// create a new account
+				owner := CreateAccountWithTest()
+				account := CreateAccountWithTest()
 
-			// create group channel
-			c := NewChannel()
-			c.CreatorId = owner.Id
-			c.TypeConstant = Channel_TYPE_GROUP
-			c.GroupName = RandomGroupName()
-			So(c.Create(), ShouldBeNil)
+				// create group channel
+				c := NewChannel()
+				c.CreatorId = owner.Id
+				c.TypeConstant = Channel_TYPE_GROUP
+				c.GroupName = RandomGroupName()
+				So(c.Create(), ShouldBeNil)
 
-			canOpen, _ := c.CanOpen(account.Id)
-			So(canOpen, ShouldBeFalse)
-		})
+				canOpen, _ := c.CanOpen(account.Id)
+				So(canOpen, ShouldBeFalse)
+			})
 
-		Convey("non participants can not open other group's topic channel", func() {
-			// create a new account
-			owner := CreateAccountWithTest()
-			account := CreateAccountWithTest()
+			Convey("non participants can not open other group's topic channel", func() {
+				// create a new account
+				owner := CreateAccountWithTest()
+				account := CreateAccountWithTest()
 
-			// create group channel
-			c := NewChannel()
-			c.CreatorId = owner.Id
-			c.TypeConstant = Channel_TYPE_TOPIC
-			c.GroupName = RandomGroupName()
-			So(c.Create(), ShouldBeNil)
+				// create group channel
+				c := NewChannel()
+				c.CreatorId = owner.Id
+				c.TypeConstant = Channel_TYPE_TOPIC
+				c.GroupName = RandomGroupName()
+				So(c.Create(), ShouldBeNil)
 
-			canOpen, _ := c.CanOpen(account.Id)
-			So(canOpen, ShouldBeFalse)
-		})
+				canOpen, _ := c.CanOpen(account.Id)
+				So(canOpen, ShouldBeFalse)
+			})
 
-		Convey("group members can open group channel", func() {
-			// create a new account
-			owner := CreateAccountWithTest()
-			account := CreateAccountWithTest()
+			Convey("group members can open group channel", func() {
+				// create a new account
+				owner := CreateAccountWithTest()
+				account := CreateAccountWithTest()
 
-			// create group channel
-			c := NewChannel()
-			c.CreatorId = owner.Id
-			c.TypeConstant = Channel_TYPE_GROUP
-			c.GroupName = RandomGroupName()
-			So(c.Create(), ShouldBeNil)
+				// create group channel
+				c := NewChannel()
+				c.CreatorId = owner.Id
+				c.TypeConstant = Channel_TYPE_GROUP
+				c.GroupName = RandomGroupName()
+				So(c.Create(), ShouldBeNil)
 
-			// add new participant
-			_, err := c.AddParticipant(account.Id)
-			So(err, ShouldBeNil)
+				// add new participant
+				_, err := c.AddParticipant(account.Id)
+				So(err, ShouldBeNil)
 
-			canOpen, _ := c.CanOpen(account.Id)
-			So(canOpen, ShouldBeTrue)
+				canOpen, _ := c.CanOpen(account.Id)
+				So(canOpen, ShouldBeTrue)
+			})
 		})
 	})
 }
 
 func TestChannelAddParticipant(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while testing adding participant to a channel", t, func() {
+		Convey("while testing adding participant to a channel", t, func() {
 
-		Convey("channel should have id", func() {
-			c := NewChannel()
-			cp, err := c.AddParticipant(1231)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrChannelIdIsNotSet)
-			So(cp, ShouldBeNil)
-		})
+			Convey("channel should have id", func() {
+				c := NewChannel()
+				cp, err := c.AddParticipant(1231)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrChannelIdIsNotSet)
+				So(cp, ShouldBeNil)
+			})
 
-		Convey("channel should creator id", func() {
-			c := NewChannel()
-			c.Id = 123
-			cp, err := c.AddParticipant(1231)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrCreatorIdIsNotSet)
-			So(cp, ShouldBeNil)
-		})
+			Convey("channel should creator id", func() {
+				c := NewChannel()
+				c.Id = 123
+				cp, err := c.AddParticipant(1231)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrCreatorIdIsNotSet)
+				So(cp, ShouldBeNil)
+			})
 
-		Convey("we can add creator to the pinned channel", func() {
-			c := createNewChannelWithTest()
-			c.TypeConstant = Channel_TYPE_PINNED_ACTIVITY
-			So(c.Create(), ShouldBeNil)
-			cp, err := c.AddParticipant(c.CreatorId)
-			So(err, ShouldBeNil)
-			So(cp, ShouldNotBeNil)
-			So(cp.AccountId, ShouldEqual, c.CreatorId)
-			So(cp.ChannelId, ShouldEqual, c.Id)
-		})
+			Convey("we can add creator to the pinned channel", func() {
+				acc := CreateAccountWithTest()
+				c := CreateTypedChannelWithTest(acc.Id, Channel_TYPE_PINNED_ACTIVITY)
 
-		Convey("we can not add others to the pinned channel", func() {
-			c := createNewChannelWithTest()
-			c.TypeConstant = Channel_TYPE_PINNED_ACTIVITY
-			So(c.Create(), ShouldBeNil)
-			account := CreateAccountWithTest()
-			cp, err := c.AddParticipant(account.Id)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrCannotAddNewParticipantToPinnedChannel)
-			So(cp, ShouldBeNil)
-		})
+				cp, err := c.AddParticipant(c.CreatorId)
+				So(err, ShouldBeNil)
+				So(cp, ShouldNotBeNil)
+				So(cp.AccountId, ShouldEqual, c.CreatorId)
+				So(cp.ChannelId, ShouldEqual, c.Id)
+			})
 
-		Convey("we can not add same user twice to channel", func() {
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
-			account := CreateAccountWithTest()
-			cp, err := c.AddParticipant(account.Id)
-			So(err, ShouldBeNil)
-			So(cp, ShouldNotBeNil)
-			// try to add it again
-			cp, err = c.AddParticipant(account.Id)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrAccountIsAlreadyInTheChannel)
-			So(cp, ShouldBeNil)
-		})
+			Convey("we can not add others to the pinned channel", func() {
+				acc := CreateAccountWithTest()
+				c := CreateTypedChannelWithTest(acc.Id, Channel_TYPE_PINNED_ACTIVITY)
 
-		Convey("we can add same user again after leaving the channel", func() {
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
-			account := CreateAccountWithTest()
-			cp, err := c.AddParticipant(account.Id)
-			So(err, ShouldBeNil)
-			So(cp, ShouldNotBeNil)
+				account := CreateAccountWithTest()
+				cp, err := c.AddParticipant(account.Id)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrCannotAddNewParticipantToPinnedChannel)
+				So(cp, ShouldBeNil)
+			})
 
-			// force him to leave the channel
-			So(cp.Delete(), ShouldBeNil)
+			Convey("we can not add same user twice to channel", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
 
-			// try to add it again
-			cp, err = c.AddParticipant(account.Id)
-			So(err, ShouldBeNil)
-			So(cp, ShouldNotBeNil)
-			So(cp.StatusConstant, ShouldEqual, ChannelParticipant_STATUS_ACTIVE)
-		})
-		Convey("we should not be able to add participants into linked channel", func() {
-			account := CreateAccountWithTest()
-			c := CreateTypedPublicChannelWithTest(
-				account.Id,
-				Channel_TYPE_LINKED_TOPIC,
-			)
+				account := CreateAccountWithTest()
+				cp, err := c.AddParticipant(account.Id)
+				So(err, ShouldBeNil)
+				So(cp, ShouldNotBeNil)
+				// try to add it again
+				cp, err = c.AddParticipant(account.Id)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrAccountIsAlreadyInTheChannel)
+				So(cp, ShouldBeNil)
+			})
 
-			cp, err := c.AddParticipant(account.Id)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrChannelIsLinked)
-			So(cp, ShouldBeNil)
+			Convey("we can add same user again after leaving the channel", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
+				cp, err := c.AddParticipant(acc.Id)
+				So(err, ShouldBeNil)
+				So(cp, ShouldNotBeNil)
+
+				// force him to leave the channel
+				So(cp.Delete(), ShouldBeNil)
+
+				// try to add it again
+				cp, err = c.AddParticipant(acc.Id)
+				So(err, ShouldBeNil)
+				So(cp, ShouldNotBeNil)
+				So(cp.StatusConstant, ShouldEqual, ChannelParticipant_STATUS_ACTIVE)
+			})
+			Convey("we should not be able to add participants into linked channel", func() {
+				account := CreateAccountWithTest()
+				c := CreateTypedPublicChannelWithTest(
+					account.Id,
+					Channel_TYPE_LINKED_TOPIC,
+				)
+
+				cp, err := c.AddParticipant(account.Id)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrChannelIsLinked)
+				So(cp, ShouldBeNil)
+			})
 		})
 	})
 }
 
 func TestChannelRemoveParticipant(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while removing participant from a channel", t, func() {
-		Convey("channel should have id", func() {
-			c := NewChannel()
-			err := c.removeParticipation(ChannelParticipant_STATUS_LEFT, 123)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrChannelIdIsNotSet)
+		Convey("while removing participant from a channel", t, func() {
+			Convey("channel should have id", func() {
+				c := NewChannel()
+				err := c.removeParticipation(ChannelParticipant_STATUS_LEFT, 123)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrChannelIdIsNotSet)
+			})
+
+			Convey("removing a non existent participant from the channel should not give error", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
+
+				err := c.removeParticipation(ChannelParticipant_STATUS_LEFT, acc.Id)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("participant can leave the channel", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
+				AddParticipantsWithTest(c.Id, acc.Id)
+
+				err := c.removeParticipation(ChannelParticipant_STATUS_LEFT, acc.Id)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("when we remove already removed account again from the channel, it should not give err", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
+				AddParticipantsWithTest(c.Id, acc.Id)
+
+				err := c.removeParticipation(ChannelParticipant_STATUS_LEFT, acc.Id)
+				So(err, ShouldBeNil)
+				// try to remove it again
+				err = c.removeParticipation(ChannelParticipant_STATUS_LEFT, acc.Id)
+				So(err, ShouldBeNil)
+			})
 		})
-
-		Convey("removing a non existent participant from the channel should not give error", func() {
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
-			account := CreateAccountWithTest()
-			err := c.removeParticipation(ChannelParticipant_STATUS_LEFT, account.Id)
-			So(err, ShouldBeNil)
-		})
-
-		Convey("participant can leave the channel", func() {
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
-			account := CreateAccountWithTest()
-			_, err := c.AddParticipant(account.Id)
-			So(err, ShouldBeNil)
-
-			err = c.removeParticipation(ChannelParticipant_STATUS_LEFT, account.Id)
-			So(err, ShouldBeNil)
-		})
-
-		Convey("when we remove already removed account again from the channel, it should not give err", func() {
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
-			account := CreateAccountWithTest()
-
-			_, err := c.AddParticipant(account.Id)
-			So(err, ShouldBeNil)
-
-			err = c.removeParticipation(ChannelParticipant_STATUS_LEFT, account.Id)
-			So(err, ShouldBeNil)
-			// try to remove it again
-			err = c.removeParticipation(ChannelParticipant_STATUS_LEFT, account.Id)
-			So(err, ShouldBeNil)
-		})
-
 	})
 }
 
 func TestChannelAddMessage(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while adding a message to a channel", t, func() {
+		Convey("while adding a message to a channel", t, func() {
 
-		Convey("it should have channel id", func() {
-			c := NewChannel()
-			cm := NewChannelMessage()
-			cm.Id = 123
-			_, err := c.AddMessage(cm)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrChannelIdIsNotSet)
-		})
+			Convey("it should have channel id", func() {
+				c := NewChannel()
+				cm := NewChannelMessage()
+				cm.Id = 123
+				_, err := c.AddMessage(cm)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrChannelIdIsNotSet)
+			})
 
-		Convey("it should have message id", func() {
-			c := NewChannel()
-			c.Id = 123
-			_, err := c.AddMessage(NewChannelMessage())
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrMessageIdIsNotSet)
-		})
+			Convey("it should have message id", func() {
+				c := NewChannel()
+				c.Id = 123
+				_, err := c.AddMessage(NewChannelMessage())
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrMessageIdIsNotSet)
+			})
 
-		Convey("it should return error if message id is not set", func() {
-			// fake channel
-			c := NewChannel()
-			c.Id = 123
+			Convey("it should return error if message id is not set", func() {
+				// fake channel
+				c := NewChannel()
+				c.Id = 123
 
-			// try to add message
-			ch, err := c.AddMessage(NewChannelMessage())
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrMessageIdIsNotSet)
-			So(ch, ShouldBeNil)
-		})
+				// try to add message
+				ch, err := c.AddMessage(NewChannelMessage())
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrMessageIdIsNotSet)
+				So(ch, ShouldBeNil)
+			})
 
-		Convey("adding message to a channel should be successful", func() {
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
+			Convey("adding message to a channel should be successful", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
 
-			cm := createMessageWithTest()
-			cm.Body = "five5"
-			So(cm.Create(), ShouldBeNil)
-			ch, err := c.AddMessage(cm)
-			So(err, ShouldBeNil)
-			So(ch, ShouldNotBeEmpty)
-		})
+				cm := CreateMessageWithTest()
+				cm.Body = "five5"
+				So(cm.Create(), ShouldBeNil)
+				ch, err := c.AddMessage(cm)
+				So(err, ShouldBeNil)
+				So(ch, ShouldNotBeEmpty)
+			})
 
-		Convey("it should return error if message is already in the channel", func() {
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
+			Convey("it should return error if message is already in the channel", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
+				cm := CreateMessageWithTest()
+				So(cm.Create(), ShouldBeNil)
 
-			cm := createMessageWithTest()
-			cm.Body = "five5"
-			So(cm.Create(), ShouldBeNil)
+				ch, err := c.AddMessage(cm)
+				So(err, ShouldBeNil)
+				So(ch, ShouldNotBeEmpty)
 
-			ch, err := c.AddMessage(cm)
-			So(err, ShouldBeNil)
-			So(ch, ShouldNotBeEmpty)
+				// try to add the same message again
+				ch, err = c.AddMessage(cm)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrMessageAlreadyInTheChannel)
+			})
 
-			// try to add the same message again
-			ch, err = c.AddMessage(cm)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrMessageAlreadyInTheChannel)
-		})
+			Convey("it should return clientRequestId in response when message is created with clientRequestId", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
 
-		Convey("it should return clientRequestId in response when message is created with clientRequestId", func() {
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
+				cm := CreateMessageWithTest()
+				cm.ClientRequestId = "ctf-123456"
+				So(cm.Create(), ShouldBeNil)
 
-			cm := createMessageWithTest()
-			cm.Body = "five5"
-			cm.ClientRequestId = "ctf-123456"
-			So(cm.Create(), ShouldBeNil)
-
-			ch, err := c.AddMessage(cm)
-			So(err, ShouldBeNil)
-			So(ch, ShouldNotBeEmpty)
-			So(ch.ClientRequestId, ShouldEqual, "ctf-123456")
+				ch, err := c.AddMessage(cm)
+				So(err, ShouldBeNil)
+				So(ch, ShouldNotBeEmpty)
+				So(ch.ClientRequestId, ShouldEqual, "ctf-123456")
+			})
 		})
 	})
 }
 
 func TestChannelRemoveMessage(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while removing a message from the channel", t, func() {
+		Convey("while removing a message from the channel", t, func() {
 
-		Convey("it should have channel id", func() {
-			c := NewChannel()
-			_, err := c.RemoveMessage(123)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrChannelIdIsNotSet)
-		})
+			Convey("it should have channel id", func() {
+				c := NewChannel()
+				_, err := c.RemoveMessage(123)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrChannelIdIsNotSet)
+			})
 
-		Convey("it should have message id", func() {
-			c := NewChannel()
-			c.Id = 123
-			_, err := c.RemoveMessage(0)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrMessageIdIsNotSet)
-		})
+			Convey("it should have message id", func() {
+				c := NewChannel()
+				c.Id = 123
+				_, err := c.RemoveMessage(0)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrMessageIdIsNotSet)
+			})
 
-		Convey("removing message from the channel should ne successful", func() {
-			// init channel
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
+			Convey("removing message from the channel should ne successful", func() {
+				acc := CreateAccountWithTest()
 
-			// init message & content of message
-			cm := createMessageWithTest()
-			cm.Body = "five5"
-			So(cm.Create(), ShouldBeNil)
+				c := CreateChannelWithTest(acc.Id)
+				cm := CreateMessageWithTest()
+				So(cm.Create(), ShouldBeNil)
 
-			_, err := c.AddMessage(cm)
-			So(err, ShouldBeNil)
+				_, err := c.AddMessage(cm)
+				So(err, ShouldBeNil)
 
-			ch, err := c.RemoveMessage(cm.Id)
-			So(err, ShouldBeNil)
-			So(ch, ShouldNotBeEmpty)
-		})
+				ch, err := c.RemoveMessage(cm.Id)
+				So(err, ShouldBeNil)
+				So(ch, ShouldNotBeEmpty)
+			})
 
-		Convey("it should return error if message is already removed from the channel", func() {
-			// init channel
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
+			Convey("it should return error if message is already removed from the channel", func() {
+				acc := CreateAccountWithTest()
 
-			// init channel message & set message content
-			// then create the message in db
-			cm := createMessageWithTest()
-			cm.Body = "five5"
-			So(cm.Create(), ShouldBeNil)
+				c := CreateChannelWithTest(acc.Id)
+				cm := CreateMessageWithTest()
+				So(cm.Create(), ShouldBeNil)
 
-			_, err := c.AddMessage(cm)
-			So(err, ShouldBeNil)
+				_, err := c.AddMessage(cm)
+				So(err, ShouldBeNil)
 
-			ch, err := c.RemoveMessage(cm.Id)
-			So(err, ShouldBeNil)
-			So(ch, ShouldNotBeEmpty)
+				ch, err := c.RemoveMessage(cm.Id)
+				So(err, ShouldBeNil)
+				So(ch, ShouldNotBeEmpty)
 
-			// try to remove the same message again
-			ch, err = c.RemoveMessage(cm.Id)
-			So(err, ShouldNotBeNil)
-			So(ch, ShouldBeNil)
+				// try to remove the same message again
+				ch, err = c.RemoveMessage(cm.Id)
+				So(err, ShouldNotBeNil)
+				So(ch, ShouldBeNil)
+			})
 		})
 	})
 }
 
 func TestChannelFetchMessageList(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while fetching channel message list", t, func() {
-		Convey("it should have channel id", func() {
-			c := NewChannel()
-			_, err := c.FetchMessageList(123)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrChannelIdIsNotSet)
-		})
+		Convey("while fetching channel message list", t, func() {
+			Convey("it should have channel id", func() {
+				c := NewChannel()
+				_, err := c.FetchMessageList(123)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrChannelIdIsNotSet)
+			})
 
-		Convey("it should have message id", func() {
-			c := NewChannel()
-			c.Id = 123
-			_, err := c.FetchMessageList(0)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrMessageIdIsNotSet)
-		})
+			Convey("it should have message id", func() {
+				c := NewChannel()
+				c.Id = 123
+				_, err := c.FetchMessageList(0)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrMessageIdIsNotSet)
+			})
 
-		Convey("non-existing message list should give error", func() {
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
+			Convey("non-existing message list should give error", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
 
-			// 1 is an arbitrary number
-			_, err := c.FetchMessageList(1)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, bongo.RecordNotFound)
-		})
+				// 1 is an arbitrary number
+				_, err := c.FetchMessageList(1)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, bongo.RecordNotFound)
+			})
 
-		Convey("existing message list should not give error", func() {
-			// create channel
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
+			Convey("existing message list should not give error", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
 
-			// create message
-			cm := createMessageWithTest()
-			So(cm.Create(), ShouldBeNil)
+				// create message
+				cm := CreateMessageWithTest()
+				So(cm.Create(), ShouldBeNil)
 
-			// add message to the channel
-			cml, err := c.AddMessage(cm)
-			So(err, ShouldBeNil)
-			So(cml, ShouldNotBeNil)
+				// add message to the channel
+				cml, err := c.AddMessage(cm)
+				So(err, ShouldBeNil)
+				So(cml, ShouldNotBeNil)
 
-			// try to fetch persisted message
-			cml2, err := c.FetchMessageList(cm.Id)
-			So(err, ShouldBeNil)
-			So(cml2, ShouldNotBeNil)
-			So(cml2.MessageId, ShouldEqual, cm.Id)
+				// try to fetch persisted message
+				cml2, err := c.FetchMessageList(cm.Id)
+				So(err, ShouldBeNil)
+				So(cml2, ShouldNotBeNil)
+				So(cml2.MessageId, ShouldEqual, cm.Id)
+			})
 		})
 	})
 }
 
 func TestChannelFetchChannelIdByNameAndGroupName(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while fetching channel id by name & group name", t, func() {
+		Convey("while fetching channel id by name & group name", t, func() {
 
-		Convey("it should have a name", func() {
-			c := NewChannel()
-			fcid, err := c.FetchChannelIdByNameAndGroupName("", "groupName")
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrNameIsNotSet)
-			So(fcid, ShouldEqual, 0)
+			Convey("it should have a name", func() {
+				c := NewChannel()
+				fcid, err := c.FetchChannelIdByNameAndGroupName("", "groupName")
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrNameIsNotSet)
+				So(fcid, ShouldEqual, 0)
+			})
+
+			Convey("it should have a group name", func() {
+				c := NewChannel()
+				fcid, err := c.FetchChannelIdByNameAndGroupName("name", "")
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrGroupNameIsNotSet)
+				So(fcid, ShouldEqual, 0)
+			})
+
+			Convey("non-existing name & groupName should give error", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
+
+				// nameTest & groupNameTest are an arbitrary strings
+				_, err := c.FetchChannelIdByNameAndGroupName("nameTest", "groupNameTest")
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, bongo.RecordNotFound)
+			})
+
+			Convey("Existing name & groupName should not give an error", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
+
+				// nameTest & groupNameTest are an arbitrary strings
+				fcid, err := c.FetchChannelIdByNameAndGroupName(c.Name, c.GroupName)
+				So(err, ShouldBeNil)
+				So(fcid, ShouldNotBeNil)
+				// Id of the FetchChannelIdByNameAndGroupName shoul equal to id which our created channel
+				So(fcid, ShouldEqual, c.Id)
+			})
 		})
-
-		Convey("it should have a group name", func() {
-			c := NewChannel()
-			fcid, err := c.FetchChannelIdByNameAndGroupName("name", "")
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrGroupNameIsNotSet)
-			So(fcid, ShouldEqual, 0)
-		})
-
-		Convey("non-existing name & groupName should give error", func() {
-			// create channel in db
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
-
-			// nameTest & groupNameTest are an arbitrary strings
-			_, err := c.FetchChannelIdByNameAndGroupName("nameTest", "groupNameTest")
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, bongo.RecordNotFound)
-		})
-
-		Convey("Existing name & groupName should not give an error", func() {
-			// create channel in db
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
-
-			// nameTest & groupNameTest are an arbitrary strings
-			fcid, err := c.FetchChannelIdByNameAndGroupName(c.Name, c.GroupName)
-			So(err, ShouldBeNil)
-			So(fcid, ShouldNotBeNil)
-			// Id of the FetchChannelIdByNameAndGroupName shoul equal to id which our created channel
-			So(fcid, ShouldEqual, c.Id)
-		})
-
 	})
 }
 
 func TestChannelFetchLastMessage(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while fetching last message", t, func() {
+		Convey("while fetching last message", t, func() {
 
-		Convey("it should have channel id", func() {
-			c := NewChannel()
-			_, err := c.FetchLastMessage()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrChannelIdIsNotSet)
+			Convey("it should have channel id", func() {
+				c := NewChannel()
+				_, err := c.FetchLastMessage()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrChannelIdIsNotSet)
+			})
+
+			Convey("existing just one message in the channel should not give error", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
+
+				// create message
+				cm := CreateMessageWithTest()
+				So(cm.Create(), ShouldBeNil)
+
+				// add message to the channel
+				cml, err := c.AddMessage(cm)
+				So(err, ShouldBeNil)
+				So(cml, ShouldNotBeNil)
+
+				// try to fetch persisted message
+				flm, err := c.FetchLastMessage()
+				So(err, ShouldBeNil)
+				So(flm, ShouldNotBeNil)
+				So(flm.Body, ShouldEqual, cm.Body)
+			})
+
+			Convey("existing two message in the channel should give last message", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
+
+				// create message
+				cm := CreateMessageWithTest()
+				So(cm.Create(), ShouldBeNil)
+
+				// add first message  to the channel
+				cml, err := c.AddMessage(cm)
+				So(err, ShouldBeNil)
+				So(cml, ShouldNotBeNil)
+
+				// create second message
+				cm2 := CreateMessageWithTest()
+				cm2.Body = "lastMessage"
+				So(cm2.Create(), ShouldBeNil)
+
+				// add second message to the same channel
+				cml2, err := c.AddMessage(cm2)
+				So(err, ShouldBeNil)
+				So(cml2, ShouldNotBeNil)
+
+				// try to fetch last message
+				flm, err := c.FetchLastMessage()
+				So(err, ShouldBeNil)
+				So(flm, ShouldNotBeNil)
+				So(flm.Body, ShouldEqual, cm2.Body)
+			})
+
+			Convey("non-existing message in channel should be nil", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
+
+				flm, err := c.FetchLastMessage()
+				So(err, ShouldBeNil)
+				So(flm, ShouldBeNil)
+			})
+
+			Convey("empty message id should be nil", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
+
+				// create message
+				cm := CreateMessageWithTest()
+				So(cm.Create(), ShouldBeNil)
+
+				// add message  to channel
+				cml, err := c.AddMessage(cm)
+				So(err, ShouldBeNil)
+				So(cml, ShouldNotBeNil)
+
+				// after adding message, remove same massage
+				// and message id in the channel should be nil
+				ch, err := c.RemoveMessage(cm.Id)
+				So(err, ShouldBeNil)
+				So(ch, ShouldNotBeEmpty)
+
+				flm, err := c.FetchLastMessage()
+				So(err, ShouldBeNil)
+				So(flm, ShouldBeNil)
+			})
 		})
-
-		Convey("existing just one message in the channel should not give error", func() {
-			// create channel
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
-
-			// create message
-			cm := createMessageWithTest()
-			So(cm.Create(), ShouldBeNil)
-
-			// add message to the channel
-			cml, err := c.AddMessage(cm)
-			So(err, ShouldBeNil)
-			So(cml, ShouldNotBeNil)
-
-			// try to fetch persisted message
-			flm, err := c.FetchLastMessage()
-			So(err, ShouldBeNil)
-			So(flm, ShouldNotBeNil)
-			So(flm.Body, ShouldEqual, cm.Body)
-		})
-
-		Convey("existing two message in the channel should give last message", func() {
-			// create channel
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
-
-			// create message
-			cm := createMessageWithTest()
-			So(cm.Create(), ShouldBeNil)
-
-			// add first message  to the channel
-			cml, err := c.AddMessage(cm)
-			So(err, ShouldBeNil)
-			So(cml, ShouldNotBeNil)
-
-			// create second message
-			cm2 := createMessageWithTest()
-			cm2.Body = "lastMessage"
-			So(cm2.Create(), ShouldBeNil)
-
-			// add second message to the same channel
-			cml2, err := c.AddMessage(cm2)
-			So(err, ShouldBeNil)
-			So(cml2, ShouldNotBeNil)
-
-			// try to fetch last message
-			flm, err := c.FetchLastMessage()
-			So(err, ShouldBeNil)
-			So(flm, ShouldNotBeNil)
-			So(flm.Body, ShouldEqual, cm2.Body)
-		})
-
-		Convey("non-existing message in channel should be nil", func() {
-			// create channel in db
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
-
-			flm, err := c.FetchLastMessage()
-			So(err, ShouldBeNil)
-			So(flm, ShouldBeNil)
-		})
-
-		Convey("empty message id should be nil", func() {
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
-
-			// create message
-			cm := createMessageWithTest()
-			So(cm.Create(), ShouldBeNil)
-
-			// add message  to channel
-			cml, err := c.AddMessage(cm)
-			So(err, ShouldBeNil)
-			So(cml, ShouldNotBeNil)
-
-			// after adding message, remove same massage
-			// and message id in the channel should be nil
-			ch, err := c.RemoveMessage(cm.Id)
-			So(err, ShouldBeNil)
-			So(ch, ShouldNotBeEmpty)
-
-			flm, err := c.FetchLastMessage()
-			So(err, ShouldBeNil)
-			So(flm, ShouldBeNil)
-		})
-
 	})
 }
 
 func TestChannelIsParticipant(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while controlling participant is in the channel or not", t, func() {
+		Convey("while controlling participant is in the channel or not", t, func() {
 
-		Convey("participant in the channel should not give error", func() {
-			// create channel
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
+			Convey("participant in the channel should not give error", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
 
-			// create account
-			acc := CreateAccountWithTest()
-			So(acc.Create(), ShouldBeNil)
+				// add the created account to the channel
+				ap, err := c.AddParticipant(acc.Id)
+				So(err, ShouldBeNil)
+				So(ap, ShouldNotBeNil)
 
-			// add the created account to the channel
-			ap, err := c.AddParticipant(acc.Id)
-			So(err, ShouldBeNil)
-			So(ap, ShouldNotBeNil)
+				part, err := c.IsParticipant(acc.Id)
+				So(err, ShouldBeNil)
+				So(part, ShouldBeTrue)
+			})
 
-			part, err := c.IsParticipant(acc.Id)
-			So(err, ShouldBeNil)
-			So(part, ShouldBeTrue)
-		})
+			Convey("non-participant in the channel should not give error", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
 
-		Convey("non-participant in the channel should not give error", func() {
-			// create channel
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
-
-			// create account
-			acc := CreateAccountWithTest()
-			So(acc.Create(), ShouldBeNil)
-
-			// account is created but didn't add to the channel
-			// it means that participant is not in the channel
-			part, err := c.IsParticipant(acc.Id)
-			So(err, ShouldBeNil)
-			So(part, ShouldBeFalse)
+				// account is created but didn't add to the channel
+				// it means that participant is not in the channel
+				part, err := c.IsParticipant(acc.Id)
+				So(err, ShouldBeNil)
+				So(part, ShouldBeFalse)
+			})
 		})
 	})
 }
 
 func TestChannelFetchParticipant(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while fetching the participants from the channel", t, func() {
+		Convey("while fetching the participants from the channel", t, func() {
 
-		Convey("it should have channel id", func() {
-			c := NewChannel()
-			_, err := c.FetchParticipant(123)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrIdIsNotSet)
-		})
+			Convey("it should have channel id", func() {
+				c := NewChannel()
+				_, err := c.FetchParticipant(123)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrIdIsNotSet)
+			})
 
-		Convey("it should have account id", func() {
-			c := NewChannel()
-			c.Id = 123
-			_, err := c.FetchParticipant(0)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrAccountIdIsNotSet)
-		})
+			Convey("it should have account id", func() {
+				c := NewChannel()
+				c.Id = 123
+				_, err := c.FetchParticipant(0)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrAccountIdIsNotSet)
+			})
 
-		Convey("participant in the channel should not give error", func() {
-			// create channel
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
+			Convey("participant in the channel should not give error", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
 
-			// create account
-			acc := CreateAccountWithTest()
-			So(acc.Create(), ShouldBeNil)
+				// add account to the channel
+				ap, err := c.AddParticipant(acc.Id)
+				So(err, ShouldBeNil)
+				So(ap, ShouldNotBeNil)
 
-			// add account to the channel
-			ap, err := c.AddParticipant(acc.Id)
-			So(err, ShouldBeNil)
-			So(ap, ShouldNotBeNil)
+				fp, err := c.FetchParticipant(acc.Id)
+				So(err, ShouldBeNil)
+				So(fp, ShouldNotBeNil)
+				So(fp.AccountId, ShouldEqual, acc.Id)
+				So(fp.ChannelId, ShouldEqual, c.Id)
+			})
 
-			fp, err := c.FetchParticipant(acc.Id)
-			So(err, ShouldBeNil)
-			So(fp, ShouldNotBeNil)
-			So(fp.AccountId, ShouldEqual, acc.Id)
-			So(fp.ChannelId, ShouldEqual, c.Id)
-		})
+			Convey("non-participant in the channel's status should be left after removing from channel ", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
 
-		Convey("non-participant in the channel's status should be left after removing from channel ", func() {
-			// create channel
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
+				// add account to the channel
+				ap, err := c.AddParticipant(acc.Id)
+				So(err, ShouldBeNil)
+				So(ap, ShouldNotBeNil)
+				//
+				// remove participant from the channel
+				err = c.RemoveParticipant(acc.Id)
+				So(err, ShouldBeNil)
 
-			// create account
-			acc := CreateAccountWithTest()
-			So(acc.Create(), ShouldBeNil)
-
-			// add account to the channel
-			ap, err := c.AddParticipant(acc.Id)
-			So(err, ShouldBeNil)
-			So(ap, ShouldNotBeNil)
-			//
-			// remove participant from the channel
-			err = c.RemoveParticipant(acc.Id)
-			So(err, ShouldBeNil)
-
-			// after adding and removing the user to/from channel
-			// status constant should be LEFT from the channel
-			// not deleted! frmo the channel
-			fp, err := c.FetchParticipant(acc.Id)
-			So(err, ShouldBeNil)
-			So(fp, ShouldNotBeNil)
-			So(fp.StatusConstant, ShouldEqual, ChannelParticipant_STATUS_LEFT)
+				// after adding and removing the user to/from channel
+				// status constant should be LEFT from the channel
+				// not deleted! frmo the channel
+				fp, err := c.FetchParticipant(acc.Id)
+				So(err, ShouldBeNil)
+				So(fp, ShouldNotBeNil)
+				So(fp.StatusConstant, ShouldEqual, ChannelParticipant_STATUS_LEFT)
+			})
 		})
 	})
 }
 
 func TestChannelgetAccountId(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while getting account id", t, func() {
+		Convey("while getting account id", t, func() {
 
-		Convey("it should have channel id", func() {
-			c := NewChannel()
-			_, err := c.getAccountId()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrChannelIdIsNotSet)
-		})
+			Convey("it should have channel id", func() {
+				c := NewChannel()
+				_, err := c.getAccountId()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrChannelIdIsNotSet)
+			})
 
-		Convey("it should have creator id", func() {
-			c := NewChannel()
-			c.CreatorId = 123
-			ac, err := c.getAccountId()
-			So(err, ShouldBeNil)
-			So(c.CreatorId, ShouldEqual, ac)
-		})
+			Convey("it should have creator id", func() {
+				c := NewChannel()
+				c.CreatorId = 123
+				ac, err := c.getAccountId()
+				So(err, ShouldBeNil)
+				So(c.CreatorId, ShouldEqual, ac)
+			})
 
-		Convey("it should get id of creator", func() {
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
-			ac, err := c.getAccountId()
-			So(err, ShouldBeNil)
-			So(c.CreatorId, ShouldEqual, ac)
+			Convey("it should get id of creator", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
+				ac, err := c.getAccountId()
+				So(err, ShouldBeNil)
+				So(c.CreatorId, ShouldEqual, ac)
+			})
 		})
 	})
 }
 
 func setupDeleteTest() (*Channel, *ChannelMessage, *ChannelMessage, *ChannelMessageList, *ChannelMessageList) {
-	c := createNewChannelWithTest()
-	So(c.Create(), ShouldBeNil)
+	acc := CreateAccountWithTest()
+	c := CreateChannelWithTest(acc.Id)
+
 	// create some messages
-	cm0 := createMessageWithTest()
-	So(cm0.Create(), ShouldBeNil)
+	cm0 := CreateMessage(c.Id, acc.Id, ChannelMessage_TYPE_POST)
+	cm1 := CreateMessage(c.Id, acc.Id, ChannelMessage_TYPE_POST)
 
-	cm1 := createMessageWithTest()
-	So(cm1.Create(), ShouldBeNil)
-
-	// add cm0 and cm1:
-	cml0, err := c.AddMessage(cm0)
+	cml0, err := c.EnsureMessage(cm0, true)
 	So(err, ShouldBeNil)
-	So(cml0, ShouldNotBeNil)
 
-	cml1, err := c.AddMessage(cm1)
+	cml1, err := c.EnsureMessage(cm1, true)
 	So(err, ShouldBeNil)
-	So(cml1, ShouldNotBeNil)
 
 	return c, cm0, cm1, cml0, cml1
 }
 
 func TestChannelDelete(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("when deleting a channel", t, func() {
-		Convey("it should delete all messages of the channel", func() {
-			c, cm0, cm1, _, _ := setupDeleteTest()
+		Convey("when deleting a channel", t, func() {
+			Convey("it should delete all messages of the channel", func() {
+				c, cm0, cm1, _, _ := setupDeleteTest()
 
-			// delete the channel
-			So(c.Delete(), ShouldBeNil)
+				// delete the channel
+				So(c.Delete(), ShouldBeNil)
 
-			// verify that the channel messages are deleted:
-			err := NewChannelMessage().ById(cm0.Id)
-			So(err, ShouldEqual, bongo.RecordNotFound)
+				// verify that the channel messages are deleted:
+				err := NewChannelMessage().ById(cm0.Id)
+				So(err, ShouldEqual, bongo.RecordNotFound)
 
-			err = NewChannelMessage().ById(cm1.Id)
-			So(err, ShouldEqual, bongo.RecordNotFound)
+				err = NewChannelMessage().ById(cm1.Id)
+				So(err, ShouldEqual, bongo.RecordNotFound)
 
-		})
-		Convey("it should delete any associated ChannelMessageList records", func() {
-			c, _, _, cml0, cml1 := setupDeleteTest()
+			})
+			Convey("it should delete any associated ChannelMessageList records", func() {
+				c, _, _, cml0, cml1 := setupDeleteTest()
 
-			// delete the channel
-			So(c.Delete(), ShouldBeNil)
+				// delete the channel
+				So(c.Delete(), ShouldBeNil)
 
-			// verify that the channel message lists are deleted:
-			err := NewChannelMessageList().ById(cml0.Id)
-			So(err, ShouldEqual, bongo.RecordNotFound)
+				// verify that the channel message lists are deleted:
+				err := NewChannelMessageList().ById(cml0.Id)
+				So(err, ShouldEqual, bongo.RecordNotFound)
 
-			err = NewChannelMessageList().ById(cml1.Id)
-			So(err, ShouldEqual, bongo.RecordNotFound)
-		})
+				err = NewChannelMessageList().ById(cml1.Id)
+				So(err, ShouldEqual, bongo.RecordNotFound)
+			})
 
-		Convey("it should delete any participants", func() {
-			c, _, _, _, _ := setupDeleteTest()
+			Convey("it should delete any participants", func() {
+				c, _, _, _, _ := setupDeleteTest()
 
-			// delete the channel
-			So(c.Delete(), ShouldBeNil)
+				// delete the channel
+				So(c.Delete(), ShouldBeNil)
 
-			participants, err := c.FetchParticipants(&request.Query{})
-			So(err, ShouldBeNil)
-			So(len(participants), ShouldEqual, 0)
-		})
+				participants, err := c.FetchParticipants(&request.Query{})
+				So(err, ShouldBeNil)
+				So(len(participants), ShouldEqual, 0)
+			})
 
-		Convey("it should delete the channel itself", func() {
-			c, _, _, _, _ := setupDeleteTest()
+			Convey("it should delete the channel itself", func() {
+				c, _, _, _, _ := setupDeleteTest()
 
-			So(c.Delete(), ShouldBeNil)
+				So(c.Delete(), ShouldBeNil)
 
-			err := NewChannel().ById(c.Id)
-			So(err, ShouldEqual, bongo.RecordNotFound)
-		})
-		Convey("it should not delete messages that are cross-indexed", func() {
-			c0, cm0, cm1, _, _ := setupDeleteTest()
+				err := NewChannel().ById(c.Id)
+				So(err, ShouldEqual, bongo.RecordNotFound)
+			})
+			Convey("it should not delete messages that are cross-indexed", func() {
+				c0, cm0, cm1, _, _ := setupDeleteTest()
 
-			// create another channel:
-			c1 := createNewChannelWithTest()
-			So(c1.Create(), ShouldBeNil)
+				acc := CreateAccountWithTest()
+				c1 := CreateChannelWithTest(acc.Id)
 
-			// only add the second message to the second channel:
-			cml0, err := c1.AddMessage(cm1)
-			So(err, ShouldBeNil)
-			So(cml0, ShouldNotBeNil)
+				// only add the second message to the second channel:
+				cml0, err := c1.AddMessage(cm1)
+				So(err, ShouldBeNil)
+				So(cml0, ShouldNotBeNil)
 
-			// delete the first channel:
-			So(c0.Delete(), ShouldBeNil)
+				// delete the first channel:
+				So(c0.Delete(), ShouldBeNil)
 
-			// verify that the first message is deleted:
-			err = NewChannelMessage().ById(cm0.Id)
-			So(err, ShouldEqual, bongo.RecordNotFound)
+				// verify that the first message is deleted:
+				err = NewChannelMessage().ById(cm0.Id)
+				So(err, ShouldEqual, bongo.RecordNotFound)
 
-			// verify that the second message is not deleted:
-			err = NewChannelMessage().ById(cm1.Id)
-			So(err, ShouldBeNil)
+				// verify that the second message is not deleted:
+				err = NewChannelMessage().ById(cm1.Id)
+				So(err, ShouldBeNil)
+			})
 		})
 	})
 }
 
 func TestFetchGroupChannel(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("when fetching a public channel", t, func() {
-		creator := CreateAccountWithTest()
+		Convey("when fetching a public channel", t, func() {
+			creator := CreateAccountWithTest()
 
-		c := NewChannel()
-		c.TypeConstant = Channel_TYPE_GROUP
-		c.GroupName = "test_group_" + RandomName()
-		c.Name = "public"
-		c.CreatorId = creator.Id
-		err := c.Create()
-		So(err, ShouldBeNil)
-		Convey("it should return a public channel with given group name", func() {
-			pc := NewChannel()
-			err := pc.FetchGroupChannel(c.GroupName)
+			c := NewChannel()
+			c.TypeConstant = Channel_TYPE_GROUP
+			c.GroupName = "test_group_" + RandomName()
+			c.Name = "public"
+			c.CreatorId = creator.Id
+			err := c.Create()
 			So(err, ShouldBeNil)
-			So(pc.GroupName, ShouldEqual, c.GroupName)
-			So(pc.TypeConstant, ShouldEqual, Channel_TYPE_GROUP)
+			Convey("it should return a public channel with given group name", func() {
+				pc := NewChannel()
+				err := pc.FetchGroupChannel(c.GroupName)
+				So(err, ShouldBeNil)
+				So(pc.GroupName, ShouldEqual, c.GroupName)
+				So(pc.TypeConstant, ShouldEqual, Channel_TYPE_GROUP)
+			})
 		})
 	})
 }
 
 func TestChannelFetchRoot(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while fetching the root", t, func() {
-		acc := CreateAccountWithTest()
-		So(acc, ShouldNotBeNil)
+		Convey("while fetching the root", t, func() {
+			acc := CreateAccountWithTest()
+			So(acc, ShouldNotBeNil)
 
-		Convey("if channel id is not set", func() {
-			c := NewChannel()
-			_, err := c.FetchRoot()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrLeafIsNotSet)
-		})
-
-		Convey("when root doesnt exist", func() {
-			leaf := CreateTypedGroupedChannelWithTest(
-				acc.Id,
-				Channel_TYPE_TOPIC,
-				RandomName(),
-			)
-
-			Convey("should return bongo error", func() {
-				_, err := leaf.FetchRoot()
+			Convey("if channel id is not set", func() {
+				c := NewChannel()
+				_, err := c.FetchRoot()
 				So(err, ShouldNotBeNil)
-				So(err, ShouldEqual, bongo.RecordNotFound)
+				So(err, ShouldEqual, ErrLeafIsNotSet)
 			})
-		})
 
-		Convey("when root does exist", func() {
-			groupName := RandomName()
-			root := CreateTypedGroupedChannelWithTest(
-				acc.Id,
-				Channel_TYPE_TOPIC,
-				groupName,
-			)
+			Convey("when root doesnt exist", func() {
+				leaf := CreateTypedGroupedChannelWithTest(
+					acc.Id,
+					Channel_TYPE_TOPIC,
+					RandomName(),
+				)
 
-			leaf := CreateTypedGroupedChannelWithTest(
-				acc.Id,
-				Channel_TYPE_TOPIC,
-				groupName,
-			)
+				Convey("should return bongo error", func() {
+					_, err := leaf.FetchRoot()
+					So(err, ShouldNotBeNil)
+					So(err, ShouldEqual, bongo.RecordNotFound)
+				})
+			})
 
-			cl := &ChannelLink{
-				RootId: root.Id,
-				LeafId: leaf.Id,
-			}
+			Convey("when root does exist", func() {
+				groupName := RandomName()
+				root := CreateTypedGroupedChannelWithTest(
+					acc.Id,
+					Channel_TYPE_TOPIC,
+					groupName,
+				)
 
-			So(cl.Create(), ShouldBeNil)
+				leaf := CreateTypedGroupedChannelWithTest(
+					acc.Id,
+					Channel_TYPE_TOPIC,
+					groupName,
+				)
 
-			Convey("should return root", func() {
-				r, err := leaf.FetchRoot()
-				So(err, ShouldBeNil)
-				So(r, ShouldNotBeNil)
-				So(r.Id, ShouldEqual, root.Id)
+				cl := &ChannelLink{
+					RootId: root.Id,
+					LeafId: leaf.Id,
+				}
+
+				So(cl.Create(), ShouldBeNil)
+
+				Convey("should return root", func() {
+					r, err := leaf.FetchRoot()
+					So(err, ShouldBeNil)
+					So(r, ShouldNotBeNil)
+					So(r.Id, ShouldEqual, root.Id)
+				})
 			})
 		})
 	})
 }
 
 func TestChannelFetchLeaves(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while fetching the root", t, func() {
-		acc := CreateAccountWithTest()
-		So(acc, ShouldNotBeNil)
+		Convey("while fetching the root", t, func() {
+			acc := CreateAccountWithTest()
+			So(acc, ShouldNotBeNil)
 
-		Convey("if channel id is not set", func() {
-			c := NewChannel()
-			_, err := c.FetchRoot()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrLeafIsNotSet)
-		})
-
-		Convey("when leaf doesnt exist", func() {
-			root := CreateTypedGroupedChannelWithTest(
-				acc.Id,
-				Channel_TYPE_TOPIC,
-				RandomName(),
-			)
-
-			Convey("should return bongo error", func() {
-				leaves, err := root.FetchLeaves()
-				So(err, ShouldBeNil)
-				So(leaves, ShouldBeNil)
+			Convey("if channel id is not set", func() {
+				c := NewChannel()
+				_, err := c.FetchRoot()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrLeafIsNotSet)
 			})
-		})
 
-		Convey("when leaves does exist", func() {
-			groupName := RandomName()
-			root := CreateTypedGroupedChannelWithTest(
-				acc.Id,
-				Channel_TYPE_TOPIC,
-				groupName,
-			)
+			Convey("when leaf doesnt exist", func() {
+				root := CreateTypedGroupedChannelWithTest(
+					acc.Id,
+					Channel_TYPE_TOPIC,
+					RandomName(),
+				)
 
-			leaf1 := CreateTypedGroupedChannelWithTest(
-				acc.Id,
-				Channel_TYPE_TOPIC,
-				groupName,
-			)
+				Convey("should return bongo error", func() {
+					leaves, err := root.FetchLeaves()
+					So(err, ShouldBeNil)
+					So(leaves, ShouldBeNil)
+				})
+			})
 
-			cl := &ChannelLink{
-				RootId: root.Id,
-				LeafId: leaf1.Id,
-			}
+			Convey("when leaves does exist", func() {
+				groupName := RandomName()
+				root := CreateTypedGroupedChannelWithTest(
+					acc.Id,
+					Channel_TYPE_TOPIC,
+					groupName,
+				)
 
-			So(cl.Create(), ShouldBeNil)
+				leaf1 := CreateTypedGroupedChannelWithTest(
+					acc.Id,
+					Channel_TYPE_TOPIC,
+					groupName,
+				)
 
-			leaf2 := CreateTypedGroupedChannelWithTest(
-				acc.Id,
-				Channel_TYPE_TOPIC,
-				groupName,
-			)
+				cl := &ChannelLink{
+					RootId: root.Id,
+					LeafId: leaf1.Id,
+				}
 
-			cl = &ChannelLink{
-				RootId: root.Id,
-				LeafId: leaf2.Id,
-			}
+				So(cl.Create(), ShouldBeNil)
 
-			So(cl.Create(), ShouldBeNil)
+				leaf2 := CreateTypedGroupedChannelWithTest(
+					acc.Id,
+					Channel_TYPE_TOPIC,
+					groupName,
+				)
 
-			Convey("should return its leaves", func() {
-				leaves, err := root.FetchLeaves()
-				So(err, ShouldBeNil)
-				So(leaves, ShouldNotBeNil)
-				So(len(leaves), ShouldEqual, 2)
+				cl = &ChannelLink{
+					RootId: root.Id,
+					LeafId: leaf2.Id,
+				}
+
+				So(cl.Create(), ShouldBeNil)
+
+				Convey("should return its leaves", func() {
+					leaves, err := root.FetchLeaves()
+					So(err, ShouldBeNil)
+					So(leaves, ShouldNotBeNil)
+					So(len(leaves), ShouldEqual, 2)
+				})
 			})
 		})
 	})
 }
 
 func TestChannelByParticipants(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	appConfig := config.MustRead(r.Conf.Path)
-	modelhelper.Initialize(appConfig.Mongo)
-	defer modelhelper.Close()
+		appConfig := config.MustRead(r.Conf.Path)
+		modelhelper.Initialize(appConfig.Mongo)
+		defer modelhelper.Close()
 
-	Convey("while fetching channels by their participants", t, func() {
-		_, _, groupName := CreateRandomGroupDataWithChecks()
+		Convey("while fetching channels by their participants", t, func() {
+			_, _, groupName := CreateRandomGroupDataWithChecks()
 
-		Convey("group name should be set in query", func() {
-			q := request.NewQuery()
-			q.GroupName = ""
+			Convey("group name should be set in query", func() {
+				q := request.NewQuery()
+				q.GroupName = ""
 
-			c := NewChannel()
-			_, err := c.ByParticipants([]int64{}, q)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrGroupNameIsNotSet)
-		})
+				c := NewChannel()
+				_, err := c.ByParticipants([]int64{}, q)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrGroupNameIsNotSet)
+			})
 
-		Convey("at least one participant should be passed", func() {
-			q := request.NewQuery()
-			q.GroupName = groupName
+			Convey("at least one participant should be passed", func() {
+				q := request.NewQuery()
+				q.GroupName = groupName
 
-			c := NewChannel()
-			_, err := c.ByParticipants([]int64{}, q)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrChannelParticipantIsNotSet)
-		})
+				c := NewChannel()
+				_, err := c.ByParticipants([]int64{}, q)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrChannelParticipantIsNotSet)
+			})
 
-		acc1 := CreateAccountWithTest()
-		acc2 := CreateAccountWithTest()
-		acc3 := CreateAccountWithTest()
+			acc1 := CreateAccountWithTest()
+			acc2 := CreateAccountWithTest()
+			acc3 := CreateAccountWithTest()
 
-		tc1 := CreateTypedGroupedChannelWithTest(
-			acc1.Id,
-			Channel_TYPE_TOPIC,
-			groupName,
-		)
-		AddParticipantsWithTest(tc1.Id, acc1.Id, acc2.Id, acc3.Id)
-
-		tc2 := CreateTypedGroupedChannelWithTest(
-			acc1.Id,
-			Channel_TYPE_TOPIC,
-			groupName,
-		)
-		AddParticipantsWithTest(tc2.Id, acc1.Id, acc2.Id, acc3.Id)
-
-		Convey("ordering should be working by channel created_at", func() {
-			q := request.NewQuery()
-			q.GroupName = groupName
-			q.Type = Channel_TYPE_TOPIC
-
-			c := NewChannel()
-			channels, err := c.ByParticipants([]int64{acc1.Id, acc2.Id, acc3.Id}, q)
-			So(err, ShouldBeNil)
-			So(len(channels), ShouldEqual, 2)
-			So(channels[0].Id, ShouldEqual, tc1.Id)
-			So(channels[1].Id, ShouldEqual, tc2.Id)
-		})
-
-		Convey("skip options should be working", func() {
-			q := request.NewQuery()
-			q.GroupName = groupName
-			q.Type = Channel_TYPE_TOPIC
-			q.Skip = 1
-
-			c := NewChannel()
-			channels, err := c.ByParticipants([]int64{acc1.Id, acc2.Id, acc3.Id}, q)
-			So(err, ShouldBeNil)
-			So(len(channels), ShouldEqual, 1)
-			So(channels[0].Id, ShouldEqual, tc2.Id)
-		})
-
-		Convey("limit options should be working", func() {
-			q := request.NewQuery()
-			q.GroupName = groupName
-			q.Type = Channel_TYPE_TOPIC
-			q.Limit = 1
-
-			c := NewChannel()
-			channels, err := c.ByParticipants([]int64{acc1.Id, acc2.Id, acc3.Id}, q)
-			So(err, ShouldBeNil)
-			So(len(channels), ShouldEqual, 1)
-			So(channels[0].Id, ShouldEqual, tc1.Id)
-		})
-
-		Convey("type option should be working", func() {
-			pc1 := CreateTypedGroupedChannelWithTest(
+			tc1 := CreateTypedGroupedChannelWithTest(
 				acc1.Id,
-				Channel_TYPE_PRIVATE_MESSAGE,
+				Channel_TYPE_TOPIC,
 				groupName,
 			)
-			AddParticipantsWithTest(pc1.Id, acc1.Id, acc2.Id, acc3.Id)
+			AddParticipantsWithTest(tc1.Id, acc1.Id, acc2.Id, acc3.Id)
 
-			q := request.NewQuery()
-			q.GroupName = groupName
-			q.Type = Channel_TYPE_PRIVATE_MESSAGE
+			tc2 := CreateTypedGroupedChannelWithTest(
+				acc1.Id,
+				Channel_TYPE_TOPIC,
+				groupName,
+			)
+			AddParticipantsWithTest(tc2.Id, acc1.Id, acc2.Id, acc3.Id)
 
-			c := NewChannel()
-			channels, err := c.ByParticipants([]int64{acc1.Id, acc2.Id, acc3.Id}, q)
-			So(err, ShouldBeNil)
-			So(len(channels), ShouldEqual, 1)
-			So(channels[0].Id, ShouldEqual, pc1.Id)
-		})
-
-		Convey("all channels should be active", func() {
-			// delete the second channel
-			So(tc2.Delete(), ShouldBeNil)
-
-			q := request.NewQuery()
-			q.GroupName = groupName
-			q.Type = Channel_TYPE_TOPIC
-
-			c := NewChannel()
-			channels, err := c.ByParticipants([]int64{acc1.Id, acc2.Id, acc3.Id}, q)
-			So(err, ShouldBeNil)
-			So(len(channels), ShouldEqual, 1)
-			So(channels[0].Id, ShouldEqual, tc1.Id)
-		})
-
-		Convey("all members should be active", func() {
-			// delete the second participant from second channel
-			So(tc2.RemoveParticipant(acc2.Id), ShouldBeNil)
-
-			q := request.NewQuery()
-			q.GroupName = groupName
-			q.Type = Channel_TYPE_TOPIC
-
-			c := NewChannel()
-			channels, err := c.ByParticipants([]int64{acc1.Id, acc2.Id, acc3.Id}, q)
-			So(err, ShouldBeNil)
-			So(len(channels), ShouldEqual, 1)
-			So(channels[0].Id, ShouldEqual, tc1.Id)
-		})
-
-		Convey("if the members are also in other groups", func() {
-			Convey("group context should be working", func() {
-				_, _, groupName := CreateRandomGroupDataWithChecks()
-
-				tc1 := CreateTypedGroupedChannelWithTest(
-					acc1.Id,
-					Channel_TYPE_TOPIC,
-					groupName,
-				)
-				AddParticipantsWithTest(tc1.Id, acc1.Id, acc2.Id, acc3.Id)
-
-				tc2 := CreateTypedGroupedChannelWithTest(
-					acc1.Id,
-					Channel_TYPE_TOPIC,
-					groupName,
-				)
-				AddParticipantsWithTest(tc2.Id, acc1.Id, acc2.Id, acc3.Id)
-
+			Convey("ordering should be working by channel created_at", func() {
 				q := request.NewQuery()
 				q.GroupName = groupName
 				q.Type = Channel_TYPE_TOPIC
@@ -1701,7 +1433,113 @@ func TestChannelByParticipants(t *testing.T) {
 				channels, err := c.ByParticipants([]int64{acc1.Id, acc2.Id, acc3.Id}, q)
 				So(err, ShouldBeNil)
 				So(len(channels), ShouldEqual, 2)
-				So(channels[0].GroupName, ShouldEqual, groupName)
+				So(channels[0].Id, ShouldEqual, tc1.Id)
+				So(channels[1].Id, ShouldEqual, tc2.Id)
+			})
+
+			Convey("skip options should be working", func() {
+				q := request.NewQuery()
+				q.GroupName = groupName
+				q.Type = Channel_TYPE_TOPIC
+				q.Skip = 1
+
+				c := NewChannel()
+				channels, err := c.ByParticipants([]int64{acc1.Id, acc2.Id, acc3.Id}, q)
+				So(err, ShouldBeNil)
+				So(len(channels), ShouldEqual, 1)
+				So(channels[0].Id, ShouldEqual, tc2.Id)
+			})
+
+			Convey("limit options should be working", func() {
+				q := request.NewQuery()
+				q.GroupName = groupName
+				q.Type = Channel_TYPE_TOPIC
+				q.Limit = 1
+
+				c := NewChannel()
+				channels, err := c.ByParticipants([]int64{acc1.Id, acc2.Id, acc3.Id}, q)
+				So(err, ShouldBeNil)
+				So(len(channels), ShouldEqual, 1)
+				So(channels[0].Id, ShouldEqual, tc1.Id)
+			})
+
+			Convey("type option should be working", func() {
+				pc1 := CreateTypedGroupedChannelWithTest(
+					acc1.Id,
+					Channel_TYPE_PRIVATE_MESSAGE,
+					groupName,
+				)
+				AddParticipantsWithTest(pc1.Id, acc1.Id, acc2.Id, acc3.Id)
+
+				q := request.NewQuery()
+				q.GroupName = groupName
+				q.Type = Channel_TYPE_PRIVATE_MESSAGE
+
+				c := NewChannel()
+				channels, err := c.ByParticipants([]int64{acc1.Id, acc2.Id, acc3.Id}, q)
+				So(err, ShouldBeNil)
+				So(len(channels), ShouldEqual, 1)
+				So(channels[0].Id, ShouldEqual, pc1.Id)
+			})
+
+			Convey("all channels should be active", func() {
+				// delete the second channel
+				So(tc2.Delete(), ShouldBeNil)
+
+				q := request.NewQuery()
+				q.GroupName = groupName
+				q.Type = Channel_TYPE_TOPIC
+
+				c := NewChannel()
+				channels, err := c.ByParticipants([]int64{acc1.Id, acc2.Id, acc3.Id}, q)
+				So(err, ShouldBeNil)
+				So(len(channels), ShouldEqual, 1)
+				So(channels[0].Id, ShouldEqual, tc1.Id)
+			})
+
+			Convey("all members should be active", func() {
+				// delete the second participant from second channel
+				So(tc2.RemoveParticipant(acc2.Id), ShouldBeNil)
+
+				q := request.NewQuery()
+				q.GroupName = groupName
+				q.Type = Channel_TYPE_TOPIC
+
+				c := NewChannel()
+				channels, err := c.ByParticipants([]int64{acc1.Id, acc2.Id, acc3.Id}, q)
+				So(err, ShouldBeNil)
+				So(len(channels), ShouldEqual, 1)
+				So(channels[0].Id, ShouldEqual, tc1.Id)
+			})
+
+			Convey("if the members are also in other groups", func() {
+				Convey("group context should be working", func() {
+					_, _, groupName := CreateRandomGroupDataWithChecks()
+
+					tc1 := CreateTypedGroupedChannelWithTest(
+						acc1.Id,
+						Channel_TYPE_TOPIC,
+						groupName,
+					)
+					AddParticipantsWithTest(tc1.Id, acc1.Id, acc2.Id, acc3.Id)
+
+					tc2 := CreateTypedGroupedChannelWithTest(
+						acc1.Id,
+						Channel_TYPE_TOPIC,
+						groupName,
+					)
+					AddParticipantsWithTest(tc2.Id, acc1.Id, acc2.Id, acc3.Id)
+
+					q := request.NewQuery()
+					q.GroupName = groupName
+					q.Type = Channel_TYPE_TOPIC
+
+					c := NewChannel()
+					channels, err := c.ByParticipants([]int64{acc1.Id, acc2.Id, acc3.Id}, q)
+					So(err, ShouldBeNil)
+					So(len(channels), ShouldEqual, 2)
+					So(channels[0].GroupName, ShouldEqual, groupName)
+				})
 			})
 		})
 	})

--- a/go/src/socialapi/models/channelcontainer_test.go
+++ b/go/src/socialapi/models/channelcontainer_test.go
@@ -35,7 +35,8 @@ func TestChannelContainerGetId(t *testing.T) {
 		})
 
 		Convey("it should have channel id if channel is exist", func() {
-			ch := createNewChannelWithTest()
+			acc := CreateAccountWithTest()
+			ch := CreateChannelWithTest(acc.Id)
 			c := NewChannelContainer()
 			c.Channel = ch
 

--- a/go/src/socialapi/models/channelmessage.go
+++ b/go/src/socialapi/models/channelmessage.go
@@ -710,3 +710,16 @@ func (cm *ChannelMessage) GetPayload(key string) *string {
 
 	return val
 }
+
+// SearchIndexable decides if message is indexable on search engine or not
+func (c *ChannelMessage) SearchIndexable() bool {
+	if IsIn(c.TypeConstant,
+		ChannelMessage_TYPE_POST,
+		ChannelMessage_TYPE_REPLY,
+		ChannelMessage_TYPE_PRIVATE_MESSAGE,
+	) {
+		return true
+	}
+
+	return false
+}

--- a/go/src/socialapi/models/channelmessage_test.go
+++ b/go/src/socialapi/models/channelmessage_test.go
@@ -3,6 +3,7 @@ package models
 import (
 	"math/rand"
 	"socialapi/request"
+	"socialapi/workers/common/tests"
 	"strconv"
 	"testing"
 	"time"
@@ -14,326 +15,318 @@ import (
 )
 
 func TestChannelMessageCreate(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("while creating channel message", t, func() {
+			Convey("0 length body could not be inserted ", func() {
+				cm := NewChannelMessage()
+				So(cm.Create(), ShouldNotBeNil)
+				So(cm.Create().Error(), ShouldContainSubstring, "message body length should be greater than")
+			})
 
-	Convey("while creating channel message", t, func() {
-		Convey("0 length body could not be inserted ", func() {
-			cm := NewChannelMessage()
-			So(cm.Create(), ShouldNotBeNil)
-			So(cm.Create().Error(), ShouldContainSubstring, "message body length should be greater than")
-		})
+			Convey("type constant should be given", func() {
+				cm := CreateMessageWithTest()
+				cm.TypeConstant = ""
+				So(cm.Create(), ShouldNotBeNil)
+				// complete error message is this: pq: invalid input value for enum channel_message_type_constant_enum: \"\"
+				// it is trimmed because wercker add schema name and returns api.channel_message_type_constant_enum
+				So(cm.Create().Error(), ShouldContainSubstring, "pq: invalid input value for enum")
+			})
 
-		Convey("type constant should be given", func() {
-			cm := createMessageWithTest()
-			cm.TypeConstant = ""
-			So(cm.Create(), ShouldNotBeNil)
-			// complete error message is this: pq: invalid input value for enum channel_message_type_constant_enum: \"\"
-			// it is trimmed because wercker add schema name and returns api.channel_message_type_constant_enum
-			So(cm.Create().Error(), ShouldContainSubstring, "pq: invalid input value for enum")
-		})
+			Convey("type constant can be post", func() {
+				cm := CreateMessageWithTest()
+				// remove type Constant
+				cm.TypeConstant = ChannelMessage_TYPE_POST
 
-		Convey("type constant can be post", func() {
-			cm := createMessageWithTest()
-			// remove type Constant
-			cm.TypeConstant = ChannelMessage_TYPE_POST
+				So(cm.Create(), ShouldBeNil)
 
-			So(cm.Create(), ShouldBeNil)
+				icm := NewChannelMessage()
+				err := icm.ById(cm.Id)
+				So(err, ShouldBeNil)
+				So(icm.Id, ShouldEqual, cm.Id)
+				So(icm.TypeConstant, ShouldEqual, ChannelMessage_TYPE_POST)
+			})
 
-			icm := NewChannelMessage()
-			err := icm.ById(cm.Id)
-			So(err, ShouldBeNil)
-			So(icm.Id, ShouldEqual, cm.Id)
-			So(icm.TypeConstant, ShouldEqual, ChannelMessage_TYPE_POST)
-		})
+			Convey("type constant can be reply", func() {
+				cm := CreateMessageWithTest()
+				// remove type Constant
+				cm.TypeConstant = ChannelMessage_TYPE_REPLY
 
-		Convey("type constant can be reply", func() {
-			cm := createMessageWithTest()
-			// remove type Constant
-			cm.TypeConstant = ChannelMessage_TYPE_REPLY
+				So(cm.Create(), ShouldBeNil)
 
-			So(cm.Create(), ShouldBeNil)
+				icm := NewChannelMessage()
+				err := icm.ById(cm.Id)
+				So(err, ShouldBeNil)
+				So(icm.Id, ShouldEqual, cm.Id)
+				So(icm.TypeConstant, ShouldEqual, ChannelMessage_TYPE_REPLY)
+			})
+			Convey("type constant can be join", func() {
+				cm := CreateMessageWithTest()
+				// remove type Constant
+				cm.TypeConstant = ChannelMessage_TYPE_JOIN
 
-			icm := NewChannelMessage()
-			err := icm.ById(cm.Id)
-			So(err, ShouldBeNil)
-			So(icm.Id, ShouldEqual, cm.Id)
-			So(icm.TypeConstant, ShouldEqual, ChannelMessage_TYPE_REPLY)
-		})
-		Convey("type constant can be join", func() {
-			cm := createMessageWithTest()
-			// remove type Constant
-			cm.TypeConstant = ChannelMessage_TYPE_JOIN
+				So(cm.Create(), ShouldBeNil)
 
-			So(cm.Create(), ShouldBeNil)
+				icm := NewChannelMessage()
+				err := icm.ById(cm.Id)
+				So(err, ShouldBeNil)
+				So(icm.Id, ShouldEqual, cm.Id)
+				So(icm.TypeConstant, ShouldEqual, ChannelMessage_TYPE_JOIN)
+			})
 
-			icm := NewChannelMessage()
-			err := icm.ById(cm.Id)
-			So(err, ShouldBeNil)
-			So(icm.Id, ShouldEqual, cm.Id)
-			So(icm.TypeConstant, ShouldEqual, ChannelMessage_TYPE_JOIN)
-		})
+			Convey("type constant can be leave", func() {
+				cm := CreateMessageWithTest()
+				// remove type Constant
+				cm.TypeConstant = ChannelMessage_TYPE_LEAVE
 
-		Convey("type constant can be leave", func() {
-			cm := createMessageWithTest()
-			// remove type Constant
-			cm.TypeConstant = ChannelMessage_TYPE_LEAVE
+				So(cm.Create(), ShouldBeNil)
 
-			So(cm.Create(), ShouldBeNil)
+				icm := NewChannelMessage()
+				err := icm.ById(cm.Id)
+				So(err, ShouldBeNil)
+				So(icm.Id, ShouldEqual, cm.Id)
+				So(icm.TypeConstant, ShouldEqual, ChannelMessage_TYPE_LEAVE)
+			})
 
-			icm := NewChannelMessage()
-			err := icm.ById(cm.Id)
-			So(err, ShouldBeNil)
-			So(icm.Id, ShouldEqual, cm.Id)
-			So(icm.TypeConstant, ShouldEqual, ChannelMessage_TYPE_LEAVE)
-		})
+			Convey("type constant can be activity", func() {
+				cm := CreateMessageWithTest()
 
-		Convey("type constant can be activity", func() {
-			cm := createMessageWithTest()
+				cm.TypeConstant = ChannelMessage_TYPE_SYSTEM
 
-			cm.TypeConstant = ChannelMessage_TYPE_SYSTEM
+				So(cm.Create(), ShouldEqual, ErrSystemTypeIsNotSet)
 
-			So(cm.Create(), ShouldEqual, ErrSystemTypeIsNotSet)
+				cm.SetPayload("systemType", "invite")
 
-			cm.SetPayload("systemType", "invite")
+				So(cm.Create(), ShouldBeNil)
 
-			So(cm.Create(), ShouldBeNil)
+				icm := NewChannelMessage()
+				err := icm.ById(cm.Id)
+				So(err, ShouldBeNil)
+				So(icm.Id, ShouldEqual, cm.Id)
+				So(icm.TypeConstant, ShouldEqual, ChannelMessage_TYPE_SYSTEM)
+			})
 
-			icm := NewChannelMessage()
-			err := icm.ById(cm.Id)
-			So(err, ShouldBeNil)
-			So(icm.Id, ShouldEqual, cm.Id)
-			So(icm.TypeConstant, ShouldEqual, ChannelMessage_TYPE_SYSTEM)
-		})
+			Convey("type constant can be privatemessage", func() {
+				cm := CreateMessageWithTest()
+				// remove type Constant
+				cm.TypeConstant = ChannelMessage_TYPE_PRIVATE_MESSAGE
 
-		Convey("type constant can be privatemessage", func() {
-			cm := createMessageWithTest()
-			// remove type Constant
-			cm.TypeConstant = ChannelMessage_TYPE_PRIVATE_MESSAGE
+				So(cm.Create(), ShouldBeNil)
 
-			So(cm.Create(), ShouldBeNil)
+				icm := NewChannelMessage()
+				err := icm.ById(cm.Id)
+				So(err, ShouldBeNil)
+				So(icm.Id, ShouldEqual, cm.Id)
+				So(icm.TypeConstant, ShouldEqual, ChannelMessage_TYPE_PRIVATE_MESSAGE)
+			})
 
-			icm := NewChannelMessage()
-			err := icm.ById(cm.Id)
-			So(err, ShouldBeNil)
-			So(icm.Id, ShouldEqual, cm.Id)
-			So(icm.TypeConstant, ShouldEqual, ChannelMessage_TYPE_PRIVATE_MESSAGE)
-		})
+			Convey("5 length body could be inserted ", func() {
+				cm := CreateMessageWithTest()
+				// set body
+				cm.Body = "5five"
 
-		Convey("5 length body could be inserted ", func() {
-			cm := createMessageWithTest()
-			// set body
-			cm.Body = "5five"
+				// try to create the message
+				So(cm.Create(), ShouldBeNil)
+			})
 
-			// try to create the message
-			So(cm.Create(), ShouldBeNil)
-		})
+			Convey("message should have slug after inserting ", func() {
+				// create message
+				cm := CreateMessageWithTest()
+				// be sure that our message doesnt have slug
+				So(cm.Id, ShouldBeZeroValue)
+				So(cm.Slug, ShouldBeZeroValue)
+				// try to create the message
+				So(cm.Create(), ShouldBeNil)
+				So(cm.Id, ShouldNotEqual, 0)
 
-		Convey("message should have slug after inserting ", func() {
-			// create message
-			cm := createMessageWithTest()
-			// be sure that our message doesnt have slug
-			So(cm.Id, ShouldBeZeroValue)
-			So(cm.Slug, ShouldBeZeroValue)
-			// try to create the message
-			So(cm.Create(), ShouldBeNil)
-			So(cm.Id, ShouldNotEqual, 0)
-
-			// fetch created message
-			icm := NewChannelMessage()
-			err := icm.ById(cm.Id)
-			So(err, ShouldBeNil)
-			So(icm.Id, ShouldNotEqual, 0)
-			So(icm.Slug, ShouldNotEqual, "")
+				// fetch created message
+				icm := NewChannelMessage()
+				err := icm.ById(cm.Id)
+				So(err, ShouldBeNil)
+				So(icm.Id, ShouldNotEqual, 0)
+				So(icm.Slug, ShouldNotEqual, "")
+			})
 		})
 	})
 }
 
 func TestChannelMessageUpdate(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("while updating channel message", t, func() {
+			Convey("0 length body could not be updated ", func() {
+				cm := CreateMessageWithTest()
+				So(cm.Create(), ShouldBeNil)
 
-	Convey("while updating channel message", t, func() {
-		Convey("0 length body could not be updated ", func() {
-			cm := createMessageWithTest()
-			So(cm.Create(), ShouldBeNil)
+				// clear message body
+				cm.Body = ""
+				So(cm.Update(), ShouldNotBeEmpty)
+				So(cm.Update().Error(), ShouldContainSubstring, "message body length should be greater than")
+			})
 
-			// clear message body
-			cm.Body = ""
-			So(cm.Update(), ShouldNotBeEmpty)
-			So(cm.Update().Error(), ShouldContainSubstring, "message body length should be greater than")
-		})
+			Convey("valid length body can be updated", func() {
+				// create message in the db
+				cm := CreateMessageWithTest()
+				So(cm.Create(), ShouldBeNil)
 
-		Convey("valid length body can be updated", func() {
-			// create message in the db
-			cm := createMessageWithTest()
-			So(cm.Create(), ShouldBeNil)
+				// update the db
+				body := "my updated text"
 
-			// update the db
-			body := "my updated text"
+				// clear message body
+				cm.Body = body
+				So(cm.Update(), ShouldBeEmpty)
 
-			// clear message body
-			cm.Body = body
-			So(cm.Update(), ShouldBeEmpty)
+				// fetch createed/updated message from db
+				icm := NewChannelMessage()
+				err := icm.ById(cm.Id)
+				So(err, ShouldBeNil)
+				So(icm.Body, ShouldEqual, body)
+			})
 
-			// fetch createed/updated message from db
-			icm := NewChannelMessage()
-			err := icm.ById(cm.Id)
-			So(err, ShouldBeNil)
-			So(icm.Body, ShouldEqual, body)
-		})
+			Convey("meta bits can not be updated", nil)
 
-		Convey("meta bits can not be updated", nil)
+			Convey("token can not  be updated ", func() {
+				// create message in the db
+				cm := CreateMessageWithTest()
+				So(cm.Create(), ShouldBeNil)
 
-		Convey("token can not  be updated ", func() {
-			// create message in the db
-			cm := createMessageWithTest()
-			So(cm.Create(), ShouldBeNil)
+				// update the db
+				token := NewToken(time.Now()).String()
 
-			// update the db
-			token := NewToken(time.Now()).String()
+				// clear message body
+				cm.Token = token
 
-			// clear message body
-			cm.Token = token
+				err := cm.Update()
+				So(err, ShouldBeNil)
 
-			err := cm.Update()
-			So(err, ShouldBeNil)
+				// fetch created/updated message from db
+				icm := NewChannelMessage()
+				err = icm.ById(cm.Id)
+				So(err, ShouldBeNil)
+				So(icm.Token, ShouldNotEqual, token)
+			})
 
-			// fetch created/updated message from db
-			icm := NewChannelMessage()
-			err = icm.ById(cm.Id)
-			So(err, ShouldBeNil)
-			So(icm.Token, ShouldNotEqual, token)
-		})
+			Convey("slug can not be updated", func() {
+				// message is created in db
+				cm := CreateMessageWithTest()
+				So(cm.Slug, ShouldBeZeroValue)
+				So(cm.Create(), ShouldBeNil)
+				So(cm.Slug, ShouldNotEqual, "")
 
-		Convey("slug can not be updated", func() {
-			// message is created in db
-			cm := createMessageWithTest()
-			So(cm.Slug, ShouldBeZeroValue)
-			So(cm.Create(), ShouldBeNil)
-			So(cm.Slug, ShouldNotEqual, "")
+				// invoke a new slug
+				slug := "another-test-for-slug"
+				cm.Slug = slug
 
-			// invoke a new slug
-			slug := "another-test-for-slug"
-			cm.Slug = slug
+				// update the message
+				// updating channel message will assign defaults
+				err := cm.Update()
+				So(err, ShouldBeNil)
 
-			// update the message
-			// updating channel message will assign defaults
-			err := cm.Update()
-			So(err, ShouldBeNil)
+				icm := NewChannelMessage()
+				err = icm.ById(cm.Id)
+				So(err, ShouldBeNil)
+				So(icm.Slug, ShouldNotEqual, slug)
+			})
 
-			icm := NewChannelMessage()
-			err = icm.ById(cm.Id)
-			So(err, ShouldBeNil)
-			So(icm.Slug, ShouldNotEqual, slug)
-		})
+			Convey("typeConstant can not be updated", func() {
+				// message is created in db
+				cm := CreateMessageWithTest()
+				So(cm.Create(), ShouldBeNil)
+				So(cm.TypeConstant, ShouldNotEqual, "")
 
-		Convey("typeConstant can not be updated", func() {
-			// message is created in db
-			cm := createMessageWithTest()
-			So(cm.Create(), ShouldBeNil)
-			So(cm.TypeConstant, ShouldNotEqual, "")
+				cm.TypeConstant = ChannelMessage_TYPE_JOIN
 
-			cm.TypeConstant = ChannelMessage_TYPE_JOIN
+				// update the message
+				// updating channel message will assign defaults
+				err := cm.Update()
+				So(err, ShouldBeNil)
 
-			// update the message
-			// updating channel message will assign defaults
-			err := cm.Update()
-			So(err, ShouldBeNil)
+				icm := NewChannelMessage()
+				err = icm.ById(cm.Id)
+				So(err, ShouldBeNil)
+				So(icm.TypeConstant, ShouldNotEqual, ChannelMessage_TYPE_JOIN)
+			})
 
-			icm := NewChannelMessage()
-			err = icm.ById(cm.Id)
-			So(err, ShouldBeNil)
-			So(icm.TypeConstant, ShouldNotEqual, ChannelMessage_TYPE_JOIN)
-		})
+			Convey("AccountId can not be updated", func() {
+				// message is created in db
+				cm := CreateMessageWithTest()
+				So(cm.Create(), ShouldBeNil)
+				So(cm.AccountId, ShouldNotEqual, 0)
 
-		Convey("AccountId can not be updated", func() {
-			// message is created in db
-			cm := createMessageWithTest()
-			So(cm.Create(), ShouldBeNil)
-			So(cm.AccountId, ShouldNotEqual, 0)
+				accId := cm.AccountId + 1
+				cm.AccountId = accId
 
-			accId := cm.AccountId + 1
-			cm.AccountId = accId
+				// update the message
+				// updating channel message will assign defaults
+				err := cm.Update()
+				So(err, ShouldBeNil)
 
-			// update the message
-			// updating channel message will assign defaults
-			err := cm.Update()
-			So(err, ShouldBeNil)
+				icm := NewChannelMessage()
+				err = icm.ById(cm.Id)
+				So(err, ShouldBeNil)
+				So(icm.AccountId, ShouldNotEqual, accId)
+			})
 
-			icm := NewChannelMessage()
-			err = icm.ById(cm.Id)
-			So(err, ShouldBeNil)
-			So(icm.AccountId, ShouldNotEqual, accId)
-		})
+			Convey("InitialChannelId can not be updated", func() {
+				// message is created in db
+				cm := CreateMessageWithTest()
+				So(cm.Create(), ShouldBeNil)
+				So(cm.InitialChannelId, ShouldNotEqual, 0)
 
-		Convey("InitialChannelId can not be updated", func() {
-			// message is created in db
-			cm := createMessageWithTest()
-			So(cm.Create(), ShouldBeNil)
-			So(cm.InitialChannelId, ShouldNotEqual, 0)
+				cId := cm.InitialChannelId + 1
+				cm.InitialChannelId = cId
 
-			cId := cm.InitialChannelId + 1
-			cm.InitialChannelId = cId
+				// update the message
+				// updating channel message will assign defaults
+				err := cm.Update()
+				So(err, ShouldBeNil)
 
-			// update the message
-			// updating channel message will assign defaults
-			err := cm.Update()
-			So(err, ShouldBeNil)
+				icm := NewChannelMessage()
+				err = icm.ById(cm.Id)
+				So(err, ShouldBeNil)
+				So(icm.InitialChannelId, ShouldNotEqual, cId)
+			})
 
-			icm := NewChannelMessage()
-			err = icm.ById(cm.Id)
-			So(err, ShouldBeNil)
-			So(icm.InitialChannelId, ShouldNotEqual, cId)
-		})
+			Convey("CreatedAt can not be updated", func() {
+				// message is created in db
+				cm := CreateMessageWithTest()
+				So(cm.Create(), ShouldBeNil)
+				So(cm.CreatedAt, ShouldNotBeEmpty)
 
-		Convey("CreatedAt can not be updated", func() {
-			// message is created in db
-			cm := createMessageWithTest()
-			So(cm.Create(), ShouldBeNil)
-			So(cm.CreatedAt, ShouldNotBeEmpty)
+				timeNow := time.Now()
+				cm.CreatedAt = timeNow
 
-			timeNow := time.Now()
-			cm.CreatedAt = timeNow
+				// update the message
+				// updating channel message will assign defaults
+				err := cm.Update()
+				So(err, ShouldBeNil)
 
-			// update the message
-			// updating channel message will assign defaults
-			err := cm.Update()
-			So(err, ShouldBeNil)
+				icm := NewChannelMessage()
+				err = icm.ById(cm.Id)
+				So(err, ShouldBeNil)
+				So(icm.CreatedAt, ShouldNotEqual, timeNow)
+			})
 
-			icm := NewChannelMessage()
-			err = icm.ById(cm.Id)
-			So(err, ShouldBeNil)
-			So(icm.CreatedAt, ShouldNotEqual, timeNow)
-		})
+			Convey("Join/Leave message can not be updated", func() {
+				// message is created in db
+				cm := CreateMessageWithTest()
+				cm.TypeConstant = ChannelMessage_TYPE_JOIN
 
-		Convey("Join/Leave message can not be updated", func() {
-			// message is created in db
-			cm := createMessageWithTest()
-			cm.TypeConstant = ChannelMessage_TYPE_JOIN
+				So(cm.Create(), ShouldBeNil)
+				So(cm.CreatedAt, ShouldNotBeEmpty)
 
-			So(cm.Create(), ShouldBeNil)
-			So(cm.CreatedAt, ShouldNotBeEmpty)
+				cm.Body = "join me"
+				err := cm.Update()
+				So(err, ShouldEqual, ErrChannelMessageUpdatedNotAllowed)
 
-			cm.Body = "join me"
-			err := cm.Update()
-			So(err, ShouldEqual, ErrChannelMessageUpdatedNotAllowed)
+				cm = CreateMessageWithTest()
+				cm.TypeConstant = ChannelMessage_TYPE_LEAVE
 
-			cm = createMessageWithTest()
-			cm.TypeConstant = ChannelMessage_TYPE_LEAVE
+				So(cm.Create(), ShouldBeNil)
+				So(cm.CreatedAt, ShouldNotBeEmpty)
 
-			So(cm.Create(), ShouldBeNil)
-			So(cm.CreatedAt, ShouldNotBeEmpty)
-
-			cm.Body = "leave me"
-			err = cm.Update()
-			So(err, ShouldEqual, ErrChannelMessageUpdatedNotAllowed)
+				cm.Body = "leave me"
+				err = cm.Update()
+				So(err, ShouldEqual, ErrChannelMessageUpdatedNotAllowed)
+			})
 		})
 	})
 }
@@ -345,286 +338,255 @@ func TestChannelMessageGetBongoName(t *testing.T) {
 }
 
 func TestChannelMessageGetAccountId(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("while getting account id ", t, func() {
+			Convey("it should have channel id", func() {
+				cm := NewChannelMessage()
 
-	Convey("while getting account id ", t, func() {
-		Convey("it should have channel id", func() {
-			cm := NewChannelMessage()
+				_, err := cm.getAccountId()
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "couldnt find accountId from content")
+			})
 
-			_, err := cm.getAccountId()
-			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldContainSubstring, "couldnt find accountId from content")
+			Convey("it should have error if account is not set", func() {
+				cm := NewChannelMessage()
+				cm.Id = 13531
+
+				_, err := cm.getAccountId()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, bongo.RecordNotFound)
+			})
+
+			Convey("it should not have error if channel & account are exist", func() {
+				cm := NewChannelMessage()
+				cm.Id = 2454
+				cm.AccountId = 4353
+
+				gid, err := cm.getAccountId()
+				So(err, ShouldBeNil)
+				So(gid, ShouldEqual, cm.AccountId)
+			})
 		})
-
-		Convey("it should have error if account is not set", func() {
-			cm := NewChannelMessage()
-			cm.Id = 13531
-
-			_, err := cm.getAccountId()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, bongo.RecordNotFound)
-		})
-
-		Convey("it should not have error if channel & account are exist", func() {
-			cm := NewChannelMessage()
-			cm.Id = 2454
-			cm.AccountId = 4353
-
-			gid, err := cm.getAccountId()
-			So(err, ShouldBeNil)
-			So(gid, ShouldEqual, cm.AccountId)
-		})
-
 	})
 }
 
 func TestChannelMessageBodyLenCheck(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("while checking body length", t, func() {
+			Convey("it should have error if body length is zero", func() {
+				cm := CreateMessageWithTest()
+				cm.Body = ""
 
-	Convey("while checking body length", t, func() {
-		Convey("it should have error if body length is zero", func() {
-			cm := createMessageWithTest()
-			cm.Body = ""
+				err := bodyLenCheck(cm.Body)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "message body length should be greater than")
+			})
 
-			err := bodyLenCheck(cm.Body)
-			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldContainSubstring, "message body length should be greater than")
+			Convey("it should not have error if length of body is greater than zero ", func() {
+				cm := CreateMessageWithTest()
+				cm.Body = "message"
+
+				err := bodyLenCheck(cm.Body)
+				So(err, ShouldBeNil)
+			})
 		})
-
-		Convey("it should not have error if length of body is greater than zero ", func() {
-			cm := createMessageWithTest()
-			cm.Body = "message"
-
-			err := bodyLenCheck(cm.Body)
-			So(err, ShouldBeNil)
-		})
-
 	})
 }
 
 func TestChannelMessageBuildEmptyMessageContainer(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("while building empty message container", t, func() {
+			Convey("it should have channel message id", func() {
+				c := NewChannelMessage()
 
-	Convey("while building empty message container", t, func() {
-		Convey("it should have channel message id", func() {
-			c := NewChannelMessage()
+				_, err := c.BuildEmptyMessageContainer()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrChannelMessageIdIsNotSet)
+			})
 
-			_, err := c.BuildEmptyMessageContainer()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrChannelMessageIdIsNotSet)
-		})
+			Convey("it should not have error if chanel is exist", func() {
+				// create message
+				c := CreateMessageWithTest()
+				So(c.Create(), ShouldBeNil)
 
-		Convey("it should not have error if chanel is exist", func() {
-			// create message
-			c := createMessageWithTest()
-			So(c.Create(), ShouldBeNil)
+				bem, err := c.BuildEmptyMessageContainer()
+				So(err, ShouldBeNil)
+				So(bem.Message, ShouldEqual, c)
+			})
+			Convey("it should not return error when account is not set", func() {
+				// create message
+				c := CreateMessageWithTest()
+				So(c.Create(), ShouldBeNil)
 
-			bem, err := c.BuildEmptyMessageContainer()
-			So(err, ShouldBeNil)
-			So(bem.Message, ShouldEqual, c)
-		})
-		Convey("it should not return error when account is not set", func() {
-			// create message
-			c := createMessageWithTest()
-			So(c.Create(), ShouldBeNil)
+				cm := NewChannelMessage()
+				cm.Id = c.Id
 
-			cm := NewChannelMessage()
-			cm.Id = c.Id
-
-			bem, err := cm.BuildEmptyMessageContainer()
-			So(err, ShouldBeNil)
-			So(bem.Message, ShouldEqual, cm)
+				bem, err := cm.BuildEmptyMessageContainer()
+				So(err, ShouldBeNil)
+				So(bem.Message, ShouldEqual, cm)
+			})
 		})
 	})
 }
 
 func TestChannelMessageFetchLatestMessages(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("while fetching latest messages of a channel with three participants and four messages", t, func() {
+			channel, accounts := CreateChannelWithParticipants()
+			cm1 := CreateMessage(channel.Id, accounts[0].Id, ChannelMessage_TYPE_PRIVATE_MESSAGE)
+			cm2 := CreateMessage(channel.Id, accounts[1].Id, ChannelMessage_TYPE_PRIVATE_MESSAGE)
+			cm3 := CreateMessage(channel.Id, accounts[0].Id, ChannelMessage_TYPE_PRIVATE_MESSAGE)
+			cm4 := CreateMessage(channel.Id, accounts[0].Id, ChannelMessage_TYPE_PRIVATE_MESSAGE)
 
-	Convey("while fetching latest messages of a channel with three participants and four messages", t, func() {
-		channel, accounts := CreateChannelWithParticipants()
-		cm1 := CreateMessage(channel.Id, accounts[0].Id, ChannelMessage_TYPE_PRIVATE_MESSAGE)
-		cm2 := CreateMessage(channel.Id, accounts[1].Id, ChannelMessage_TYPE_PRIVATE_MESSAGE)
-		cm3 := CreateMessage(channel.Id, accounts[0].Id, ChannelMessage_TYPE_PRIVATE_MESSAGE)
-		cm4 := CreateMessage(channel.Id, accounts[0].Id, ChannelMessage_TYPE_PRIVATE_MESSAGE)
+			query := request.NewQuery()
+			query.Limit = 3
+			query.AddSortField("CreatedAt", request.ORDER_DESC)
+			query.Type = ChannelMessage_TYPE_PRIVATE_MESSAGE
 
-		query := request.NewQuery()
-		query.Limit = 3
-		query.AddSortField("CreatedAt", request.ORDER_DESC)
-		query.Type = ChannelMessage_TYPE_PRIVATE_MESSAGE
+			Convey("first user should see last three messages when no parameters are set", func() {
+				c := NewChannelMessage()
+				cms, err := c.FetchMessagesByChannelId(channel.Id, query)
+				So(err, ShouldBeNil)
+				So(len(cms), ShouldEqual, 3)
+				So(cms[2].Id, ShouldEqual, cm2.Id)
+			})
 
-		Convey("first user should see last three messages when no parameters are set", func() {
-			c := NewChannelMessage()
-			cms, err := c.FetchMessagesByChannelId(channel.Id, query)
-			So(err, ShouldBeNil)
-			So(len(cms), ShouldEqual, 3)
-			So(cms[2].Id, ShouldEqual, cm2.Id)
-		})
+			Convey("first user should see one message when their account id is excluded", func() {
+				query.ExcludeField("AccountId", cm1.AccountId)
+				c := NewChannelMessage()
+				cms, err := c.FetchMessagesByChannelId(channel.Id, query)
+				So(err, ShouldBeNil)
+				So(len(cms), ShouldEqual, 1)
+				So(cms[0].Id, ShouldEqual, cm2.Id)
+			})
 
-		Convey("first user should see one message when their account id is excluded", func() {
-			query.ExcludeField("AccountId", cm1.AccountId)
-			c := NewChannelMessage()
-			cms, err := c.FetchMessagesByChannelId(channel.Id, query)
-			So(err, ShouldBeNil)
-			So(len(cms), ShouldEqual, 1)
-			So(cms[0].Id, ShouldEqual, cm2.Id)
-		})
+			Convey("second user should see two messages starting with their own message", func() {
+				c := NewChannelMessage()
+				query.ExcludeField("AccountId", cm2.AccountId)
+				query.From = cm2.CreatedAt
 
-		Convey("second user should see two messages starting with their own message", func() {
-			c := NewChannelMessage()
-			query.ExcludeField("AccountId", cm2.AccountId)
-			query.From = cm2.CreatedAt
+				cms, err := c.FetchMessagesByChannelId(channel.Id, query)
+				So(err, ShouldBeNil)
+				So(len(cms), ShouldEqual, 2)
+				So(cms[0].Id, ShouldEqual, cm4.Id)
+				So(cms[1].Id, ShouldEqual, cm3.Id)
+			})
 
-			cms, err := c.FetchMessagesByChannelId(channel.Id, query)
-			So(err, ShouldBeNil)
-			So(len(cms), ShouldEqual, 2)
-			So(cms[0].Id, ShouldEqual, cm4.Id)
-			So(cms[1].Id, ShouldEqual, cm3.Id)
-		})
+			Convey("third user should see three messages when all parameters are set", func() {
+				c := NewChannelMessage()
+				query.ExcludeField("AccountId", accounts[2].Id)
+				query.From = cm1.CreatedAt
 
-		Convey("third user should see three messages when all parameters are set", func() {
-			c := NewChannelMessage()
-			query.ExcludeField("AccountId", accounts[2].Id)
-			query.From = cm1.CreatedAt
-
-			cms, err := c.FetchMessagesByChannelId(channel.Id, query)
-			So(err, ShouldBeNil)
-			So(len(cms), ShouldEqual, 3)
-			So(cms[0].Id, ShouldEqual, cm4.Id)
-			So(cms[1].Id, ShouldEqual, cm3.Id)
-			So(cms[2].Id, ShouldEqual, cm2.Id)
+				cms, err := c.FetchMessagesByChannelId(channel.Id, query)
+				So(err, ShouldBeNil)
+				So(len(cms), ShouldEqual, 3)
+				So(cms[0].Id, ShouldEqual, cm4.Id)
+				So(cms[1].Id, ShouldEqual, cm3.Id)
+				So(cms[2].Id, ShouldEqual, cm2.Id)
+			})
 		})
 	})
 }
 
 func TestChannelMessageFetchMessageCount(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("while fetching message count since the given time", t, func() {
+			channel, accounts := CreateChannelWithParticipants()
+			cm1 := CreateMessage(channel.Id, accounts[0].Id, ChannelMessage_TYPE_PRIVATE_MESSAGE)
+			CreateMessage(channel.Id, accounts[1].Id, ChannelMessage_TYPE_PRIVATE_MESSAGE)
+			CreateMessage(channel.Id, accounts[0].Id, ChannelMessage_TYPE_PRIVATE_MESSAGE)
+			CreateMessage(channel.Id, accounts[0].Id, ChannelMessage_TYPE_PRIVATE_MESSAGE)
 
-	Convey("while fetching message count since the given time", t, func() {
-		channel, accounts := CreateChannelWithParticipants()
-		cm1 := CreateMessage(channel.Id, accounts[0].Id, ChannelMessage_TYPE_PRIVATE_MESSAGE)
-		CreateMessage(channel.Id, accounts[1].Id, ChannelMessage_TYPE_PRIVATE_MESSAGE)
-		CreateMessage(channel.Id, accounts[0].Id, ChannelMessage_TYPE_PRIVATE_MESSAGE)
-		CreateMessage(channel.Id, accounts[0].Id, ChannelMessage_TYPE_PRIVATE_MESSAGE)
+			query := request.NewQuery()
+			query.Type = ChannelMessage_TYPE_PRIVATE_MESSAGE
+			query.GroupChannelId = channel.Id
+			query.From = cm1.CreatedAt
 
-		query := request.NewQuery()
-		query.Type = ChannelMessage_TYPE_PRIVATE_MESSAGE
-		query.GroupChannelId = channel.Id
-		query.From = cm1.CreatedAt
+			Convey("first user should see 4 messages when their account is not excluded", func() {
+				c := NewChannelMessage()
+				count, err := c.FetchTotalMessageCount(query)
+				So(err, ShouldBeNil)
+				So(count, ShouldEqual, 4)
+			})
 
-		Convey("first user should see 4 messages when their account is not excluded", func() {
-			c := NewChannelMessage()
-			count, err := c.FetchTotalMessageCount(query)
-			So(err, ShouldBeNil)
-			So(count, ShouldEqual, 4)
-		})
-
-		Convey("second user should see 3 messages then their account is excluded", func() {
-			c := NewChannelMessage()
-			query.ExcludeField("AccountId", accounts[1].Id)
-			count, err := c.FetchTotalMessageCount(query)
-			So(err, ShouldBeNil)
-			So(count, ShouldEqual, 3)
+			Convey("second user should see 3 messages then their account is excluded", func() {
+				c := NewChannelMessage()
+				query.ExcludeField("AccountId", accounts[1].Id)
+				count, err := c.FetchTotalMessageCount(query)
+				So(err, ShouldBeNil)
+				So(count, ShouldEqual, 3)
+			})
 		})
 	})
 }
 
 func TestChannelMessageFetchParentChannel(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("we should be able to fetch message's parent channel", t, func() {
+			var accountId int64
+			accountId = 3
 
-	Convey("we should be able to fetch message's parent channel", t, func() {
-		var accountId int64
-		accountId = 3
+			channel := NewChannel()
+			channel.CreatorId = accountId
 
-		channel := NewChannel()
-		channel.CreatorId = accountId
+			Convey("When channel type is not topic, fetch the initial channel of the message as parent", func() {
+				channel.TypeConstant = Channel_TYPE_PRIVATE_MESSAGE
+				err := channel.Create()
+				So(err, ShouldBeNil)
+				cm := CreateMessage(channel.Id, accountId, Channel_TYPE_PRIVATE_MESSAGE)
+				parentChannel, err := cm.FetchParentChannel()
+				So(err, ShouldBeNil)
+				So(parentChannel.Id, ShouldEqual, channel.Id)
+			})
 
-		Convey("When channel type is not topic, fetch the initial channel of the message as parent", func() {
-			channel.TypeConstant = Channel_TYPE_PRIVATE_MESSAGE
-			err := channel.Create()
-			So(err, ShouldBeNil)
-			cm := CreateMessage(channel.Id, accountId, Channel_TYPE_PRIVATE_MESSAGE)
-			parentChannel, err := cm.FetchParentChannel()
-			So(err, ShouldBeNil)
-			So(parentChannel.Id, ShouldEqual, channel.Id)
+			Convey("When channel type is topic, group channel must be fetched", func() {
+				rand.Seed(time.Now().UnixNano())
+				groupName := "groupie-" + strconv.Itoa(rand.Intn(10e9))
+
+				channel.TypeConstant = Channel_TYPE_TOPIC
+				channel.GroupName = groupName
+				err := channel.Create()
+				So(err, ShouldBeNil)
+
+				groupChannel := NewChannel()
+				groupChannel.GroupName = groupName
+				groupChannel.TypeConstant = Channel_TYPE_GROUP
+				groupChannel.CreatorId = 4
+				err = groupChannel.Create()
+				So(err, ShouldBeNil)
+
+				cm := CreateMessage(channel.Id, accountId, ChannelMessage_TYPE_POST)
+				parentChannel, err := cm.FetchParentChannel()
+				So(err, ShouldBeNil)
+				So(parentChannel.Id, ShouldEqual, groupChannel.Id)
+			})
 		})
-
-		Convey("When channel type is topic, group channel must be fetched", func() {
-			rand.Seed(time.Now().UnixNano())
-			groupName := "groupie-" + strconv.Itoa(rand.Intn(10e9))
-
-			channel.TypeConstant = Channel_TYPE_TOPIC
-			channel.GroupName = groupName
-			err := channel.Create()
-			So(err, ShouldBeNil)
-
-			groupChannel := NewChannel()
-			groupChannel.GroupName = groupName
-			groupChannel.TypeConstant = Channel_TYPE_GROUP
-			groupChannel.CreatorId = 4
-			err = groupChannel.Create()
-			So(err, ShouldBeNil)
-
-			cm := CreateMessage(channel.Id, accountId, ChannelMessage_TYPE_POST)
-			parentChannel, err := cm.FetchParentChannel()
-			So(err, ShouldBeNil)
-			So(parentChannel.Id, ShouldEqual, groupChannel.Id)
-		})
-
 	})
 }
 
 func TestChannelMessageAddReply(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
 
-	Convey("while adding reply message", t, func() {
+		Convey("while adding reply message", t, func() {
 
-		Convey("channel message should have an id", func() {
-			chm := NewChannelMessage()
-			cm, err := chm.AddReply(chm)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrChannelMessageIdIsNotSet)
-			So(cm, ShouldBeNil)
+			Convey("channel message should have an id", func() {
+				chm := NewChannelMessage()
+				cm, err := chm.AddReply(chm)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrChannelMessageIdIsNotSet)
+				So(cm, ShouldBeNil)
+			})
+
+			Convey("channel message id should equal to reply message id ", func() {
+				c := CreateMessageWithTest()
+				So(c.Create(), ShouldBeNil)
+				c2 := CreateMessageWithTest()
+				So(c2.Create(), ShouldBeNil)
+				cm, err := c.AddReply(c2)
+				So(err, ShouldBeNil)
+				So(cm.MessageId, ShouldEqual, c.Id)
+			})
 		})
-
-		Convey("channel message id should equal to reply message id ", func() {
-			c := createMessageWithTest()
-			So(c.Create(), ShouldBeNil)
-			c2 := createMessageWithTest()
-			So(c2.Create(), ShouldBeNil)
-			cm, err := c.AddReply(c2)
-			So(err, ShouldBeNil)
-			So(cm.MessageId, ShouldEqual, c.Id)
-		})
-
 	})
 }
 

--- a/go/src/socialapi/models/channelmessagecontainer_test.go
+++ b/go/src/socialapi/models/channelmessagecontainer_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"socialapi/workers/common/tests"
 	"testing"
 
 	"github.com/koding/runner"
@@ -74,62 +75,53 @@ func TestChannelMessageContainerBongoName(t *testing.T) {
 }
 
 func TestChannelMessageContainerGetId(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
-
-	Convey("while getting id", t, func() {
-		Convey("it should be zero value if channel message is not exist", func() {
-			cmc := NewChannelMessageContainer()
-
-			gi := cmc.GetId()
-			So(gi, ShouldEqual, 0)
-		})
-		/*
-			Convey("it should not have any error if channel message is exist", func() {
-				// create message
-				c := createMessageWithTest()
-				So(c.Create(), ShouldBeNil)
-
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("while getting id", t, func() {
+			Convey("it should be zero value if channel message is not exist", func() {
 				cmc := NewChannelMessageContainer()
-				cmc.Message.Body = c.Body
-				cmc.Message.Id = c.Id
 
 				gi := cmc.GetId()
-				So(gi, ShouldEqual, c.Id)
+				So(gi, ShouldEqual, 0)
 			})
-		*/
+			/*
+				Convey("it should not have any error if channel message is exist", func() {
+					// create message
+					c := CreateMessageWithTest()
+					So(c.Create(), ShouldBeNil)
 
+					cmc := NewChannelMessageContainer()
+					cmc.Message.Body = c.Body
+					cmc.Message.Id = c.Id
+
+					gi := cmc.GetId()
+					So(gi, ShouldEqual, c.Id)
+				})
+			*/
+		})
 	})
 }
 
 func TestChannelMessageContainerAddAccountOldId(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("while adding account old id", t, func() {
+			Convey("it should be empty account old if channel is not set", func() {
+				cmc := NewChannelMessageContainer()
 
-	Convey("while adding account old id", t, func() {
-		Convey("it should be empty account old if channel is not set", func() {
-			cmc := NewChannelMessageContainer()
+				gi := cmc.AddAccountOldId()
+				So(gi.AccountOldId, ShouldEqual, "")
+			})
 
-			gi := cmc.AddAccountOldId()
-			So(gi.AccountOldId, ShouldEqual, "")
-		})
+			Convey("it should add account old id successfully ", func() {
+				// create account
+				acc := CreateAccountWithTest()
+				So(acc.Create(), ShouldBeNil)
 
-		Convey("it should add account old id successfully ", func() {
-			// create account
-			acc := CreateAccountWithTest()
-			So(acc.Create(), ShouldBeNil)
+				cmc := NewChannelMessageContainer()
+				cmc.AccountOldId = acc.OldId
 
-			cmc := NewChannelMessageContainer()
-			cmc.AccountOldId = acc.OldId
-
-			gi := cmc.AddAccountOldId()
-			So(gi.AccountOldId, ShouldEqual, cmc.AccountOldId)
+				gi := cmc.AddAccountOldId()
+				So(gi.AccountOldId, ShouldEqual, cmc.AccountOldId)
+			})
 		})
 	})
 }

--- a/go/src/socialapi/models/channelmessagelist_test.go
+++ b/go/src/socialapi/models/channelmessagelist_test.go
@@ -25,8 +25,12 @@ func TestChannelMessageListFetchMessageChannels(t *testing.T) {
 				cm.InitialChannelId = c1.Id
 				So(cm.Create(), ShouldBeNil)
 
+				// add to first channel
+				_, err := c1.AddMessage(cm)
+				So(err, ShouldBeNil)
+
 				// add to second channel
-				_, err := c2.AddMessage(cm)
+				_, err = c2.AddMessage(cm)
 				So(err, ShouldBeNil)
 
 				// add to 3rd channel

--- a/go/src/socialapi/models/channelmessagelist_test.go
+++ b/go/src/socialapi/models/channelmessagelist_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"socialapi/workers/common/tests"
 	"testing"
 
 	"github.com/koding/bongo"
@@ -10,493 +11,434 @@ import (
 )
 
 func TestChannelMessageListFetchMessageChannels(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("while fethcing channel message of a message", t, func() {
+			Convey("channels should be valid", func() {
+				acc := CreateAccountWithTest()
+				c1 := CreateChannelWithTest(acc.Id)
+				c2 := CreateChannelWithTest(acc.Id)
+				c3 := CreateChannelWithTest(acc.Id)
 
-	Convey("while fethcing channel message of a message", t, func() {
-		Convey("channels should be valid", func() {
-			c1 := createNewChannelWithTest()
-			So(c1.Create(), ShouldBeNil)
+				cm := NewChannelMessage()
+				cm.Body = "gel beri abi"
+				cm.AccountId = c1.CreatorId
+				cm.InitialChannelId = c1.Id
+				So(cm.Create(), ShouldBeNil)
 
-			c2 := createNewChannelWithTest()
-			So(c2.Create(), ShouldBeNil)
+				// add to second channel
+				_, err := c2.AddMessage(cm)
+				So(err, ShouldBeNil)
 
-			c3 := createNewChannelWithTest()
-			So(c3.Create(), ShouldBeNil)
+				// add to 3rd channel
+				_, err = c3.AddMessage(cm)
+				So(err, ShouldBeNil)
 
-			cm := NewChannelMessage()
-			cm.Body = "gel beri abi"
-			cm.AccountId = c1.CreatorId
-			cm.InitialChannelId = c1.Id
-			So(cm.Create(), ShouldBeNil)
+				channels, err := NewChannelMessageList().FetchMessageChannels(cm.Id)
+				So(err, ShouldBeNil)
+				So(len(channels), ShouldEqual, 3)
 
-			// add to first channel
-			_, err := c1.AddMessage(cm)
-			So(err, ShouldBeNil)
+				So(c1.Name, ShouldEqual, channels[0].Name)
+				So(c2.Name, ShouldEqual, channels[1].Name)
+				So(c3.Name, ShouldEqual, channels[2].Name)
 
-			// add to second channel
-			_, err = c2.AddMessage(cm)
-			So(err, ShouldBeNil)
-
-			// add to 3rd channel
-			_, err = c3.AddMessage(cm)
-			So(err, ShouldBeNil)
-
-			channels, err := NewChannelMessageList().FetchMessageChannels(cm.Id)
-			So(err, ShouldBeNil)
-			So(len(channels), ShouldEqual, 3)
-
-			So(c1.Name, ShouldEqual, channels[0].Name)
-			So(c2.Name, ShouldEqual, channels[1].Name)
-			So(c3.Name, ShouldEqual, channels[2].Name)
-
-			So(c1.GroupName, ShouldEqual, channels[0].GroupName)
-			So(c2.GroupName, ShouldEqual, channels[1].GroupName)
-			So(c3.GroupName, ShouldEqual, channels[2].GroupName)
+				So(c1.GroupName, ShouldEqual, channels[0].GroupName)
+				So(c2.GroupName, ShouldEqual, channels[1].GroupName)
+				So(c3.GroupName, ShouldEqual, channels[2].GroupName)
+			})
 		})
 	})
 }
 
 func TestChannelMessageListCount(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("while counting messages", t, func() {
+			Convey("it should error if channel id is not set", func() {
+				cml := NewChannelMessageList()
 
-	Convey("while counting messages", t, func() {
-		Convey("it should error if channel id is not set", func() {
-			cml := NewChannelMessageList()
+				c, err := cml.Count(0)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrChannelIdIsNotSet)
+				So(c, ShouldEqual, 0)
+			})
 
-			c, err := cml.Count(0)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrChannelIdIsNotSet)
-			So(c, ShouldEqual, 0)
-		})
+			Convey("it should not error if message in the channel", func() {
+				// create message
+				cm := CreateMessageWithTest()
+				So(cm.Create(), ShouldBeNil)
 
-		Convey("it should not error if message in the channel", func() {
-			// create message
-			cm := createMessageWithTest()
-			So(cm.Create(), ShouldBeNil)
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
 
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
+				_, err := c.AddMessage(cm)
+				So(err, ShouldBeNil)
 
-			_, err := c.AddMessage(cm)
-			So(err, ShouldBeNil)
+				cml := NewChannelMessageList()
+				cml.ChannelId = c.Id
 
-			cml := NewChannelMessageList()
-			cml.ChannelId = c.Id
+				cnt, err := cml.Count(cml.ChannelId)
+				So(err, ShouldBeNil)
+				So(cnt, ShouldEqual, 1)
+			})
 
-			cnt, err := cml.Count(cml.ChannelId)
-			So(err, ShouldBeNil)
-			So(cnt, ShouldEqual, 1)
-		})
+			Convey("it should not count message if account of message is troll ", func() {
+				// create channel
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
 
-		Convey("it should not count message if account of message is troll ", func() {
-			// create channel
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
+				// create account as troll
+				acc1 := CreateAccountWithTest()
+				err := acc1.MarkAsTroll()
+				So(err, ShouldBeNil)
 
-			// create account as troll
-			acc1 := CreateAccountWithTest()
-			err := acc1.MarkAsTroll()
-			So(err, ShouldBeNil)
+				acc2 := CreateAccountWithTest()
 
-			acc2 := CreateAccountWithTest()
+				// create message that creator is troll
+				msg := CreateMessageWithTest()
+				msg.AccountId = acc1.Id
+				So(msg.Create(), ShouldBeNil)
 
-			// create message that creator is troll
-			msg := createMessageWithTest()
-			msg.AccountId = acc1.Id
-			So(msg.Create(), ShouldBeNil)
+				msg2 := CreateMessageWithTest()
+				msg2.AccountId = acc2.Id
+				So(msg2.Create(), ShouldBeNil)
 
-			msg2 := createMessageWithTest()
-			msg2.AccountId = acc2.Id
-			So(msg2.Create(), ShouldBeNil)
+				// add message to the channel
+				// account is troll !!
+				_, erro := c.AddMessage(msg)
+				So(erro, ShouldBeNil)
 
-			// add message to the channel
-			// account is troll !!
-			_, erro := c.AddMessage(msg)
-			So(erro, ShouldBeNil)
+				_, erre := c.AddMessage(msg2)
+				So(erre, ShouldBeNil)
 
-			_, erre := c.AddMessage(msg2)
-			So(erre, ShouldBeNil)
+				cml := NewChannelMessageList()
+				cml.ChannelId = c.Id
 
-			cml := NewChannelMessageList()
-			cml.ChannelId = c.Id
-
-			// there is 2 message in the channel
-			// but one of the account of message is troll so;
-			// Count will not count this message
-			// messages of troll is not valid to count
-			cnt, err := cml.Count(cml.ChannelId)
-			So(err, ShouldBeNil)
-			So(cnt, ShouldEqual, 1)
+				// there is 2 message in the channel
+				// but one of the account of message is troll so;
+				// Count will not count this message
+				// messages of troll is not valid to count
+				cnt, err := cml.Count(cml.ChannelId)
+				So(err, ShouldBeNil)
+				So(cnt, ShouldEqual, 1)
+			})
 		})
 	})
 }
 
 func TestChannelMessageListisExempt(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("while testing is exempt", t, func() {
+			Convey("it should have error if message id is not set ", func() {
+				cml := NewChannelMessageList()
 
-	Convey("while testing is exempt", t, func() {
-		Convey("it should have error if message id is not set ", func() {
-			cml := NewChannelMessageList()
+				is, err := cml.isExempt()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrMessageIdIsNotSet)
+				So(is, ShouldEqual, false)
+			})
 
-			is, err := cml.isExempt()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrMessageIdIsNotSet)
-			So(is, ShouldEqual, false)
-		})
+			Convey("it should return true is channel is exempt", func() {
+				// create account as troll
+				acc := CreateAccountWithTest()
+				So(acc.MarkAsTroll(), ShouldBeNil)
 
-		Convey("it should return true is channel is exempt", func() {
-			// create account as troll
-			acc := CreateAccountWithTest()
-			err := acc.MarkAsTroll()
-			So(err, ShouldBeNil)
+				c := CreateChannelWithTest(acc.Id)
 
-			// create channel
-			c := createNewChannelWithTest()
-			c.CreatorId = acc.Id
+				// create message
+				msg := CreateMessageWithTest()
+				msg.AccountId = acc.Id
+				So(msg.Create(), ShouldBeNil)
 
-			// create message
-			msg := createMessageWithTest()
-			msg.AccountId = acc.Id
-			So(msg.Create(), ShouldBeNil)
+				cml := NewChannelMessageList()
+				cml.ChannelId = c.Id
+				cml.MessageId = msg.Id
 
-			cml := NewChannelMessageList()
-			cml.ChannelId = c.Id
-			cml.MessageId = msg.Id
+				is, err := cml.isExempt()
+				So(err, ShouldBeNil)
+				So(is, ShouldEqual, true)
+			})
 
-			is, err := cml.isExempt()
-			So(err, ShouldBeNil)
-			So(is, ShouldEqual, true)
-		})
+			Convey("it should return false is channel is not exempt", func() {
+				// create account as not troll
+				acc := CreateAccountWithTest()
+				acc.IsTroll = false
 
-		Convey("it should return false is channel is not exempt", func() {
-			// create account as not troll
-			acc := CreateAccountWithTest()
-			acc.IsTroll = false
+				c := CreateChannelWithTest(acc.Id)
+				c.CreatorId = acc.Id
 
-			// create channel
-			c := createNewChannelWithTest()
-			c.CreatorId = acc.Id
+				// create message
+				msg := CreateMessageWithTest()
+				msg.AccountId = acc.Id
+				So(msg.Create(), ShouldBeNil)
 
-			// create message
-			msg := createMessageWithTest()
-			msg.AccountId = acc.Id
-			So(msg.Create(), ShouldBeNil)
+				cml := NewChannelMessageList()
+				cml.ChannelId = c.Id
+				cml.MessageId = msg.Id
 
-			cml := NewChannelMessageList()
-			cml.ChannelId = c.Id
-			cml.MessageId = msg.Id
-
-			is, err := cml.isExempt()
-			So(err, ShouldBeNil)
-			So(is, ShouldEqual, false)
+				is, err := cml.isExempt()
+				So(err, ShouldBeNil)
+				So(is, ShouldEqual, false)
+			})
 		})
 	})
 }
 
 func TestChannelMessageListMarkIfExempt(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("while marking if channel is exempt", t, func() {
+			Convey("it should have error if message id is not set", func() {
+				cml := NewChannelMessageList()
 
-	Convey("while marking if channel is exempt", t, func() {
-		Convey("it should have error if message id is not set", func() {
-			cml := NewChannelMessageList()
+				err := cml.MarkIfExempt()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrMessageIdIsNotSet)
+			})
 
-			err := cml.MarkIfExempt()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrMessageIdIsNotSet)
+			Convey("it should mark as exempt if channel is exempt", func() {
+				// create account as troll
+				acc := CreateAccountWithTest()
+				err := acc.MarkAsTroll()
+				So(err, ShouldBeNil)
+
+				// create channel
+				c := CreateChannelWithTest(acc.Id)
+
+				// create message
+				msg := CreateMessageWithTest()
+				msg.AccountId = acc.Id
+				So(msg.Create(), ShouldBeNil)
+
+				cml := NewChannelMessageList()
+				cml.ChannelId = c.Id
+				cml.MessageId = msg.Id
+
+				errr := cml.MarkIfExempt()
+				So(errr, ShouldBeNil)
+			})
 		})
-
-		Convey("it should mark as exempt if channel is exempt", func() {
-			// create account as troll
-			acc := CreateAccountWithTest()
-			err := acc.MarkAsTroll()
-			So(err, ShouldBeNil)
-
-			// create channel
-			c := createNewChannelWithTest()
-			c.CreatorId = acc.Id
-
-			// create message
-			msg := createMessageWithTest()
-			msg.AccountId = acc.Id
-			So(msg.Create(), ShouldBeNil)
-
-			cml := NewChannelMessageList()
-			cml.ChannelId = c.Id
-			cml.MessageId = msg.Id
-
-			errr := cml.MarkIfExempt()
-			So(errr, ShouldBeNil)
-		})
-
 	})
 }
 
 func TestChannelMessageListUpdateAddedAt(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("while updating addedAt", t, func() {
+			Convey("it should have message id otherwise error occurs", func() {
+				cml := NewChannelMessageList()
 
-	Convey("while updating addedAt", t, func() {
-		Convey("it should have message id otherwise error occurs", func() {
-			cml := NewChannelMessageList()
+				err := cml.UpdateAddedAt(0, 1092)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrChannelOrMessageIdIsNotSet)
+			})
 
-			err := cml.UpdateAddedAt(0, 1092)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrChannelOrMessageIdIsNotSet)
-		})
+			Convey("it should have channel id otherwise error occurs", func() {
+				cml := NewChannelMessageList()
 
-		Convey("it should have channel id otherwise error occurs", func() {
-			cml := NewChannelMessageList()
+				err := cml.UpdateAddedAt(1091, 0)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrChannelOrMessageIdIsNotSet)
+			})
 
-			err := cml.UpdateAddedAt(1091, 0)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrChannelOrMessageIdIsNotSet)
-		})
+			Convey("it should have record not found error if channel id or message id does not exist", func() {
+				cml := NewChannelMessageList()
 
-		Convey("it should have record not found error if channel id or message id does not exist", func() {
-			cml := NewChannelMessageList()
+				err := cml.UpdateAddedAt(1091, 1092)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, bongo.RecordNotFound)
+			})
 
-			err := cml.UpdateAddedAt(1091, 1092)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, bongo.RecordNotFound)
-		})
+			Convey("it should not have error if update is done successfuly", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
 
-		Convey("it should not have error if update is done successfuly", func() {
-			// create account
-			acc := CreateAccountWithTest()
+				// create message
+				msg := CreateMessageWithTest()
+				msg.AccountId = acc.Id
+				So(msg.Create(), ShouldBeNil)
 
-			// create channel
-			c := createNewChannelWithTest()
-			c.CreatorId = acc.Id
-			So(c.Create(), ShouldBeNil)
+				_, erro := c.AddMessage(msg)
+				So(erro, ShouldBeNil)
 
-			// create message
-			msg := createMessageWithTest()
-			msg.AccountId = acc.Id
-			So(msg.Create(), ShouldBeNil)
+				cml := NewChannelMessageList()
+				cml.ChannelId = c.Id
+				cml.MessageId = msg.Id
 
-			_, erro := c.AddMessage(msg)
-			So(erro, ShouldBeNil)
-
-			cml := NewChannelMessageList()
-			cml.ChannelId = c.Id
-			cml.MessageId = msg.Id
-
-			err := cml.UpdateAddedAt(cml.ChannelId, cml.MessageId)
-			So(err, ShouldBeNil)
+				err := cml.UpdateAddedAt(cml.ChannelId, cml.MessageId)
+				So(err, ShouldBeNil)
+			})
 		})
 	})
 }
 
 func TestChannelMessageListUnreadCount(t *testing.T) {
-	r := runner.New("test")
-	defer r.Close()
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("while counting unread messages", t, func() {
+			Convey("it should have error if channel id is not set", func() {
+				cml := NewChannelMessageList()
+				cp := NewChannelParticipant()
 
-	Convey("while counting unread messages", t, func() {
-		Convey("it should have error if channel id is not set", func() {
-			cml := NewChannelMessageList()
-			cp := NewChannelParticipant()
+				cnt, err := cml.UnreadCount(cp)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrChannelIdIsNotSet)
+				So(cnt, ShouldEqual, 0)
+			})
 
-			cnt, err := cml.UnreadCount(cp)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrChannelIdIsNotSet)
-			So(cnt, ShouldEqual, 0)
-		})
+			Convey("it should have error if account id doesn't exist", func() {
+				cp := NewChannelParticipant()
+				cml := NewChannelMessageList()
+				cp.ChannelId = 1920
 
-		Convey("it should have error if account id doesn't exist", func() {
-			cp := NewChannelParticipant()
-			cml := NewChannelMessageList()
-			cp.ChannelId = 1920
+				cnt, err := cml.UnreadCount(cp)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrAccountIdIsNotSet)
+				So(cnt, ShouldEqual, 0)
+			})
 
-			cnt, err := cml.UnreadCount(cp)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrAccountIdIsNotSet)
-			So(cnt, ShouldEqual, 0)
-		})
+			Convey("it should have error if last seen time is zero", func() {
+				cml := NewChannelMessageList()
+				cp := NewChannelParticipant()
+				cp.ChannelId = 1920
+				cp.AccountId = 1903
+				cp.LastSeenAt = ZeroDate()
 
-		Convey("it should have error if last seen time is zero", func() {
-			cml := NewChannelMessageList()
-			cp := NewChannelParticipant()
-			cp.ChannelId = 1920
-			cp.AccountId = 1903
-			cp.LastSeenAt = ZeroDate()
+				cnt, err := cml.UnreadCount(cp)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrLastSeenAtIsNotSet)
+				So(cnt, ShouldEqual, 0)
+			})
 
-			cnt, err := cml.UnreadCount(cp)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrLastSeenAtIsNotSet)
-			So(cnt, ShouldEqual, 0)
-		})
+			Convey("it should count if participant is troll", func() {
+				// create account as troll
+				accTroll := CreateAccountWithTest()
+				So(accTroll.MarkAsTroll(), ShouldBeNil)
 
-		Convey("it should count if participant is troll", func() {
-			// create account as troll
-			accTroll := CreateAccountWithTest()
-			err := accTroll.MarkAsTroll()
-			So(err, ShouldBeNil)
+				c := CreateChannelWithTest(accTroll.Id)
 
-			// create channel
-			c := createNewChannelWithTest()
-			c.CreatorId = accTroll.Id
-			So(c.Create(), ShouldBeNil)
+				// create message
+				msg := CreateMessageWithTest()
+				msg.AccountId = accTroll.Id
+				So(msg.Create(), ShouldBeNil)
 
-			// create message
-			msg := createMessageWithTest()
-			msg.AccountId = accTroll.Id
-			So(msg.Create(), ShouldBeNil)
+				cml := NewChannelMessageList()
+				cml.ChannelId = c.Id
+				cml.MessageId = msg.Id
 
-			cml := NewChannelMessageList()
-			cml.ChannelId = c.Id
-			cml.MessageId = msg.Id
+				_, errs := c.AddParticipant(accTroll.Id)
+				So(errs, ShouldBeNil)
 
-			_, errs := c.AddParticipant(accTroll.Id)
-			So(errs, ShouldBeNil)
+				cp := NewChannelParticipant()
+				cp.ChannelId = c.Id
+				cp.AccountId = accTroll.Id
 
-			cp := NewChannelParticipant()
-			cp.ChannelId = c.Id
-			cp.AccountId = accTroll.Id
+				_, erre := c.AddMessage(msg)
+				So(erre, ShouldBeNil)
 
-			_, erre := c.AddMessage(msg)
-			So(erre, ShouldBeNil)
-
-			cnt, err := cml.UnreadCount(cp)
-			So(err, ShouldBeNil)
-			So(cnt, ShouldEqual, 1)
+				cnt, err := cml.UnreadCount(cp)
+				So(err, ShouldBeNil)
+				So(cnt, ShouldEqual, 1)
+			})
 		})
 	})
 }
 
 func TestChannelMessageListIsInChannel(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("while testing message is in channel", t, func() {
+			Convey("it should have error if message id doesn't exist", func() {
+				cml := NewChannelMessageList()
 
-	Convey("while testing message is in channel", t, func() {
-		Convey("it should have error if message id doesn't exist", func() {
-			cml := NewChannelMessageList()
+				ch, err := cml.IsInChannel(0, 1020)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrChannelOrMessageIdIsNotSet)
+				So(ch, ShouldEqual, false)
+			})
 
-			ch, err := cml.IsInChannel(0, 1020)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrChannelOrMessageIdIsNotSet)
-			So(ch, ShouldEqual, false)
-		})
+			Convey("it should have channel id, otherwise error occurs", func() {
+				cml := NewChannelMessageList()
 
-		Convey("it should have channel id, otherwise error occurs", func() {
-			cml := NewChannelMessageList()
+				ch, err := cml.IsInChannel(1040, 0)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrChannelOrMessageIdIsNotSet)
+				So(ch, ShouldEqual, false)
+			})
 
-			ch, err := cml.IsInChannel(1040, 0)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrChannelOrMessageIdIsNotSet)
-			So(ch, ShouldEqual, false)
-		})
+			Convey("it should have record not found error if message or channel id doesn't exist in db", func() {
+				cml := NewChannelMessageList()
 
-		Convey("it should have record not found error if message or channel id doesn't exist in db", func() {
-			cml := NewChannelMessageList()
+				ch, err := cml.IsInChannel(1091, 1092)
+				So(err, ShouldBeNil)
+				So(ch, ShouldEqual, false)
+			})
 
-			ch, err := cml.IsInChannel(1091, 1092)
-			So(err, ShouldBeNil)
-			So(ch, ShouldEqual, false)
-		})
+			Convey("it should return false if message is not in the channel", func() {
+				// create account as troll
+				accTroll := CreateAccountWithTest()
 
-		Convey("it should return false if message is not in the channel", func() {
-			// create account as troll
-			accTroll := CreateAccountWithTest()
+				// create channel
+				c := CreateChannelWithTest(accTroll.Id)
 
-			// create channel
-			c := createNewChannelWithTest()
-			c.CreatorId = accTroll.Id
-			So(c.Create(), ShouldBeNil)
+				// create message
+				msg := CreateMessageWithTest()
+				msg.AccountId = accTroll.Id
+				So(msg.Create(), ShouldBeNil)
 
-			// create message
-			msg := createMessageWithTest()
-			msg.AccountId = accTroll.Id
-			So(msg.Create(), ShouldBeNil)
+				// we created messsage
+				// but didn't add it to the channel
+				cml := NewChannelMessageList()
+				cml.ChannelId = c.Id
+				cml.MessageId = msg.Id
 
-			// we created messsage
-			// but didn't add it to the channel
-			cml := NewChannelMessageList()
-			cml.ChannelId = c.Id
-			cml.MessageId = msg.Id
+				ch, errr := cml.IsInChannel(cml.MessageId, cml.ChannelId)
+				So(errr, ShouldBeNil)
+				So(ch, ShouldEqual, false)
+			})
 
-			ch, errr := cml.IsInChannel(cml.MessageId, cml.ChannelId)
-			So(errr, ShouldBeNil)
-			So(ch, ShouldEqual, false)
-		})
+			Convey("it should return true if message is in the channel", func() {
+				// create account as troll
+				acc := CreateAccountWithTest()
 
-		Convey("it should return true if message is in the channel", func() {
-			// create account as troll
-			acc := CreateAccountWithTest()
+				// create channel
+				c := CreateChannelWithTest(acc.Id)
 
-			// create channel
-			c := createNewChannelWithTest()
-			c.CreatorId = acc.Id
-			So(c.Create(), ShouldBeNil)
+				// create message
+				msg := CreateMessageWithTest()
+				msg.AccountId = acc.Id
+				So(msg.Create(), ShouldBeNil)
 
-			// create message
-			msg := createMessageWithTest()
-			msg.AccountId = acc.Id
-			So(msg.Create(), ShouldBeNil)
+				_, err := c.AddMessage(msg)
+				So(err, ShouldBeNil)
 
-			_, err := c.AddMessage(msg)
-			So(err, ShouldBeNil)
+				cml := NewChannelMessageList()
+				cml.ChannelId = c.Id
+				cml.MessageId = msg.Id
 
-			cml := NewChannelMessageList()
-			cml.ChannelId = c.Id
-			cml.MessageId = msg.Id
-
-			ch, errr := cml.IsInChannel(cml.MessageId, cml.ChannelId)
-			So(errr, ShouldBeNil)
-			So(ch, ShouldEqual, true)
+				ch, errr := cml.IsInChannel(cml.MessageId, cml.ChannelId)
+				So(errr, ShouldBeNil)
+				So(ch, ShouldEqual, true)
+			})
 		})
 	})
 }
 
 func TestChannelMessageListFetchMessageChannelIds(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("while fetching message channel ids", t, func() {
+			Convey("it should have message id otherwise error occurs", func() {
+				cml := NewChannelMessageList()
 
-	Convey("while fetching message channel ids", t, func() {
-		Convey("it should have message id otherwise error occurs", func() {
-			cml := NewChannelMessageList()
+				fm, err := cml.FetchMessageChannelIds(0)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrMessageIdIsNotSet)
+				So(fm, ShouldEqual, nil)
+			})
 
-			fm, err := cml.FetchMessageChannelIds(0)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrMessageIdIsNotSet)
-			So(fm, ShouldEqual, nil)
+			// Convey("it should ", func() {
+			// 	cml := NewChannelMessageList()
+			// 	cml.MessageId = 1982
+
+			// 	fm, err := cml.FetchMessageChannelIds(cml.MessageId)
+			// 	// So(err, ShouldNotBeNil)
+			// 	So(err, ShouldEqual, bongo.RecordNotFound)
+			// 	So(fm, ShouldEqual, nil)
+			// })
 		})
-
-		// Convey("it should ", func() {
-		// 	cml := NewChannelMessageList()
-		// 	cml.MessageId = 1982
-
-		// 	fm, err := cml.FetchMessageChannelIds(cml.MessageId)
-		// 	// So(err, ShouldNotBeNil)
-		// 	So(err, ShouldEqual, bongo.RecordNotFound)
-		// 	So(fm, ShouldEqual, nil)
-		// })
 	})
 }

--- a/go/src/socialapi/models/channelparticipant_test.go
+++ b/go/src/socialapi/models/channelparticipant_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"socialapi/workers/common/tests"
 	"testing"
 	"time"
 
@@ -45,527 +46,447 @@ func TestChannelParticipantBongoName(t *testing.T) {
 }
 
 func TestChannelParticipantBeforeUpdate(t *testing.T) {
-	Convey("While testing before update", t, func() {
-		Convey("LastSeenAt should be updated", func() {
-			lastSeenAt := time.Now().UTC()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("While testing before update", t, func() {
+			Convey("LastSeenAt should be updated", func() {
+				lastSeenAt := time.Now().UTC()
 
-			account, err := createAccount()
-			So(err, ShouldBeNil)
-			So(account, ShouldNotBeNil)
-			So(account.Id, ShouldNotEqual, 0)
+				account, err := createAccount()
+				So(err, ShouldBeNil)
+				So(account, ShouldNotBeNil)
+				So(account.Id, ShouldNotEqual, 0)
 
-			c := NewChannelParticipant()
-			c.LastSeenAt = lastSeenAt
-			c.AccountId = account.Id
+				c := NewChannelParticipant()
+				c.LastSeenAt = lastSeenAt
+				c.AccountId = account.Id
 
-			// call before update
-			err = c.BeforeUpdate()
+				// call before update
+				err = c.BeforeUpdate()
 
-			// make sure err is nil
-			So(err, ShouldBeNil)
-			// check preset last seen at is not same after calling
-			// before update function
-			So(c.LastSeenAt, ShouldNotEqual, lastSeenAt)
+				// make sure err is nil
+				So(err, ShouldBeNil)
+				// check preset last seen at is not same after calling
+				// before update function
+				So(c.LastSeenAt, ShouldNotEqual, lastSeenAt)
+			})
 		})
 	})
 }
 
 func TestChannelParticipantCheckAccountStatus(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("While testing account status", t, func() {
+			Convey("it should have channel id", func() {
+				cp := NewChannelParticipant()
+				ip, err := cp.IsParticipant(1123)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrChannelIdIsNotSet)
+				So(ip, ShouldEqual, false)
+			})
 
-	Convey("While testing account status", t, func() {
-		Convey("it should have channel id", func() {
-			cp := NewChannelParticipant()
+			Convey("it should return false if account does not exist", func() {
+				cp := NewChannelParticipant()
+				cp.ChannelId = 120
 
-			ip, err := cp.IsParticipant(1123)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrChannelIdIsNotSet)
-			So(ip, ShouldEqual, false)
-		})
+				ip, err := cp.IsParticipant(112345)
+				So(err, ShouldBeNil)
+				So(ip, ShouldEqual, false)
+			})
 
-		Convey("it should return false if account is not exist", func() {
-			cp := NewChannelParticipant()
-			cp.ChannelId = 120
+			Convey("it should not have error if account is exist", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
 
-			ip, err := cp.IsParticipant(112345)
-			So(err, ShouldBeNil)
-			So(ip, ShouldEqual, false)
-		})
+				cp := NewChannelParticipant()
+				cp.ChannelId = c.Id
+				cp.AccountId = acc.Id
+				err := cp.Create()
+				So(err, ShouldBeNil)
 
-		Convey("it should not have error if account is exist", func() {
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
-			acc := CreateAccountWithTest()
-			So(acc.Create(), ShouldBeNil)
-			cp := NewChannelParticipant()
-			cp.ChannelId = c.Id
-			cp.AccountId = acc.Id
-			So(cp.Create(), ShouldBeNil)
+				ip, err := c.IsParticipant(acc.Id)
+				So(err, ShouldBeNil)
+				So(ip, ShouldEqual, true)
+				So(cp.StatusConstant, ShouldEqual, ChannelParticipant_STATUS_ACTIVE)
+			})
 
-			_, err := c.AddParticipant(acc.Id)
+			Convey("it should return true for pending participant", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
 
-			ip, err := cp.IsParticipant(acc.Id)
-			So(err, ShouldBeNil)
-			So(ip, ShouldEqual, true)
-			So(cp.StatusConstant, ShouldEqual, ChannelParticipant_STATUS_ACTIVE)
-		})
-		Convey("it should return true for pending participant", func() {
+				cp := NewChannelParticipant()
+				cp.ChannelId = c.Id
+				cp.AccountId = acc.Id
+				cp.StatusConstant = ChannelParticipant_STATUS_REQUEST_PENDING
+				So(cp.Create(), ShouldBeNil)
 
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
-			acc := CreateAccountWithTest()
-			So(acc.Create(), ShouldBeNil)
-			cp := NewChannelParticipant()
-			cp.ChannelId = c.Id
-			cp.AccountId = acc.Id
-			cp.StatusConstant = ChannelParticipant_STATUS_REQUEST_PENDING
-			So(cp.Create(), ShouldBeNil)
-
-			ip, err := cp.IsInvited(acc.Id)
-			So(err, ShouldBeNil)
-			So(ip, ShouldEqual, true)
-			So(cp.StatusConstant, ShouldEqual, ChannelParticipant_STATUS_REQUEST_PENDING)
+				ip, err := cp.IsInvited(acc.Id)
+				So(err, ShouldBeNil)
+				So(ip, ShouldEqual, true)
+				So(cp.StatusConstant, ShouldEqual, ChannelParticipant_STATUS_REQUEST_PENDING)
+			})
 		})
 	})
 }
 
 func TestChannelParticipantBlock(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("While testing blocking a participant", t, func() {
+			Convey("it should have channel id", func() {
+				cp := NewChannelParticipant()
 
-	Convey("While testing blocking a participant", t, func() {
-		Convey("it should have channel id", func() {
-			cp := NewChannelParticipant()
+				err := cp.Block()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrChannelIdIsNotSet)
+			})
 
-			err := cp.Block()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrChannelIdIsNotSet)
-		})
+			Convey("it should return false if account is not exist", func() {
+				cp := NewChannelParticipant()
+				cp.ChannelId = 120
 
-		Convey("it should return false if account is not exist", func() {
-			cp := NewChannelParticipant()
-			cp.ChannelId = 120
+				err := cp.Block()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrAccountIdIsNotSet)
+			})
 
-			err := cp.Block()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrAccountIdIsNotSet)
-		})
+			Convey("it should not have error if account is exist", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
 
-		Convey("it should not have error if account is exist", func() {
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
-			acc := CreateAccountWithTest()
-			So(acc.Create(), ShouldBeNil)
-			cp, err := c.AddParticipant(acc.Id)
-			So(err, ShouldBeNil)
-			So(cp, ShouldNotBeNil)
-			err = cp.Block()
-			So(err, ShouldBeNil)
+				cp, err := c.AddParticipant(acc.Id)
+				So(err, ShouldBeNil)
+				So(cp, ShouldNotBeNil)
+				err = cp.Block()
+				So(err, ShouldBeNil)
 
-			// fetch the updated participant
-			So(cp.FetchParticipant(), ShouldBeNil)
-			So(cp.StatusConstant, ShouldEqual, ChannelParticipant_STATUS_BLOCKED)
+				// fetch the updated participant
+				So(cp.FetchParticipant(), ShouldBeNil)
+				So(cp.StatusConstant, ShouldEqual, ChannelParticipant_STATUS_BLOCKED)
+			})
 		})
 	})
 }
 
 func TestChannelParticipantFetchParticipantCount(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("While fetching participant count", t, func() {
+			Convey("it should have channel id", func() {
+				cp := NewChannelParticipant()
 
-	Convey("While fetching participant count", t, func() {
-		Convey("it should have channel id", func() {
-			cp := NewChannelParticipant()
+				_, err := cp.FetchParticipantCount()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrChannelIdIsNotSet)
+			})
 
-			_, err := cp.FetchParticipantCount()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrChannelIdIsNotSet)
-		})
+			Convey("it should have zero value if account is not exist in the channel", func() {
+				cp := NewChannelParticipant()
+				cp.ChannelId = 2442
 
-		Convey("it should have zero value if account is not exist in the channel", func() {
-			cp := NewChannelParticipant()
-			cp.ChannelId = 2442
+				fp, err := cp.FetchParticipantCount()
+				So(err, ShouldBeNil)
+				So(fp, ShouldEqual, 0)
+			})
 
-			fp, err := cp.FetchParticipantCount()
-			So(err, ShouldBeNil)
-			So(fp, ShouldEqual, 0)
-		})
+			Convey("it should return participant count successfully", func() {
+				acc := CreateAccountWithTest()
+				acc1 := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
 
-		Convey("it should return participant count successfully", func() {
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
-			acc := CreateAccountWithTest()
-			So(acc.Create(), ShouldBeNil)
-			acc1 := CreateAccountWithTest()
-			So(acc1.Create(), ShouldBeNil)
-			cp := NewChannelParticipant()
-			cp.ChannelId = c.Id
-			cp.AccountId = acc.Id
-			So(cp.Create(), ShouldBeNil)
+				AddParticipantsWithTest(c.Id, acc.Id, acc1.Id)
 
-			c.AddParticipant(acc.Id)
-			c.AddParticipant(acc1.Id)
+				cp := NewChannelParticipant()
+				cp.ChannelId = c.Id
 
-			ip, err := cp.FetchParticipantCount()
-			So(err, ShouldBeNil)
-			So(ip, ShouldNotEqual, 2)
-
+				ip, err := cp.FetchParticipantCount()
+				So(err, ShouldBeNil)
+				So(ip, ShouldEqual, 2)
+			})
 		})
 	})
-
 }
 
 func TestChannelParticipantgetAccountId(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("While getting account id", t, func() {
+			Convey("it should have channel id", func() {
+				cp := NewChannelParticipant()
 
-	Convey("While getting account id", t, func() {
-		Convey("it should have channel id", func() {
-			cp := NewChannelParticipant()
+				gai, err := cp.getAccountId()
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "couldnt find accountId from content")
+				So(gai, ShouldEqual, 0)
+			})
 
-			gai, err := cp.getAccountId()
-			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldContainSubstring, "couldnt find accountId from content")
-			So(gai, ShouldEqual, 0)
+			Convey("it should have error if account is not exist", func() {
+				cp := NewChannelParticipant()
+				cp.Id = 123145
+
+				gai, err := cp.getAccountId()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, bongo.RecordNotFound)
+				So(gai, ShouldEqual, 0)
+			})
+
+			Convey("it should return account id if account is exist", func() {
+				// create account
+				acc := CreateAccountWithTest()
+				So(acc.Create(), ShouldBeNil)
+
+				cp := NewChannelParticipant()
+				cp.Id = 1201
+				cp.AccountId = acc.Id
+
+				gai, err := cp.getAccountId()
+				So(err, ShouldBeNil)
+				So(gai, ShouldEqual, acc.Id)
+			})
 		})
-
-		Convey("it should have error if account is not exist", func() {
-			cp := NewChannelParticipant()
-			cp.Id = 123145
-
-			gai, err := cp.getAccountId()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, bongo.RecordNotFound)
-			So(gai, ShouldEqual, 0)
-		})
-
-		Convey("it should return account id if account is exist", func() {
-			// create account
-			acc := CreateAccountWithTest()
-			So(acc.Create(), ShouldBeNil)
-
-			cp := NewChannelParticipant()
-			cp.Id = 1201
-			cp.AccountId = acc.Id
-
-			gai, err := cp.getAccountId()
-			So(err, ShouldBeNil)
-			So(gai, ShouldEqual, acc.Id)
-		})
-
 	})
-
 }
 
 func TestChannelParticipantFetchParticipant(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("While fetching participant", t, func() {
+			Convey("it should have error if channel id is not set", func() {
+				cp := NewChannelParticipant()
 
-	Convey("While fetching participant", t, func() {
-		Convey("it should have error if channel id is not set", func() {
-			cp := NewChannelParticipant()
+				err := cp.FetchParticipant()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrChannelIdIsNotSet)
+			})
 
-			err := cp.FetchParticipant()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrChannelIdIsNotSet)
-		})
+			Convey("it should have error if account id is not set", func() {
+				cp := NewChannelParticipant()
+				cp.ChannelId = 1453
 
-		Convey("it should have error if account id is not set", func() {
-			cp := NewChannelParticipant()
-			cp.ChannelId = 1453
+				err := cp.FetchParticipant()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrAccountIdIsNotSet)
+			})
 
-			err := cp.FetchParticipant()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrAccountIdIsNotSet)
-		})
+			Convey("it should have error if account is not exist", func() {
+				cp := NewChannelParticipant()
+				cp.ChannelId = 1453
+				cp.AccountId = 1454
 
-		Convey("it should have error if account is not exist", func() {
-			cp := NewChannelParticipant()
-			cp.ChannelId = 1453
-			cp.AccountId = 1454
+				err := cp.FetchParticipant()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, bongo.RecordNotFound)
+			})
 
-			err := cp.FetchParticipant()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, bongo.RecordNotFound)
-		})
+			Convey("it should not have any error if account is exist in channel", func() {
+				// create account
+				acc := CreateAccountWithTest()
 
-		Convey("it should not have any error if account is exist in channel", func() {
-			// create account
-			acc := CreateAccountWithTest()
-			So(acc.Create(), ShouldBeNil)
+				// create channel
+				c := CreateChannelWithTest(acc.Id)
 
-			// create channel
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
+				AddParticipantsWithTest(c.Id, acc.Id)
 
-			_, errr := c.AddParticipant(acc.Id)
-			So(errr, ShouldBeNil)
+				cp := NewChannelParticipant()
+				cp.ChannelId = c.Id
+				cp.AccountId = acc.Id
 
-			cp := NewChannelParticipant()
-			cp.ChannelId = c.Id
-			cp.AccountId = acc.Id
-
-			err := cp.FetchParticipant()
-			So(err, ShouldBeNil)
+				err := cp.FetchParticipant()
+				So(err, ShouldBeNil)
+			})
 		})
 	})
 }
 
 func TestChannelParticipantFetchActiveParticipant(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("While fetching active participant", t, func() {
+			Convey("it should have error if channel id is not set", func() {
+				cp := NewChannelParticipant()
 
-	Convey("While fetching active participant", t, func() {
-		Convey("it should have error if channel id is not set", func() {
-			cp := NewChannelParticipant()
+				err := cp.FetchParticipant()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrChannelIdIsNotSet)
+			})
 
-			err := cp.FetchParticipant()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrChannelIdIsNotSet)
+			Convey("it should return active participant successfully", func() {
+				acc := CreateAccountWithTest()
+				c := CreateChannelWithTest(acc.Id)
+				_, errr := c.AddParticipant(acc.Id)
+				So(errr, ShouldBeNil)
+
+				cp := NewChannelParticipant()
+				cp.ChannelId = c.Id
+				cp.AccountId = acc.Id
+
+				err := cp.FetchActiveParticipant()
+				So(err, ShouldBeNil)
+			})
+
+			Convey("it should have error if account is not exist in channel", func() {
+				// create account
+				acc := CreateAccountWithTest()
+				// create channel
+				c := CreateChannelWithTest(acc.Id)
+
+				_, errr := c.AddParticipant(acc.Id)
+				So(errr, ShouldBeNil)
+
+				erro := c.RemoveParticipant(acc.Id)
+				So(erro, ShouldBeNil)
+
+				cp := NewChannelParticipant()
+				cp.ChannelId = c.Id
+				cp.AccountId = acc.Id
+
+				err := cp.FetchActiveParticipant()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, bongo.RecordNotFound)
+			})
 		})
-
-		Convey("it should return active participant successfully", func() {
-			// create account
-			acc := CreateAccountWithTest()
-			So(acc.Create(), ShouldBeNil)
-
-			// create channel
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
-
-			_, errr := c.AddParticipant(acc.Id)
-			So(errr, ShouldBeNil)
-
-			cp := NewChannelParticipant()
-			cp.ChannelId = c.Id
-			cp.AccountId = acc.Id
-
-			err := cp.FetchActiveParticipant()
-			So(err, ShouldBeNil)
-		})
-
-		Convey("it should have error if account is not exist in channel", func() {
-			// create account
-			acc := CreateAccountWithTest()
-			So(acc.Create(), ShouldBeNil)
-
-			// create channel
-			c := createNewChannelWithTest()
-			So(c.Create(), ShouldBeNil)
-
-			_, errr := c.AddParticipant(acc.Id)
-			So(errr, ShouldBeNil)
-
-			erro := c.RemoveParticipant(acc.Id)
-			So(erro, ShouldBeNil)
-
-			cp := NewChannelParticipant()
-			cp.ChannelId = c.Id
-			cp.AccountId = acc.Id
-
-			err := cp.FetchActiveParticipant()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, bongo.RecordNotFound)
-		})
-
 	})
 }
 
 func TestChannelParticipantMarkIfExempt(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("While marking if participant is exempt", t, func() {
+			Convey("it should be nil if participant is already exempt", func() {
+				// create account
+				acc := CreateAccountWithTest()
+				acc.IsTroll = true
+				So(acc.Update(), ShouldBeNil)
 
-	Convey("While marking if participant is exempt", t, func() {
-		Convey("it should be nil if participant is already exempt", func() {
-			// create account
-			acc := CreateAccountWithTest()
-			acc.IsTroll = true
-			So(acc.Update(), ShouldBeNil)
+				c := CreateChannelWithTest(acc.Id)
+				c.CreatorId = acc.Id
+				So(c.Create(), ShouldBeNil)
 
-			c := createNewChannelWithTest()
-			c.CreatorId = acc.Id
-			So(c.Create(), ShouldBeNil)
+				msg := CreateMessageWithTest()
+				msg.AccountId = acc.Id
+				So(msg.Create(), ShouldBeNil)
 
-			msg := createMessageWithTest()
-			msg.AccountId = acc.Id
-			So(msg.Create(), ShouldBeNil)
+				_, errs := c.AddMessage(msg)
+				So(errs, ShouldBeNil)
 
-			_, errs := c.AddMessage(msg)
-			So(errs, ShouldBeNil)
+				cp := NewChannelParticipant()
+				cp.ChannelId = c.Id
+				cp.AccountId = acc.Id
 
-			cp := NewChannelParticipant()
-			cp.ChannelId = c.Id
-			cp.AccountId = acc.Id
+				_, erro := c.AddParticipant(acc.Id)
+				So(erro, ShouldBeNil)
 
-			_, erro := c.AddParticipant(acc.Id)
-			So(erro, ShouldBeNil)
+				err := cp.MarkIfExempt()
+				So(err, ShouldBeNil)
+			})
 
-			err := cp.MarkIfExempt()
-			So(err, ShouldBeNil)
+			Convey("it should have error if account is not set", func() {
+				// create account
+				acc := CreateAccountWithTest()
+				acc.IsTroll = false
+				So(acc.Update(), ShouldBeNil)
+
+				c := CreateChannelWithTest(acc.Id)
+
+				cp := NewChannelParticipant()
+				cp.ChannelId = c.Id
+
+				err := cp.MarkIfExempt()
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "couldnt find accountId from content")
+			})
 		})
+	})
+}
 
-		Convey("it should have error if account is not set", func() {
+func TestChannelFetchAllParticipatedChannelIds(t *testing.T) {
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("fetching all channels of an account should succeed", t, func() {
 			// create account
 			acc := CreateAccountWithTest()
 			acc.IsTroll = false
 			So(acc.Update(), ShouldBeNil)
 
-			c := createNewChannelWithTest()
-			c.CreatorId = acc.Id
-			So(c.Create(), ShouldBeNil)
+			for i := 0; i < 10; i++ {
+				c := CreateChannelWithTest(acc.Id)
+				c.CreatorId = acc.Id
+				So(c.Create(), ShouldBeNil)
+
+				_, err := c.AddParticipant(acc.Id)
+				So(err, ShouldBeNil)
+			}
 
 			cp := NewChannelParticipant()
-			cp.ChannelId = c.Id
-
-			err := cp.MarkIfExempt()
-			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldContainSubstring, "couldnt find accountId from content")
-		})
-
-	})
-}
-
-func TestChannelFetchAllParticipatedChannelIds(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
-
-	Convey("fetching all channels of an account should succeed", t, func() {
-		// create account
-		acc := CreateAccountWithTest()
-		acc.IsTroll = false
-		So(acc.Update(), ShouldBeNil)
-
-		for i := 0; i < 10; i++ {
-			c := createNewChannelWithTest()
-			c.CreatorId = acc.Id
-			So(c.Create(), ShouldBeNil)
-
-			_, err := c.AddParticipant(acc.Id)
+			ids, err := cp.FetchAllParticipatedChannelIds(acc.Id)
 			So(err, ShouldBeNil)
-		}
-
-		cp := NewChannelParticipant()
-		ids, err := cp.FetchAllParticipatedChannelIds(acc.Id)
-		So(err, ShouldBeNil)
-		So(len(ids), ShouldEqual, 10)
+			So(len(ids), ShouldEqual, 10)
+		})
 	})
 }
 
 func TestChannelFetchAllParticipatedChannelIdsInGroup(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("fetching all channels of an account by group name should succeed", t, func() {
+			// create account
+			acc := CreateAccountWithTest()
+			acc.IsTroll = false
+			So(acc.Update(), ShouldBeNil)
 
-	Convey("fetching all channels of an account by group name should succeed", t, func() {
-		// create account
-		acc := CreateAccountWithTest()
-		acc.IsTroll = false
-		So(acc.Update(), ShouldBeNil)
+			groupName1 := RandomGroupName()
+			groupName2 := RandomGroupName()
+			for i := 0; i < 5; i++ {
+				c := CreateTypedGroupedChannelWithTest(acc.Id, Channel_TYPE_TOPIC, groupName1)
+				AddParticipantsWithTest(c.Id, acc.Id)
+			}
 
-		groupName1 := RandomGroupName()
-		groupName2 := RandomGroupName()
-		for i := 0; i < 5; i++ {
-			c := createNewChannelWithTest()
-			c.CreatorId = acc.Id
-			c.GroupName = groupName1
-			So(c.Create(), ShouldBeNil)
+			for i := 0; i < 5; i++ {
+				c := CreateTypedGroupedChannelWithTest(acc.Id, Channel_TYPE_TOPIC, groupName2)
+				AddParticipantsWithTest(c.Id, acc.Id)
+			}
 
-			_, err := c.AddParticipant(acc.Id)
+			cp := NewChannelParticipant()
+			ids, err := cp.FetchAllParticipatedChannelIdsInGroup(acc.Id, groupName1)
 			So(err, ShouldBeNil)
-		}
+			So(len(ids), ShouldEqual, 5)
 
-		for i := 0; i < 5; i++ {
-			c := createNewChannelWithTest()
-			c.CreatorId = acc.Id
-			c.GroupName = groupName2
-			So(c.Create(), ShouldBeNil)
-
-			_, err := c.AddParticipant(acc.Id)
-			So(err, ShouldBeNil)
-		}
-
-		cp := NewChannelParticipant()
-		ids, err := cp.FetchAllParticipatedChannelIdsInGroup(acc.Id, groupName1)
-		So(err, ShouldBeNil)
-		So(len(ids), ShouldEqual, 5)
-
-		Convey("fetching non participated channel, should return 0", func() {
-			ids, err := cp.FetchAllParticipatedChannelIdsInGroup(acc.Id, RandomGroupName())
-			So(err, ShouldBeNil)
-			So(len(ids), ShouldEqual, 0)
+			Convey("fetching non participated channel, should return 0", func() {
+				ids, err := cp.FetchAllParticipatedChannelIdsInGroup(acc.Id, RandomGroupName())
+				So(err, ShouldBeNil)
+				So(len(ids), ShouldEqual, 0)
+			})
 		})
 	})
 }
 
 func TestChannelParticipantisExempt(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("While testing channel participant is exempt or not", t, func() {
+			Convey("it should have error while getting account id from db when channel id is not set", func() {
+				cp := NewChannelParticipant()
 
-	Convey("While testing channel participant is exempt or not", t, func() {
-		Convey("it should have error while getting account id from db when channel id is not set", func() {
-			cp := NewChannelParticipant()
+				ex, err := cp.isExempt()
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "couldnt find accountId from content")
+				So(ex, ShouldEqual, false)
+			})
 
-			ex, err := cp.isExempt()
-			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldContainSubstring, "couldnt find accountId from content")
-			So(ex, ShouldEqual, false)
+			Convey("it should return true if participant is troll", func() {
+				// create account
+				acc := CreateAccountWithTest()
+				So(acc.MarkAsTroll(), ShouldBeNil)
+
+				cp := NewChannelParticipant()
+				cp.AccountId = acc.Id
+
+				ex, err := cp.isExempt()
+				So(err, ShouldBeNil)
+				So(ex, ShouldEqual, true)
+			})
+
+			Convey("it should return true if participant is not troll", func() {
+				// create account
+				acc := CreateAccountWithTest()
+
+				cp := NewChannelParticipant()
+				cp.AccountId = acc.Id
+
+				ex, err := cp.isExempt()
+				So(err, ShouldBeNil)
+				So(ex, ShouldEqual, false)
+			})
 		})
-
-		Convey("it should return true if participant is troll", func() {
-			// create account
-			acc := CreateAccountWithTest()
-			err := acc.MarkAsTroll()
-			So(err, ShouldBeNil)
-
-			cp := NewChannelParticipant()
-			cp.AccountId = acc.Id
-
-			ex, err := cp.isExempt()
-			So(err, ShouldBeNil)
-			So(ex, ShouldEqual, true)
-		})
-
-		Convey("it should return true if participant is not troll", func() {
-			// create account
-			acc := CreateAccountWithTest()
-
-			cp := NewChannelParticipant()
-			cp.AccountId = acc.Id
-
-			ex, err := cp.isExempt()
-			So(err, ShouldBeNil)
-			So(ex, ShouldEqual, false)
-		})
-
 	})
 }

--- a/go/src/socialapi/models/helpers.go
+++ b/go/src/socialapi/models/helpers.go
@@ -104,10 +104,10 @@ func CreateMessageWithBody(channelId, accountId int64, typeConstant, body string
 	err := cm.Create()
 	So(err, ShouldBeNil)
 
-	cml := NewChannelMessageList()
-	cml.MessageId = cm.Id
-	cml.ChannelId = channelId
-	So(cml.Create(), ShouldBeNil)
+	c := NewChannel()
+	c.Id = channelId
+	_, err = c.EnsureMessage(cm, false)
+	So(err, ShouldBeNil)
 
 	return cm
 }
@@ -182,24 +182,13 @@ func createChannel(accountId int64) (*Channel, error) {
 	return channel, nil
 }
 
-func createMessageWithTest() *ChannelMessage {
+func CreateMessageWithTest() *ChannelMessage {
+	account := CreateAccountWithTest()
+	channel := CreateChannelWithTest(account.Id)
+
 	cm := NewChannelMessage()
-
-	// init account
-	account, err := createAccount()
-	So(err, ShouldBeNil)
-	So(account, ShouldNotBeNil)
-	So(account.Id, ShouldNotEqual, 0)
-	// init channel
-	channel, err := createChannel(account.Id)
-	So(err, ShouldBeNil)
-	So(channel, ShouldNotBeNil)
-
-	// set account id
 	cm.AccountId = account.Id
-	// set channel id
 	cm.InitialChannelId = channel.Id
-	// set body
 	cm.Body = "5five"
 	return cm
 }

--- a/go/src/socialapi/models/interaction_test.go
+++ b/go/src/socialapi/models/interaction_test.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 	"socialapi/config"
 	"socialapi/request"
+	"socialapi/workers/common/tests"
 	"strconv"
 	"testing"
 	"time"
@@ -15,255 +16,231 @@ import (
 )
 
 func TestInteractiongetAccountId(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("while getting account id", t, func() {
+			Convey("it should have error if interaction id is not set", func() {
+				i := NewInteraction()
 
-	Convey("while getting account id", t, func() {
-		Convey("it should have error if interaction id is not set", func() {
-			i := NewInteraction()
+				in, err := i.getAccountId()
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "couldnt find accountId from content")
+				So(in, ShouldEqual, 0)
+			})
 
-			in, err := i.getAccountId()
-			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldContainSubstring, "couldnt find accountId from content")
-			So(in, ShouldEqual, 0)
-		})
+			Convey("it should have error if account is not set in db", func() {
+				i := NewInteraction()
+				i.Id = 4590
 
-		Convey("it should have error if account is not set in db", func() {
-			i := NewInteraction()
-			i.Id = 4590
+				in, err := i.getAccountId()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, bongo.RecordNotFound)
+				So(in, ShouldEqual, 0)
+			})
 
-			in, err := i.getAccountId()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, bongo.RecordNotFound)
-			So(in, ShouldEqual, 0)
-		})
+			Convey("it should return quickly account id if id is set", func() {
+				i := NewInteraction()
+				i.AccountId = 1020
 
-		Convey("it should return quickly account id if id is set", func() {
-			i := NewInteraction()
-			i.AccountId = 1020
-
-			in, err := i.getAccountId()
-			So(err, ShouldBeNil)
-			So(in, ShouldEqual, i.AccountId)
+				in, err := i.getAccountId()
+				So(err, ShouldBeNil)
+				So(in, ShouldEqual, i.AccountId)
+			})
 		})
 	})
 }
 
 func TestInteractionListLikedMessage(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		config.MustRead(r.Conf.Path)
+		Convey("while creating requirements", t, func() {
+			account := CreateAccountWithTest()
+			kodingGroup := "koding"
 
-	config.MustRead(r.Conf.Path)
+			channel := CreateTypedGroupedChannelWithTest(account.Id, Channel_TYPE_GROUP, kodingGroup)
 
-	Convey("while creating requirements", t, func() {
-		account := CreateAccountWithTest()
-		kodingGroup := "koding"
+			message1 := CreateMessageWithBody(channel.Id, account.Id, ChannelMessage_TYPE_POST, "bisiler")
+			message2 := CreateMessageWithBody(channel.Id, account.Id, ChannelMessage_TYPE_POST, "bisiler22")
 
-		channel := CreateTypedGroupedChannelWithTest(account.Id, Channel_TYPE_GROUP, kodingGroup)
+			query := request.NewQuery()
+			query.AccountId = account.Id
+			query.Type = Interaction_TYPE_LIKE
 
-		message1 := CreateMessageWithBody(channel.Id, account.Id, ChannelMessage_TYPE_POST, "bisiler")
-		message2 := CreateMessageWithBody(channel.Id, account.Id, ChannelMessage_TYPE_POST, "bisiler22")
-
-		query := request.NewQuery()
-		query.AccountId = account.Id
-		query.Type = Interaction_TYPE_LIKE
-
-		int1, err := AddInteractionWithTest(Interaction_TYPE_LIKE, message1.Id, account.Id)
-		So(int1, ShouldNotBeNil)
-		So(err, ShouldBeNil)
-		int2, err := AddInteractionWithTest(Interaction_TYPE_LIKE, message2.Id, account.Id)
-		So(int2, ShouldNotBeNil)
-		So(err, ShouldBeNil)
-
-		Convey("it should list the message ids that liked", func() {
-			i := NewInteraction()
-			messageIds, err := i.ListLikedMessageIds(query, channel.Id)
-			So(messageIds, ShouldNotBeNil)
+			int1, err := AddInteractionWithTest(Interaction_TYPE_LIKE, message1.Id, account.Id)
+			So(int1, ShouldNotBeNil)
 			So(err, ShouldBeNil)
-			So(len(messageIds), ShouldEqual, 2)
-		})
+			int2, err := AddInteractionWithTest(Interaction_TYPE_LIKE, message2.Id, account.Id)
+			So(int2, ShouldNotBeNil)
+			So(err, ShouldBeNil)
 
-		Convey("it should list the messages that liked", func() {
-			messages, err := NewInteraction().ListLikedMessages(query, channel.Id)
-			So(err, ShouldBeNil)
-			So(messages, ShouldNotBeNil)
-			So(messages[1].Body, ShouldEqual, message1.Body) // last liked will be listed as first
-		})
+			Convey("it should list the message ids that liked", func() {
+				i := NewInteraction()
+				messageIds, err := i.ListLikedMessageIds(query, channel.Id)
+				So(messageIds, ShouldNotBeNil)
+				So(err, ShouldBeNil)
+				So(len(messageIds), ShouldEqual, 2)
+			})
 
-		Convey("it should fetch the messages even if type is not same ", func() {
-			channel2 := CreateTypedGroupedChannelWithTest(account.Id, Channel_TYPE_TOPIC, kodingGroup)
-			message3 := CreateMessageWithBody(channel2.Id, account.Id, ChannelMessage_TYPE_POST, "topic-not topic ?")
-			int3, err := AddInteractionWithTest(Interaction_TYPE_LIKE, message3.Id, account.Id)
-			So(int3, ShouldNotBeNil)
-			So(err, ShouldBeNil)
-			i := NewInteraction()
-			messageIds, err := i.ListLikedMessageIds(query, channel2.Id)
-			So(messageIds, ShouldNotBeNil)
-			So(err, ShouldBeNil)
-			So(len(messageIds), ShouldEqual, 1)
-		})
+			Convey("it should list the messages that liked", func() {
+				messages, err := NewInteraction().ListLikedMessages(query, channel.Id)
+				So(err, ShouldBeNil)
+				So(messages, ShouldNotBeNil)
+				So(messages[1].Body, ShouldEqual, message1.Body) // last liked will be listed as first
+			})
 
-		Convey("it should not fetch the messages if group is different ", func() {
-			// 2 messages is sent the group84 & 2 msg sent to groupKoding,
-			// we should only fetch 2 messages in group84, not messages in the groupKoding
-			rand.Seed(time.Now().UnixNano())
-			group84 := "group" + strconv.Itoa(rand.Intn(10e9))
-			channel2 := CreateTypedGroupedChannelWithTest(account.Id, Channel_TYPE_GROUP, group84)
-			message4 := CreateMessageWithBody(channel2.Id, account.Id, ChannelMessage_TYPE_POST, "GroupSeksenDort")
-			message5 := CreateMessageWithBody(channel2.Id, account.Id, ChannelMessage_TYPE_POST, "GroupSeksenDort-5")
-			int4, err := AddInteractionWithTest(Interaction_TYPE_LIKE, message4.Id, account.Id)
-			So(int4, ShouldNotBeNil)
-			So(err, ShouldBeNil)
-			int5, err := AddInteractionWithTest(Interaction_TYPE_LIKE, message5.Id, account.Id)
-			So(int5, ShouldNotBeNil)
-			So(err, ShouldBeNil)
-			i := NewInteraction()
-			messageIds, err := i.ListLikedMessageIds(query, channel2.Id)
-			So(messageIds, ShouldNotBeNil)
-			So(err, ShouldBeNil)
-			So(len(messageIds), ShouldEqual, 2)
-		})
+			Convey("it should fetch the messages even if type is not same ", func() {
+				channel2 := CreateTypedGroupedChannelWithTest(account.Id, Channel_TYPE_TOPIC, kodingGroup)
+				message3 := CreateMessageWithBody(channel2.Id, account.Id, ChannelMessage_TYPE_POST, "topic-not topic ?")
+				int3, err := AddInteractionWithTest(Interaction_TYPE_LIKE, message3.Id, account.Id)
+				So(int3, ShouldNotBeNil)
+				So(err, ShouldBeNil)
+				i := NewInteraction()
+				messageIds, err := i.ListLikedMessageIds(query, channel2.Id)
+				So(messageIds, ShouldNotBeNil)
+				So(err, ShouldBeNil)
+				So(len(messageIds), ShouldEqual, 1)
+			})
 
-		Convey("it should not fetch the messages if message is troll", func() {
-			// Normally, we have 3 messages(2 message is exist above),
-			// but one of the messages is troll message,
-			// so, we should fetch 2 messages, not troll message
-			messageTroll := CreateTrollMessage(channel.Id, account.Id, ChannelMessage_TYPE_POST)
-			int6, err := AddInteractionWithTest(Interaction_TYPE_LIKE, messageTroll.Id, account.Id)
-			So(int6, ShouldNotBeNil)
-			So(err, ShouldBeNil)
-			i := NewInteraction()
-			messageIds, err := i.ListLikedMessageIds(query, channel.Id)
-			So(messageIds, ShouldNotBeNil)
-			So(err, ShouldBeNil)
-			So(len(messageIds), ShouldEqual, 2)
+			Convey("it should not fetch the messages if group is different ", func() {
+				// 2 messages is sent the group84 & 2 msg sent to groupKoding,
+				// we should only fetch 2 messages in group84, not messages in the groupKoding
+				rand.Seed(time.Now().UnixNano())
+				group84 := "group" + strconv.Itoa(rand.Intn(10e9))
+				channel2 := CreateTypedGroupedChannelWithTest(account.Id, Channel_TYPE_GROUP, group84)
+				message4 := CreateMessageWithBody(channel2.Id, account.Id, ChannelMessage_TYPE_POST, "GroupSeksenDort")
+				message5 := CreateMessageWithBody(channel2.Id, account.Id, ChannelMessage_TYPE_POST, "GroupSeksenDort-5")
+				int4, err := AddInteractionWithTest(Interaction_TYPE_LIKE, message4.Id, account.Id)
+				So(int4, ShouldNotBeNil)
+				So(err, ShouldBeNil)
+				int5, err := AddInteractionWithTest(Interaction_TYPE_LIKE, message5.Id, account.Id)
+				So(int5, ShouldNotBeNil)
+				So(err, ShouldBeNil)
+				i := NewInteraction()
+				messageIds, err := i.ListLikedMessageIds(query, channel2.Id)
+				So(messageIds, ShouldNotBeNil)
+				So(err, ShouldBeNil)
+				So(len(messageIds), ShouldEqual, 2)
+			})
+
+			Convey("it should not fetch the messages if message is troll", func() {
+				// Normally, we have 3 messages(2 message is exist above),
+				// but one of the messages is troll message,
+				// so, we should fetch 2 messages, not troll message
+				messageTroll := CreateTrollMessage(channel.Id, account.Id, ChannelMessage_TYPE_POST)
+				int6, err := AddInteractionWithTest(Interaction_TYPE_LIKE, messageTroll.Id, account.Id)
+				So(int6, ShouldNotBeNil)
+				So(err, ShouldBeNil)
+				i := NewInteraction()
+				messageIds, err := i.ListLikedMessageIds(query, channel.Id)
+				So(messageIds, ShouldNotBeNil)
+				So(err, ShouldBeNil)
+				So(len(messageIds), ShouldEqual, 2)
+			})
 		})
 	})
 }
 
 func TestInteractionisExempt(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("While testing interaction is exempt or not", t, func() {
+			Convey("it should have error while getting account id from db when channel id is not set", func() {
+				i := NewInteraction()
 
-	Convey("While testing interaction is exempt or not", t, func() {
-		Convey("it should have error while getting account id from db when channel id is not set", func() {
-			i := NewInteraction()
+				ie, err := i.isExempt()
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "couldnt find accountId from content")
+				So(ie, ShouldEqual, false)
+			})
 
-			ie, err := i.isExempt()
-			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldContainSubstring, "couldnt find accountId from content")
-			So(ie, ShouldEqual, false)
+			Convey("it should have error if account id is not set", func() {
+				i := NewInteraction()
+				i.Id = 1098
+
+				ie, err := i.isExempt()
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, bongo.RecordNotFound)
+				So(ie, ShouldEqual, false)
+			})
+
+			Convey("it should return true if account is troll", func() {
+				// create troll account
+				accTroll := CreateAccountWithTest()
+				err := accTroll.MarkAsTroll()
+				So(err, ShouldBeNil)
+
+				i := NewInteraction()
+				i.AccountId = accTroll.Id
+
+				ie, err := i.isExempt()
+				So(err, ShouldBeNil)
+				So(ie, ShouldEqual, true)
+			})
+
+			Convey("it should return false if account is not troll", func() {
+				// create account
+				acc := CreateAccountWithTest()
+
+				i := NewInteraction()
+				i.AccountId = acc.Id
+
+				ie, err := i.isExempt()
+				So(err, ShouldBeNil)
+				So(ie, ShouldEqual, false)
+			})
 		})
-
-		Convey("it should have error if account id is not set", func() {
-			i := NewInteraction()
-			i.Id = 1098
-
-			ie, err := i.isExempt()
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, bongo.RecordNotFound)
-			So(ie, ShouldEqual, false)
-		})
-
-		Convey("it should return true if account is troll", func() {
-			// create troll account
-			accTroll := CreateAccountWithTest()
-			err := accTroll.MarkAsTroll()
-			So(err, ShouldBeNil)
-
-			i := NewInteraction()
-			i.AccountId = accTroll.Id
-
-			ie, err := i.isExempt()
-			So(err, ShouldBeNil)
-			So(ie, ShouldEqual, true)
-		})
-
-		Convey("it should return false if account is not troll", func() {
-			// create account
-			acc := CreateAccountWithTest()
-
-			i := NewInteraction()
-			i.AccountId = acc.Id
-
-			ie, err := i.isExempt()
-			So(err, ShouldBeNil)
-			So(ie, ShouldEqual, false)
-		})
-
 	})
 }
 
 func TestInteractionMarkIfExempt(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("While marking if interaction isexempt ", t, func() {
+			Convey("it should return nil if exempt", func() {
+				accTroll := CreateAccountWithTest()
+				err := accTroll.MarkAsTroll()
+				So(err, ShouldBeNil)
 
-	Convey("While marking if interaction isexempt ", t, func() {
-		Convey("it should return nil if exempt", func() {
-			accTroll := CreateAccountWithTest()
-			err := accTroll.MarkAsTroll()
-			So(err, ShouldBeNil)
+				msg := CreateMessageWithTest()
+				So(msg.Create(), ShouldBeNil)
 
-			msg := createMessageWithTest()
-			So(msg.Create(), ShouldBeNil)
+				i := NewInteraction()
+				i.AccountId = accTroll.Id
+				i.MessageId = msg.Id
 
-			i := NewInteraction()
-			i.AccountId = accTroll.Id
-			i.MessageId = msg.Id
-
-			errs := i.MarkIfExempt()
-			So(errs, ShouldBeNil)
+				errs := i.MarkIfExempt()
+				So(errs, ShouldBeNil)
+			})
 		})
-
 	})
 }
 
 func TestInteractionIsInteracted(t *testing.T) {
-	r := runner.New("test")
-	if err := r.Init(); err != nil {
-		t.Fatalf("couldnt start bongo %s", err.Error())
-	}
-	defer r.Close()
+	tests.WithRunner(t, func(r *runner.Runner) {
+		Convey("while testing account is interacted", t, func() {
+			Convey("it should have error if message id is not set", func() {
+				i := NewInteraction()
 
-	Convey("while testing account is interacted", t, func() {
-		Convey("it should have error if message id is not set", func() {
-			i := NewInteraction()
+				cnt, err := i.IsInteracted(0)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldEqual, ErrMessageIdIsNotSet)
+				So(cnt, ShouldEqual, false)
+			})
 
-			cnt, err := i.IsInteracted(0)
-			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, ErrMessageIdIsNotSet)
-			So(cnt, ShouldEqual, false)
+			Convey("it should return false if account id is not set", func() {
+				i := NewInteraction()
+				i.MessageId = 1050
+
+				cnt, err := i.IsInteracted(0)
+				So(err, ShouldBeNil)
+				So(cnt, ShouldEqual, false)
+			})
+
+			Convey("it should return false&nil if account id is not found in db", func() {
+				i := NewInteraction()
+				i.MessageId = 1050
+
+				cnt, err := i.IsInteracted(10209)
+				So(err, ShouldBeNil)
+				So(cnt, ShouldEqual, false)
+			})
 		})
-
-		Convey("it should return false if account id is not set", func() {
-			i := NewInteraction()
-			i.MessageId = 1050
-
-			cnt, err := i.IsInteracted(0)
-			So(err, ShouldBeNil)
-			So(cnt, ShouldEqual, false)
-		})
-
-		Convey("it should return false&nil if account id is not found in db", func() {
-			i := NewInteraction()
-			i.MessageId = 1050
-
-			cnt, err := i.IsInteracted(10209)
-			So(err, ShouldBeNil)
-			So(cnt, ShouldEqual, false)
-		})
-
 	})
 }

--- a/go/src/socialapi/models/timesegmentor_test.go
+++ b/go/src/socialapi/models/timesegmentor_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestTimeSegmentor(t *testing.T) {
-
 	Convey("time segmentor should not fail", t, func() {
 		ts := NewTimeSegmentor(30)
 		expectedSegment := time.Now().Minute() / 30

--- a/go/src/socialapi/models/utils_test.go
+++ b/go/src/socialapi/models/utils_test.go
@@ -3,7 +3,6 @@ package models
 import "testing"
 
 func TestUnifyStringSlice(t *testing.T) {
-
 	testData := []struct {
 		slice    []string
 		expected []string

--- a/go/src/socialapi/workers/algoliaconnector/algoliaconnector/account.go
+++ b/go/src/socialapi/workers/algoliaconnector/algoliaconnector/account.go
@@ -43,7 +43,7 @@ func (f *Controller) AccountUpdated(data *models.Account) error {
 
 	record, err := f.get(IndexAccounts, data.OldId)
 	if err != nil &&
-		!IsAlgoliaError(err, ErrAlgoliaObjectIdNotFoundMsg) &&
+		!IsAlgoliaError(err, ErrAlgoliaObjectIDNotFoundMsg) &&
 		!IsAlgoliaError(err, ErrAlgoliaIndexNotExistMsg) {
 		return err
 	}
@@ -141,7 +141,7 @@ func (f *Controller) handleParticipantOperation(p *models.ChannelParticipant) er
 
 	record, err := f.get(IndexAccounts, a.OldId)
 	if err != nil &&
-		!IsAlgoliaError(err, ErrAlgoliaObjectIdNotFoundMsg) &&
+		!IsAlgoliaError(err, ErrAlgoliaObjectIDNotFoundMsg) &&
 		!IsAlgoliaError(err, ErrAlgoliaIndexNotExistMsg) {
 		return err
 	}

--- a/go/src/socialapi/workers/algoliaconnector/algoliaconnector/algoliaconnector.go
+++ b/go/src/socialapi/workers/algoliaconnector/algoliaconnector/algoliaconnector.go
@@ -24,7 +24,7 @@ const (
 )
 
 var (
-	ErrAlgoliaObjectIdNotFoundMsg = "ObjectID does not exist"
+	ErrAlgoliaObjectIDNotFoundMsg = "ObjectID does not exist"
 	ErrAlgoliaIndexNotExistMsg    = "Index messages.test does not exist"
 
 	ErrTimeoutForSettings = errors.New("settings timed out")

--- a/go/src/socialapi/workers/algoliaconnector/algoliaconnector/algoliaconnector_test.go
+++ b/go/src/socialapi/workers/algoliaconnector/algoliaconnector/algoliaconnector_test.go
@@ -2,17 +2,13 @@ package algoliaconnector
 
 import (
 	"koding/db/mongodb/modelhelper"
-	"math/rand"
 	"socialapi/config"
 	"socialapi/models"
-	"strconv"
 	"testing"
 	"time"
 
 	"github.com/algolia/algoliasearch-client-go/algoliasearch"
-	"github.com/koding/bongo"
 	"github.com/koding/runner"
-	"labix.org/v2/mgo/bson"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -268,39 +264,6 @@ func makeSureSynonyms(handler *Controller, indexName string, f func([][]string, 
 	}
 }
 
-func createAccount() (*models.Account, error) {
-	// create and account instance
-	author := models.NewAccount()
-
-	// create a fake mongo id
-	oldId := bson.NewObjectId()
-	// assign it to our test user
-	author.OldId = oldId.Hex()
-
-	// seed the random data generator
-	rand.Seed(time.Now().UnixNano())
-
-	author.Nick = "malitest" + strconv.Itoa(rand.Intn(10e9))
-
-	if err := author.Create(); err != nil {
-		return nil, err
-	}
-
-	return author, nil
-}
-
-func createChannel(accountId int64) (*models.Channel, error) {
-	// create and account instance
-	channel := models.NewChannel()
-	channel.CreatorId = accountId
-
-	if err := channel.Create(); err != nil {
-		return nil, err
-	}
-
-	return channel, nil
-}
-
 func createChannelMessageList(channelId, messageId int64) *models.ChannelMessageList {
 	cml := models.NewChannelMessageList()
 
@@ -310,39 +273,4 @@ func createChannelMessageList(channelId, messageId int64) *models.ChannelMessage
 	So(cml.Create(), ShouldBeNil)
 
 	return cml
-}
-
-func createAndSaveMessage() (*models.ChannelMessage, *models.Account) {
-	cm := models.NewChannelMessage()
-
-	// init account
-	account, err := createAccount()
-	So(err, ShouldBeNil)
-	So(account, ShouldNotBeNil)
-	So(account.Id, ShouldNotEqual, 0)
-	// init channel
-	channel, err := createChannel(account.Id)
-	So(err, ShouldBeNil)
-	So(channel, ShouldNotBeNil)
-	// set account id
-	cm.AccountId = account.Id
-	// set channel id
-	cm.InitialChannelId = channel.Id
-	// set body
-	cm.Body = "5five"
-	So(cm.Create(), ShouldBeNil)
-	// init listing
-	cml := createChannelMessageList(channel.Id, cm.Id)
-	So(cml, ShouldNotBeNil)
-
-	return cm, account
-}
-
-func getListings(message *models.ChannelMessage) []models.ChannelMessageList {
-	mockListing := models.NewChannelMessageList()
-	var listings []models.ChannelMessageList
-	err := mockListing.Some(&listings, &bongo.Query{
-		Selector: map[string]interface{}{"message_id": message.Id}})
-	So(err, ShouldBeNil)
-	return listings
 }

--- a/go/src/socialapi/workers/algoliaconnector/algoliaconnector/channel_test.go
+++ b/go/src/socialapi/workers/algoliaconnector/algoliaconnector/channel_test.go
@@ -102,7 +102,7 @@ func TestChannelUpdated(t *testing.T) {
 					So(err, ShouldBeNil)
 
 					err = makeSureChannel(handler, mockTopic.Id, func(record map[string]interface{}, err error) bool {
-						if IsAlgoliaError(err, ErrAlgoliaObjectIdNotFoundMsg) {
+						if IsAlgoliaError(err, ErrAlgoliaObjectIDNotFoundMsg) {
 							return true
 						}
 

--- a/go/src/socialapi/workers/algoliaconnector/algoliaconnector/helpers.go
+++ b/go/src/socialapi/workers/algoliaconnector/algoliaconnector/helpers.go
@@ -55,6 +55,39 @@ func (f *Controller) partialUpdate(indexName string, record map[string]interface
 	return nil
 }
 
+// AddUniqueTag Adds a number or string element to an array based-attribute if it doesn’t exist
+func (f *Controller) AddUniqueTag(indexName string, objectID, value interface{}) error {
+	return f.partialUpdate(indexName, map[string]interface{}{
+		"objectID": objectID,
+		"_tags": map[string]interface{}{
+			"_operation": "AddUnique",
+			"value":      value,
+		},
+	})
+}
+
+// RemoveTag Removes the first element from an array-based attribute
+func (f *Controller) RemoveTag(indexName string, objectID, value interface{}) error {
+	return f.partialUpdate(indexName, map[string]interface{}{
+		"objectID": objectID,
+		"_tags": map[string]interface{}{
+			"_operation": "Remove",
+			"value":      value,
+		},
+	})
+}
+
+// AddTag Appends a number or string element to an array-based attribute
+func (f *Controller) AddTag(indexName string, objectID, value interface{}) error {
+	return f.partialUpdate(indexName, map[string]interface{}{
+		"objectID": objectID,
+		"_tags": map[string]interface{}{
+			"_operation": "Add",
+			"value":      value,
+		},
+	})
+}
+
 func appendTag(record map[string]interface{}, channelId string) []interface{} {
 	if record == nil {
 		return []interface{}{channelId}

--- a/go/src/socialapi/workers/algoliaconnector/algoliaconnector/message_test.go
+++ b/go/src/socialapi/workers/algoliaconnector/algoliaconnector/message_test.go
@@ -1,6 +1,7 @@
 package algoliaconnector
 
 import (
+	"socialapi/models"
 	"strconv"
 	"testing"
 	"time"
@@ -12,131 +13,134 @@ func TestMessageListSaved(t *testing.T) {
 	runner, handler := getTestHandler()
 	defer runner.Close()
 
-	Convey("messages can be saved", t, func() {
-		mockMessage, _ := createAndSaveMessage()
-		mockListing := getListings(mockMessage)[0]
+	Convey("while testing message list save", t, func() {
+		account := models.CreateAccountWithTest()
+		channel := models.CreateChannelWithTest(account.Id)
+		cm := models.CreateMessage(channel.Id, account.Id, models.ChannelMessage_TYPE_POST)
 
-		So(handler.MessageListSaved(&mockListing), ShouldBeNil)
-		So(doBasicTestForMessage(handler, mockListing.MessageId), ShouldBeNil)
-	})
+		Convey("messages can be saved", func() {
+			cmls, err := cm.GetChannelMessageLists()
+			So(err, ShouldBeNil)
+			So(len(cmls), ShouldBeGreaterThan, 0)
 
-	Convey("messages can be cross-indexed", t, func() {
-		mockMessage, owner := createAndSaveMessage()
-
-		// init channel
-		cm, err := createChannel(owner.Id)
-		So(err, ShouldBeNil)
-		So(cm, ShouldNotBeNil)
-		// init channel message list
-		cml := createChannelMessageList(cm.Id, mockMessage.Id)
-		So(cml, ShouldNotBeNil)
-
-		listings := getListings(mockMessage)
-		So(len(listings), ShouldEqual, 2)
-
-		So(handler.MessageListSaved(&listings[0]), ShouldBeNil)
-		So(doBasicTestForMessage(handler, listings[0].MessageId), ShouldBeNil)
-
-		So(handler.MessageListSaved(&listings[1]), ShouldBeNil)
-		err = makeSureMessage(handler, listings[1].MessageId, func(record map[string]interface{}, err error) bool {
-			if err != nil {
-				return false
-			}
-
-			if len((record["_tags"]).([]interface{})) != 2 {
-				return false
-			}
-
-			return true
+			So(handler.MessageListSaved(&cmls[0]), ShouldBeNil)
+			So(doBasicTestForMessage(handler, cmls[0].MessageId), ShouldBeNil)
 		})
-		So(err, ShouldBeNil)
+
+		Convey("messages can be cross-indexed", func() {
+			c1 := models.CreateChannelWithTest(account.Id)
+			_, err := c1.AddMessage(cm)
+			So(err, ShouldBeNil)
+
+			cmls, err := cm.GetChannelMessageLists()
+			So(err, ShouldBeNil)
+			So(len(cmls), ShouldEqual, 2)
+
+			So(handler.MessageListSaved(&cmls[0]), ShouldBeNil)
+			So(doBasicTestForMessage(handler, cmls[0].MessageId), ShouldBeNil)
+
+			So(handler.MessageListSaved(&cmls[1]), ShouldBeNil)
+			err = makeSureMessage(handler, cmls[1].MessageId, func(record map[string]interface{}, err error) bool {
+				if err != nil {
+					return false
+				}
+
+				if len((record["_tags"]).([]interface{})) != 2 {
+					return false
+				}
+
+				return true
+			})
+			So(err, ShouldBeNil)
+		})
 	})
 }
 
 func TestMessageListDeleted(t *testing.T) {
 	runner, handler := getTestHandler()
 	defer runner.Close()
+	Convey("while testing message list delete", t, func() {
 
-	Convey("messages can be deleted", t, func() {
-		mockMessage, _ := createAndSaveMessage()
-		mockListing := getListings(mockMessage)[0]
+		account := models.CreateAccountWithTest()
+		channel := models.CreateChannelWithTest(account.Id)
+		cm := models.CreateMessage(channel.Id, account.Id, models.ChannelMessage_TYPE_POST)
 
-		So(handler.MessageListSaved(&mockListing), ShouldBeNil)
-		So(doBasicTestForMessage(handler, mockListing.MessageId), ShouldBeNil)
+		Convey("messages can be deleted", func() {
+			cmls, err := cm.GetChannelMessageLists()
+			So(err, ShouldBeNil)
+			So(len(cmls), ShouldBeGreaterThan, 0)
 
-		So(handler.MessageListDeleted(&mockListing), ShouldBeNil)
-		err := makeSureMessage(handler, mockListing.MessageId, func(record map[string]interface{}, err error) bool {
-			if err == nil {
-				return false
-			}
+			So(handler.MessageListSaved(&cmls[0]), ShouldBeNil)
+			So(doBasicTestForMessage(handler, cmls[0].MessageId), ShouldBeNil)
 
-			if record != nil {
-				return false
-			}
+			So(handler.MessageListDeleted(&cmls[0]), ShouldBeNil)
+			err = makeSureMessage(handler, cmls[0].MessageId, func(record map[string]interface{}, err error) bool {
+				if err == nil {
+					return false
+				}
 
-			return true
-		})
-		So(err, ShouldBeNil)
-	})
+				if record != nil {
+					return false
+				}
 
-	Convey("cross-indexed messages will not be deleted", t, func() {
-		mockMessage, owner := createAndSaveMessage()
-
-		// init channel
-		cm, err := createChannel(owner.Id)
-		So(err, ShouldBeNil)
-		So(cm, ShouldNotBeNil)
-		// init channel message list
-		cml := createChannelMessageList(cm.Id, mockMessage.Id)
-		So(cml, ShouldNotBeNil)
-
-		listings := getListings(mockMessage)
-		So(len(listings), ShouldEqual, 2)
-
-		So(handler.MessageListSaved(&listings[0]), ShouldBeNil)
-		err = makeSureMessage(handler, listings[0].MessageId, func(record map[string]interface{}, err error) bool {
-			if err != nil {
-				return false
-			}
-
-			if len((record["_tags"]).([]interface{})) != 1 {
-				return false
-			}
-
-			return true
-		})
-		So(err, ShouldBeNil)
-
-		So(handler.MessageListSaved(&listings[1]), ShouldBeNil)
-
-		err = makeSureMessage(handler, listings[1].MessageId, func(record map[string]interface{}, err error) bool {
-			if err != nil {
-				return false
-			}
-
-			if len((record["_tags"]).([]interface{})) != 2 {
-				return false
-			}
-
-			return true
-		})
-		So(err, ShouldBeNil)
-
-		So(handler.MessageListDeleted(&listings[1]), ShouldBeNil)
-
-		err = makeSureMessage(handler, listings[1].MessageId, func(record map[string]interface{}, err error) bool {
-			if err != nil {
-				return false
-			}
-
-			if len((record["_tags"]).([]interface{})) != 1 {
-				return false
-			}
-
-			return true
+				return true
+			})
+			So(err, ShouldBeNil)
 		})
 
-		So(err, ShouldBeNil)
+		Convey("cross-indexed messages will not be deleted", func() {
+			channel := models.CreateChannelWithTest(account.Id)
+			channel.AddMessage(cm)
+
+			cmls, err := cm.GetChannelMessageLists()
+			So(err, ShouldBeNil)
+			So(len(cmls), ShouldEqual, 2)
+
+			So(handler.MessageListSaved(&cmls[0]), ShouldBeNil)
+			err = makeSureMessage(handler, cmls[0].MessageId, func(record map[string]interface{}, err error) bool {
+				if err != nil {
+					return false
+				}
+
+				if len((record["_tags"]).([]interface{})) != 1 {
+					return false
+				}
+
+				return true
+			})
+			So(err, ShouldBeNil)
+
+			So(handler.MessageListSaved(&cmls[1]), ShouldBeNil)
+
+			err = makeSureMessage(handler, cmls[1].MessageId, func(record map[string]interface{}, err error) bool {
+				if err != nil {
+					return false
+				}
+
+				if len((record["_tags"]).([]interface{})) != 2 {
+					return false
+				}
+
+				return true
+			})
+			So(err, ShouldBeNil)
+
+			So(handler.MessageListDeleted(&cmls[1]), ShouldBeNil)
+
+			err = makeSureMessage(handler, cmls[1].MessageId, func(record map[string]interface{}, err error) bool {
+				if err != nil {
+					return false
+				}
+
+				if len((record["_tags"]).([]interface{})) != 1 {
+					return false
+				}
+
+				return true
+			})
+
+			So(err, ShouldBeNil)
+		})
 	})
 }
 
@@ -145,11 +149,16 @@ func TestMessageUpdated(t *testing.T) {
 	defer runner.Close()
 
 	Convey("messages can be updated", t, func() {
-		mockMessage, _ := createAndSaveMessage()
-		mockListing := getListings(mockMessage)[0]
+		account := models.CreateAccountWithTest()
+		channel := models.CreateChannelWithTest(account.Id)
+		cm := models.CreateMessage(channel.Id, account.Id, models.ChannelMessage_TYPE_POST)
 
-		So(handler.MessageListSaved(&mockListing), ShouldBeNil)
-		err := makeSureMessage(handler, mockListing.MessageId, func(record map[string]interface{}, err error) bool {
+		cmls, err := cm.GetChannelMessageLists()
+		So(err, ShouldBeNil)
+		So(len(cmls), ShouldBeGreaterThan, 0)
+
+		So(handler.MessageListSaved(&cmls[0]), ShouldBeNil)
+		err = makeSureMessage(handler, cmls[0].MessageId, func(record map[string]interface{}, err error) bool {
 			if err != nil {
 				return false
 			}
@@ -158,11 +167,11 @@ func TestMessageUpdated(t *testing.T) {
 		})
 		So(err, ShouldBeNil)
 
-		mockMessage.Body = "updated body"
+		cm.Body = "updated body"
 
-		So(mockMessage.Update(), ShouldBeNil)
-		So(handler.MessageUpdated(mockMessage), ShouldBeNil)
-		err = makeSureMessage(handler, mockListing.MessageId, func(record map[string]interface{}, err error) bool {
+		So(cm.Update(), ShouldBeNil)
+		So(handler.MessageUpdated(cm), ShouldBeNil)
+		err = makeSureMessage(handler, cmls[0].MessageId, func(record map[string]interface{}, err error) bool {
 			if err != nil {
 				return false
 			}
@@ -191,6 +200,36 @@ func doBasicTestForMessage(handler *Controller, id int64) error {
 	})
 }
 
+func ensureMessageWithTag(handler *Controller, id int64, tag string) error {
+	return makeSureMessage(handler, id, func(record map[string]interface{}, err error) bool {
+		if err != nil {
+			return false
+		}
+
+		if record == nil {
+			return false
+		}
+
+		tags, ok := record["_tags"]
+		if !ok {
+			return false
+		}
+
+		tis, ok := tags.([]interface{})
+		if !ok {
+			return false
+		}
+
+		for _, t := range tis {
+			if t.(string) == tag {
+				return true
+			}
+		}
+
+		return false
+	})
+}
+
 // makeSureMessage checks if the given id's get request returns the desired err, it
 // will re-try every 100ms until deadline of 15 seconds reached. Algolia doesnt
 // index the records right away, so try to go to a desired state
@@ -206,8 +245,7 @@ func makeSureMessage(handler *Controller, id int64, f func(map[string]interface{
 			}
 		case <-deadLine:
 			handler.log.Critical("deadline reached on message but not returning an error")
-			// return errDeadline
-			return nil
+			return errDeadline
 		}
 	}
 }


### PR DESCRIPTION
- Most of the CL is refactoring and indentation issues
- Major thing this PR adds is as explained here https://www.algolia.com/doc/rest#partially-update-an-object updating the object tags atomically with this helper functions, is seems previously we had so many race conditions while adding/updating accounts 
