### PR TITLE
Permissions and social worker improvements for plan support [#107284362] [#105996682]

### DIFF
--- a/client/admin/lib/views/stacks/definestackview.coffee
+++ b/client/admin/lib/views/stacks/definestackview.coffee
@@ -343,8 +343,11 @@ module.exports = class DefineStackView extends KDView
 
     showCredentialContent = (credential) =>
       credential.fetchData (err, data) =>
-        return failed err  if err
-        @outputView.add JSON.stringify data.meta, null, 2
+        if err?.name is 'AccessDenied'
+          @outputView.add "Couldn't fetch credential data, not shared."
+        else
+          return failed err  if err
+          @outputView.add JSON.stringify data.meta, null, 2
         callback null, [credential]
 
     @outputView

--- a/client/app/lib/activity/sidebar/sidebarstackmachinelist.coffee
+++ b/client/app/lib/activity/sidebar/sidebarstackmachinelist.coffee
@@ -27,7 +27,6 @@ module.exports = class SidebarStackMachineList extends SidebarOwnMachineList
 
     computeController
       .on 'StackRevisionChecked', @bound 'onStackRevisionChecked'
-      .on 'StacksInconsistent',   @bound 'addStackModifiedWarning'
 
 
   onStackRevisionChecked: (stack) ->
@@ -49,17 +48,3 @@ module.exports = class SidebarStackMachineList extends SidebarOwnMachineList
     super
 
     @addSubView @warningWrapper = new kd.CustomHTMLView
-
-
-  addStackModifiedWarning: (stack) ->
-
-    return  if stack.getId() isnt @getOption('stack').getId()
-    return  @stackModifiedWarning.show()  if @stackModifiedWarning?
-
-    @stackModifiedWarning = new kd.CustomHTMLView
-      cssClass : 'warning-section re-init'
-      partial  : "You have different resources in your stack.
-                  <span>Click here</span> to re-initialize this stack."
-      click    : -> new EnvironmentsModal
-
-    @warningWrapper.addSubView @stackModifiedWarning

--- a/workers/social/lib/social/models/computeproviders/credential.coffee
+++ b/workers/social/lib/social/models/computeproviders/credential.coffee
@@ -220,7 +220,7 @@ module.exports = class JCredential extends jraphical.Module
   fetchUsers: permit
 
     advanced: [
-      { permission: 'modify credential' }
+      # { permission: 'modify credential' }
       { permission: 'update credential', validateWith: Validators.own }
     ]
 
@@ -299,7 +299,7 @@ module.exports = class JCredential extends jraphical.Module
   shareWith$: permit
 
     advanced: [
-      { permission: 'modify credential' }
+      # { permission: 'modify credential' }
       { permission: 'update credential', validateWith: Validators.own }
     ]
 
@@ -336,7 +336,7 @@ module.exports = class JCredential extends jraphical.Module
   clone: permit
 
     advanced: [
-      { permission: 'modify credential' }
+      # { permission: 'modify credential' }
       { permission: 'update credential', validateWith: Validators.own }
     ]
 
@@ -388,7 +388,7 @@ module.exports = class JCredential extends jraphical.Module
   fetchData$: permit
 
     advanced: [
-      { permission: 'modify credential' }
+      # { permission: 'modify credential' }
       { permission: 'update credential', validateWith: Validators.own }
     ]
 
@@ -400,7 +400,7 @@ module.exports = class JCredential extends jraphical.Module
   update$: permit
 
     advanced: [
-      { permission: 'modify credential' }
+      # { permission: 'modify credential' }
       { permission: 'update credential', validateWith: Validators.own }
     ]
 
@@ -429,8 +429,7 @@ module.exports = class JCredential extends jraphical.Module
   isBootstrapped: permit
 
     advanced: [
-      { permission: 'modify credential' }
-      { permission: 'update credential', validateWith: Validators.own }
+      { permission: 'update credential' } # , validateWith: Validators.own }
     ]
 
     success: (client, callback) ->

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -296,8 +296,7 @@ module.exports = class JStackTemplate extends Module
         # Keep last updater info in the template details
         data.template.details.lastUpdaterId = delegate.getId()
 
-        data.meta = @getAt 'meta'
-        data.meta.modifiedAt = new Date
+        data['meta.modifiedAt'] = new Date
 
       @update { $set: data }, (err) => callback err, this
 

--- a/workers/social/lib/social/models/group/permissionset.coffee
+++ b/workers/social/lib/social/models/group/permissionset.coffee
@@ -83,13 +83,10 @@ module.exports = class JPermissionSet extends Module
     # permission = [permission]  unless Array.isArray permission
     groupName = \
       if 'function' is typeof target
-        module = target.name
         client?.context?.group ? 'koding'
       else if target instanceof JGroup
-        module = 'JGroup'
         target.slug
       else
-        module = target.constructor.name
         target.group ? client.context.group ? 'koding'
 
     client.groupName = groupName
@@ -108,28 +105,34 @@ module.exports = class JPermissionSet extends Module
             kallback group, permissionSet
 
   @permit = (permission, promise) ->
+
     # parameter hockey to allow either parameter to be optional
     if arguments.length is 1 and 'string' isnt typeof permission
-      [promise, permission] = [permission, promise]
+      [ promise, permission ] = [ permission, promise ]
     promise ?= {}
+
     # convert simple rules to complex rules:
     advanced =
       if promise.advanced then promise.advanced
       else wrapPermission permission
+
     # Support a "stub" form of permit that simply calls back with yes if the
     # permission is supported:
     promise.success ?= (client, callback) -> callback null, yes
+
     # return the validator:
     permit = secure (client, rest...) ->
+
       if 'function' is typeof rest[rest.length - 1]
         [rest..., callback] = rest
       else
         callback = (->)
+
+      # success/failure functions assignment
       success =
         if 'function' is typeof promise then promise.bind this
         else promise.success.bind this
       failure = promise.failure?.bind this
-      { delegate } = client.connection
       JPermissionSet.checkPermission client, advanced, this, rest,
         (err, hasPermission, roles) ->
           client.roles = roles

--- a/workers/social/lib/social/models/group/permissionset.coffee
+++ b/workers/social/lib/social/models/group/permissionset.coffee
@@ -133,6 +133,13 @@ module.exports = class JPermissionSet extends Module
         if 'function' is typeof promise then promise.bind this
         else promise.success.bind this
       failure = promise.failure?.bind this
+
+      module =
+        if 'function' is typeof this then @name
+        else @constructor.name
+
+      permissions = (p.permission for p in advanced).join ', '
+
       JPermissionSet.checkPermission client, advanced, this, rest,
         (err, hasPermission, roles) ->
           client.roles = roles
@@ -143,6 +150,15 @@ module.exports = class JPermissionSet extends Module
           else if failure?
             failure.apply null, args
           else
+
+            try
+              { context: { group }, clientIP, connection } = client
+              { profile: { nickname } } = connection.delegate
+              from = "'#{nickname}' on '#{group}' group. ip: '#{clientIP}'"
+            catch
+              from = "unknown: #{args}"
+
+            console.log \
+              "[#{module}] permission '#{permissions}' denied for #{from}"
+
             callback new KodingError 'Access denied'
-
-

--- a/workers/social/lib/social/models/group/role.coffee
+++ b/workers/social/lib/social/models/group/role.coffee
@@ -60,7 +60,4 @@ module.exports = class JGroupRole extends Module
       unless count is @defaultRoles.length
         createDefaultRolesHelper callback
       else
-        callback new KodingError 'Default group roles are already created.'
-
-
-
+        callback { message: 'Default group roles are already created.' }

--- a/workers/social/lib/social/models/group/validators.coffee
+++ b/workers/social/lib/social/models/group/validators.coffee
@@ -70,3 +70,19 @@ module.exports =
     roleSelector = getRoleSelector delegate, group, permission, permissionSet
     return callback null, yes  if roleSelector is -1
     Relationship.count roleSelector, createExistenceCallback callback
+
+
+  custom  :
+
+    owner : (client, group, permission, permissionSet, _, callback) ->
+
+      { delegate } = client.connection
+
+      return  unless hasDelegate delegate, callback
+
+      relSelector  =
+        targetId   : @getId()
+        sourceId   : delegate.getId()
+        as         : 'owner'
+
+      Relationship.count relSelector, createExistenceCallback callback

--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -1720,17 +1720,17 @@ module.exports = class JUser extends jraphical.Module
     JSession.one { clientId: client.sessionToken }, (err, session) ->
       return callback err  if err
 
-      noUserError = new KodingError \
+      noUserError = -> new KodingError \
         'No user found! Not logged in or session expired'
 
       if not session or not session.username
-        return callback noUserError
+        return callback noUserError()
 
       JUser.one { username: session.username }, (err, user) ->
 
         if err or not user
           console.log '[JUser::fetchUser]', err  if err?
-          callback noUserError
+          callback noUserError()
         else
           callback null, user
 


### PR DESCRIPTION
This is a start, includes some improvements and fixes;
- [x] Fix for `JStackTemplate`'s `meta.modifiedDate` issue
- [x] Improvements for `AccessDenied` errors, now they includes the `Model` and `permission` info alongside the requester information like following;

```
[JCredential] permission 'update credential' denied for 'dicle' on 'rakun' group. ip: '127.0.0.1'
{ [AccessDenied: Access denied] message: 'Access denied', name: 'AccessDenied' }
```
- [x] Removed duplicate stack template inconsistent views from sidebar
- [x] Updated `JCredential` permissions which was a requirement since we are using permission grid for `JCredential` permissions and a user in `foo` group can be `owner/admin` in that group which makes him/her to bypass all the methods has admin allowance. We also need to check other models for that.
