### PR TITLE
Exit with success code

### DIFF
--- a/scripts/notify-cebeci.sh
+++ b/scripts/notify-cebeci.sh
@@ -15,3 +15,5 @@ if [ ! -n "$EB_ENV_NAME" ]; then
 fi
 
 curl -s --connect-timeout 2 -X POST -d "name=$NAME&sha=$SHA&message=$MESSAGE&status=$STATUS&percentage=$PERCENTAGE&branch=$BRANCH&env=$ENV_NAME" http://cebeci.koding.com/cebeci/hook/wercker/incoming >> /dev/null
+
+exit 0


### PR DESCRIPTION
`curl` command fails sometimes which is interrupting build process as a
result.
