### PR TITLE
nginx: use case insensitive matching for hackathon redirect to hubspot

### DIFF
--- a/deployment/nginx.coffee
+++ b/deployment/nginx.coffee
@@ -314,17 +314,13 @@ module.exports.create = (KONFIG, environment)->
         resolver 8.8.8.8;
       }
 
-      location /Hackathon {
+      location ~* /Hackathon {
         proxy_set_header      X-Real-IP       $remote_addr;
         proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
 
         resolver 8.8.8.8;
         proxy_connect_timeout 10;
         proxy_pass https://teams-koding.hs-sites.com;
-      }
-
-      location /hackathon {
-        return 301 /Hackathon ;
       }
 
       #{createRootLocation(KONFIG)}


### PR DESCRIPTION
caused `nginx: [emerg] duplicate location "/hackathon" in /Users/gokhanturunc/development/koding-4/.dev.nginx.conf:197`
