### PR TITLE
Pricing: Title fonts on the payments overlays are different than the usual one. [fixes #94388446]

### DIFF
--- a/client/app/lib/styl/resurrection.styl
+++ b/client/app/lib/styl/resurrection.styl
@@ -746,7 +746,7 @@ paymentGrayLighter  = #f8f8f8
       text-align        center
 
       span.title
-        font-weight     600
+        font-family     SoleilFamily
         color           paymentGreen
         line-height     34px
         margin          0 0 6px


### PR DESCRIPTION
![screenshot at 23-08-07](https://cloud.githubusercontent.com/assets/1278794/10981726/1d215184-8412-11e5-8ddd-f25661739730.png)

![screenshot at 23-12-03](https://cloud.githubusercontent.com/assets/1278794/10981824/a6807db0-8412-11e5-81f0-1072b0e39e4f.png)

![screenshot at 23-10-23](https://cloud.githubusercontent.com/assets/1278794/10981783/6b1e5878-8412-11e5-9049-79c60e784928.png)

**Story:** https://www.pivotaltracker.com/n/projects/1217662/stories/94388446

**Notes:** Removed the font-weight and added the correct font-family as used on the titles on the inner modals.

/cc @sinan 
