### PR TITLE
Builder: Don't create source map files for stylus. [fixes #107256568]

### DIFF
--- a/client/builder/lib/index.coffee
+++ b/client/builder/lib/index.coffee
@@ -419,8 +419,8 @@ class Haydar extends events.EventEmitter
         import    : includes
         define    :
           assetsPath: "#{opts.baseurl}/#{ASSETS_OUTDIR}"
-        sourcemap :
-          inline: if opts.debugCss then yes else no
+        # sourcemap :
+        #   inline: if opts.debugCss then yes else no
 
       basename = manifest.name + '.css'
       outfile = path.join opts.stylesOutdir, basename


### PR DESCRIPTION
After these changes i'm still seeing that error on Safari console:

`[Error] Failed to load resource: the server responded with a status of 404 (Not Found) (performance-now.map, line 0)`

It looks related to CoffeeScript / Javascript but i don't have any idea about this.

![aaa](https://cloud.githubusercontent.com/assets/728733/11010683/797c10c6-8495-11e5-840b-28d0b8410fb1.png)

Shouldn't we disable the `source maps` for Javascripts? I think yes.

@sinan what do you think?

/cc @sinan @szkl @gokmen @fatihacet @usirin 
