### PR TITLE
Activity: Widget: Set absolute path to Hackathon link.

### DIFF
--- a/client/activity/lib/views/activityannouncementwidget.coffee
+++ b/client/activity/lib/views/activityannouncementwidget.coffee
@@ -18,7 +18,7 @@ module.exports = class ActivityAnnouncementWidget extends JView
       <div class="logo"></div>
       <h3>New: Koding Hackathon is Back!</h3>
       <p>Win over $150,000 in cash prizes! Hack from wherever you are!</p>
-      <a href="/Hackathon" title="Apply Now, space limited!">Apply Now, space limited!</a>
+      <a href="https://koding.com/Hackathon" target="_blank" title="Apply Now, space limited!">Apply Now, space limited!</a>
     """
 
 


### PR DESCRIPTION
This PR is a quick fix. 
At first I set it as relative path `/Hackathon` and it wasn't working because it was part of a `KD` framework link. But now, it's completely native link.

/cc @sinan @fatihacet @gokmen @szkl @usirin 
