### PR TITLE
Separate single message route

### DIFF
--- a/client/activity/lib/components/chatlistitem/index.coffee
+++ b/client/activity/lib/components/chatlistitem/index.coffee
@@ -24,7 +24,6 @@ getMessageOwner       = require 'app/util/getMessageOwner'
 showErrorNotification = require 'app/util/showErrorNotification'
 showNotification      = require 'app/util/showNotification'
 ImmutableRenderMixin  = require 'react-immutable-render-mixin'
-MessageLink           = require 'activity/components/publicchannelmessagelink'
 EmbedBox              = require 'activity/components/embedbox'
 KeyboardKeys          = require 'app/util/keyboardKeys'
 ChatInputWidget       = require 'activity/components/chatinputwidget'
@@ -335,9 +334,7 @@ module.exports = class ChatListItem extends React.Component
             <span className="ChatItem-authorName">
               {makeProfileLink message.get 'account'}
             </span>
-            <MessageLink message={message} absolute={yes}>
-              <MessageTime date={message.get 'createdAt'}/>
-            </MessageLink>
+            {makeMessageLink message}
             <ActivityLikeLink messageId={message.get('id')} interactions={message.get('interactions').toJS()}/>
           </div>
           <div className="ChatItem-contentBody">
@@ -361,6 +358,20 @@ makeProfileLink = (imAccount) ->
   <ProfileLinkContainer origin={imAccount.toJS()}>
     <ProfileText />
   </ProfileLinkContainer>
+
+
+makeMessageLink = (message) ->
+
+  PublicMessageLink = require 'activity/components/publicchannelmessagelink'
+  PrivateMessageLink = require 'activity/components/privatechannelmessagelink'
+
+  MessageLink = if message.get('typeConstant') is 'privatemessage'
+  then PrivateMessageLink
+  else PublicMessageLink
+
+  <MessageLink message={message} absolute={yes}>
+    <MessageTime date={message.get 'createdAt'}/>
+  </MessageLink>
 
 
 makeAvatar = (imAccount) ->

--- a/client/activity/lib/components/chatlistitem/simplechatlistitem.coffee
+++ b/client/activity/lib/components/chatlistitem/simplechatlistitem.coffee
@@ -28,9 +28,7 @@ module.exports = class SimpleChatListItem extends ChatListItem
     <div {...@getItemProps()}>
       <div className={@getContentClassNames()}>
         <div className={@getMediaObjectClassNames()}>
-          <MessageLink message={message} absolute={yes}>
-            <MessageTime date={message.get 'createdAt'}/>
-          </MessageLink>
+          {makeMessageLink message}
           <ActivityLikeLink messageId={message.get('id')} interactions={message.get('interactions').toJS()}/>
           <div className="ChatItem-contentBody">
             <MessageBody message={message} />
@@ -47,5 +45,19 @@ module.exports = class SimpleChatListItem extends ChatListItem
         <BlockUserModal {...@getBlockUserModalProps()} isOpen={@state.isBlockUserModalVisible} />
       </div>
     </div>
+
+
+makeMessageLink = (message) ->
+
+  PublicMessageLink = require 'activity/components/publicchannelmessagelink'
+  PrivateMessageLink = require 'activity/components/privatechannelmessagelink'
+
+  MessageLink = if message.get('typeConstant') is 'privatemessage'
+  then PrivateMessageLink
+  else PublicMessageLink
+
+  <MessageLink message={message} absolute={yes}>
+    <MessageTime date={message.get 'createdAt'}/>
+  </MessageLink>
 
 

--- a/client/activity/lib/components/privatechannelmessagelink/index.coffee
+++ b/client/activity/lib/components/privatechannelmessagelink/index.coffee
@@ -1,0 +1,37 @@
+kd        = require 'kd'
+Link      = require 'app/components/common/link'
+React     = require 'kd-react'
+immutable = require 'immutable'
+
+
+module.exports = class PrivateChannelMessageLink extends React.Component
+
+  @defaultProps = { message: immutable.Map() }
+
+
+  computeHref: ->
+
+    return '#'  if @props.message.get 'isFake'
+
+    { message } = @props
+
+    channelId = message.get 'initialChannelId'
+    channel = kd.singletons.socialapi.retrieveCachedItemById channelId
+
+    return  unless channel
+
+    id = message.get 'id'
+
+    return "/Messages/#{channel.id}/#{id}"
+
+
+  render: ->
+    <Link {...@props}
+      href={@computeHref()}
+      className={kd.utils.curry 'MessageLink PrivateChannelMessageLink', @props.className}>
+      {@props.children}
+    </Link>
+
+
+
+

--- a/client/activity/lib/routes/publicchannelnotificationsettings.coffee
+++ b/client/activity/lib/routes/publicchannelnotificationsettings.coffee
@@ -10,7 +10,7 @@ module.exports = class PublicChannelNotificationSettingsRoute
 
   constructor: ->
 
-    @path = '/Channels/:channelName/NotificationSettings'
+    @path = 'NotificationSettings'
 
 
   getComponent: (state, callback) -> callback null, NotificationSettingsModal
@@ -18,11 +18,7 @@ module.exports = class PublicChannelNotificationSettingsRoute
 
   onEnter: (nextState, replaceState, done) ->
 
-    { channelName } = nextState.params
+    channel = channelByName nextState.params.channelName
 
-    channel   = channelByName channelName
-    channelId = channel.id
-
-    NotificationSettingsFlux.actions.channel.load channelId
-      .then -> done()
+    NotificationSettingsFlux.actions.channel.load(channel.id).then -> done()
 

--- a/client/activity/lib/routes/singlemessage.coffee
+++ b/client/activity/lib/routes/singlemessage.coffee
@@ -1,0 +1,12 @@
+{ message: messageActions } = require('activity/flux').actions
+
+module.exports = class SingleMessageRoute
+
+  constructor: ->
+
+    @path = ':postId'
+
+
+  onEnter: (nextState) -> messageActions.changeSelectedMessage nextState.params.postId
+
+  onLeave: -> messageActions.changeSelectedMessage null

--- a/client/activity/lib/routes/singleprivatechannel.coffee
+++ b/client/activity/lib/routes/singleprivatechannel.coffee
@@ -13,16 +13,18 @@ changeToChannel          = require 'activity/util/changeToChannel'
 
 NewPrivateChannelRoute = require './newprivatechannel'
 AllPrivateChannelsRoute = require './allprivatechannels'
+SingleMessageRoute = require './singlemessage'
 
 
 module.exports = class SinglePrivateMessageRoute
 
   constructor: ->
 
-    @path = ':privateChannelId(/:postId)'
+    @path = ':privateChannelId'
     @childRoutes = [
       new NewPrivateChannelRoute
       new AllPrivateChannelsRoute
+      new SingleMessageRoute
     ]
 
 
@@ -48,7 +50,7 @@ module.exports = class SinglePrivateMessageRoute
         privateChannelId = botChannel.id
 
     if privateChannelId
-      transitionToChannel privateChannelId, postId, done
+      transitionToChannel privateChannelId, done
     else if not thread
       threadActions.changeSelectedThread null
       done()
@@ -62,9 +64,12 @@ module.exports = class SinglePrivateMessageRoute
     messageActions.changeSelectedMessage null
 
 
-transitionToChannel = (channelId, postId, done) ->
+transitionToChannel = (channelId, done) ->
 
-  successFn = ({ channel }) -> changeToChannel channel, postId, done
+  successFn = ({ channel }) ->
+    threadActions.changeSelectedThread channel.id
+    channelActions.loadParticipants channel.id
+    done()
 
   channel = kd.singletons.reactor.evaluateToJS ['ChannelsStore', channelId]
 

--- a/client/activity/lib/routes/singleprivatechannel.coffee
+++ b/client/activity/lib/routes/singleprivatechannel.coffee
@@ -39,19 +39,19 @@ module.exports = class SinglePrivateMessageRoute
 
     { privateChannelId, postId } = nextState.params
 
-    thread = kd.singletons.reactor.evaluate selectedChannelThread
+    selectedThread = kd.singletons.reactor.evaluate selectedChannelThread
 
     # if there is no channel id set on the route (/Messages, /NewMessage)
     unless privateChannelId
       # if there is not a selected chat
-      unless thread
+      unless selectedThread
         botChannel = kd.singletons.socialapi.getPrefetchedData 'bot'
         # set channel id to bot channel id.
         privateChannelId = botChannel.id
 
     if privateChannelId
       transitionToChannel privateChannelId, done
-    else if not thread
+    else if not selectedThread
       threadActions.changeSelectedThread null
       done()
     else

--- a/client/activity/lib/routes/singleprivatechannel.coffee
+++ b/client/activity/lib/routes/singleprivatechannel.coffee
@@ -16,7 +16,7 @@ AllPrivateChannelsRoute = require './allprivatechannels'
 SingleMessageRoute = require './singlemessage'
 
 
-module.exports = class SinglePrivateMessageRoute
+module.exports = class SinglePrivateChannelRoute
 
   constructor: ->
 

--- a/client/activity/lib/routes/singlepublicchannel.coffee
+++ b/client/activity/lib/routes/singlepublicchannel.coffee
@@ -41,18 +41,18 @@ module.exports = class SingleChannelRoute
     messageActions.changeSelectedMessage null
 
     { channelName } = nextState.params
-    thread = kd.singletons.reactor.evaluate selectedChannelThread
+    selectedThread = kd.singletons.reactor.evaluate selectedChannelThread
 
     # if there is no channel name set on the route (/NewChannel, /Channels)
     unless channelName
       # if there is not a selected chat
-      unless thread
+      unless selectedThread
         # set channel name to group channel name.
         channelName = getGroup().slug
 
     if channelName
       transitionToChannel channelName, done
-    else if not thread
+    else if not selectedThread
       threadActions.changeSelectedThread null
       done()
     else


### PR DESCRIPTION
This PR, moves single message route to its own route, and removes the unnecessary `postId` calculations in `SingleChannel` routes (for both private and public channels). The reason for this change was since the higher level route path was `:channelName(/:postId)`, its child route, `PublicChannelNotificationSettingsRoute` was not working, because of the fact that higher level routes will match and after that react-router stop looking for another route since it's already matched.

Removing `postId` calculations and putting it into its own route, made things easier, and also enabled us to reuse that route for `private channel`s as well.

Also we didn't have a proper component to create links for `PrivateChannelMessages`, i added that, and modified the usage of `MessageLink` component in `ChatListItem` and `SimpleChatListItem`.

/cc @gokhansongul @alex-ionochkin 
