### PR TITLE
Fix ObjectId issue for JMachine.getSelector

### DIFF
--- a/workers/social/lib/social/models/computeproviders/machine.coffee
+++ b/workers/social/lib/social/models/computeproviders/machine.coffee
@@ -332,16 +332,20 @@ module.exports = class JMachine extends Module
     userObj    = if owner then { sudo: yes, owner: yes } else {}
     userObj.id = user.getId()
 
-    selector  =
-      $or     : [
-        { _id : ObjectId machineId }
-        { uid : machineId }
+    selector       =
+      $or          : [
+        { uid      : machineId }
       ]
       users        :
         $elemMatch : userObj
       groups       :
         $elemMatch :
           id       : group.getId()
+
+    # ObjectId throws error when a string passed to it ~ GG
+    try
+      asObjectId = ObjectId machineId
+      selector.$or.push { _id : asObjectId }
 
     return selector
 

--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -195,9 +195,6 @@ module.exports = class JUser extends jraphical.Module
       ownAccount        :
         targetType      : JAccount
         as              : 'owner'
-      leasedAccount     :
-        targetType      : JAccount
-        as              : 'leasor'
 
   sessions  = {}
   users     = {}


### PR DESCRIPTION
`ObjectId` is throwing error when a non objectId string is given and since we are using it with `uid` (which is not a objectId` this was causing to crash social workers.
