### PR TITLE
activity: hightlight urls even if they do not have a protocol [fixes #101988638]

### DIFF
--- a/client/app/lib/util/formatContent.coffee
+++ b/client/app/lib/util/formatContent.coffee
@@ -5,6 +5,7 @@ formatQuotes = require './formatQuotes'
 formatBlockquotes = require './formatBlockquotes'
 applyMarkdown = require './applyMarkdown'
 expandUsernames = require './expandUsernames'
+markdownUrls = require './markdownUrls'
 
 module.exports = (body = '', markdownOptions = {}) ->
 
@@ -14,6 +15,7 @@ module.exports = (body = '', markdownOptions = {}) ->
     transformEmails
     formatQuotes
     formatBlockquotes
+    markdownUrls
   ]
 
   body = fn body for fn in fns


### PR DESCRIPTION
@sinan, can you please review this fix? This is for [this bug](https://www.pivotaltracker.com/story/show/101988638). I use the same logic as in reactivity, i.e. urls without protocols become links in messages so user can understand why embed preview is shown for them
