### PR TITLE
Minor reactivity style fixes [fixes #108247092 #106617764]

### DIFF
--- a/client/activity/lib/components/channelparticipantavatars/styl/channelparticipantavatars.styl
+++ b/client/activity/lib/components/channelparticipantavatars/styl/channelparticipantavatars.styl
@@ -57,7 +57,6 @@
 
 .ChannelParticipantAvatars .ProfilePicture
   vertical-align          middle
-  rounded                 $border-radius
 
 .ChannelParticipantAvatars-moreCount
   pointer()

--- a/client/activity/lib/components/createpublicchannelmodal/styl/createchannelmodal.styl
+++ b/client/activity/lib/components/createpublicchannelmodal/styl/createchannelmodal.styl
@@ -4,7 +4,6 @@
   .ChannelParticipantsDropdownItem
     .ProfilePicture
       size                  23px !important, 23px !important
-      rounded               3px
 
   .Button--danger
     bg                      color, $green

--- a/client/activity/lib/components/mentiondropboxitem/styl/mentiondropboxitem.styl
+++ b/client/activity/lib/components/mentiondropboxitem/styl/mentiondropboxitem.styl
@@ -2,7 +2,6 @@
   padding-top               4px !important
 
   .ProfilePicture
-    rounded                 3px
     display                 block
     fl()
     margin-right            15px

--- a/client/activity/lib/styl/activity.typography.styl
+++ b/client/activity/lib/styl/activity.typography.styl
@@ -71,14 +71,17 @@
   h1
   .u-h1
     font-size                 36px
+    line-height               36px
 
   h2
   .u-h2
     font-size                 30px
+    line-height               30px
 
   h3
   .u-h3
     font-size                 24px
+    line-height               24px
 
   h4
   .u-h4

--- a/client/app/lib/components/profile/styl/profile.styl
+++ b/client/app/lib/components/profile/styl/profile.styl
@@ -1,0 +1,2 @@
+.ProfilePicture
+  rounded                   $border-radius


### PR DESCRIPTION
@usirin, can you please review these changes? They contain:
- line-height fix for header elements like `h1`, `h2`, `h3` (see [bug](https://www.pivotaltracker.com/story/show/108247092))
- fix and small style refactoring for rounded avatars (see [bug](https://www.pivotaltracker.com/story/show/106617764))

/cc @sinan 
