### PR TITLE
api/amazon: add a wrapper for ec.EC2

### DIFF
--- a/go/src/koding/kites/kloud/api/amazon/client.go
+++ b/go/src/koding/kites/kloud/api/amazon/client.go
@@ -15,10 +15,12 @@ import (
 
 // TODO(rjeczalik): make all Create* methods blocking with aws.WaitUntil*
 
+// TODO(rjeczalik): support paginated replies for Describe* calls
+
 // Client wraps *ec.EC2 with an API that hides Input/Output structs
 // while dealing with EC2 service API.
 //
-// TODO(rjeczalik): add `Log logging.Logger`
+// TODO(rjeczalik): add `Log logging.Logger` & replace log.Printfs
 type Client struct {
 	EC2    *ec2.EC2 // underlying client
 	Region string   // region name

--- a/go/src/koding/kites/kloud/api/amazon/client.go
+++ b/go/src/koding/kites/kloud/api/amazon/client.go
@@ -1,0 +1,603 @@
+package amazon
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"koding/kites/kloud/awscompat"
+	"log"
+	"net/url"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+// TODO(rjeczalik): make all Create* methods blocking with aws.WaitUntil*
+
+// Client wraps *ec.EC2 with an API that hides Input/Output structs
+// while dealing with EC2 service API.
+//
+// TODO(rjeczalik): add `Log logging.Logger`
+type Client struct {
+	EC2    *ec2.EC2 // underlying client
+	Region string   // region name
+	Zones  []string // zone list
+}
+
+func newClient(cfg client.ConfigProvider, region string) (*Client, error) {
+	svc := ec2.New(cfg, aws.NewConfig().WithRegion(region))
+	svc.Client.Retryer = awscompat.Retry
+	zones, err := svc.DescribeAvailabilityZones(&ec2.DescribeAvailabilityZonesInput{})
+	if err != nil {
+		return nil, awsError(err)
+	}
+	c := &Client{
+		EC2:    svc,
+		Region: region,
+		Zones:  make([]string, len(zones.AvailabilityZones)),
+	}
+	for i, zone := range zones.AvailabilityZones {
+		c.Zones[i] = aws.StringValue(zone.ZoneName)
+	}
+	return c, nil
+}
+
+// AddressesByIP is a wrapper for (*ec2.EC2).DescribeAddresses.
+//
+// If call succeeds but no addresses were found, it returns non-nil
+// *NotFoundError error.
+func (c *Client) AddressesByIP(publicIP string) ([]*ec2.Address, error) {
+	params := &ec2.DescribeAddressesInput{
+		PublicIps: []*string{aws.String(publicIP)},
+	}
+	resp, err := c.EC2.DescribeAddresses(params)
+	if err != nil {
+		return nil, awsError(err)
+	}
+	if len(resp.Addresses) == 0 {
+		return nil, newNotFoundError("Address", fmt.Errorf("no addresses found with ip=%q", publicIP))
+	}
+	return resp.Addresses, nil
+}
+
+// ReleaseAddresss is a wrapper for (*ec2.EC2).ReleaseAddress.
+func (c *Client) ReleaseAddress(allocID string) error {
+	params := &ec2.ReleaseAddressInput{
+		AllocationId: aws.String(allocID),
+	}
+	_, err := c.EC2.ReleaseAddress(params)
+	return awsError(err)
+}
+
+// AllocateAddress is a wrapper for (*ec2.EC2).AllocateAddress.
+//
+// The domain type can be either classic or vpc.
+func (c *Client) AllocateAddress(domainType string) (allocID, publicIP string, err error) {
+	params := &ec2.AllocateAddressInput{
+		Domain: aws.String(domainType),
+	}
+	resp, err := c.EC2.AllocateAddress(params)
+	if err != nil {
+		return "", "", awsError(err)
+	}
+	return aws.StringValue(resp.AllocationId), aws.StringValue(resp.PublicIp), nil
+}
+
+// AssociateAddress is a wrapper for (*ec2.EC2).AssociateAddres.
+func (c *Client) AssociateAddress(instanceID, allocID string) error {
+	params := &ec2.AssociateAddressInput{
+		InstanceId:   aws.String(instanceID),
+		AllocationId: aws.String(allocID),
+	}
+	_, err := c.EC2.AssociateAddress(params)
+	return awsError(err)
+}
+
+// Images is a wrapper for (*ec2.EC2).DescribeImages.
+//
+// If call succeeds but no images were found, it returns non-nil
+// *NotFoundError error.
+func (c *Client) Images() ([]*ec2.Image, error) {
+	params := &ec2.DescribeImagesInput{}
+	resp, err := c.EC2.DescribeImages(params)
+	if err != nil {
+		return nil, awsError(err)
+	}
+	if len(resp.Images) == 0 {
+		return nil, newNotFoundError("Image", errors.New("no images found"))
+	}
+	return resp.Images, nil
+}
+
+// ImageByID is a wrapper for (*ec2.EC2).DescribeImages with image-id filter.
+func (c *Client) ImageByID(id string) (*ec2.Image, error) {
+	return c.imageBy("image-id", id)
+}
+
+// ImageByName is a wrapper for (*ec2.EC2).DescribeImages with name filter.
+func (c *Client) ImageByName(name string) (*ec2.Image, error) {
+	return c.imageBy("name", name)
+}
+
+// ImageByTag is a wrapper for (*ec2.EC2).DescribeImages with tag:Name filter.
+func (c *Client) ImageByTag(tag string) (*ec2.Image, error) {
+	return c.imageBy("tag:Name", tag)
+}
+
+func (c *Client) imageBy(key, value string) (*ec2.Image, error) {
+	params := &ec2.DescribeImagesInput{
+		Filters: []*ec2.Filter{{
+			Name:   aws.String(key),
+			Values: []*string{aws.String(value)},
+		}},
+	}
+	resp, err := c.EC2.DescribeImages(params)
+	if err != nil {
+		return nil, awsError(err)
+	}
+	switch n := len(resp.Images); n {
+	case 1: // ok
+	case 0:
+		return nil, newNotFoundError("Image", fmt.Errorf("no image found with key=%v, value=%v", key, value))
+	default:
+		log.Printf("multiec2: more than one image found with key=%q, value=%q: %d", key, value, n)
+	}
+	return resp.Images[0], nil
+}
+
+// RegisterImage is a wrapper for (*ec2.EC2).RegisterImage.
+func (c *Client) RegisterImage(params *ec2.RegisterImageInput) (imageID string, err error) {
+	resp, err := c.EC2.RegisterImage(params)
+	if err != nil {
+		return "", awsError(err)
+	}
+	return aws.StringValue(resp.ImageId), nil
+}
+
+// DeregisterImage is a wrapper for (*ec2.EC2).DeregisterImage.
+func (c *Client) DeregisterImage(imageID string) error {
+	params := &ec2.DeregisterImageInput{
+		ImageId: aws.String(imageID),
+	}
+	_, err := c.EC2.DeregisterImage(params)
+	return awsError(err)
+}
+
+// Snapshots is a wrapper for (*ec2.EC2).DescribeSnapshots.
+//
+// If call succeeds but no snapshots were found, it returns non-nil
+// *NotFoundError error.
+func (c *Client) Snapshots() ([]*ec2.Snapshot, error) {
+	params := &ec2.DescribeSnapshotsInput{}
+	resp, err := c.EC2.DescribeSnapshots(params)
+	if err != nil {
+		return nil, awsError(err)
+	}
+	if len(resp.Snapshots) == 0 {
+		return nil, newNotFoundError("Snapshot", errors.New("no snapshots found"))
+	}
+	return resp.Snapshots, nil
+}
+
+// SnapshotByID is a wrapper for (*ec.EC2).DescribeSnapshots with id filter.
+func (c *Client) SnapshotByID(id string) (*ec2.Snapshot, error) {
+	params := &ec2.DescribeSnapshotsInput{
+		SnapshotIds: []*string{aws.String(id)},
+	}
+	resp, err := c.EC2.DescribeSnapshots(params)
+	if err != nil {
+		return nil, awsError(err)
+	}
+	switch n := len(resp.Snapshots); n {
+	case 1: // ok
+	case 0:
+		return nil, newNotFoundError("Snapshot", fmt.Errorf("no snapshot found with id=%s", id))
+	default:
+		log.Printf("multiec2: more than one snapshot found  with id=%s: %d", id, n)
+	}
+	return resp.Snapshots[0], nil
+}
+
+// CreateSnapshot is a wrapper for (*ec2.EC2).CreateSnapshot.
+func (c *Client) CreateSnapshot(volumeID, desc string) (*ec2.Snapshot, error) {
+	params := &ec2.CreateSnapshotInput{
+		VolumeId:    aws.String(volumeID),
+		Description: aws.String(desc),
+	}
+	snapshot, err := c.EC2.CreateSnapshot(params)
+	return snapshot, awsError(err)
+}
+
+// DeleteSnapshot is a wrapper for (*ec2.EC2).DeleteSnapshot.
+func (c *Client) DeleteSnapshot(id string) error {
+	params := &ec2.DeleteSnapshotInput{
+		SnapshotId: aws.String(id),
+	}
+	_, err := c.EC2.DeleteSnapshot(params)
+	return awsError(err)
+}
+
+// VPCs is a wrapper for (*ec2.EC2).DescribeVpcs.
+//
+// If call succeeds but no VPCs were found, it returns non-nil
+// *NotFoundError error.
+func (c *Client) VPCs() ([]*ec2.Vpc, error) {
+	params := &ec2.DescribeVpcsInput{}
+	resp, err := c.EC2.DescribeVpcs(params)
+	if err != nil {
+		return nil, awsError(err)
+	}
+	if len(resp.Vpcs) == 0 {
+		return nil, newNotFoundError("VPC", errors.New("no VPCs found"))
+	}
+	return resp.Vpcs, nil
+}
+
+// Subnets is a wrapper for (*ec2.EC2).DescribeSubnets.
+//
+// If call succeeds but no subnets were found, it returns non-nil
+// *NotFoundError error.
+func (c *Client) Subnets() ([]*ec2.Subnet, error) {
+	params := &ec2.DescribeSubnetsInput{}
+	resp, err := c.EC2.DescribeSubnets(params)
+	if err != nil {
+		return nil, awsError(err)
+	}
+	if len(resp.Subnets) == 0 {
+		return nil, newNotFoundError("Subnet", errors.New("no subnets found"))
+	}
+	return resp.Subnets, nil
+}
+
+// SubnetsByTag is a wrapper for (*ec2.EC2).DescribeSubnets with tag-value filter.
+//
+// If call succeeds but no subnets were found, it returns non-nil
+// *NotFoundError error.
+func (c *Client) SubnetsByTag(value string) ([]*ec2.Subnet, error) {
+	params := &ec2.DescribeSubnetsInput{
+		Filters: []*ec2.Filter{{
+			Name:   aws.String("tag-value"),
+			Values: []*string{aws.String(value)},
+		}},
+	}
+	resp, err := c.EC2.DescribeSubnets(params)
+	if err != nil {
+		return nil, awsError(err)
+	}
+	if len(resp.Subnets) == 0 {
+		return nil, newNotFoundError("Subnet", fmt.Errorf("no subnets found with tag=%q", value))
+	}
+	return resp.Subnets, nil
+}
+
+// SecurityGroupByID is a wrapper for (*ec2.EC2).DescribeSecurityGroups with id filter.
+func (c *Client) SecurityGroupByID(id string) (*ec2.SecurityGroup, error) {
+	params := &ec2.DescribeSecurityGroupsInput{
+		GroupIds: []*string{aws.String(id)},
+	}
+	return c.securityGroupBy(params, id)
+}
+
+// SecurityGroupByName is a wrapper for (*ec2.EC2).DescribeSecurityGroups with name filter.
+func (c *Client) SecurityGroupByName(name string) (*ec2.SecurityGroup, error) {
+	params := &ec2.DescribeSecurityGroupsInput{
+		GroupNames: []*string{aws.String(name)},
+	}
+	return c.securityGroupBy(params, name)
+}
+
+// SecurityGroupByFilters is a wrapper for (*ec2.EC2).DescribeSecurityGroups
+// with user-defined filters.
+//
+// If the value of a certain filter is an empty string, the filter is ignored.
+func (c *Client) SecurityGroupByFilters(filters url.Values) (*ec2.SecurityGroup, error) {
+	params := &ec2.DescribeSecurityGroupsInput{
+		Filters: NewFilters(filters),
+	}
+	return c.securityGroupBy(params, filters)
+}
+
+// SecurityGroupFromVPC is a wrapper for (*ec2.EC2).DescribeSecurityGroups
+// with vpc-id and tag-key filters.
+//
+// If the value of either argument is empty, the filter is ignored.
+func (c *Client) SecurityGroupFromVPC(vpcID, tag string) (*ec2.SecurityGroup, error) {
+	filters := url.Values{
+		"vpc-id":  {vpcID},
+		"tag-key": {tag},
+	}
+	return c.SecurityGroupByFilters(filters)
+
+}
+
+func (c *Client) securityGroupBy(params *ec2.DescribeSecurityGroupsInput, key interface{}) (*ec2.SecurityGroup, error) {
+	resp, err := c.EC2.DescribeSecurityGroups(params)
+	if err != nil {
+		return nil, awsError(err)
+	}
+	switch n := len(resp.SecurityGroups); n {
+	case 1: // ok
+	case 0:
+		return nil, newNotFoundError("SecurityGroup", fmt.Errorf("no security group found with key=%v", key))
+	default:
+		log.Printf("multiec2: more than one security group found with key=%v: %d", key, n)
+	}
+	return resp.SecurityGroups[0], nil
+}
+
+// CreateSecurityGroup is a wrapper for (*ec2.EC2).CreateSecurityGroup.
+func (c *Client) CreateSecurityGroup(name, vpcID, desc string) (groupID string, err error) {
+	params := &ec2.CreateSecurityGroupInput{
+		GroupName:   aws.String(name),
+		VpcId:       aws.String(vpcID),
+		Description: aws.String(desc),
+	}
+	resp, err := c.EC2.CreateSecurityGroup(params)
+	if err != nil {
+		return "", awsError(err)
+	}
+	return aws.StringValue(resp.GroupId), nil
+}
+
+// AuthorizeSecurityGroup is a wrapper for (*ec2.EC2).AuthorizeSecurityGroup.
+func (c *Client) AuthorizeSecurityGroup(id string, perm []*ec2.IpPermission) error {
+	params := &ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId:       aws.String(id),
+		IpPermissions: perm,
+	}
+	_, err := c.EC2.AuthorizeSecurityGroupIngress(params)
+	return awsError(err)
+}
+
+// AddTag is a wrapper for (*ec2.EC2).CreateTags.
+func (c *Client) AddTag(instanceID, key, value string) error {
+	return c.AddTags(instanceID, map[string]string{key: value})
+}
+
+// AddTags is a wrapper for (*ec2.EC2).CreateTags.
+func (c *Client) AddTags(instanceID string, tags map[string]string) error {
+	params := &ec2.CreateTagsInput{
+		Resources: []*string{aws.String(instanceID)},
+		Tags:      NewTags(tags),
+	}
+	_, err := c.EC2.CreateTags(params)
+	return awsError(err)
+}
+
+// InstaceByID is a wrapper for (*ec2.EC2).DescribeInstances with id filter.
+func (c *Client) InstanceByID(id string) (*ec2.Instance, error) {
+	params := &ec2.DescribeInstancesInput{
+		InstanceIds: []*string{aws.String(id)},
+	}
+	resp, err := c.EC2.DescribeInstances(params)
+	if err != nil {
+		return nil, awsError(err)
+	}
+	switch n := len(resp.Reservations); {
+	case n == 1 && len(resp.Reservations[0].Instances) == 1: // ok
+	case n == 0 || len(resp.Reservations[0].Instances) == 0:
+		return nil, newNotFoundError("Instance", fmt.Errorf("no instance found with id=%d", id))
+	default:
+		log.Printf("multiec2: more than one instance found with id=%d", id)
+	}
+	return resp.Reservations[0].Instances[0], nil
+}
+
+// InstancesByFilters is a wrapper for (*ec2.EC2).DescribeInstances with
+// user-defined filters.
+//
+// If the value of a certain filter is an empty string, the filter is ignored.
+// If call succeeds but no instances were found, it returns non-nil
+// *NotFoundError error.
+func (c *Client) InstancesByFilters(filters url.Values) ([]*ec2.Instance, error) {
+	params := &ec2.DescribeInstancesInput{
+		Filters: NewFilters(filters),
+	}
+	resp, err := c.EC2.DescribeInstances(params)
+	if err != nil {
+		return nil, awsError(err)
+	}
+	var instances []*ec2.Instance
+	for _, r := range resp.Reservations {
+		for _, i := range r.Instances {
+			instances = append(instances, i)
+		}
+	}
+	if len(instances) == 0 {
+		return nil, newNotFoundError("Instance", fmt.Errorf("no instances found with filters=%v", filters))
+	}
+	return instances, nil
+}
+
+// StartInstance is a wrapper for (*ec2.EC2).StartInstances.
+func (c *Client) StartInstance(id string) (*ec2.InstanceStateChange, error) {
+	params := &ec2.StartInstancesInput{
+		InstanceIds: []*string{aws.String(id)},
+	}
+	resp, err := c.EC2.StartInstances(params)
+	if err != nil {
+		return nil, awsError(err)
+	}
+	switch n := len(resp.StartingInstances); n {
+	case 1: // ok
+	case 0:
+		return nil, newNotFoundError("Instance", fmt.Errorf("no instance found with id=%q", id))
+	default:
+		log.Printf("multiec2: more than one instance started with id=%q: %d", id, n)
+	}
+	return resp.StartingInstances[0], nil
+}
+
+// StopInstance is a wrapper for (*ec2.EC2).StopInstances.
+func (c *Client) StopInstance(id string) (*ec2.InstanceStateChange, error) {
+	params := &ec2.StopInstancesInput{
+		InstanceIds: []*string{aws.String(id)},
+	}
+	resp, err := c.EC2.StopInstances(params)
+	if err != nil {
+		return nil, awsError(err)
+	}
+	switch n := len(resp.StoppingInstances); n {
+	case 1: // ok
+	case 0:
+		return nil, newNotFoundError("Instance", fmt.Errorf("no instance found with id=%q", id))
+	default:
+		log.Printf("multiec2: more than one instance stopped with id=%q: %d", id, n)
+	}
+	return resp.StoppingInstances[0], nil
+}
+
+// RebootInstance is a wrapper for (*ec2.EC2).RebootInstances.
+func (c *Client) RebootInstance(id string) error {
+	params := &ec2.RebootInstancesInput{
+		InstanceIds: []*string{aws.String(id)},
+	}
+	_, err := c.EC2.RebootInstances(params)
+	return awsError(err)
+}
+
+// TerminateInstance is a wrapper for (*ec2.EC2).TerminateInstances.
+func (c *Client) TerminateInstance(id string) (*ec2.InstanceStateChange, error) {
+	params := &ec2.TerminateInstancesInput{
+		InstanceIds: []*string{aws.String(id)},
+	}
+	resp, err := c.EC2.TerminateInstances(params)
+	if err != nil {
+		return nil, awsError(err)
+	}
+	switch n := len(resp.TerminatingInstances); n {
+	case 1: // ok
+	case 0:
+		return nil, newNotFoundError("Instance", fmt.Errorf("no instance found with id=%q", id))
+	default:
+		log.Printf("multiec2: more than one instance terminated with id=%q: %d", id, n)
+	}
+	return resp.TerminatingInstances[0], nil
+}
+
+// KeyPairByName is a wrapper for (*ec2.EC2).DescribeKeyPairs with name filter.
+func (c *Client) KeyPairByName(name string) (*ec2.KeyPairInfo, error) {
+	params := &ec2.DescribeKeyPairsInput{
+		KeyNames: []*string{aws.String(name)},
+	}
+	resp, err := c.EC2.DescribeKeyPairs(params)
+	if err != nil {
+		return nil, awsError(err)
+	}
+	switch n := len(resp.KeyPairs); n {
+	case 1: // ok
+	case 0:
+		return nil, newNotFoundError("KeyPair", fmt.Errorf("no key pair found with name=%q", name))
+	default:
+		log.Printf("multiec2: more than one key pair found with name=%q", name)
+	}
+	return resp.KeyPairs[0], nil
+}
+
+// DeleteKeyPair is a wrapper for (*ec2.EC2).DeleteKeyPair.
+func (c *Client) DeleteKeyPair(name string) error {
+	params := &ec2.DeleteKeyPairInput{
+		KeyName: aws.String(name),
+	}
+	_, err := c.EC2.DeleteKeyPair(params)
+	return awsError(err)
+}
+
+// ImportKeyPair is a wrapper for (*ec2.EC2).ImportKeyPair.
+func (c *Client) ImportKeyPair(name string, publicKey []byte) (fingerprint string, err error) {
+	params := &ec2.ImportKeyPairInput{
+		KeyName:           aws.String(name),
+		PublicKeyMaterial: []byte(base64.StdEncoding.EncodeToString(publicKey)),
+	}
+	resp, err := c.EC2.ImportKeyPair(params)
+	if err != nil {
+		return "", awsError(err)
+	}
+	return aws.StringValue(resp.KeyFingerprint), nil
+}
+
+// Volume is a wrapper for (*ec2.EC2).DescribeVolumes with id filter.
+func (c *Client) VolumeByID(id string) (*ec2.Volume, error) {
+	params := &ec2.DescribeVolumesInput{
+		VolumeIds: []*string{aws.String(id)},
+	}
+	resp, err := c.EC2.DescribeVolumes(params)
+	if err != nil {
+		return nil, awsError(err)
+	}
+	switch n := len(resp.Volumes); n {
+	case 1: // ok
+	case 0:
+		return nil, newNotFoundError("Volume", fmt.Errorf("no volume found with id=%q", id))
+	default:
+		log.Printf("multiec2: more than one volume found with id=%q", id)
+	}
+	return resp.Volumes[0], nil
+}
+
+// CreateVolume is a wrapper for (*ec2.EC2).Volume.
+func (c *Client) CreateVolume(snapshotID, zone, typ string, size int64) (*ec2.Volume, error) {
+	params := &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String(typ),
+		Size:             aws.Int64(size),
+		SnapshotId:       aws.String(snapshotID),
+		VolumeType:       aws.String(typ),
+	}
+	vol, err := c.EC2.CreateVolume(params)
+	if err != nil {
+		return nil, awsError(err)
+	}
+	return vol, nil
+}
+
+// DeleteVolume is a wrapper for (*ec.EC2).DeleteVolume.
+func (c *Client) DeleteVolume(volID string) error {
+	params := &ec2.DeleteVolumeInput{
+		VolumeId: aws.String(volID),
+	}
+	_, err := c.EC2.DeleteVolume(params)
+	return awsError(err)
+}
+
+// AttachVolume is a wrapper for (*ec2.EC2).Volume.
+func (c *Client) AttachVolume(volumeID, instanceID, devicePath string) error {
+	params := &ec2.AttachVolumeInput{
+		VolumeId:   aws.String(volumeID),
+		InstanceId: aws.String(instanceID),
+		Device:     aws.String(devicePath),
+	}
+	_, err := c.EC2.AttachVolume(params)
+	return awsError(err)
+}
+
+// Volume is a wrapper for (*ec2.EC2).Volume.
+func (c *Client) DetachVolume(id string) error {
+	params := &ec2.DetachVolumeInput{
+		VolumeId: aws.String(id),
+	}
+	_, err := c.EC2.DetachVolume(params)
+	return awsError(err)
+}
+
+// RunInstances is a wrapper for (*ec2.EC2).RunInstances.
+func (c *Client) RunInstances(params *ec2.RunInstancesInput) (*ec2.Instance, error) {
+	resp, err := c.EC2.RunInstances(params)
+	if err != nil {
+		return nil, awsError(err)
+	}
+	switch n := len(resp.Instances); n {
+	case 1: // ok
+	case 0:
+		return nil, newNotFoundError("Instance", fmt.Errorf("no instance ran with params=%v", params))
+	default:
+		log.Printf("multiec2: more than one instance ran with params=%v", params)
+	}
+	return resp.Instances[0], nil
+}
+
+// ModifyInstance is a wrapper for (*ec2.EC2).ModiftInstanceAttribute.
+func (c *Client) ModifyInstance(params *ec2.ModifyInstanceAttributeInput) error {
+	_, err := c.EC2.ModifyInstanceAttribute(params)
+	return awsError(err)
+}

--- a/go/src/koding/kites/kloud/api/amazon/clients.go
+++ b/go/src/koding/kites/kloud/api/amazon/clients.go
@@ -43,6 +43,9 @@ func (c Clients) Region(region string) (*Client, error) {
 }
 
 // Regions returns all instantiated clients per region.
+//
+// The returned map is meant to be used for a read-only access only,
+/// as it's not safe to mutate the map.
 func (c Clients) Regions() map[string]*Client {
 	return c.regions
 }

--- a/go/src/koding/kites/kloud/api/amazon/clients.go
+++ b/go/src/koding/kites/kloud/api/amazon/clients.go
@@ -1,0 +1,60 @@
+package amazon
+
+import (
+	"fmt"
+
+	"koding/kites/kloud/awscompat"
+
+	oldaws "github.com/mitchellh/goamz/aws"
+)
+
+// Clients provides wrappers for a EC2 client per region.
+type Clients struct {
+	regions map[string]*Client // read-only, written once on New()
+}
+
+// NewClientPerRegion is returning a new multi clients refernce for the given
+// regions names.
+func NewClientPerRegion(auth oldaws.Auth, regions []string) (*Clients, error) {
+	c := &Clients{
+		regions: make(map[string]*Client, len(regions)),
+	}
+	session := awscompat.NewSession(auth)
+	for _, region := range regions {
+		client, err := newClient(session, region)
+		if err != nil {
+			return nil, err
+		}
+		c.regions[region] = client
+	}
+	return c, nil
+}
+
+// Region gives a client for the given region.
+//
+// If there's no client instantiated for the given region, the method returns
+// *NotFoundError error.
+func (c Clients) Region(region string) (*Client, error) {
+	client, ok := c.regions[region]
+	if !ok {
+		return nil, newNotFoundError("Region", fmt.Errorf("no client found for %q region", region))
+	}
+	return client, nil
+}
+
+// Regions returns all instantiated clients per region.
+func (c Clients) Regions() map[string]*Client {
+	return c.regions
+}
+
+// Zones gives all availability zones for the given region.
+//
+// If there's no client instantiated for the given region, thus no availability zones,
+// the method returns *NotFoundError error.
+func (c Clients) Zones(region string) ([]string, error) {
+	client, ok := c.regions[region]
+	if !ok {
+		return nil, newNotFoundError("Region", fmt.Errorf("no zones found for %q region", region))
+	}
+	return client.Zones, nil
+}

--- a/go/src/koding/kites/kloud/api/amazon/error.go
+++ b/go/src/koding/kites/kloud/api/amazon/error.go
@@ -1,0 +1,128 @@
+package amazon
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+)
+
+var (
+	ErrInstanceTerminated = errors.New("instance is terminated")
+	ErrInstanceEmptyID    = errors.New("instance ID is empty")
+)
+
+// OrigErr returns (unboxes) the underlying reason for the error.
+//
+// If err was not boxed and/or is not a specialised error, the function
+// is effectively a nop.
+func OrigErr(err error) error {
+	switch e := err.(type) {
+	case *NotFoundError:
+		return e.Err
+	case awserr.Error:
+		return e.OrigErr()
+	default:
+		return err
+	}
+}
+
+// EqualErr returns true when both errors are equal or underlying error for
+// both of them are equal.
+func EqualErr(lhs, rhs error) bool {
+	return OrigErr(lhs) == OrigErr(rhs)
+}
+
+// IsErrCode returns true if err is of awserr.Error type and its code
+// is one of the given codes; otherwise it returns false.
+//
+// For the list of possible error codes see:
+//
+//   https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html
+//
+func IsErrCode(err error, codes ...string) bool {
+	e, ok := err.(awserr.Error)
+	if !ok {
+		return false
+	}
+	for _, code := range codes {
+		if e.Code() == code {
+			return true
+		}
+	}
+	return false
+}
+
+// NotFoundError is a special kind of error returned by the Client wrapper.
+// This error may occur because the recently created resource has not
+// propagated through the system.
+//
+// For more details see:
+//
+//   https://docs.aws.amazon.com/AWSEC2/latest/APIReference/query-api-troubleshooting.html#eventual-consistency
+//
+type NotFoundError struct {
+	Resource string // resource type that was requested
+	Err      error  // underlying reason that caused the error
+}
+
+// Error implements the builtin error interface.
+func (err *NotFoundError) Error() string {
+	return fmt.Sprintf("%s not found after a call to %s: %s", err.Resource, err.Err)
+}
+
+// IsNotFound returns true if the given error is of *NotFound
+func IsNotFound(err error) bool {
+	_, ok := err.(*NotFoundError)
+	return ok
+}
+
+func newNotFoundError(res string, err error) error {
+	return &NotFoundError{
+		Resource: res,
+		Err:      err,
+	}
+}
+
+// awsError wraps the given awserr.Error with:
+//
+//   - *NotFoundError, if the given error has one of the *.NotFound error codes
+//
+// Otherwise or if the err was nil the function is a nop.
+func awsError(err error) error {
+	e, ok := err.(awserr.Error)
+	if !ok || err == nil {
+		return err
+	}
+	// Based on: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html
+	//
+	// Not all error codes are listed as we don't use all AWS API calls.
+	switch e.Code() {
+	case "InvalidAddress.NotFound":
+		return newNotFoundError("Address", err)
+	case "InvalidAMIID.NotFound":
+		return newNotFoundError("Image", err)
+	case "InvalidGroup.NotFound":
+		return newNotFoundError("SecurityGroup", err)
+	case "InvalidInstanceID.NotFound":
+		return newNotFoundError("Instance", err)
+	case "InvalidKeyPair.NotFound":
+		return newNotFoundError("KeyPair", err)
+	case "InvalidSecurityGroupID.NotFound":
+		return newNotFoundError("SecurityGroup", err)
+	case "InvalidSnapshot.NotFound":
+		return newNotFoundError("Snapshot", err)
+	case "InvalidSubnetID.NotFound":
+		return newNotFoundError("Subnet", err)
+	case "InvalidVolume.NotFound":
+		return newNotFoundError("Volume", err)
+	case "InvalidVpcEndpointId.NotFound":
+		return newNotFoundError("VPC", err)
+	case "InvalidVpcID.NotFound":
+		return newNotFoundError("VPC", err)
+	case "InvalidZone.NotFound":
+		return newNotFoundError("Zone", err)
+	default:
+		return err
+	}
+}

--- a/go/src/koding/kites/kloud/api/amazon/error.go
+++ b/go/src/koding/kites/kloud/api/amazon/error.go
@@ -10,6 +10,7 @@ import (
 var (
 	ErrInstanceTerminated = errors.New("instance is terminated")
 	ErrInstanceEmptyID    = errors.New("instance ID is empty")
+	ErrNoInstances        = errors.New("no instances found")
 )
 
 // OrigErr returns (unboxes) the underlying reason for the error.
@@ -71,7 +72,7 @@ func (err *NotFoundError) Error() string {
 	return fmt.Sprintf("%s not found after a call to %s: %s", err.Resource, err.Err)
 }
 
-// IsNotFound returns true if the given error is of *NotFound
+// IsNotFound returns true if the given error is of *NotFoundError type.
 func IsNotFound(err error) bool {
 	_, ok := err.(*NotFoundError)
 	return ok
@@ -117,7 +118,7 @@ func awsError(err error) error {
 	case "InvalidVolume.NotFound":
 		return newNotFoundError("Volume", err)
 	case "InvalidVpcEndpointId.NotFound":
-		return newNotFoundError("VPC", err)
+		return newNotFoundError("VPCEndpoint", err)
 	case "InvalidVpcID.NotFound":
 		return newNotFoundError("VPC", err)
 	case "InvalidZone.NotFound":

--- a/go/src/koding/kites/kloud/api/amazon/helper.go
+++ b/go/src/koding/kites/kloud/api/amazon/helper.go
@@ -1,0 +1,115 @@
+package amazon
+
+import (
+	"net/url"
+	"sort"
+	"strings"
+
+	"koding/kites/kloud/machinestate"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+// PermAllPorts is a conveniance value for opening all ports for inbound
+// requests.
+//
+// For use with AuthorizeSecurityGroup method.
+var PermAllPorts = []*ec2.IpPermission{{
+	IpProtocol: aws.String("tcp"),
+	FromPort:   aws.Int64(0),
+	ToPort:     aws.Int64(65535),
+	IpRanges: []*ec2.IpRange{{
+		CidrIp: aws.String("0.0.0.0/0"),
+	}},
+}}
+
+// TagsMatch returns true when tags contains all tags described by the m map.
+func TagsMatch(tags []*ec2.Tag, m map[string]string) bool {
+	matches := make(map[string]struct{}, len(m))
+	for _, tag := range tags {
+		key := aws.StringValue(tag.Key)
+		if v, ok := m[key]; ok && aws.StringValue(tag.Value) == v {
+			matches[key] = struct{}{}
+		}
+	}
+	return len(matches) == len(m)
+}
+
+// StatusToState converts a amazon status to a sensible machinestate.State
+// enum.
+func StatusToState(status string) machinestate.State {
+	// For available state enums see:
+	//
+	//   https://godoc.org/github.com/aws/aws-sdk-go/service/ec2#InstanceState
+	//
+	switch strings.ToLower(status) {
+	case ec2.InstanceStateNamePending:
+		return machinestate.Starting // intentional
+	case ec2.InstanceStateNameRunning:
+		return machinestate.Running
+	case ec2.InstanceStateNameStopped:
+		return machinestate.Stopped
+	case ec2.InstanceStateNameStopping:
+		return machinestate.Stopping
+	case ec2.InstanceStateNameShuttingDown:
+		return machinestate.Terminating
+	case ec2.InstanceStateNameTerminated:
+		return machinestate.Terminated
+	default:
+		return machinestate.Unknown
+	}
+}
+
+func NewTags(tags map[string]string) []*ec2.Tag {
+	if len(tags) == 0 {
+		return nil
+	}
+	t := make([]*ec2.Tag, 0, len(tags))
+	for k, v := range tags {
+		tag := &ec2.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		}
+		t = append(t, tag)
+	}
+	return t
+}
+
+func NewFilters(filters url.Values) []*ec2.Filter {
+	f := make([]*ec2.Filter, 0, len(filters))
+	for k, v := range filters {
+		filter := &ec2.Filter{
+			Name:   aws.String(k),
+			Values: make([]*string, 0, len(v)),
+		}
+		for _, v := range v {
+			if v == "" {
+				continue
+			}
+			filter.Values = append(filter.Values, aws.String(v))
+		}
+		if len(filter.Values) != 0 {
+			f = append(f, filter)
+		}
+	}
+	if len(f) == 0 {
+		return nil
+	}
+	sort.Sort(filtersByName(f))
+	return f
+}
+
+type filtersByName []*ec2.Filter
+
+func (f filtersByName) Len() int {
+	return len(f)
+}
+
+func (f filtersByName) Less(i, j int) bool {
+	return aws.StringValue(f[i].Name) <= aws.StringValue(f[j].Name)
+}
+
+func (f filtersByName) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
+}

--- a/go/src/koding/kites/kloud/api/amazon/helper_test.go
+++ b/go/src/koding/kites/kloud/api/amazon/helper_test.go
@@ -1,0 +1,71 @@
+package amazon_test
+
+import (
+	"koding/kites/kloud/api/amazon"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+func TestTagMatch(t *testing.T) {
+	tags := []*ec2.Tag{
+		{Key: aws.String("key1"), Value: aws.String("value1")},
+		{Key: aws.String("key2"), Value: aws.String("value2")},
+		{Key: aws.String("key3"), Value: aws.String("value3")},
+	}
+	cases := []struct {
+		m  map[string]string
+		ok bool
+	}{{
+		map[string]string{"key2": "value2", "key3": "value3"},
+		true,
+	}, {
+		map[string]string{"key4": "value4"},
+		false,
+	}, {
+		map[string]string{"key3": "value3", "key2": "different"},
+		false,
+	}}
+	for i, cas := range cases {
+		ok := amazon.TagsMatch(tags, cas.m)
+		if ok != cas.ok {
+			t.Errorf("%d: want ok=%v; got %v", i, cas.ok, ok)
+		}
+	}
+}
+
+func TestNewFilters(t *testing.T) {
+	filters := []*ec2.Filter{{
+		Name: aws.String("filter 1"),
+		Values: []*string{
+			aws.String("value 11"),
+		},
+	}, {
+		Name: aws.String("filter 2"),
+		Values: []*string{
+			aws.String("value 21"),
+			aws.String("value 22"),
+		},
+	}}
+	cases := []url.Values{{
+		"filter 1": {"value 11"},
+		"filter 2": {"value 21", "value 22"},
+	}, {
+		"filter 1": {"", "value 11", ""},
+		"filter 2": {"", "value 21", "", "value 22"},
+	}, {
+		"filter 1": {"value 11"},
+		"filter 2": {"value 21", "value 22"},
+		"empty 3":  {""},
+		"empty 4":  {"", "", ""},
+	}}
+	for i, cas := range cases {
+		f := amazon.NewFilters(cas)
+		if !reflect.DeepEqual(filters, f) {
+			t.Errorf("%d: want f=%#v; got %#v", i, filters, f)
+		}
+	}
+}

--- a/go/src/koding/kites/kloud/api/amazon/instance.go
+++ b/go/src/koding/kites/kloud/api/amazon/instance.go
@@ -1,7 +1,6 @@
 package amazon
 
 import (
-	"errors"
 	"fmt"
 	"koding/kites/kloud/eventer"
 	"koding/kites/kloud/machinestate"
@@ -12,8 +11,6 @@ import (
 
 	"github.com/mitchellh/goamz/ec2"
 )
-
-var ErrNoInstances = errors.New("no instances found")
 
 func (a *Amazon) Build(buildData *ec2.RunInstances) (string, error) {
 	resp, err := a.Client.RunInstances(buildData)

--- a/go/src/koding/kites/kloud/api/amazon/instance.go
+++ b/go/src/koding/kites/kloud/api/amazon/instance.go
@@ -13,10 +13,7 @@ import (
 	"github.com/mitchellh/goamz/ec2"
 )
 
-var (
-	ErrInstanceTerminated = errors.New("instance is terminated")
-	ErrNoInstances        = errors.New("no instances found")
-)
+var ErrNoInstances = errors.New("no instances found")
 
 func (a *Amazon) Build(buildData *ec2.RunInstances) (string, error) {
 	resp, err := a.Client.RunInstances(buildData)

--- a/go/src/koding/kites/kloud/api/amazon/state.go
+++ b/go/src/koding/kites/kloud/api/amazon/state.go
@@ -6,7 +6,6 @@ import (
 	"koding/kites/kloud/eventer"
 	"koding/kites/kloud/machinestate"
 	"koding/kites/kloud/waitstate"
-	"strings"
 
 	"github.com/mitchellh/goamz/ec2"
 	"golang.org/x/net/context"
@@ -225,29 +224,4 @@ func (a *Amazon) Destroy(ctx context.Context, start, finish int) error {
 		Finish:       finish,
 	}
 	return ws.Wait()
-}
-
-// StatusToState converts a amazon status to a sensible machinestate.State
-// format
-func StatusToState(status string) machinestate.State {
-	status = strings.ToLower(status)
-
-	// Valid values: pending | running | shutting-down | terminated | stopping | stopped
-
-	switch status {
-	case "pending":
-		return machinestate.Starting
-	case "running":
-		return machinestate.Running
-	case "stopped":
-		return machinestate.Stopped
-	case "stopping":
-		return machinestate.Stopping
-	case "shutting-down":
-		return machinestate.Terminating
-	case "terminated":
-		return machinestate.Terminated
-	default:
-		return machinestate.Unknown
-	}
 }


### PR DESCRIPTION
@fatih @cihangir @leeola ptal

overview: In order to issue a call with the aws-sdk-go package we need to juggle various `*Input` structs which, being cluttered with pointers, are cumbersome to work with; this CL introduces a `amazon.Client` which is just a thin wrapper over `ec2.EC2` service to make the API more friendly to work with.

(1st part of https://github.com/koding/koding/pull/5796)
