### PR TITLE
reactivity: invite dropup fix [fixes #108370038]

### DIFF
--- a/client/activity/lib/flux/chatinput/getters.coffee
+++ b/client/activity/lib/flux/chatinput/getters.coffee
@@ -190,12 +190,15 @@ userMentions = (stateId) -> [
 
 
 # Returns a list of channel mentions depending on the current query
+# If current command is /invite, doesn't return anything
 # If query is empty, returns all channel mentions
 # Otherwise, returns mentions filtered by query
 channelMentions = (stateId) -> [
   ChannelMentionsStore
+  currentCommand stateId
   mentionsQuery stateId
-  (mentions, query) ->
+  (mentions, command, query) ->
+    return immutable.List()  if command?.name is '/invite'
     return mentions  unless query
 
     query = query.toLowerCase()

--- a/client/activity/lib/flux/chatinput/getters.coffee
+++ b/client/activity/lib/flux/chatinput/getters.coffee
@@ -171,14 +171,15 @@ userMentions = (stateId) -> [
   currentCommand stateId
   ActivityFluxGetters.notSelectedChannelParticipants
   (allUsers, participants, query, command, notParticipants) ->
-    unless query
-      list = if command?.name is '/invite'
-      then notParticipants
-      else participants?.toList()
-      return list ? immutable.List()
+    isInviteCommand = command?.name is '/invite'
 
-    query = query.toLowerCase()
-    allUsers.toList().filter (user) ->
+    unless query
+      map = if isInviteCommand then notParticipants else participants
+      return if map then map.toList() else immutable.List()
+
+    query  = query.toLowerCase()
+    map = if isInviteCommand then notParticipants else allUsers
+    map.toList().filter (user) ->
       profile = user.get 'profile'
       names = [
         profile.get 'nickname'

--- a/client/activity/lib/flux/getters.coffee
+++ b/client/activity/lib/flux/getters.coffee
@@ -355,11 +355,9 @@ notSelectedChannelParticipants = [
   UsersStore
   selectedChannelParticipants
   (users, participants) ->
-    list = users.toList()
-    return list  unless participants
+    return users  unless participants
 
-    list.filterNot (user) ->
-      userId = user.get '_id'
+    users.filterNot (user, userId) ->
       return participants.get(userId) or whoami()._id is userId
 ]
 


### PR DESCRIPTION
@usirin, can you please review the fix for [this bug](https://www.pivotaltracker.com/story/show/108370038)?

On the video below you can see that invite dropup doesn't contain group mentions while regular mentions dropup contains them
![invite dropup](http://g.recordit.co/wwnWWndkuc.gif)
