### PR TITLE
activity: payload synchronization fix after message is updated [fixes #108497542]

### DIFF
--- a/client/activity/lib/views/activityinputwidget.coffee
+++ b/client/activity/lib/views/activityinputwidget.coffee
@@ -202,8 +202,9 @@ module.exports = class ActivityInputWidget extends KDView
         err.message = 'You are not allowed to edit this post.'  unless err.message
         return @showError err
 
-      activity.body = body
-      activity.link = payload
+      activity.body    = body
+      activity.payload = message.payload
+      activity.link    = payload
 
       activity.emit 'update'
 


### PR DESCRIPTION
@usirin, can you please review the fix for [this bug](https://www.pivotaltracker.com/story/show/108497542)?
The reason why bug happens is that message `link` property is updated with old `payload` data in https://github.com/koding/koding/blob/master/client/app/lib/messageeventmanager.coffee#L140 when message is updated. That's why it's important to update `activity.payload` in `ActivityInputWidget.update()` with data which comes from server
