### PR TITLE
Stack editor fixes [fixes #108413650]

### DIFF
--- a/client/ace/lib/aceview.coffee
+++ b/client/ace/lib/aceview.coffee
@@ -72,6 +72,8 @@ module.exports = class AceView extends JView
 
   forEachPaneByFile: (path, callback) ->
 
+    return  unless @getDelegate().tabView
+
     { handles, panes } = @getDelegate().tabView
 
     for pane in panes when pane.getData()?.path is path

--- a/client/admin/lib/views/stacks/editors/basestackeditorview.coffee
+++ b/client/admin/lib/views/stacks/editors/basestackeditorview.coffee
@@ -25,7 +25,7 @@ module.exports = class BaseStackEditorView extends IDEEditorPane
     options.content     = content
     options.contentType = contentType
     options.file        = FSHelper.createFileInstance
-      path: "localfile:/stack.#{contentType}"
+      path: "localfile:/stack-#{Date.now()}.#{contentType}"
 
     super options, data
 

--- a/workers/social/lib/social/models/computeproviders/computeprovider.coffee
+++ b/workers/social/lib/social/models/computeproviders/computeprovider.coffee
@@ -306,6 +306,8 @@ module.exports = class ComputeProvider extends Base
       { passed, results } = konstraints template, rules, { log: yes }
       return callback new KodingError results.last[1]  unless passed
 
+      callback null
+
 
   # Takes an array of stack template ids and returns the final result ^^
   @validateTemplates = (client, stackTemplates, group, callback) ->


### PR DESCRIPTION
Since new Ace updates contents of other Ace instances based on the file path and since we were using the same file name for all stack editor panes this was causing lots of issues on stack editing flow.
