### PR TITLE
Social: return early if JUser is not set yet

### DIFF
--- a/workers/social/lib/social/main.coffee
+++ b/workers/social/lib/social/main.coffee
@@ -74,6 +74,8 @@ koding = new Bongo {
     [callback, context] = [context, callback] unless callback
     callback            ?= ->
 
+    return callback null  unless JUser
+
     JUser.authenticateClient sessionToken, (err, res = {}) ->
 
       { account, session } = res


### PR DESCRIPTION
```
Nov 13 00:00:05 latest-54.172.197.174 socialworker.log:  TypeError: Cannot call method 'authenticateClient' of undefined
Nov 13 00:00:05 latest-54.172.197.174 socialworker.log:    at Bongo.fetchClient (/var/app/current/workers/social/lib/social/main.coffee:77:11)
Nov 13 00:00:05 latest-54.172.197.174 socialworker.log:    at /var/app/current/node_modules_koding/bongo/lib/expressify.coffee:45:13
```
