### PR TITLE
Validate Stack Templates on save [completes #108551338]

### DIFF
--- a/client/admin/lib/views/stacks/definestackview.coffee
+++ b/client/admin/lib/views/stacks/definestackview.coffee
@@ -250,7 +250,7 @@ module.exports = class DefineStackView extends KDView
 
     @saveTemplate (err, stackTemplate) =>
 
-      if @outputView.handleError err
+      if @outputView.handleError err, "Stack template save failed:"
         @saveButton.hideLoader()
         return
 

--- a/client/admin/lib/views/stacks/definestackview.coffee
+++ b/client/admin/lib/views/stacks/definestackview.coffee
@@ -513,10 +513,11 @@ module.exports = class DefineStackView extends KDView
     }, (err, stackTemplate) =>
 
       if not err and stackTemplate
+
         @setData { stackTemplate }
         @emit 'Reload'
 
-      stackTemplate._updated = currentSum isnt stackTemplate.template.sum
+        stackTemplate._updated = currentSum isnt stackTemplate.template.sum
 
       callback err, stackTemplate
 

--- a/client/admin/lib/views/stacks/outputview.coffee
+++ b/client/admin/lib/views/stacks/outputview.coffee
@@ -85,13 +85,13 @@ module.exports = class OutputView extends kd.ScrollView
     return this
 
 
-  handleError: (err) ->
+  handleError: (err, prefix = 'An error occured:') ->
     return no  unless err
 
     kd.warn '[outputView]', err
     outputParser.showUserFriendlyError err.message
 
-    return @add 'An error occured:', err.message or err
+    return @add prefix, err.message or err
 
 
   pistachio: ->

--- a/client/admin/lib/views/stacks/updatestacktemplate.coffee
+++ b/client/admin/lib/views/stacks/updatestacktemplate.coffee
@@ -22,8 +22,9 @@ module.exports = updateStackTemplate = (data, callback) ->
 
     stackTemplate.update dataToUpdate, (err, _stackTemplate) ->
 
-      _stackTemplate._updated = updated
-      _stackTemplate.inuse    = inuse
+      if _stackTemplate
+        _stackTemplate._updated = updated
+        _stackTemplate.inuse    = inuse
 
       callback err, _stackTemplate
 

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -7,6 +7,7 @@ module.exports = class JStackTemplate extends Module
 
   { permit }   = require '../group/permissionset'
   Validators   = require '../group/validators'
+  { revive }   = require './computeutils'
 
   @trait __dirname, '../../traits/protected'
 
@@ -124,8 +125,14 @@ module.exports = class JStackTemplate extends Module
 
   @create = permit 'create stack template',
 
-    success: (client, data, callback) ->
+    success: revive
 
+      shouldReviveClient   : yes
+      shouldReviveProvider : no
+
+    , (client, data, callback) ->
+
+      { group }    = client.r # we have revived JGroup and JUser here ~ GG
       { delegate } = client.connection
 
       unless data?.title
@@ -271,8 +278,14 @@ module.exports = class JStackTemplate extends Module
       { permission: 'update stack template' }
     ]
 
-    success: (client, data, callback) ->
+    success: revive
 
+      shouldReviveClient   : yes
+      shouldReviveProvider : no
+
+    , (client, data, callback) ->
+
+      { group }    = client.r
       { delegate } = client.connection
 
       # It's not allowed to change a stack template group or owner

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -123,6 +123,15 @@ module.exports = class JStackTemplate extends Module
     }
 
 
+  validateTemplate = (template, group) ->
+
+    plan = group.getAt 'config.plan'
+    return  unless plan # No plan, no pain.
+
+    ComputeProvider = require './computeprovider'
+    return ComputeProvider.validateTemplateContent template, plan
+
+
   @create = permit 'create stack template',
 
     success: revive
@@ -137,6 +146,9 @@ module.exports = class JStackTemplate extends Module
 
       unless data?.title
         return callback new KodingError 'Title required.'
+
+      if validationError = validateTemplate data.template, group
+        return callback validationError
 
       stackTemplate = new JStackTemplate
         originId    : delegate.getId()
@@ -296,6 +308,10 @@ module.exports = class JStackTemplate extends Module
       { template, templateDetails, rawContent } = data
 
       if template?
+
+        if validationError = validateTemplate template, group
+          return callback validationError
+
         data.template = generateTemplateObject \
           template, rawContent, templateDetails
 


### PR DESCRIPTION
We were validating stack templates on requests to set them as default group template in https://github.com/koding/koding/pull/5761 PR this PR provides same validation check on stacktemplate save/update requests based on the group plan. If there is no plan associated with the group at the time the update/save requests taken; this won't do anything and allows any stack templates to save. which is intentionally designed in that way to not break anything on current production.
