### PR TITLE
Set "app" class to "content-display" views [fixes #105736950]

### DIFF
--- a/client/app/lib/mainviewcontroller.coffee
+++ b/client/app/lib/mainviewcontroller.coffee
@@ -87,7 +87,7 @@ module.exports = class MainViewController extends KDViewController
     html     = global.document.documentElement
     mainView = @getView()
 
-    fullSizeApps    = [ 'Login', 'Pricing', 'Activity', 'Teams', 'Welcome' ]
+    fullSizeApps    = [ 'Login', 'Pricing', 'Activity', 'Teams', 'Welcome', 'content-display' ]
     appsWithSidebar = [
       'Activity', 'Members', 'content-display', 'Apps', 'Dashboard', 'Account'
       'Environments', 'Bugs', 'Welcome'


### PR DESCRIPTION
/cc @sinan @szkl @fatihacet 

If you can remember i opened a pr like this about a month ago but it wasn't accepted. But now we can merge this because except `IDE` everywhere will change with `React`. Major changes will be waste time.
