### PR TITLE
Pricing: Fix "current plan" issue [fixes #109161736]

### DIFF
--- a/client/pricing/lib/pricingappview.coffee
+++ b/client/pricing/lib/pricingappview.coffee
@@ -226,6 +226,7 @@ module.exports = class PricingAppView extends KDView
    * if this method will be called or not.
   ###
   planSelected: (options) ->
+
     return  if @state.inProcess
 
     @state.inProcess = yes
@@ -251,7 +252,7 @@ module.exports = class PricingAppView extends KDView
         'expired'             isnt subscriptionState
 
       if isCurrentPlan
-        inProcess = no
+        @state.inProcess = no
         return showError "That's already your current plan."
 
       { PAYPAL, KODING } = PaymentConstants.provider


### PR DESCRIPTION
Before this fix, user could not select any plan except current plan. Because we didn't set false / no to `@state.inProcess` state.

/cc @fatihacet @usirin @gokmen @szkl 

![kd7psxd0m3](https://cloud.githubusercontent.com/assets/728733/11482034/6d1e44d4-9755-11e5-9697-96c8b48eb1c8.gif)
