### PR TITLE
Fixes PreExistingChannel problem [fixes #109072984]

### DIFF
--- a/client/activity/lib/components/createprivatechannelmodal/index.coffee
+++ b/client/activity/lib/components/createprivatechannelmodal/index.coffee
@@ -73,10 +73,21 @@ module.exports = class CreatePrivateChannelModal extends React.Component
       { loadChannelByParticipants } = ActivityFlux.actions.channel
 
       loadChannelByParticipants(participants).then ({ channels }) =>
-        if channels.length
-          @setState { preExistingChannel: toImmutable channels[0] }
-        else
-          @setState { preExistingChannel: null }
+
+      loadChannelByParticipants(participants).then ({ channels }) =>
+        preExistingChannel = @getPreExistingChannel(channels, participants)
+        @setState { preExistingChannel }
+
+
+  getPreExistingChannel: (channels, participants) ->
+
+    preExistingChannel = null
+
+    channels.forEach (channel) ->
+      if (channel.participantsPreview.length - 1) is participants.length
+        preExistingChannel = toImmutable channel
+
+    return preExistingChannel
 
 
   getDataBindings: ->


### PR DESCRIPTION
<img src='http://g.recordit.co/Se4gWblphF.gif' />

/cc @sinan @usirin 

if any private channel exist before with multiple participant, we can't create new private channel with a user who is already participant of first one.In each trial only `Continue Existing Conversation` button rendered. This pr fixes this problem with checking participants count.
