### PR TITLE
Fixed: Position of the Create VM from snapshot overlay is incorrect for low screen height [fixes #107792378]

### DIFF
--- a/client/app/lib/providers/computeplansmodalpaid.coffee
+++ b/client/app/lib/providers/computeplansmodalpaid.coffee
@@ -20,6 +20,8 @@ module.exports = class ComputePlansModalPaid extends ComputePlansModal
   constructor:(options = {}, data)->
 
     options.cssClass = 'paid-plan'
+    options.position =
+        top : '78'
 
     super options, data
 


### PR DESCRIPTION
Old
![screenshot at 23-47-41](https://cloud.githubusercontent.com/assets/1278794/11515318/0a9a6e64-9886-11e5-928c-db5fa71e65e3.png)

New
![screenshot at 23-48-23](https://cloud.githubusercontent.com/assets/1278794/11515319/0aa1cc86-9886-11e5-8dc9-2bd1812889df.png)

Story: https://www.pivotaltracker.com/story/show/107792378

Notes: The position relative to top has been changed globally for this modal, even if there are no snapshots. This could have been done in two ways: 1) change the position globally even if there is no snapshots container 2) change the position only when the snapshots container is present (though I'm not sure about this one, since the modal is already built / shown and only after the modal is present is the check being made for snapshots and the snapshots container shown if there are any).

The new position has been tested using multiple screen sizes.

/cc @sinan 
