### PR TITLE
Clear snapshot data for kicked or leaved participant on shared vms [fixes #108226170]

### DIFF
--- a/client/app/lib/applicationmanager.coffee
+++ b/client/app/lib/applicationmanager.coffee
@@ -262,15 +262,12 @@ class ApplicationManager extends KDObject
       @quit appController.instances[appController.lastActiveIndex]
 
 
-  get:(name)->
+  get: (name, all = no)->
 
-    if apps = @appControllers[name]
-      apps.instances[apps.lastActiveIndex] or apps.instances.first
-    else
-      null
-
-
-  getInstances: (name) -> @appControllers[name]?.instances
+   if apps = @appControllers[name]
+     if all then apps else apps.instances[apps.lastActiveIndex] or apps.instances.first
+   else
+     null
 
 
   getByView: (view)->

--- a/client/app/lib/applicationmanager.coffee
+++ b/client/app/lib/applicationmanager.coffee
@@ -270,9 +270,7 @@ class ApplicationManager extends KDObject
       null
 
 
-  getInstances: (name) ->
-
-    @appControllers[name]?.instances
+  getInstances: (name) -> @appControllers[name]?.instances
 
 
   getByView: (view)->

--- a/client/app/lib/applicationmanager.coffee
+++ b/client/app/lib/applicationmanager.coffee
@@ -270,9 +270,9 @@ class ApplicationManager extends KDObject
       null
 
 
-  getIDEInstances: ->
+  getInstances: (name) ->
 
-    @appControllers['IDE']?.instances
+    @appControllers[name]?.instances
 
 
   getByView: (view)->

--- a/client/app/lib/applicationmanager.coffee
+++ b/client/app/lib/applicationmanager.coffee
@@ -270,6 +270,11 @@ class ApplicationManager extends KDObject
       null
 
 
+  getIDEInstances: ->
+
+    @appControllers['IDE']?.instances
+
+
   getByView: (view)->
 
     appInstance = null

--- a/client/app/lib/notificationcontroller.coffee
+++ b/client/app/lib/notificationcontroller.coffee
@@ -1,12 +1,13 @@
-kookies            = require 'kookies'
-getGroup           = require 'app/util/getGroup'
-whoami             = require 'app/util/whoami'
-envDataProvider    = require 'app/userenvironmentdataprovider'
-kd                 = require 'kd'
-articlize          = require 'indefinite-article'
-KDModalView        = kd.ModalView
-KDNotificationView = kd.NotificationView
-KDObject           = kd.Object
+kookies             = require 'kookies'
+getGroup            = require 'app/util/getGroup'
+whoami              = require 'app/util/whoami'
+envDataProvider     = require 'app/userenvironmentdataprovider'
+kd                  = require 'kd'
+articlize           = require 'indefinite-article'
+KDModalView         = kd.ModalView
+KDNotificationView  = kd.NotificationView
+KDObject            = kd.Object
+IDEHelpers          = require 'ide/idehelpers'
 
 
 module.exports = class NotificationController extends KDObject

--- a/client/app/lib/notificationcontroller.coffee
+++ b/client/app/lib/notificationcontroller.coffee
@@ -98,9 +98,12 @@ module.exports = class NotificationController extends KDObject
     @on 'MachineListUpdated', ({machineUId, action}) ->
       switch action
         when 'removed'
-          if ideInstance = envDataProvider.getIDEFromUId machineUId
-            if ideInstance.mountedMachine.isPermanent()
-              ideInstance.showUserRemovedModal()
+          instances = IDEHelpers.getOpenedIDEInstancesByMachineUId machineUId
+
+          return  unless instances.length
+
+          instances.last.showUserRemovedModal ->
+            instances.forEach (instance) -> instance.quit()
 
       kd.singletons.computeController.reset yes
 

--- a/client/app/lib/providers/machinesettingsvmsharingview.coffee
+++ b/client/app/lib/providers/machinesettingsvmsharingview.coffee
@@ -1,14 +1,15 @@
-kd                               = require 'kd'
-nick                             = require 'app/util/nick'
-remote                           = require('app/remote').getInstance()
-KDView                           = kd.View
-Machine                          = require 'app/providers/machine'
-UserItem                         = require 'app/useritem'
-KDCustomHTMLView                 = kd.CustomHTMLView
-ComputeErrorUsageModal           = require './computeerrorusagemodal'
-KDAutoCompleteController         = kd.AutoCompleteController
-MachineSettingsCommonView        = require './machinesettingscommonview'
-ActivityAutoCompleteUserItemView = require 'activity/views/activityautocompleteuseritemview'
+kd                                = require 'kd'
+nick                              = require 'app/util/nick'
+remote                            = require('app/remote').getInstance()
+KDView                            = kd.View
+Machine                           = require 'app/providers/machine'
+UserItem                          = require 'app/useritem'
+IDEHelpers                        = require 'ide/idehelpers'
+KDCustomHTMLView                  = kd.CustomHTMLView
+ComputeErrorUsageModal            = require './computeerrorusagemodal'
+KDAutoCompleteController          = kd.AutoCompleteController
+MachineSettingsCommonView         = require './machinesettingscommonview'
+ActivityAutoCompleteUserItemView  = require 'activity/views/activityautocompleteuseritemview'
 
 
 module.exports = class MachineSettingsVMSharingView extends MachineSettingsCommonView

--- a/client/app/lib/providers/machinesettingsvmsharingview.coffee
+++ b/client/app/lib/providers/machinesettingsvmsharingview.coffee
@@ -93,6 +93,8 @@ module.exports = class MachineSettingsVMSharingView extends MachineSettingsCommo
       kite   = @machine.getBaseKite()
       method = if task is 'add' then 'klientShare' else 'klientUnshare'
 
+      IDEHelpers.deleteSnapshotData @machine, nickname  if task is 'kick'
+
       kite[method] { username: nickname, permanent: yes }
 
         .then => @updateUserList task, user, userItem

--- a/client/app/lib/providers/machinesettingsvmsharingview.coffee
+++ b/client/app/lib/providers/machinesettingsvmsharingview.coffee
@@ -90,10 +90,13 @@ module.exports = class MachineSettingsVMSharingView extends MachineSettingsCommo
 
       return @showNotification err  if err
 
-      kite   = @machine.getBaseKite()
-      method = if task is 'add' then 'klientShare' else 'klientUnshare'
+      kite = @machine.getBaseKite()
 
-      IDEHelpers.deleteSnapshotData @machine, nickname  if task is 'kick'
+      if task is 'add'
+        method = 'klientShare'
+      else
+        method = 'klientUnshare'
+        IDEHelpers.deleteSnapshotData @machine, nickname
 
       kite[method] { username: nickname, permanent: yes }
 


### PR DESCRIPTION
We have to clear snapshot data for kicked or leaved participants. There are 2 options to do this:
- [x] Clear it when host kicked a participant
- [ ] Clear it when participant leaved from a shared vm

@fatih can we make a session when you're available? Because `Kite` doesn't allow to exec `storageDelete` method as participant. Maybe we can find a solution for this. So this pr can wait as `wip`.

/cc @fatihacet @gokmen @szkl @usirin @sinan 

Also can someone add `wip` label to this pr?
