### PR TITLE
reinit: fix in a very elegant way

### DIFF
--- a/go/src/koding/kites/kloud/kloud/controller.go
+++ b/go/src/koding/kites/kloud/kloud/controller.go
@@ -27,12 +27,12 @@ type statePair struct {
 
 var states = map[string]*statePair{
 	"build":          &statePair{start: machinestate.Building, final: machinestate.Running},
+	"reinit":         &statePair{start: machinestate.Building, final: machinestate.Running},
 	"start":          &statePair{start: machinestate.Starting, final: machinestate.Running},
 	"stop":           &statePair{start: machinestate.Stopping, final: machinestate.Stopped},
 	"destroy":        &statePair{start: machinestate.Terminating, final: machinestate.Terminated},
 	"restart":        &statePair{start: machinestate.Rebooting, final: machinestate.Running},
 	"resize":         &statePair{start: machinestate.Pending, final: machinestate.Running},
-	"reinit":         &statePair{start: machinestate.Terminating, final: machinestate.Running},
 	"createSnapshot": &statePair{start: machinestate.Snapshotting, final: machinestate.Running},
 	"deleteSnapshot": &statePair{start: machinestate.Snapshotting, final: machinestate.Running},
 }
@@ -114,6 +114,7 @@ func (k *Kloud) coreMethods(r *kite.Request, fn machineFunc) (result interface{}
 	k.cleanupEventers(args.MachineId)
 
 	// each method has his own unique eventer
+
 	eventId := r.Method + "-" + args.MachineId
 	ev := k.NewEventer(eventId)
 	ctx = eventer.NewContext(ctx, ev)

--- a/go/src/koding/kites/kloud/provider/koding/reinit.go
+++ b/go/src/koding/kites/kloud/provider/koding/reinit.go
@@ -33,7 +33,9 @@ func (m *Machine) Reinit(ctx context.Context) error {
 
 	// go and terminate the old instance, we don't need to wait for it
 	go func(machine *Machine) {
-		if err := machine.Session.AWSClient.Destroy(ctx, 10, 50); err != nil {
+		instanceId := machine.Session.AWSClient.Id()
+		_, err := machine.Session.AWSClient.TerminateInstance(instanceId)
+		if err != nil {
 			m.Log.Warning("couldn't terminate instance: %s", err)
 		}
 	}(m)

--- a/go/src/koding/kites/kloud/provider/koding/reinit.go
+++ b/go/src/koding/kites/kloud/provider/koding/reinit.go
@@ -10,27 +10,10 @@ import (
 	"golang.org/x/net/context"
 )
 
-func (m *Machine) Reinit(ctx context.Context) (err error) {
-	if err := m.UpdateState("Machine is starting", machinestate.Starting); err != nil {
-		return err
-	}
-
-	// update the state to intiial state if something goes wrong, we are going
-	// to change latestate to a more safe state if we passed a certain step
-	// below
-	latestState := m.State()
-	defer func() {
-		if err != nil {
-			m.UpdateState("Machine is marked as "+latestState.String(), latestState)
-		}
-	}()
-
-	if err := m.Session.AWSClient.Destroy(ctx, 10, 50); err != nil {
-		return err
-	}
-
-	// clean up old data, so if build fails below at least we give the chance to build it again
-	err = m.Session.DB.Run("jMachines", func(c *mgo.Collection) error {
+func (m *Machine) Reinit(ctx context.Context) error {
+	// clean up old data, so if build fails below at least we give the chance
+	// to build it again
+	err := m.Session.DB.Run("jMachines", func(c *mgo.Collection) error {
 		return c.UpdateId(
 			m.Id,
 			bson.M{"$set": bson.M{
@@ -40,13 +23,20 @@ func (m *Machine) Reinit(ctx context.Context) (err error) {
 				"meta.instanceName": "",
 				"status.state":      machinestate.NotInitialized.String(),
 				"status.modifiedAt": time.Now().UTC(),
-				"status.reason":     "Reinit cleanup",
+				"status.reason":     "Reinit initalized",
 			}},
 		)
 	})
 	if err != nil {
-		return err
+		m.Log.Warning("couldn't update reinit db: %s", err)
 	}
+
+	// go and terminate the old instance, we don't need to wait for it
+	go func(machine *Machine) {
+		if err := machine.Session.AWSClient.Destroy(ctx, 10, 50); err != nil {
+			m.Log.Warning("couldn't terminate instance: %s", err)
+		}
+	}(m)
 
 	// cleanup this too so "build" can continue with a clean setup
 	m.IpAddress = ""


### PR DESCRIPTION
Reinit was always causing problems for us due to two states (terminating and building) and the interaction with the client. Now an easy fix for all our problems is just to assume that we're going to build a new machine from scratch (which we are doing actually in anyway). 

So we're terminating the machine in the background and don't wait for it (because we really don't need to wait for it) and  just start to build (and setting the state to building). This fixes the following problems:
1. No more state mismatches anymore, because there is only one state
2. Reinit is much more faster as we don't wait for terminating anymore
3. Client side interaction is going to much more easier.

We still listen to `reinit-.....` eventer id btw. 

/cc @gokmen @fatihacet @rjeczalik 
