### PR TITLE
Render private/public channels with the same name [#109443872]

### DIFF
--- a/client/activity/lib/flux/getters.coffee
+++ b/client/activity/lib/flux/getters.coffee
@@ -201,7 +201,7 @@ selectedChannelThread = [
     return thread.set 'channel', channel
 ]
 
-channelByName = (name, types = ['topic', 'group']) ->
+channelByName = (name, types = ['topic', 'group', 'announcement']) ->
   channels = kd.singletons.reactor.evaluateToJS allChannels
   for id, _channel of channels when _channel.name is name and _channel.typeConstant in types
     return _channel

--- a/client/activity/lib/flux/getters.coffee
+++ b/client/activity/lib/flux/getters.coffee
@@ -1,6 +1,5 @@
 kd                         = require 'kd'
 immutable                  = require 'immutable'
-isPublicChatChannel        = require 'activity/util/isPublicChatChannel'
 whoami                     = require 'app/util/whoami'
 isPublicChannel            = require 'app/util/isPublicChannel'
 calculateListSelectedIndex = require 'activity/util/calculateListSelectedIndex'
@@ -202,10 +201,10 @@ selectedChannelThread = [
     return thread.set 'channel', channel
 ]
 
-channelByName = (name) ->
+channelByName = (name, types = ['topic', 'group']) ->
   channels = kd.singletons.reactor.evaluateToJS allChannels
-  channel = _channel for id, _channel of channels when _channel.name is name
-  return channel
+  for id, _channel of channels when _channel.name is name and _channel.typeConstant in types
+    return _channel
 
 # Returns followed public channel threads mapped with relevant channel
 # instances.

--- a/client/activity/lib/util/isPublicChatChannel.coffee
+++ b/client/activity/lib/util/isPublicChatChannel.coffee
@@ -1,8 +1,0 @@
-immutable = require 'immutable'
-
-module.exports = isPublicChatChannel = (channel) ->
-
-  if immutable.Iterable.isIterable channel
-  then channel.getIn(['payload', '__publicChat'])?
-  else channel.payload.__publicChat?
-


### PR DESCRIPTION
We were assuming that whenever a channel is required by name it will be a public channel for sure, but apparently we missed this case.

Right now, `channelByName` getter accepts a `type` argument as an array of types that is allowed, and defaults it to `['topic', 'group']` types, since those are the `public` channel types we have at this moment.
