### PR TITLE
Tests: reinit vm; terminate + create a new vm for a non-paying user

### DIFF
--- a/client/test/lib/environments/vm-advanced.coffee
+++ b/client/test/lib/environments/vm-advanced.coffee
@@ -1,0 +1,38 @@
+helpers = require '../helpers/helpers.js'
+assert  = require 'assert'
+environmentHelpers = require '../helpers/environmenthelpers.js'
+
+module.exports =
+
+  reinitVM: (browser) ->
+
+    helpers.beginTest(browser)
+    helpers.waitForVMRunning(browser)
+
+    environmentHelpers.openAdvancedSettings(browser)
+    environmentHelpers.reinitVM(browser)
+
+    browser.end()
+
+
+  terminateVMForNonPayingUserAndCreateNewOne: (browser) ->
+
+    helpers.beginTest(browser)
+    helpers.waitForVMRunning(browser)
+
+    environmentHelpers.openAdvancedSettings(browser)
+    environmentHelpers.terminateVM(browser)
+    environmentHelpers.createNewVMForNonPayingUsers(browser)
+
+    browser.end()
+
+
+  terminateVm: (browser) ->
+
+    helpers.beginTest(browser)
+    helpers.waitForVMRunning(browser)
+
+    environmentHelpers.openAdvancedSettings(browser)
+    environmentHelpers.terminateVM(browser)
+
+    browser.end()

--- a/client/test/lib/environments/vm.coffee
+++ b/client/test/lib/environments/vm.coffee
@@ -32,14 +32,14 @@ module.exports =
     browser.end()
 
 
-  terminateVMforNonPayingUserAndCreateAnewOne: (browser) ->
+  terminateVMForNonPayingUserAndCreateNewOne: (browser) ->
 
     helpers.beginTest(browser)
     helpers.waitForVMRunning(browser)
 
     environmentHelpers.openAdvancedSettings(browser)
     environmentHelpers.terminateVM(browser)
-    environmentHelpers.createAnewVMforNonPayingUsers(browser)
+    environmentHelpers.createNewVMForNonPayingUsers(browser)
 
     browser.end()
 

--- a/client/test/lib/environments/vm.coffee
+++ b/client/test/lib/environments/vm.coffee
@@ -23,12 +23,35 @@ module.exports =
       .waitForElementVisible   vmStateModal + ' .state-label.stopped', 300000
       .waitForElementVisible   vmStateModal + ' .turn-on.state-button', 20000 # Assertion
       .end()
-
+  
 
   turnOnVm: (browser) ->
 
     helpers.beginTest(browser)
     helpers.waitForVMRunning(browser)
+    browser.end()
+
+
+  terminateVMforNonPayingUserAndCreateAnewOne: (browser) ->
+
+    helpers.beginTest(browser)
+    helpers.waitForVMRunning(browser)
+
+    environmentHelpers.openAdvancedSettings(browser)
+    environmentHelpers.terminateVM(browser)
+    environmentHelpers.createAnewVMforNonPayingUsers(browser)
+
+    browser.end()
+
+
+  reinitVM: (browser) ->
+
+    helpers.beginTest(browser)
+    helpers.waitForVMRunning(browser)
+
+    environmentHelpers.openAdvancedSettings(browser)
+    environmentHelpers.reinitVM(browser)
+
     browser.end()
 
 
@@ -76,24 +99,13 @@ module.exports =
 
   terminateVm: (browser) ->
 
-    terminateSelector       = '.kdmodal.AppModal .advanced .advanced.terminate'
-    proceedSelector         = '.kdmodal.with-buttons .kdbutton.red'
-    terminatedLabelSelector = '.kdmodal.env-modal .state-label.terminated'
-
     helpers.beginTest(browser)
-    browser.pause 1000
     helpers.waitForVMRunning(browser)
 
     environmentHelpers.openAdvancedSettings(browser)
+    environmentHelpers.terminateVM(browser)
 
-    browser
-      .waitForElementVisible  terminateSelector, 20000
-      .click                  terminateSelector
-      .waitForElementVisible  proceedSelector, 20000
-      .click                  proceedSelector
-      .waitForElementVisible  terminatedLabelSelector, 100000
-      .assert.containsText    terminatedLabelSelector, "successfully deleted" #Assertion
-      .end()
+    browser.end()
 
 ### DISABLED - takes too long (10m 41s)
   resizeVm: (browser) ->

--- a/client/test/lib/environments/vm.coffee
+++ b/client/test/lib/environments/vm.coffee
@@ -32,29 +32,6 @@ module.exports =
     browser.end()
 
 
-  terminateVMForNonPayingUserAndCreateNewOne: (browser) ->
-
-    helpers.beginTest(browser)
-    helpers.waitForVMRunning(browser)
-
-    environmentHelpers.openAdvancedSettings(browser)
-    environmentHelpers.terminateVM(browser)
-    environmentHelpers.createNewVMForNonPayingUsers(browser)
-
-    browser.end()
-
-
-  reinitVM: (browser) ->
-
-    helpers.beginTest(browser)
-    helpers.waitForVMRunning(browser)
-
-    environmentHelpers.openAdvancedSettings(browser)
-    environmentHelpers.reinitVM(browser)
-
-    browser.end()
-
-
   checkVMDiskUsage: (browser) ->
 
     diskUsageSelector  = modalSelector + ' .disk-usage'
@@ -97,15 +74,6 @@ module.exports =
     browser.pause 1000 #Doesn't work without it
     browser.end()
 
-  terminateVm: (browser) ->
-
-    helpers.beginTest(browser)
-    helpers.waitForVMRunning(browser)
-
-    environmentHelpers.openAdvancedSettings(browser)
-    environmentHelpers.terminateVM(browser)
-
-    browser.end()
 
 ### DISABLED - takes too long (10m 41s)
   resizeVm: (browser) ->

--- a/client/test/lib/helpers/environmenthelpers.coffee
+++ b/client/test/lib/helpers/environmenthelpers.coffee
@@ -289,20 +289,23 @@ module.exports =
 
   reinitVM: (browser) ->
 
-    reinitSelector  = '.kdmodal.AppModal .advanced .advanced.reinit'
-    proceedSelector = '.kdmodal.with-buttons .kdbutton.red'
-    vmStateModal    = '.env-machine-state .kdmodal-content'
-    vmSelector      = '.sidebar-machine-box'
+    reinitSelector   = '.kdmodal.AppModal .advanced .advanced.reinit'
+    proceedSelector  = '.kdmodal.with-buttons .kdbutton.red'
+    vmStateModal     = '.env-machine-state .kdmodal-content'
+    vmSelector       = '.sidebar-machine-box'
+    envModalSelector = ".env-modal.env-machine-state"
 
     browser
-      .waitForElementVisible  reinitSelector, 20000
-      .click                  reinitSelector
-      .waitForElementVisible  proceedSelector, 20000
-      .click                  proceedSelector
-      .waitForElementVisible  vmSelector   + ' .vm.building', 200000
-      .waitForElementVisible  vmStateModal + ' .content-container .building', 200000
-      .waitForElementVisible  vmSelector   + ' .vm.running', 600000
-      .assert.containsText    vmSelector, 'koding-vm-0'
+      .waitForElementVisible     reinitSelector, 20000
+      .click                     reinitSelector
+      .waitForElementVisible     proceedSelector, 20000
+      .click                     proceedSelector
+      .waitForElementVisible     vmSelector   + ' .vm.building', 200000
+      .waitForElementVisible     vmStateModal + ' .content-container .building', 200000
+      .waitForElementNotPresent  envModalSelector, 600000
+      .pause                     5000 # wait for sidebar redraw
+      .waitForElementVisible     vmSelector + ' .running.vm', 20000
+      .assert.containsText       vmSelector + ' .running.vm', 'koding-vm-0'
 
 
   terminateVM: (browser) ->

--- a/client/test/lib/helpers/environmenthelpers.coffee
+++ b/client/test/lib/helpers/environmenthelpers.coffee
@@ -303,6 +303,9 @@ module.exports =
       .waitForElementVisible  vmSelector + ' .vm.terminating', 20000
       .waitForElementVisible  vmSelector + ' .vm.building', 300000
       .waitForElementVisible  vmSelector + ' .vm.running', 600000
+      .waitForElementVisible  vmSelector, 20000
+      .assert.containsText    vmSelector, 'koding-vm-0'
+
 
 
   terminateVM: (browser) ->
@@ -310,26 +313,31 @@ module.exports =
     terminateSelector       = '.kdmodal.AppModal .advanced .advanced.terminate'
     proceedSelector         = '.kdmodal.with-buttons .kdbutton.red'
     terminatedLabelSelector = '.kdmodal.env-modal .state-label.terminated'
+    vmSelector              = '.sidebar-machine-box'
 
     browser
       .waitForElementVisible  terminateSelector, 20000
       .click                  terminateSelector
       .waitForElementVisible  proceedSelector, 20000
       .click                  proceedSelector
-      .waitForElementVisible  terminatedLabelSelector, 100000
+      .waitForElementVisible  vmSelector + ' .vm.terminating', 200000
+      .waitForElementVisible  terminatedLabelSelector, 200000
       .assert.containsText    terminatedLabelSelector, "successfully deleted" #Assertion
 
 
   createAnewVMforNonPayingUsers: (browser) ->
 
-  	createVMbutton    = '.content-container .kdbutton'
-  	addKodingVmButton = '.environments-modal .kdbutton.add-vm-button'
-  	vmSelector        = '.sidebar-machine-box .notinitialized'
+    createVMbutton    = '.content-container .kdbutton'
+    addKodingVmButton = '.environments-modal .kdbutton.add-vm-button'
+    vmSelector        = '.sidebar-machine-box .notinitialized'
+    vmStateModal      = '.env-machine-state .kdmodal-content'
 
-  	browser
-  	  .waitForElementVisible  createVMbutton, 20000
-  	  .click                  createVMbutton
-  	  .waitForElementVisible  addKodingVmButton, 20000
-  	  .click                  addKodingVmButton
-  	  .waitForElementVisible  vmSelector, 20000
-  	  .assert.containsText    vmSelector, 'koding-vm-0'
+    browser
+      .waitForElementVisible  createVMbutton, 20000
+      .click                  createVMbutton
+      .waitForElementVisible  addKodingVmButton, 20000
+      .click                  addKodingVmButton
+      .waitForElementVisible  vmSelector, 20000
+      .assert.containsText    vmSelector, 'koding-vm-0'
+      .waitForElementVisible  vmStateModal + ' .turn-on', 20000
+      .assert.containsText    vmStateModal + ' .turn-on', 'TURN IT ON'

--- a/client/test/lib/helpers/environmenthelpers.coffee
+++ b/client/test/lib/helpers/environmenthelpers.coffee
@@ -286,6 +286,7 @@ module.exports =
       .clearValue             nicknameInput
       .setValue               nicknameInput, name + '\n'
   
+
   reinitVM: (browser) ->
 
     reinitSelector  = '.kdmodal.AppModal .advanced .advanced.reinit'
@@ -331,5 +332,4 @@ module.exports =
   	  .waitForElementVisible  addKodingVmButton, 20000
   	  .click                  addKodingVmButton
   	  .waitForElementVisible  vmSelector, 20000
-
   	  .assert.containsText    vmSelector, 'koding-vm-0'

--- a/client/test/lib/helpers/environmenthelpers.coffee
+++ b/client/test/lib/helpers/environmenthelpers.coffee
@@ -299,10 +299,8 @@ module.exports =
       .click                  reinitSelector
       .waitForElementVisible  proceedSelector, 20000
       .click                  proceedSelector
-      .waitForElementVisible  vmStateModal + ' .content-container .terminating', 20000
-      .waitForElementVisible  vmSelector   + ' .vm.terminating', 20000
-      .waitForElementVisible  vmSelector   + ' .vm.building', 200000
       .waitForElementVisible  vmStateModal + ' .content-container .building', 200000
+      .waitForElementVisible  vmSelector   + ' .vm.building', 200000
       .waitForElementVisible  vmSelector   + ' .vm.running', 600000
       .assert.containsText    vmSelector, 'koding-vm-0'
 

--- a/client/test/lib/helpers/environmenthelpers.coffee
+++ b/client/test/lib/helpers/environmenthelpers.coffee
@@ -299,8 +299,8 @@ module.exports =
       .click                  reinitSelector
       .waitForElementVisible  proceedSelector, 20000
       .click                  proceedSelector
-      .waitForElementVisible  vmStateModal + ' .content-container .building', 200000
       .waitForElementVisible  vmSelector   + ' .vm.building', 200000
+      .waitForElementVisible  vmStateModal + ' .content-container .building', 200000
       .waitForElementVisible  vmSelector   + ' .vm.running', 600000
       .assert.containsText    vmSelector, 'koding-vm-0'
 

--- a/client/test/lib/helpers/environmenthelpers.coffee
+++ b/client/test/lib/helpers/environmenthelpers.coffee
@@ -313,13 +313,15 @@ module.exports =
     proceedSelector         = '.kdmodal.with-buttons .kdbutton.red'
     terminatedLabelSelector = '.kdmodal.env-modal .state-label.terminated'
     vmSelector              = '.sidebar-machine-box'
+    vmStateModal            = '.env-machine-state .kdmodal-content'
 
     browser
       .waitForElementVisible  terminateSelector, 20000
       .click                  terminateSelector
       .waitForElementVisible  proceedSelector, 20000
       .click                  proceedSelector
-      .waitForElementVisible  vmSelector + ' .vm.terminating', 200000
+      .waitForElementVisible  vmSelector   + ' .vm.terminating', 200000
+      .waitForElementVisible  vmStateModal + ' .terminating', 20000
       .waitForElementVisible  terminatedLabelSelector, 200000
       .assert.containsText    terminatedLabelSelector, "successfully deleted" #Assertion
 

--- a/client/test/lib/helpers/environmenthelpers.coffee
+++ b/client/test/lib/helpers/environmenthelpers.coffee
@@ -300,12 +300,11 @@ module.exports =
       .waitForElementVisible  proceedSelector, 20000
       .click                  proceedSelector
       .waitForElementVisible  vmStateModal + ' .content-container .terminating', 20000
-      .waitForElementVisible  vmSelector + ' .vm.terminating', 20000
-      .waitForElementVisible  vmSelector + ' .vm.building', 300000
-      .waitForElementVisible  vmSelector + ' .vm.running', 600000
-      .waitForElementVisible  vmSelector, 20000
+      .waitForElementVisible  vmSelector   + ' .vm.terminating', 20000
+      .waitForElementVisible  vmSelector   + ' .vm.building', 200000
+      .waitForElementVisible  vmStateModal + ' .content-container .building', 200000
+      .waitForElementVisible  vmSelector   + ' .vm.running', 600000
       .assert.containsText    vmSelector, 'koding-vm-0'
-
 
 
   terminateVM: (browser) ->
@@ -325,7 +324,7 @@ module.exports =
       .assert.containsText    terminatedLabelSelector, "successfully deleted" #Assertion
 
 
-  createAnewVMforNonPayingUsers: (browser) ->
+  createNewVMForNonPayingUsers: (browser) ->
 
     createVMbutton    = '.content-container .kdbutton'
     addKodingVmButton = '.environments-modal .kdbutton.add-vm-button'
@@ -339,5 +338,5 @@ module.exports =
       .click                  addKodingVmButton
       .waitForElementVisible  vmSelector, 20000
       .assert.containsText    vmSelector, 'koding-vm-0'
-      .waitForElementVisible  vmStateModal + ' .turn-on', 20000
+      .waitForElementVisible  vmStateModal + ' .turn-on', 50000
       .assert.containsText    vmStateModal + ' .turn-on', 'TURN IT ON'

--- a/client/test/lib/helpers/environmenthelpers.coffee
+++ b/client/test/lib/helpers/environmenthelpers.coffee
@@ -338,5 +338,6 @@ module.exports =
       .click                  addKodingVmButton
       .waitForElementVisible  vmSelector, 20000
       .assert.containsText    vmSelector, 'koding-vm-0'
+      .pause                   2500 # wait for correct pop-up to appear
       .waitForElementVisible  vmStateModal + ' .turn-on', 50000
       .assert.containsText    vmStateModal + ' .turn-on', 'TURN IT ON'

--- a/client/test/lib/helpers/environmenthelpers.coffee
+++ b/client/test/lib/helpers/environmenthelpers.coffee
@@ -285,3 +285,51 @@ module.exports =
       .waitForElementVisible  nicknameInput, 20000
       .clearValue             nicknameInput
       .setValue               nicknameInput, name + '\n'
+  
+  reinitVM: (browser) ->
+
+    reinitSelector  = '.kdmodal.AppModal .advanced .advanced.reinit'
+    proceedSelector = '.kdmodal.with-buttons .kdbutton.red'
+    vmStateModal    = '.env-machine-state .kdmodal-content'
+    vmSelector      = '.sidebar-machine-box'
+
+    browser
+      .waitForElementVisible  reinitSelector, 20000
+      .click                  reinitSelector
+      .waitForElementVisible  proceedSelector, 20000
+      .click                  proceedSelector
+      .waitForElementVisible  vmStateModal + ' .content-container .terminating', 20000
+      .waitForElementVisible  vmSelector + ' .vm.terminating', 20000
+      .waitForElementVisible  vmSelector + ' .vm.building', 300000
+      .waitForElementVisible  vmSelector + ' .vm.running', 600000
+
+
+  terminateVM: (browser) ->
+
+    terminateSelector       = '.kdmodal.AppModal .advanced .advanced.terminate'
+    proceedSelector         = '.kdmodal.with-buttons .kdbutton.red'
+    terminatedLabelSelector = '.kdmodal.env-modal .state-label.terminated'
+
+    browser
+      .waitForElementVisible  terminateSelector, 20000
+      .click                  terminateSelector
+      .waitForElementVisible  proceedSelector, 20000
+      .click                  proceedSelector
+      .waitForElementVisible  terminatedLabelSelector, 100000
+      .assert.containsText    terminatedLabelSelector, "successfully deleted" #Assertion
+
+
+  createAnewVMforNonPayingUsers: (browser) ->
+
+  	createVMbutton    = '.content-container .kdbutton'
+  	addKodingVmButton = '.environments-modal .kdbutton.add-vm-button'
+  	vmSelector        = '.sidebar-machine-box .notinitialized'
+
+  	browser
+  	  .waitForElementVisible  createVMbutton, 20000
+  	  .click                  createVMbutton
+  	  .waitForElementVisible  addKodingVmButton, 20000
+  	  .click                  addKodingVmButton
+  	  .waitForElementVisible  vmSelector, 20000
+
+  	  .assert.containsText    vmSelector, 'koding-vm-0'

--- a/scripts/test-instance/parallel-sets.coffee
+++ b/scripts/test-instance/parallel-sets.coffee
@@ -70,6 +70,7 @@ module.exports = [
   [
     { name: 'ide general' }
     { name: 'ide layout' }
+    { name: 'environments vm-advanced' }
   ]
 
   [


### PR DESCRIPTION
The following tests were added:
- Reinit an existing VM
- Terminate VM for a non-paid user and create a new one

Note: The test "Update VM nickname" already exists in the environments\vm.coffee file, named "updateVMNickname".

cc: @didemacet 
