### PR TITLE
Sidebar: (+) button to create a new private message thread should be visible only when you hover over the title. [fixes #109452476]

### DIFF
--- a/client/app/lib/styl/resurrection.sidebar.styl
+++ b/client/app/lib/styl/resurrection.sidebar.styl
@@ -1053,7 +1053,7 @@ h3.sidebar-title
         border              3px solid sidebarGray
         borderBox()
       > span
-        abs                 4px -5px 0 0
+        abs                 4px 1px 0 0
         opacity             0
         r-sprite            app vm-settings-icon
         vendor              transition, opacity .1s .1s ease

--- a/client/app/lib/styl/resurrection.sidebar.styl
+++ b/client/app/lib/styl/resurrection.sidebar.styl
@@ -868,9 +868,6 @@ h3.sidebar-title
     top                     11px
 
 
-.messages.empty h3.sidebar-title a.add-icon
-  opacity           1
-
 
 
 //Coming soon modal


### PR DESCRIPTION
Old
![ide 2015-12-03 5 pm-19-08](https://cloud.githubusercontent.com/assets/1278794/11600714/5047631a-9ad7-11e5-8d4e-26db6f119e97.png)

New
![lolkq49p7j](https://cloud.githubusercontent.com/assets/1278794/11600719/55b67a2a-9ad7-11e5-8206-365a41f9a5f9.gif)

Story: https://www.pivotaltracker.com/story/show/109452476

Notes: Noticed the VM options icon was not aligned with the rest of them, so I aligned that as well.

/cc @sinan 
