### PR TITLE
Shortcuts: Restore defaults button is not working when using the Chrome Koding app [fixes #94513580]

### DIFF
--- a/client/account/lib/views/accounteditshortcuts.coffee
+++ b/client/account/lib/views/accounteditshortcuts.coffee
@@ -3,14 +3,26 @@ _        = require 'lodash'
 recorder = require 'record-shortcuts'
 Pane     = require './accounteditshortcutspane'
 facade   = require './accounteditshortcutsfacade'
+KDModalView = kd.ModalView
 
 RESTORE_CONFIRM_TEXT = 'Are you sure you want to restore the default shortcuts?'
 
 restoreDefaults = ->
 
-  return  unless confirm RESTORE_CONFIRM_TEXT
-  kd.getSingleton('shortcuts').restore()
-  @domElement.blur()
+  @restoreModal = KDModalView.confirm
+    title        : 'Are you sure?'
+    description  : RESTORE_CONFIRM_TEXT
+    ok           :
+      style      : 'solid medium red'
+      title      : 'Restore'
+      callback   : =>
+        kd.getSingleton('shortcuts').restore()
+        @domElement.blur()
+        @restoreModal.destroy()
+    cancel       :
+      style      : 'solid medium light-gray'
+      title      : 'Cancel'
+      callback   : => @restoreModal.destroy()
 
 
 module.exports =

--- a/client/account/lib/views/accounteditshortcuts.coffee
+++ b/client/account/lib/views/accounteditshortcuts.coffee
@@ -1,15 +1,15 @@
-kd       = require 'kd'
-_        = require 'lodash'
-recorder = require 'record-shortcuts'
-Pane     = require './accounteditshortcutspane'
-facade   = require './accounteditshortcutsfacade'
+kd          = require 'kd'
+_           = require 'lodash'
+recorder    = require 'record-shortcuts'
+Pane        = require './accounteditshortcutspane'
+facade      = require './accounteditshortcutsfacade'
 KDModalView = kd.ModalView
 
 RESTORE_CONFIRM_TEXT = 'Are you sure you want to restore the default shortcuts?'
 
 restoreDefaults = ->
 
-  @restoreModal = KDModalView.confirm
+  modal = KDModalView.confirm
     title        : 'Are you sure?'
     description  : RESTORE_CONFIRM_TEXT
     ok           :
@@ -18,11 +18,11 @@ restoreDefaults = ->
       callback   : =>
         kd.getSingleton('shortcuts').restore()
         @domElement.blur()
-        @restoreModal.destroy()
+        modal.destroy()
     cancel       :
       style      : 'solid medium light-gray'
       title      : 'Cancel'
-      callback   : => @restoreModal.destroy()
+      callback   : => modal.destroy()
 
 
 module.exports =


### PR DESCRIPTION
Old
![vofd5yjg44](https://cloud.githubusercontent.com/assets/1278794/11603879/7c24d758-9aee-11e5-9bd6-0b3cea519bc3.gif)

New
![gthcp4hkzk](https://cloud.githubusercontent.com/assets/1278794/11603878/7c23190e-9aee-11e5-92a4-5aec33483553.gif)

Story: https://www.pivotaltracker.com/story/show/94513580

Notes: This did not work initially because instead of a kd confirm modal it showed a native browser alert and Chrome apps don't allow that. Not sure about the text inside the modal though.

/cc @sinan 
