### PR TITLE
activity: embedbox fix [fixes #109550704]

### DIFF
--- a/client/activity/lib/views/activityinputwidget.coffee
+++ b/client/activity/lib/views/activityinputwidget.coffee
@@ -158,10 +158,10 @@ module.exports = class ActivityInputWidget extends KDView
     options = { channelId, body, payload, clientRequestId }
 
     if activity
-    then @update options, @bound 'submissionCallback'
-    else @create options, @bound 'submissionCallback'
-
-    @embedBox.close()
+      @update options, @bound 'submissionCallback'
+    else
+      @create options, @bound 'submissionCallback'
+      @embedBox.close()
 
 
   submissionCallback: (err, activity) ->

--- a/client/activity/lib/views/activityinputwidget.coffee
+++ b/client/activity/lib/views/activityinputwidget.coffee
@@ -132,17 +132,28 @@ module.exports = class ActivityInputWidget extends KDView
     return  if @locked
     return @reset yes  unless body = value.trim()
 
+    @lockSubmit()
+
+    timestamp       = Date.now()
+    clientRequestId = generateFakeIdentifier timestamp
+
+    if @embedBox.isFetching
+      @embedBox.once 'EmbedFetched', @lazyBound 'submitOnEmbedBoxReady', clientRequestId, body
+    else
+      @submitOnEmbedBoxReady clientRequestId, body
+
+    @emit 'SubmitStarted', body, clientRequestId
+
+
+  submitOnEmbedBoxReady: (clientRequestId, body) ->
+
     activity        = @getData()
     {app, channel}  = @getOptions()
     embedBoxPayload = @getEmbedBoxPayload()
 
     payload = _.assign {}, activity?.payload, embedBoxPayload
 
-    timestamp       = Date.now()
-    clientRequestId = generateFakeIdentifier timestamp
     channelId       = channel?.id
-
-    @lockSubmit()
 
     options = { channelId, body, payload, clientRequestId }
 
@@ -150,7 +161,7 @@ module.exports = class ActivityInputWidget extends KDView
     then @update options, @bound 'submissionCallback'
     else @create options, @bound 'submissionCallback'
 
-    @emit 'SubmitStarted', body, clientRequestId
+    @embedBox.close()
 
 
   submissionCallback: (err, activity) ->

--- a/client/activity/lib/views/comments/commentinputwidget.coffee
+++ b/client/activity/lib/views/comments/commentinputwidget.coffee
@@ -68,8 +68,11 @@ module.exports = class CommentInputWidget extends ActivityInputWidget
 
   submit: (value) ->
 
-    return  if @locked
-    return @reset yes  unless body = value.trim()
+    super value
+    kd.utils.defer @bound 'focus'
+
+
+  submitOnEmbedBoxReady: (clientRequestId, body) ->
 
     activity = @getData()
     {app}    = @getOptions()
@@ -77,11 +80,6 @@ module.exports = class CommentInputWidget extends ActivityInputWidget
     embedBoxPayload = @getEmbedBoxPayload()
 
     payload = _.assign {}, activity?.payload, embedBoxPayload
-
-    timestamp = Date.now()
-    clientRequestId = generateFakeIdentifier timestamp
-
-    @lockSubmit()
 
     obj = { body, payload, clientRequestId }
 
@@ -91,9 +89,7 @@ module.exports = class CommentInputWidget extends ActivityInputWidget
 
     fn(obj, @bound 'submissionCallback')
 
-    @emit 'SubmitStarted', body, clientRequestId
-
-    kd.utils.defer @bound 'focus'
+    @embedBox.close()
 
 
   create: ({body, payload, clientRequestId}, callback) ->


### PR DESCRIPTION
@usirin, can you please review the fix this [bug](https://www.pivotaltracker.com/story/show/109550704)?

The problem of embed box widget in old activity is that user can submit a message/comment with url but without embed data. For example, user pastes url of image or page into activity input widget and quickly hits enter. In this case there is no enough time to get data from embed.ly and message is submitted without embed data.
I made a fix similar to how it works in reactivity, i.e. if user submits a message/comment and embed data is being requested from embed.ly at the moment, we wait for embed.ly response and then submit a message/comment

/cc @sinan 
