### PR TITLE
provider/aws: improve per-user logging

### DIFF
--- a/go/src/koding/kites/kloud/api/amazon/transport.go
+++ b/go/src/koding/kites/kloud/api/amazon/transport.go
@@ -53,8 +53,8 @@ func (tr *transportRetryer) MaxRetries() int {
 
 func (tr *transportRetryer) ShouldRetry(r *request.Request) bool {
 	doretry := isNetworkRecoverable(r.Error, true) || tr.DefaultRetryer.ShouldRetry(r)
-	tr.logf("request failed (RetryCount=%d, Operation=%+v, ShouldRetry=%t): %+v",
-		r.RetryCount, r.Operation, doretry, r.Error)
+	tr.logf("request failed (RetryCount=%d, Operation=%+v, ShouldRetry=%t): %q (%T)",
+		r.RetryCount, r.Operation, doretry, r.Error, r.Error)
 	return doretry
 }
 

--- a/go/src/koding/kites/kloud/provider/aws/provider.go
+++ b/go/src/koding/kites/kloud/provider/aws/provider.go
@@ -106,7 +106,7 @@ func (p *Provider) AttachSession(ctx context.Context, machine *Machine) error {
 	opts := &amazon.ClientOptions{
 		Credentials: credentials.NewStaticCredentials(creds.Meta.AccessKey, creds.Meta.SecretKey, ""),
 		Region:      machine.Meta.Region,
-		Log:         p.Log,
+		Log:         p.Log.New(machine.Id.Hex()),
 	}
 
 	amazonClient, err := amazon.NewWithOptions(structs.Map(machine.Meta), opts)
@@ -114,8 +114,7 @@ func (p *Provider) AttachSession(ctx context.Context, machine *Machine) error {
 		return fmt.Errorf("koding-amazon err: %s", err)
 	}
 
-	// attach user specific log
-	machine.Log = p.Log.New(machine.Id.Hex())
+	machine.Log = opts.Log // attach user specific log
 
 	sess := &session.Session{
 		DB:         p.DB,


### PR DESCRIPTION
/cc @cihangir @fatih @leeola 

Every log line produced by aws provider is now prefixed with user machine id.

/cc @sent-hil 
