### PR TITLE
kloud: improve logging [fixes #109663984]

### DIFF
--- a/go/src/koding/kites/kloud/provider/aws/destroy.go
+++ b/go/src/koding/kites/kloud/provider/aws/destroy.go
@@ -43,12 +43,12 @@ func (m *Machine) Destroy(ctx context.Context) (err error) {
 	if err := m.Session.DNSClient.Delete(m.Domain); err != nil {
 		// if it's already deleted, for example because of a STOP, than we just
 		// log it here instead of returning the error
-		m.Log.Error("deleting domain during destroying err: %s", err.Error())
+		m.Log.Error("deleting domain during destroying err: %s", err)
 	}
 
 	domains, err := m.Session.DNSStorage.GetByMachine(m.Id.Hex())
 	if err != nil {
-		m.Log.Error("fetching domains for unsetting err: %s", err.Error())
+		m.Log.Error("fetching domains for unsetting err: %s", err)
 	}
 
 	m.push("Deleting custom domain", 90, machinestate.Terminating)
@@ -59,7 +59,7 @@ func (m *Machine) Destroy(ctx context.Context) (err error) {
 
 		err := m.Session.DNSStorage.UpdateMachine(domain.Name, "")
 		if err != nil {
-			m.Log.Error("couldn't unset machine domain: %s", err.Error())
+			m.Log.Error("couldn't unset machine domain: %s", err)
 		}
 	}
 

--- a/go/src/koding/kites/kloud/provider/aws/info.go
+++ b/go/src/koding/kites/kloud/provider/aws/info.go
@@ -34,7 +34,7 @@ func (m *Machine) Info(ctx context.Context) (map[string]string, error) {
 				resultState, reason)
 
 			if err := m.checkAndUpdateState(resultState); err != nil {
-				m.Log.Debug("Info decision: Error while updating the machine state. Err: %v", m.Id, err)
+				m.Log.Debug("Info decision: Error while updating the machine %q state. Err: %v", m.Id, err)
 			}
 		}
 	}()

--- a/go/src/koding/kites/kloud/provider/aws/provider.go
+++ b/go/src/koding/kites/kloud/provider/aws/provider.go
@@ -100,13 +100,13 @@ func (p *Provider) AttachSession(ctx context.Context, machine *Machine) error {
 
 	creds, err := p.credential(machine.Credential)
 	if err != nil {
-		return fmt.Errorf("Could not fetch credential %q: %s", machine.Credential, err.Error())
+		return fmt.Errorf("Could not fetch credential %q: %s", machine.Credential, err)
 	}
 
 	opts := &amazon.ClientOptions{
 		Credentials: credentials.NewStaticCredentials(creds.Meta.AccessKey, creds.Meta.SecretKey, ""),
 		Region:      machine.Meta.Region,
-		Log:         p.Log.New(machine.Id.Hex()),
+		Log:         p.Log.New(fmt.Sprintf("user=%d, machine=%s", user.Uid, machine.Id.Hex())),
 	}
 
 	amazonClient, err := amazon.NewWithOptions(structs.Map(machine.Meta), opts)

--- a/go/src/koding/kites/kloud/provider/koding/cleaners.go
+++ b/go/src/koding/kites/kloud/provider/koding/cleaners.go
@@ -86,7 +86,7 @@ func (p *Provider) CleanDeletedVMs() error {
 	for _, machine := range machines {
 		go func(m Machine) {
 			if err := deleteMachine(m); err != nil {
-				p.Log.Error("[%s] couldn't terminate user deleted machine: %s", m.Id.Hex(), err.Error())
+				p.Log.Error("[%s] couldn't terminate user deleted machine: %s", m.Id.Hex(), err)
 			}
 		}(machine)
 	}

--- a/go/src/koding/kites/kloud/provider/koding/destroy.go
+++ b/go/src/koding/kites/kloud/provider/koding/destroy.go
@@ -45,23 +45,23 @@ func (m *Machine) Destroy(ctx context.Context) (err error) {
 	if err := m.Session.DNSClient.Delete(m.Domain); err != nil {
 		// if it's already deleted, for example because of a STOP, than we just
 		// log it here instead of returning the error
-		m.Log.Error("deleting domain during destroying err: %s", err.Error())
+		m.Log.Error("deleting domain during destroying err: %s", err)
 	}
 
 	domains, err := m.Session.DNSStorage.GetByMachine(m.Id.Hex())
 	if err != nil {
-		m.Log.Error("fetching domains for unsetting err: %s", err.Error())
+		m.Log.Error("fetching domains for unsetting err: %s", err)
 	}
 
 	m.push("Deleting custom domain", 90, machinestate.Terminating)
 	for _, domain := range domains {
 		if err := m.Session.DNSClient.Delete(domain.Name); err != nil {
-			m.Log.Error("couldn't delete domain: %s", err.Error())
+			m.Log.Error("couldn't delete domain: %s", err)
 		}
 
 		err := m.Session.DNSStorage.UpdateMachine(domain.Name, "")
 		if err != nil {
-			m.Log.Error("couldn't unset machine domain: %s", err.Error())
+			m.Log.Error("couldn't unset machine domain: %s", err)
 		}
 	}
 

--- a/go/src/koding/kites/kloud/provider/koding/info.go
+++ b/go/src/koding/kites/kloud/provider/koding/info.go
@@ -71,7 +71,7 @@ func (m *Machine) Info(ctx context.Context) (map[string]string, error) {
 
 				err := machine.Stop(ctx)
 				if err != nil {
-					machine.Log.Debug("Info decision: Error while Stopping machine. Err: %v",
+					machine.Log.Debug("Info decision: Error while Stopping machine %q. Err: %v",
 						machine.Id, err)
 				}
 				machine.Log.Info("======> STOP finished (inconsistent state)<======")
@@ -80,7 +80,7 @@ func (m *Machine) Info(ctx context.Context) (map[string]string, error) {
 		}
 
 		if err := m.checkAndUpdateState(resultState); err != nil {
-			m.Log.Debug("Info decision: Error while updating the machine state. Err: %v", m.Id, err)
+			m.Log.Debug("Info decision: Error while updating the machine %q state. Err: %v", m.Id, err)
 		}
 	}()
 

--- a/go/src/koding/kites/kloud/provider/koding/locker.go
+++ b/go/src/koding/kites/kloud/provider/koding/locker.go
@@ -46,7 +46,7 @@ func (p *Provider) Lock(id string) error {
 
 	// some other error, this shouldn't be happed
 	if err != nil {
-		p.Log.Error("Storage get error: %s", err.Error())
+		p.Log.Error("Storage get error: %s", err)
 		return kloud.NewError(kloud.ErrBadState)
 	}
 

--- a/go/src/koding/kites/kloud/provider/koding/provider.go
+++ b/go/src/koding/kites/kloud/provider/koding/provider.go
@@ -112,7 +112,7 @@ func (p *Provider) AttachSession(ctx context.Context, machine *Machine) error {
 
 	amazonClient, err := amazon.New(structs.Map(machine.Meta), client)
 	if err != nil {
-		return fmt.Errorf("koding-amazon err: %s", err)
+		return fmt.Errorf("koding-amazon error: %s", err)
 	}
 
 	// attach user specific log
@@ -208,7 +208,7 @@ func (p *Provider) getOwner(requesterName string, users []models.Permissions) (*
 	if err := p.DB.Run("jUsers", func(c *mgo.Collection) error {
 		return c.Find(bson.M{"_id": bson.M{"$in": allowedIds}}).All(&allowedUsers)
 	}); err != nil {
-		return nil, fmt.Errorf("username lookup error: %v", err)
+		return nil, fmt.Errorf("username lookup error: %s", err)
 	}
 
 	// now we have all allowed users, if we have someone that is in match with

--- a/go/src/koding/kites/kloud/provider/koding/resize.go
+++ b/go/src/koding/kites/kloud/provider/koding/resize.go
@@ -179,12 +179,12 @@ func (m *Machine) Resize(ctx context.Context) (resErr error) {
 		if resErr != nil {
 			m.Log.Info("(an error occurred) detaching newly created volume volume %s ", newVolumeId)
 			if err := a.DetachVolume(newVolumeId); err != nil {
-				m.Log.Error("couldn't detach: %s", err.Error())
+				m.Log.Error("couldn't detach: %s", err)
 			}
 
 			m.Log.Info("(an error occurred) attaching back old volume %s", oldVolumeId)
 			if err = a.AttachVolume(oldVolumeId, a.Id(), "/dev/sda1"); err != nil {
-				m.Log.Error("couldn't attach: %s", err.Error())
+				m.Log.Error("couldn't attach: %s", err)
 			}
 		} else {
 			// if not just delete, it's not used anymore
@@ -250,25 +250,25 @@ func (m *Machine) Resize(ctx context.Context) (resErr error) {
 	m.push("Updating domain", 85, machinestate.Pending)
 
 	if err := m.Session.DNSClient.Validate(m.Domain, m.Username); err != nil {
-		m.Log.Error("couldn't update machine domain: %s", err.Error())
+		m.Log.Error("couldn't update machine domain: %s", err)
 	}
 	if err := m.Session.DNSClient.Upsert(m.Domain, m.IpAddress); err != nil {
-		m.Log.Error("couldn't update machine domain: %s", err.Error())
+		m.Log.Error("couldn't update machine domain: %s", err)
 	}
 
 	m.push("Updating domain aliases", 87, machinestate.Pending)
 	// also get all domain aliases that belongs to this machine and unset
 	domains, err := m.Session.DNSStorage.GetByMachine(m.Id.Hex())
 	if err != nil {
-		m.Log.Error("fetching domains for unsetting err: %s", err.Error())
+		m.Log.Error("fetching domains for unsetting err: %s", err)
 	}
 
 	for _, domain := range domains {
 		if err := m.Session.DNSClient.Validate(domain.Name, m.Username); err != nil {
-			m.Log.Error("couldn't update machine domain: %s", err.Error())
+			m.Log.Error("couldn't update machine domain: %s", err)
 		}
 		if err := m.Session.DNSClient.Upsert(domain.Name, m.IpAddress); err != nil {
-			m.Log.Error("couldn't update machine domain: %s", err.Error())
+			m.Log.Error("couldn't update machine domain: %s", err)
 		}
 	}
 

--- a/go/src/koding/kites/kloud/provider/koding/start.go
+++ b/go/src/koding/kites/kloud/provider/koding/start.go
@@ -72,7 +72,7 @@ func (m *Machine) Start(ctx context.Context) (err error) {
 	// type.
 	if aws.StringValue(instance.InstanceType) != m.Meta.InstanceType {
 		m.Log.Warning("instance is using '%s'. Changing back to '%s'",
-			instance.InstanceType, m.Meta.InstanceType)
+			aws.StringValue(instance.InstanceType), m.Meta.InstanceType)
 
 		params := &ec2.ModifyInstanceAttributeInput{
 			InstanceId: aws.String(m.Meta.InstanceId),
@@ -140,7 +140,7 @@ func (m *Machine) Start(ctx context.Context) (err error) {
 			} else if err != nil {
 				m.Log.Error(
 					"Failed to retrieve Elastic IP information: %s (username: %s, instanceId: %s, region: %s, ip: %s)",
-					err.Error(), m.Credential, m.Meta.InstanceId, m.Meta.Region, m.IpAddress,
+					err, m.Credential, m.Meta.InstanceId, m.Meta.Region, m.IpAddress,
 				)
 			}
 		}
@@ -205,26 +205,26 @@ func (m *Machine) Start(ctx context.Context) (err error) {
 
 	m.push("Initializing domain instance", 65, machinestate.Starting)
 	if err := m.Session.DNSClient.Validate(m.Domain, m.Username); err != nil {
-		m.Log.Error("couldn't update machine domain: %s", err.Error())
+		m.Log.Error("couldn't update machine domain: %s", err)
 	}
 
 	if err := m.Session.DNSClient.Upsert(m.Domain, m.IpAddress); err != nil {
-		m.Log.Error("couldn't update machine domain: %s", err.Error())
+		m.Log.Error("couldn't update machine domain: %s", err)
 	}
 
 	// also get all domain aliases that belongs to this machine and unset
 	m.push("Updating domain aliases", 80, machinestate.Starting)
 	domains, err := m.Session.DNSStorage.GetByMachine(m.Id.Hex())
 	if err != nil {
-		m.Log.Error("fetching domains for starting err: %s", err.Error())
+		m.Log.Error("fetching domains for starting err: %s", err)
 	}
 
 	for _, domain := range domains {
 		if err := m.Session.DNSClient.Validate(domain.Name, m.Username); err != nil {
-			m.Log.Error("couldn't update machine domain: %s", err.Error())
+			m.Log.Error("couldn't update machine domain: %s", err)
 		}
 		if err := m.Session.DNSClient.Upsert(domain.Name, m.IpAddress); err != nil {
-			m.Log.Error("couldn't update machine domain: %s", err.Error())
+			m.Log.Error("couldn't update machine domain: %s", err)
 		}
 	}
 

--- a/go/src/koding/kites/kloud/provider/koding/stop.go
+++ b/go/src/koding/kites/kloud/provider/koding/stop.go
@@ -43,7 +43,7 @@ func (m *Machine) StopMachine(ctx context.Context) (err error) {
 	// also get all domain aliases that belongs to this machine and unset
 	domains, err := m.Session.DNSStorage.GetByMachine(m.Id.Hex())
 	if err != nil {
-		m.Log.Error("fetching domains for unseting err: %s", err.Error())
+		m.Log.Error("fetching domains for unseting err: %s", err)
 	}
 
 	for _, domain := range domains {


### PR DESCRIPTION
This CL adds `user` prefix to teams provider logging (to address transport warnings about invalid creds).

It also fixes logging on the production:

![log](https://cldup.com/d0TnOMdSdq.png)

During transition from goamz to aws-sdk-go changed data structures, those coming from aws-sdk-go have pointers everywhere, which broke the logging like above.

Initially I used `go vet` to find such cases, but due to `koding/logger` interface, `go vet` reports different problem and does no go further with validating format strings:

```
koding/kites/kloud/provider/aws $ go vet .
build.go:321: possible formatting directive in Error call
build.go:379: possible formatting directive in Error call
build.go:383: possible formatting directive in Error call
build.go:389: possible formatting directive in Error call
build.go:394: possible formatting directive in Error call
build.go:397: possible formatting directive in Error call
build.go:411: possible formatting directive in Error call
destroy.go:46: possible formatting directive in Error call
destroy.go:51: possible formatting directive in Error call
destroy.go:57: possible formatting directive in Error call
destroy.go:62: possible formatting directive in Error call
exit status 1
```

I went manually over both providers to verify the logging.

/cc @fatih @cihangir @leeola 
