### PR TITLE
provider/koding: ensure safe Machine zero-value

### DIFF
--- a/go/src/koding/kites/kloud/provider/koding/locker.go
+++ b/go/src/koding/kites/kloud/provider/koding/locker.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (p *Provider) Lock(id string) error {
-	machine := &Machine{}
+	machine := NewMachine()
 	err := p.DB.Run("jMachines", func(c *mgo.Collection) error {
 		// we use findAndModify() to get a unique lock from the DB. That means only
 		// one instance should be responsible for this action. We will update the

--- a/go/src/koding/kites/kloud/provider/koding/machine.go
+++ b/go/src/koding/kites/kloud/provider/koding/machine.go
@@ -47,6 +47,13 @@ type Machine struct {
 	cleanFuncs []func()
 }
 
+// NewMachine gives new Machine value.
+func NewMachine() *Machine {
+	return &Machine{
+		Machine: &models.Machine{},
+	}
+}
+
 func (m *Machine) GetMeta() (*Meta, error) {
 	var mt Meta
 	if err := mapstructure.Decode(m.Meta, &mt); err != nil {

--- a/go/src/koding/kites/kloud/provider/koding/provider.go
+++ b/go/src/koding/kites/kloud/provider/koding/provider.go
@@ -51,7 +51,7 @@ func (p *Provider) Machine(ctx context.Context, id string) (interface{}, error) 
 	// really doesn't exist or if there is an assignee which is a different
 	// thing. (Because findAndModify() also returns "not found" for the case
 	// where the id exist but someone else is the assignee).
-	machine := &Machine{}
+	machine := NewMachine()
 	if err := p.DB.Run("jMachines", func(c *mgo.Collection) error {
 		return c.FindId(bson.ObjectIdHex(id)).One(&machine.Machine)
 	}); err == mgo.ErrNotFound {

--- a/go/src/koding/kites/kloud/queue/queue.go
+++ b/go/src/koding/kites/kloud/queue/queue.go
@@ -38,7 +38,7 @@ func (q *Queue) RunCheckers(interval time.Duration) {
 }
 
 func (q *Queue) CheckKoding() {
-	var machine koding.Machine
+	machine := koding.NewMachine()
 	err := q.FetchProvider("koding", &machine.Machine)
 	if err != nil {
 		// do not show an error if the query didn't find anything, that
@@ -54,7 +54,7 @@ func (q *Queue) CheckKoding() {
 	// Don't forget to set any important non-db related Machine values.
 	machine.Locker = q.KodingProvider
 
-	if err := q.CheckKodingUsage(&machine); err != nil {
+	if err := q.CheckKodingUsage(machine); err != nil {
 		// only log if it's something else
 		switch err {
 		case kite.ErrNoKitesAvailable,


### PR DESCRIPTION
Fixes panics like:

```
koding/kites/kloud/provider/koding.(*Provider).AttachSession(0xc2080bd5e0, 0x18bd778, 0xc2080da418, 0xc208096780, 0x0, 0x0)
    /Users/gokmen/Code/koding/go/src/koding/kites/kloud/provider/koding/provider.go:93 +0x48
koding/kites/kloud/provider/koding.func·010(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
    /Users/gokmen/Code/koding/go/src/koding/kites/kloud/provider/koding/cleaners.go:73 +0xe5
koding/kites/kloud/provider/koding.func·011(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
    /Users/gokmen/Code/koding/go/src/koding/kites/kloud/provider/koding/cleaners.go:93 +0x4e
created by koding/kites/kloud/provider/koding.(*Provider).CleanDeletedVMs
    /Users/gokmen/Code/koding/go/src/koding/kites/kloud/provider/koding/cleaners.go:97 +0x2e4
```

/cc @fatih @cihangir @leeola @gokmen 
