### PR TITLE
provider/koding: revert #6034; embed models.Koding instead

### DIFF
--- a/go/src/koding/kites/kloud/provider/koding/cleaners.go
+++ b/go/src/koding/kites/kloud/provider/koding/cleaners.go
@@ -55,7 +55,7 @@ func (p *Provider) CleanDeletedVMs() error {
 			"userDeleted": true,
 		}
 
-		machine := NewMachine()
+		machine := &Machine{}
 		iter := c.Find(deletedMachines).Batch(50).Iter()
 		for iter.Next(machine) {
 			machines = append(machines, machine)

--- a/go/src/koding/kites/kloud/provider/koding/locker.go
+++ b/go/src/koding/kites/kloud/provider/koding/locker.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (p *Provider) Lock(id string) error {
-	machine := NewMachine()
+	var machine Machine
 	err := p.DB.Run("jMachines", func(c *mgo.Collection) error {
 		// we use findAndModify() to get a unique lock from the DB. That means only
 		// one instance should be responsible for this action. We will update the

--- a/go/src/koding/kites/kloud/provider/koding/machine.go
+++ b/go/src/koding/kites/kloud/provider/koding/machine.go
@@ -31,7 +31,7 @@ type Meta struct {
 // Machine represents a single MongodDB document that represents a Koding
 // Provider from the jMachines collection.
 type Machine struct {
-	*models.Machine
+	models.Machine
 
 	// internal fields, not availabile in MongoDB schema
 	Username string                 `bson:"-"`
@@ -45,13 +45,6 @@ type Machine struct {
 	// cleanFuncs are a list of functions that are called when after a method
 	// is finished
 	cleanFuncs []func()
-}
-
-// NewMachine gives new Machine value.
-func NewMachine() *Machine {
-	return &Machine{
-		Machine: &models.Machine{},
-	}
 }
 
 func (m *Machine) GetMeta() (*Meta, error) {

--- a/go/src/koding/kites/kloud/provider/koding/provider.go
+++ b/go/src/koding/kites/kloud/provider/koding/provider.go
@@ -51,7 +51,7 @@ func (p *Provider) Machine(ctx context.Context, id string) (interface{}, error) 
 	// really doesn't exist or if there is an assignee which is a different
 	// thing. (Because findAndModify() also returns "not found" for the case
 	// where the id exist but someone else is the assignee).
-	machine := NewMachine()
+	var machine Machine
 	if err := p.DB.Run("jMachines", func(c *mgo.Collection) error {
 		return c.FindId(bson.ObjectIdHex(id)).One(&machine.Machine)
 	}); err == mgo.ErrNotFound {
@@ -75,12 +75,12 @@ func (p *Provider) Machine(ctx context.Context, id string) (interface{}, error) 
 		p.Log.Debug("[%s] using region: %s", machine.ObjectId.Hex(), meta.Region)
 	}
 
-	if err := p.AttachSession(ctx, machine); err != nil {
+	if err := p.AttachSession(ctx, &machine); err != nil {
 		return nil, err
 	}
 
 	// check for validation and permission
-	if err := p.validate(machine, req); err != nil {
+	if err := p.validate(&machine, req); err != nil {
 		return nil, err
 	}
 

--- a/go/src/koding/kites/kloud/queue/queue.go
+++ b/go/src/koding/kites/kloud/queue/queue.go
@@ -38,7 +38,7 @@ func (q *Queue) RunCheckers(interval time.Duration) {
 }
 
 func (q *Queue) CheckKoding() {
-	machine := koding.NewMachine()
+	var machine koding.Machine
 	err := q.FetchProvider("koding", &machine.Machine)
 	if err != nil {
 		// do not show an error if the query didn't find anything, that
@@ -54,7 +54,7 @@ func (q *Queue) CheckKoding() {
 	// Don't forget to set any important non-db related Machine values.
 	machine.Locker = q.KodingProvider
 
-	if err := q.CheckKodingUsage(machine); err != nil {
+	if err := q.CheckKodingUsage(&machine); err != nil {
 		// only log if it's something else
 		switch err {
 		case kite.ErrNoKitesAvailable,


### PR DESCRIPTION
Reverting #6034 as it does not fully fix the problem; the embedded `machine.Machine` is being shallow copied [here](https://github.com/koding/koding/blob/master/go/src/koding/kites/kloud/provider/koding/cleaners.go#L58-L62), embedding the value instead is going to fix the problem.

/cc @fatih @cihangir @leeola @gokmen
