### PR TITLE
reactivity: update scroller when message edit mode is closed [fixes #109588526]

### DIFF
--- a/client/activity/lib/components/chatlistitem/index.coffee
+++ b/client/activity/lib/components/chatlistitem/index.coffee
@@ -185,7 +185,7 @@ module.exports = class ChatListItem extends React.Component
 
     messageId = @props.message.get '_id'
 
-    ActivityFlux.actions.message.setMessageEditMode messageId
+    ActivityFlux.actions.message.setMessageEditMode messageId, @props.channelId
 
 
   showDeletePostPromptModal: ->
@@ -239,7 +239,7 @@ module.exports = class ChatListItem extends React.Component
 
     messageId = @props.message.get '_id'
 
-    ActivityFlux.actions.message.unsetMessageEditMode messageId
+    ActivityFlux.actions.message.unsetMessageEditMode messageId, @props.channelId
 
     ActivityFlux.actions.message.editMessage(
       @props.message.get('id')
@@ -253,7 +253,7 @@ module.exports = class ChatListItem extends React.Component
     return @closeDeletePostModal()  if @state.isDeleting
 
     messageId = @props.message.get '_id'
-    ActivityFlux.actions.message.unsetMessageEditMode messageId
+    ActivityFlux.actions.message.unsetMessageEditMode messageId, @props.channelId
 
 
   onEditStarted: ->

--- a/client/activity/lib/components/chatpane/index.coffee
+++ b/client/activity/lib/components/chatpane/index.coffee
@@ -8,6 +8,7 @@ ScrollerMixin        = require 'app/components/scroller/scrollermixin'
 EmojiPreloaderMixin  = require 'activity/components/emojipreloadermixin'
 ChannelInfoContainer = require 'activity/components/channelinfocontainer'
 scrollToTarget       = require 'app/util/scrollToTarget'
+scrollerActions      = require 'app/components/scroller/scrolleractions'
 
 
 module.exports = class ChatPane extends React.Component
@@ -95,9 +96,19 @@ module.exports = class ChatPane extends React.Component
 
     { thread } = nextProps
 
-    isMessageBeingSubmitted = @flag 'isMessageBeingSubmitted'
+    { SCROLL_TO_BOTTOM, KEEP_POSITION, UPDATE } = scrollerActions
 
-    @shouldScrollToBottom = yes  if isMessageBeingSubmitted
+    isMessageBeingSubmitted = @flag 'isMessageBeingSubmitted'
+    willStopMessageEditing  = @flag('isMessageInEditMode') and not thread.getIn [ 'flags', 'isMessageInEditMode' ]
+
+    @scrollerAction = switch
+      when isMessageBeingSubmitted then SCROLL_TO_BOTTOM
+      when @isThresholdReached     then KEEP_POSITION
+      when willStopMessageEditing  then UPDATE
+      else @scrollerAction # keep the value calculated in ScrollerMixin
+
+
+  componentDidUpdate: -> @isThresholdReached = no
 
 
   onTopThresholdReached: (event) ->

--- a/client/activity/lib/flux/actions/message.coffee
+++ b/client/activity/lib/flux/actions/message.coffee
@@ -465,22 +465,24 @@ changeSelectedMessageBySlug = (slug) ->
  * Sets message edit mode
  *
  * @param {string} messageId
+ * @param {string} channelId
 ###
-setMessageEditMode = (messageId) ->
+setMessageEditMode = (messageId, channelId) ->
 
   { SET_MESSAGE_EDIT_MODE } = actionTypes
-  dispatch SET_MESSAGE_EDIT_MODE, { messageId }
+  dispatch SET_MESSAGE_EDIT_MODE, { messageId, channelId }
 
 
 ###*
  * Unsets message edit mode
  *
  * @param {string} messageId
+ * @param {string} channelId
 ###
-unsetMessageEditMode = (messageId) ->
+unsetMessageEditMode = (messageId, channelId) ->
 
   { UNSET_MESSAGE_EDIT_MODE } = actionTypes
-  dispatch UNSET_MESSAGE_EDIT_MODE, { messageId }
+  dispatch UNSET_MESSAGE_EDIT_MODE, { messageId, channelId }
 
 
 fetchEmbedPayload = (messageData, callback = kd.noop) ->

--- a/client/activity/lib/flux/chatinput/actions/message.coffee
+++ b/client/activity/lib/flux/chatinput/actions/message.coffee
@@ -18,6 +18,7 @@ setLastMessageEditMode = ->
   accountId = whoami()._id
   thread    = reactor.evaluate Getters.selectedChannelThread
   messages  = thread.get 'messages'
+  channelId = thread.get 'channelId'
 
   lastMessage = messages.findLast (message) ->
     message.getIn(['account', '_id']) is accountId and
@@ -25,7 +26,7 @@ setLastMessageEditMode = ->
 
   return  unless lastMessage
 
-  MessageActions.setMessageEditMode lastMessage.get '_id'
+  MessageActions.setMessageEditMode lastMessage.get('_id'), channelId
 
 
 module.exports = {

--- a/client/activity/lib/flux/stores/channelflagsstore.coffee
+++ b/client/activity/lib/flux/stores/channelflagsstore.coffee
@@ -21,6 +21,8 @@ module.exports = class ChannelFlagsStore extends KodingFluxStore
     @on actions.UNSET_ALL_MESSAGES_LOADED, @handleUnsetAllMessagesLoaded
     @on actions.SET_CHANNEL_SCROLL_POSITION, @handleSetScrollPosition
     @on actions.SET_CHANNEL_LAST_SEEN_TIME, @handleSetLastSeenTime
+    @on actions.SET_MESSAGE_EDIT_MODE, @handleSetMessageEditMode
+    @on actions.UNSET_MESSAGE_EDIT_MODE, @handleUnsetMessageEditMode
 
 
   handleLoadChannel: (channelFlags, { channelId }) ->
@@ -62,6 +64,18 @@ module.exports = class ChannelFlagsStore extends KodingFluxStore
 
     channelFlags = helper.ensureChannelMap channelFlags, channelId
     return channelFlags.setIn [channelId, 'lastSeenTime'], timestamp
+
+
+  handleSetMessageEditMode: (channelFlags, { channelId }) ->
+
+    channelFlags = helper.ensureChannelMap channelFlags, channelId
+    return channelFlags.setIn [channelId, 'isMessageInEditMode'], yes
+
+
+  handleUnsetMessageEditMode: (channelFlags, { channelId }) ->
+
+    channelFlags = helper.ensureChannelMap channelFlags, channelId
+    return channelFlags.setIn [channelId, 'isMessageInEditMode'], no
 
 
 helper =

--- a/client/activity/lib/flux/test/channelflagsstore.coffee
+++ b/client/activity/lib/flux/test/channelflagsstore.coffee
@@ -115,3 +115,31 @@ describe 'ChannelFlagsStore', ->
 
       expect(storeState[42].lastSeenTime).to.eql timestamp
 
+
+  describe 'handleSetMessageEditMode', ->
+
+    it 'sets isMessageInEditMode flag to true', ->
+
+      @reactor.dispatch actionTypes.SET_MESSAGE_EDIT_MODE, {
+        messageId : 1
+        channelId : 1
+      }
+
+      storeState = @reactor.evaluateToJS ['ChannelFlagsStore']
+
+      expect(storeState[1].isMessageInEditMode).to.be.true
+
+
+  describe 'handleUnsetMessageEditMode', ->
+
+    it 'unsets isMessageInEditMode flag', ->
+
+      @reactor.dispatch actionTypes.UNSET_MESSAGE_EDIT_MODE, {
+        messageId : 1
+        channelId : 1
+      }
+
+      storeState = @reactor.evaluateToJS ['ChannelFlagsStore']
+
+      expect(storeState[1].isMessageInEditMode).to.be.false
+

--- a/client/app/lib/components/perfectscrollbar/index.coffee
+++ b/client/app/lib/components/perfectscrollbar/index.coffee
@@ -63,7 +63,7 @@ module.exports = class PerfectScrollbar extends Component
     # FIXME: remove `wait` from here and make sure it handles each case.
     kd.utils.wait 500, -> Ps.update container
 
-    @addListener 'resize', @bound 'onResize'
+    @addListener 'resize', @bound 'update'
 
     if _.isFunction @props.onScrollY
       @addListener 'ps-scroll-y', @props.onScrollY
@@ -104,7 +104,7 @@ module.exports = class PerfectScrollbar extends Component
     @_listeners = {}
 
 
-  onResize: ->
+  update: ->
 
     Ps.update ReactDOM.findDOMNode @refs.container
 

--- a/client/app/lib/components/scroller/index.coffee
+++ b/client/app/lib/components/scroller/index.coffee
@@ -28,6 +28,9 @@ module.exports = class Scroller extends React.Component
     @props.onThresholdReached?()
 
 
+  update: -> @refs.scrollContainer.update()
+
+
   render: ->
 
     <PerfectScrollbar

--- a/client/app/lib/components/scroller/scrolleractions.coffee
+++ b/client/app/lib/components/scroller/scrolleractions.coffee
@@ -1,0 +1,5 @@
+module.exports = {
+  'SCROLL_TO_BOTTOM'
+  'KEEP_POSITION'
+  'UPDATE'
+}


### PR DESCRIPTION
@usirin, can you please review the fix for [this bug](https://www.pivotaltracker.com/story/show/109588526)?

When fixing the bug, I decided to do a small refactoring of `ScrollerMixin`. Its behavior depends on 2 fileds `shouldScrollToBottom` and `isThresholdReached`. When any of this filed is true, scroller should do a specific action and both actions can't be done at the same time, i.e. they exclude each other. I needed to add one more action - update scroller when message stops being edited. It could lead to adding one more field for a new action. I don't like that idea. That's why I got rid of those fields in `ScrollerMixin` and introduced another field `scrollerAction` which contains a value of enum `ScrollerActions`. This field can be set by the component which includes `ScrollerMixin` to specify what action scroller should do after the component is updated. You can see how `scrollerAction` is set in `ChatPane.componentWillUpdate()` method.
I believe it makes scroller logic cleaner since we deal with only 1 field instead of multiple fields as before.
I checked logic related to `shouldScrollToBottom` and `isThresholdReached` with my changes - everything works as before

/cc @sinan 
