### PR TITLE
provider/aws: do not log AuthFailure for user credentials

### DIFF
--- a/go/src/koding/kites/kloud/api/amazon/clients.go
+++ b/go/src/koding/kites/kloud/api/amazon/clients.go
@@ -31,6 +31,10 @@ type ClientOptions struct {
 
 	// MaxResults sets the limit for Describe* calls.
 	MaxResults int64
+
+	// IgnoreAuthErr when true makes the transport not log
+	// AuthFailure errors.
+	IgnoreAuthErr bool
 }
 
 // Clients provides wrappers for a EC2 client per region.

--- a/go/src/koding/kites/kloud/api/amazon/transport.go
+++ b/go/src/koding/kites/kloud/api/amazon/transport.go
@@ -25,7 +25,8 @@ var transportParams = &httputil.ClientConfig{
 func NewTransport(opts *ClientOptions) *aws.Config {
 	cfg := aws.NewConfig().WithHTTPClient(httputil.NewClient(transportParams))
 	retryer := &transportRetryer{
-		MaxTries: 3,
+		MaxTries:      3,
+		IgnoreAuthErr: opts.IgnoreAuthErr,
 	}
 	if opts.Log != nil {
 		retryer.Log = opts.Log.New("transport")
@@ -43,8 +44,9 @@ func NewTransport(opts *ClientOptions) *aws.Config {
 // caused by a timeout.
 type transportRetryer struct {
 	client.DefaultRetryer
-	MaxTries int
-	Log      logging.Logger
+	MaxTries      int
+	Log           logging.Logger
+	IgnoreAuthErr bool
 }
 
 func (tr *transportRetryer) MaxRetries() int {
@@ -53,8 +55,10 @@ func (tr *transportRetryer) MaxRetries() int {
 
 func (tr *transportRetryer) ShouldRetry(r *request.Request) bool {
 	doretry := isNetworkRecoverable(r.Error, true) || tr.DefaultRetryer.ShouldRetry(r)
-	tr.logf("request failed (RetryCount=%d, Operation=%+v, ShouldRetry=%t): %q (%T)",
-		r.RetryCount, r.Operation, doretry, r.Error, r.Error)
+	if !tr.ignored(r.Error) {
+		tr.logf("request failed (RetryCount=%d, Operation=%+v, ShouldRetry=%t): %q (%T)",
+			r.RetryCount, r.Operation, doretry, r.Error, r.Error)
+	}
 	return doretry
 }
 
@@ -62,6 +66,10 @@ func (tr *transportRetryer) logf(format string, args ...interface{}) {
 	if tr.Log != nil {
 		tr.Log.Warning(format, args...)
 	}
+}
+
+func (tr *transportRetryer) ignored(err error) bool {
+	return tr.IgnoreAuthErr && IsErrCode(err, "AuthFailure")
 }
 
 func isNetworkRecoverable(err error, initial bool) bool {

--- a/go/src/koding/kites/kloud/provider/aws/provider.go
+++ b/go/src/koding/kites/kloud/provider/aws/provider.go
@@ -123,9 +123,10 @@ func (p *Provider) AttachSession(ctx context.Context, machine *Machine) error {
 	}
 
 	opts := &amazon.ClientOptions{
-		Credentials: credentials.NewStaticCredentials(awsCred.AccessKey, awsCred.SecretKey, ""),
-		Region:      meta.Region,
-		Log:         p.Log.New(fmt.Sprintf("user=%d, machine=%s", user.Uid, machine.ObjectId.Hex())),
+		Credentials:   credentials.NewStaticCredentials(awsCred.AccessKey, awsCred.SecretKey, ""),
+		Region:        meta.Region,
+		Log:           p.Log.New(machine.ObjectId.Hex()),
+		IgnoreAuthErr: true, // do not log user credential validations failures
 	}
 
 	amazonClient, err := amazon.NewWithOptions(machine.Meta, opts)


### PR DESCRIPTION
Gets rid of AuthFailure warnings for user creds - should do this before, fixing in this CL.

/cc @fatih @cihangir @leeola  
