### PR TITLE
Fix ide quit on team stack reinit [fixes #109879840]

### DIFF
--- a/client/app/lib/applicationmanager.coffee
+++ b/client/app/lib/applicationmanager.coffee
@@ -238,6 +238,7 @@ class ApplicationManager extends KDObject
   quit:(appInstance, callback = kd.noop)->
     view = appInstance.getView?()
     destroyer = if view? then view else appInstance
+    appInstance.beforeQuit?()
     destroyer.destroy()
     callback()
 

--- a/client/app/lib/maincontroller/groupscontroller.coffee
+++ b/client/app/lib/maincontroller/groupscontroller.coffee
@@ -192,7 +192,6 @@ module.exports = class GroupsController extends kd.Controller
         # Re-call create default stack flow to make sure it exists
         computeController.createDefaultStack yes
 
-
         if stackTemplate._updated
           id = currentGroup.socialApiDefaultChannelId
 

--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -1145,9 +1145,8 @@ module.exports = class ComputeController extends KDController
             new kd.NotificationView
               title : 'Stack reinitialized'
 
-            # We need to quit here to be able to re-load
-            # IDE with new machine stack, there might be better solution ~ GG
-            frontApp = kd.singletons.appManager.getFrontApp()
-            frontApp.quit()  if frontApp?.options.name is 'IDE'
+            kd.singletons.appManager.quitByName 'IDE'
+            kd.utils.defer ->
+              kd.singletons.router.handleRoute '/IDE'
 
           .createDefaultStack()

--- a/workers/social/lib/social/models/invitation.coffee
+++ b/workers/social/lib/social/models/invitation.coffee
@@ -291,10 +291,10 @@ module.exports = class JInvitation extends jraphical.Module
       return  if group.slug in ['guests', 'koding']
 
       member.fetchUser (err, user) ->
-        return log 'Failed to fetch member:', err  if err or not user
+        return console.log 'Failed to fetch member:', err  if err or not user
 
         JInvitation.remove {
           email     : user.email
           groupName : group.slug
         }, (err) ->
-          log 'Failed to remove existing invitations', err  if err
+          console.log 'Failed to remove existing invitations', err  if err


### PR DESCRIPTION
We were destroying IDE instance if it's the frontApp and we were doing it for one IDE instance. With this we will quit from all of them on group stack reinit requested.
