### PR TITLE
checker: check directly for koding-user tag [fixes #109891698]

### DIFF
--- a/go/src/koding/kites/kloud/plans/checker.go
+++ b/go/src/koding/kites/kloud/plans/checker.go
@@ -297,8 +297,9 @@ func (p *Plan) userInstances(username string) ([]*ec2.Instance, error) {
 	filters := map[string][]string{
 		// Anything except "terminated" and "shutting-down"
 		"instance-state-name": {"pending", "running", "stopping", "stopped"},
-		"tag-value":           {username},
+		"tag:koding-user":     {username},
 	}
+
 	instances, err := p.AWSClient.InstancesByFilters(filters)
 	switch {
 	case amazon.IsNotFound(err):

--- a/go/src/koding/kites/kloud/provider/koding/build.go
+++ b/go/src/koding/kites/kloud/provider/koding/build.go
@@ -544,10 +544,13 @@ func (m *Machine) buildData(ctx context.Context) (*BuildData, error) {
 
 // checkLimits checks whether the given buildData is valid to be used to create a new instance
 func (m *Machine) checkLimits(buildData *BuildData) error {
+
+	m.Log.Debug("Checking Total instances limits")
 	if err := m.Checker.Total(m.Username); err != nil {
 		return err
 	}
 
+	m.Log.Debug("Checking AlwaysOn requireement")
 	if err := m.Checker.AlwaysOn(m.Username); err != nil {
 		return err
 	}
@@ -560,8 +563,10 @@ func (m *Machine) checkLimits(buildData *BuildData) error {
 		buildData.EC2Data.InstanceType = aws.String(plans.T2Micro.String())
 	}
 
+	wantSize := int(aws.Int64Value(buildData.EC2Data.BlockDeviceMappings[0].Ebs.VolumeSize))
+	m.Log.Debug("Checking if user is eglible for a '%d' storage size", wantSize)
 	// check if the user is egligible to create a vm with this size
-	if err := m.Checker.Storage(int(aws.Int64Value(buildData.EC2Data.BlockDeviceMappings[0].Ebs.VolumeSize)), m.Username); err != nil {
+	if err := m.Checker.Storage(wantSize, m.Username); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This code is used for checking the limits of the `total limit checker`, which check if the user is has the permission to create yet another instance. 

The `tag-value` field is slow and failing for the Region `eu-west-1`. In my tests, changing it to explicitly look for the key `koding-user` was instantaneously. I assume this will fix the issue we had with this region. The QA team needs to test it of course.
