### PR TITLE
kloud: stop logging warnings by the aws transport; don't log ErrNotRecord [part of #110150546]

### DIFF
--- a/go/src/koding/kites/kloud/api/amazon/clients.go
+++ b/go/src/koding/kites/kloud/api/amazon/clients.go
@@ -31,10 +31,6 @@ type ClientOptions struct {
 
 	// MaxResults sets the limit for Describe* calls.
 	MaxResults int64
-
-	// IgnoreAuthErr when true makes the transport not log
-	// AuthFailure errors.
-	IgnoreAuthErr bool
 }
 
 // Clients provides wrappers for a EC2 client per region.

--- a/go/src/koding/kites/kloud/provider/aws/provider.go
+++ b/go/src/koding/kites/kloud/provider/aws/provider.go
@@ -123,10 +123,9 @@ func (p *Provider) AttachSession(ctx context.Context, machine *Machine) error {
 	}
 
 	opts := &amazon.ClientOptions{
-		Credentials:   credentials.NewStaticCredentials(awsCred.AccessKey, awsCred.SecretKey, ""),
-		Region:        meta.Region,
-		Log:           p.Log.New(machine.ObjectId.Hex()),
-		IgnoreAuthErr: true, // do not log user credential validations failures
+		Credentials: credentials.NewStaticCredentials(awsCred.AccessKey, awsCred.SecretKey, ""),
+		Region:      meta.Region,
+		Log:         p.Log.New(machine.ObjectId.Hex()),
 	}
 
 	amazonClient, err := amazon.NewWithOptions(machine.Meta, opts)


### PR DESCRIPTION
This CL makes the transport warning silent and gets rid of the following errors:

```
ERROR    no records available
```

In order to diagnose whether `[kloud-dns] ERROR    Domain doesn't contain username 'aonissa'` are legit, I need to get more info about the input from sandbox/production - it may be user input which is wrong.

/cc @cihangir @fatih @leeola 
