### PR TITLE
Prevent reinit while building [fixes #109949722]

### DIFF
--- a/client/app/lib/environment/environmentlistitem.coffee
+++ b/client/app/lib/environment/environmentlistitem.coffee
@@ -100,8 +100,9 @@ module.exports = class EnvironmentListItem extends kd.ListItemView
 
   handleStackDelete: ->
 
-    { computeController } = kd.singletons
+    @getDelegate().emit 'ModalDestroyRequested'
 
+    { computeController } = kd.singletons
     computeController.ui.askFor 'deleteStack', {}, =>
       @getDelegate().emit 'StackDeleteRequested', @getData()
 

--- a/client/app/lib/environment/environmentsmodal.coffee
+++ b/client/app/lib/environment/environmentsmodal.coffee
@@ -46,7 +46,8 @@ module.exports = class EnvironmentsModal extends kd.ModalView
     { computeController, appManager } = kd.singletons
 
     listView.on 'StackDeleteRequested', (stack) =>
-      stack.delete (err) =>
+
+      computeController.destroyStack stack, (err) =>
         return  if showError err
 
         new kd.NotificationView

--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -677,12 +677,15 @@ module.exports = class ComputeController extends KDController
 
       machine.getBaseKite( createIfNotExists = no ).disconnect()
 
-    call = @getKloud().buildStack { stackId: stack._id }
+    stackId = stack._id
+    call    = @getKloud().buildStack { stackId }
 
     .then (res) =>
 
+      (@findStackFromStackId stackId)?.status.state = 'Building'
+
       kd.log "build stack res:", res
-      @eventListener.addListener 'apply', stack._id
+      @eventListener.addListener 'apply', stackId
 
     .timeout globals.COMPUTECONTROLLER_TIMEOUT
 

--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -703,7 +703,7 @@ module.exports = class ComputeController extends KDController
     if state in [ 'Building', 'Destroying' ]
       return callback
         name    : 'InProgress'
-        message : "This is stack is currently #{state.toLowerCase()}."
+        message : "This stack is currently #{state.toLowerCase()}."
 
     stack.machines.forEach (machineId) =>
       return  unless machine = @findMachineFromMachineId machineId

--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -698,6 +698,13 @@ module.exports = class ComputeController extends KDController
 
     return  unless stack
 
+    { state } = stack.status
+
+    if state in [ 'Building', 'Destroying' ]
+      return callback
+        name    : 'InProgress'
+        message : "This is stack is currently #{state.toLowerCase()}."
+
     stack.machines.forEach (machineId) =>
       return  unless machine = @findMachineFromMachineId machineId
 


### PR DESCRIPTION
The multiple stack issue on `reinit` as described in https://www.pivotaltracker.com/story/show/109949722 only happens when you try to `reinit` a stack while it's `Building`. So, I've disabled it. but this is not the best and complete fix the issue.

![](http://g.recordit.co/mRiO9YAkEZ.gif)

While investigating the issue I realized that `kloud` is sending back an `ACK` when we do request to start destroy on a given stack, so my flow in the client-side was broken because of that. `kloud` should throw an error when we do a request to `build` a stack if it's currently `in progress`, all the other methods of `kloud` is providing that flow.

![](http://take.ms/EbkST)

Created another story for `kloud` part https://www.pivotaltracker.com/n/projects/1340878/stories/110163580

cc/ @fatih 
