### PR TITLE
Tests: Unit tests for ApplicationManager. [ completes #110406688 ] [ completes #GEN-1459 ]

### DIFF
--- a/client/app/lib/applicationmanager.coffee
+++ b/client/app/lib/applicationmanager.coffee
@@ -212,6 +212,8 @@ class ApplicationManager extends KDObject
     appOptions  = getAppOptions name
     appInstance = @get name
 
+    return if appOptions.background
+
     appView     = appInstance.getView?()
     return unless appView
 

--- a/client/app/lib/applicationmanager.coffee
+++ b/client/app/lib/applicationmanager.coffee
@@ -317,18 +317,23 @@ class ApplicationManager extends KDObject
     @emit "AppRegistered", name, appInstance.options
 
 
-  unregister:(appInstance)->
+  unregister: (appInstance) ->
 
-    name  = appInstance.getOption "name"
-    index = @appControllers[name].instances.indexOf appInstance
+    name  = appInstance.getOption 'name'
+    app   = @appControllers[name]
 
-    if index >= 0
-      @appControllers[name].instances.splice index, 1
+    return no  unless app
 
-      @emit "AppUnregistered", name, appInstance.options
+    index = app.instances.indexOf appInstance
 
-      if @appControllers[name].instances.length is 0
-        delete @appControllers[name]
+    return  no  unless index >=0
+
+    @appControllers[name].instances.splice index, 1
+
+    @emit "AppUnregistered", name, appInstance.options
+
+    if @appControllers[name].instances.length is 0
+      delete @appControllers[name]
 
 
   createPromptModal:(appOptions, callback)->

--- a/client/app/test/applicationmanager.test.coffee
+++ b/client/app/test/applicationmanager.test.coffee
@@ -1,6 +1,5 @@
 kd                 = require 'kd'
 expect             = require 'expect'
-sinon              = require 'sinon'
 globals            = require 'globals'
 AppController      = require '../lib/appcontroller'
 registerAppClass   = require '../lib/util/registerAppClass'
@@ -23,13 +22,13 @@ describe 'ApplicationManager', ->
 
       isRegistered = no
       appInstance  = new AppController name: 'FooApp'
-      sinon.spy(appManager, 'setListeners')
+      expect.spyOn appManager, 'setListeners'
 
       appManager.on 'AppRegistered', -> isRegistered = yes
       appManager.register appInstance
 
       expect(appManager.appControllers.FooApp.instances).toInclude appInstance
-      expect(appManager.setListeners.calledOnce).toBe yes
+      expect(appManager.setListeners).toHaveBeenCalled()
       expect(isRegistered).toBe yes
 
 
@@ -47,11 +46,11 @@ describe 'ApplicationManager', ->
 
     it 'should warn if there is no name', ->
 
-      sinon.spy(kd, 'warn')
+      expect.spyOn kd, 'warn'
 
       appManager.tell()
 
-      expect(kd.warn.calledOnce).toBe yes
+      expect(kd.warn).toHaveBeenCalled()
 
 
   describe '::create', ->

--- a/client/app/test/applicationmanager.test.coffee
+++ b/client/app/test/applicationmanager.test.coffee
@@ -7,6 +7,13 @@ ApplicationManager   = require '../lib/applicationmanager'
 KodingAppsController = require '../lib/kodingappscontroller'
 
 appManager = null
+createApps = (appNames = [], shouldShow) ->
+
+  appNames.forEach (name) ->
+    registerAppClass AppController, { name }
+
+    appManager.create name
+    appManager.show   name  if shouldShow
 
 
 describe 'kd.singletons.appManager', ->
@@ -116,13 +123,10 @@ describe 'kd.singletons.appManager', ->
       isCallbackExecuted           = no
       isAppIsShownCallbackExecuted = no
 
-      registerAppClass AppController, { name: 'FooApp' }
-      registerAppClass AppController, { name: 'BarApp' }
+      createApps [ 'FooApp', 'BarApp' ]
+
       appManager.on 'AppIsBeingShown', -> isAppShown = yes
       expect.spyOn appManager, 'setLastActiveIndex'
-
-      appManager.create 'FooApp'
-      appManager.create 'BarApp'
 
       appManager.appControllers.FooApp.instances.first.appIsShown = ->
         isAppIsShownCallbackExecuted = yes
@@ -149,11 +153,7 @@ describe 'kd.singletons.appManager', ->
 
       isBeforeQuitCalled = no
 
-      registerAppClass AppController, { name: 'AwesomeApp' }
-      registerAppClass AppController, { name: 'BadApp'     }
-
-      appManager.create 'AwesomeApp'
-      appManager.create 'BadApp'
+      createApps [ 'AwesomeApp', 'BadApp' ]
 
       { appControllers } = appManager
       awesomeInstances   = appControllers.AwesomeApp.instances
@@ -177,11 +177,7 @@ describe 'kd.singletons.appManager', ->
 
     it 'should quit all apps', ->
 
-      registerAppClass AppController, { name: 'AnotherApp'    }
-      registerAppClass AppController, { name: 'YetAnotherApp' }
-
-      appManager.create 'AnotherApp'
-      appManager.create 'YetAnotherApp'
+      createApps [ 'AnotherApp', 'YetAnotherApp' ]
 
       expect(Object.keys(appManager.appControllers).length).toBe 2
 
@@ -194,11 +190,14 @@ describe 'kd.singletons.appManager', ->
 
     it 'should quit an app by name', ->
 
-      registerAppClass AppController, { name: 'FooBarApp' }
-      appManager.create 'FooBarApp'
+      createApps [ 'FooBarApp', 'BarFooApp' ]
+
+      expect(Object.keys(appManager.appControllers).length).toBe 2
+
+      appManager.quitByName 'FooBarApp'
 
       expect(Object.keys(appManager.appControllers).length).toBe 1
 
-      appManager.quitByName 'FooBarApp'
+      appManager.quitByName 'BarFooApp'
 
       expect(Object.keys(appManager.appControllers).length).toBe 0

--- a/client/app/test/applicationmanager.test.coffee
+++ b/client/app/test/applicationmanager.test.coffee
@@ -20,18 +20,10 @@ createApps = (appNames = [], shouldShow) ->
 describe 'kd.singletons.appManager', ->
 
 
-  beforeEach ->
-
-    spy        = null
-    appManager = new ApplicationManager
+  beforeEach -> appManager = new ApplicationManager
 
 
-  afterEach ->
-
-    if spy
-      spy.restore()
-      expect.restoreSpies()
-      spy = null
+  afterEach -> expect.restoreSpies()
 
 
   describe 'constructor', ->
@@ -45,7 +37,7 @@ describe 'kd.singletons.appManager', ->
 
       isRegistered = no
       appInstance  = new AppController name: 'FooApp'
-      spy = expect.spyOn appManager, 'setListeners'
+      expect.spyOn appManager, 'setListeners'
 
       appManager.on 'AppRegistered', -> isRegistered = yes
       appManager.register appInstance
@@ -135,7 +127,7 @@ describe 'kd.singletons.appManager', ->
 
     it 'should warn if there is no name', ->
 
-      spy = expect.spyOn kd, 'warn'
+      expect.spyOn kd, 'warn'
 
       appManager.tell()
       expect(kd.warn).toHaveBeenCalled()
@@ -224,7 +216,7 @@ describe 'kd.singletons.appManager', ->
     it 'should load app', (done) ->
 
       globals.config.apps.InternalApp = name: 'InternalApp'
-      spy = expect.spyOn KodingAppsController, 'loadInternalApp'
+      expect.spyOn KodingAppsController, 'loadInternalApp'
 
       appManager.create 'InternalApp', {}
 
@@ -244,7 +236,7 @@ describe 'kd.singletons.appManager', ->
       createApps [ 'FooApp', 'BarApp' ]
 
       appManager.on 'AppIsBeingShown', -> isAppShown = yes
-      spy = expect.spyOn appManager, 'setLastActiveIndex'
+      expect.spyOn appManager, 'setLastActiveIndex'
 
       appManager.appControllers.FooApp.instances.first.appIsShown = ->
         isAppIsShownCallbackExecuted = yes
@@ -275,7 +267,7 @@ describe 'kd.singletons.appManager', ->
 
       createApps [ 'App1', 'App2', 'App3' ], yes
       appManager.on 'AppIsBeingShown', -> isEventEmitted = yes
-      spy = expect.spyOn appManager, 'setLastActiveIndex'
+      expect.spyOn appManager, 'setLastActiveIndex'
 
       expect(appManager.getFrontApp().options.name).toBe 'App3'
 
@@ -369,7 +361,7 @@ describe 'kd.singletons.appManager', ->
 
     it 'should warn if open called with no name', ->
 
-      spy = expect.spyOn(kd, 'warn')
+      expect.spyOn(kd, 'warn')
       appManager.open()
       expect(kd.warn).toHaveBeenCalled()
 

--- a/client/app/test/applicationmanager.test.coffee
+++ b/client/app/test/applicationmanager.test.coffee
@@ -6,6 +6,7 @@ registerAppClass     = require '../lib/util/registerAppClass'
 ApplicationManager   = require '../lib/applicationmanager'
 KodingAppsController = require '../lib/kodingappscontroller'
 
+spy        = null
 appManager = null
 createApps = (appNames = [], shouldShow) ->
 
@@ -19,7 +20,18 @@ createApps = (appNames = [], shouldShow) ->
 describe 'kd.singletons.appManager', ->
 
 
-  beforeEach -> appManager = new ApplicationManager
+  beforeEach ->
+
+    spy        = null
+    appManager = new ApplicationManager
+
+
+  afterEach ->
+
+    if spy
+      spy.restore()
+      expect.restoreSpies()
+      spy = null
 
 
   describe 'constructor', ->
@@ -33,7 +45,7 @@ describe 'kd.singletons.appManager', ->
 
       isRegistered = no
       appInstance  = new AppController name: 'FooApp'
-      expect.spyOn appManager, 'setListeners'
+      spy = expect.spyOn appManager, 'setListeners'
 
       appManager.on 'AppRegistered', -> isRegistered = yes
       appManager.register appInstance
@@ -123,10 +135,9 @@ describe 'kd.singletons.appManager', ->
 
     it 'should warn if there is no name', ->
 
-      expect.spyOn kd, 'warn'
+      spy = expect.spyOn kd, 'warn'
 
       appManager.tell()
-
       expect(kd.warn).toHaveBeenCalled()
 
 
@@ -213,7 +224,7 @@ describe 'kd.singletons.appManager', ->
     it 'should load app', (done) ->
 
       globals.config.apps.InternalApp = name: 'InternalApp'
-      expect.spyOn KodingAppsController, 'loadInternalApp'
+      spy = expect.spyOn KodingAppsController, 'loadInternalApp'
 
       appManager.create 'InternalApp', {}
 
@@ -233,7 +244,7 @@ describe 'kd.singletons.appManager', ->
       createApps [ 'FooApp', 'BarApp' ]
 
       appManager.on 'AppIsBeingShown', -> isAppShown = yes
-      expect.spyOn appManager, 'setLastActiveIndex'
+      spy = expect.spyOn appManager, 'setLastActiveIndex'
 
       appManager.appControllers.FooApp.instances.first.appIsShown = ->
         isAppIsShownCallbackExecuted = yes
@@ -264,7 +275,7 @@ describe 'kd.singletons.appManager', ->
 
       createApps [ 'App1', 'App2', 'App3' ], yes
       appManager.on 'AppIsBeingShown', -> isEventEmitted = yes
-      expect.spyOn appManager, 'setLastActiveIndex'
+      spy = expect.spyOn appManager, 'setLastActiveIndex'
 
       expect(appManager.getFrontApp().options.name).toBe 'App3'
 

--- a/client/app/test/applicationmanager.test.coffee
+++ b/client/app/test/applicationmanager.test.coffee
@@ -1,0 +1,92 @@
+kd                 = require 'kd'
+expect             = require 'expect'
+sinon              = require 'sinon'
+globals            = require 'globals'
+AppController      = require '../lib/appcontroller'
+registerAppClass   = require '../lib/util/registerAppClass'
+ApplicationManager = require '../lib/applicationmanager'
+appManager         = null
+
+
+describe 'ApplicationManager', ->
+
+
+  beforeEach -> appManager = new ApplicationManager
+
+
+  it 'should work', -> expect(appManager).toBeA ApplicationManager
+
+
+  describe '::register', ->
+
+    it 'should have appControllers with registered app name', ->
+
+      isRegistered = no
+      appInstance  = new AppController name: 'FooApp'
+      sinon.spy(appManager, 'setListeners')
+
+      appManager.on 'AppRegistered', -> isRegistered = yes
+      appManager.register appInstance
+
+      expect(appManager.appControllers.FooApp.instances).toInclude appInstance
+      expect(appManager.setListeners.calledOnce).toBe yes
+      expect(isRegistered).toBe yes
+
+
+  describe '::get', ->
+
+    it 'should return null if there is no appControllers', ->
+      expect(appManager.get('foo')).toBe.null
+
+    it 'should return app', ->
+      appManager.register fooApp = new AppController name: 'FooApp'
+      expect(appManager.get('FooApp')).toEqual fooApp
+
+
+  describe '::tell', ->
+
+    it 'should warn if there is no name', ->
+
+      sinon.spy(kd, 'warn')
+
+      appManager.tell()
+
+      expect(kd.warn.calledOnce).toBe yes
+
+
+  describe '::create', ->
+
+    it 'should emit AppCouldntBeCreated event when app is not created', (done) ->
+
+      isRegistered   = no
+      isEventEmitted = no
+
+      appManager.on 'AppRegistered',       -> isRegistered   = yes
+      appManager.on 'AppCouldntBeCreated', -> isEventEmitted = yes
+      appManager.create 'HelloApp'
+
+      kd.utils.defer ->
+        expect(isRegistered).toBe no
+        expect(isEventEmitted).toBe yes
+        done()
+
+
+    it 'should create app if app config exists in globals', (done) ->
+
+      isAppCreated       = no
+      isRegistered       = no
+      isCallbackExecuted = no
+      createdAppInstance = null
+
+      registerAppClass kd.Object, { name: 'FakeApp' }
+      appManager.on 'AppRegistered', -> isRegistered = yes
+
+      appManager.create 'FakeApp', {}, (appInstance) ->
+        isCallbackExecuted = yes
+        createdAppInstance = appInstance
+
+      kd.utils.defer ->
+        expect(isRegistered).toBe yes, 'isRegistered'
+        expect(isCallbackExecuted).toBe yes, 'isCallbackExecuted'
+        expect(appManager.appControllers.FakeApp.instances).toInclude createdAppInstance
+        done()

--- a/client/app/test/applicationmanager.test.coffee
+++ b/client/app/test/applicationmanager.test.coffee
@@ -43,6 +43,40 @@ describe 'kd.singletons.appManager', ->
       expect(isRegistered).toBe yes
 
 
+  describe '::unregister', ->
+
+
+    it 'should return no if there is no app for the given instance', ->
+
+      createApps [ 'TestApp' ], yes
+      expect(appManager.unregister new kd.View).toBe no
+
+
+    it 'should unregister the given app instance', ->
+
+      unregisteredAppName = null
+
+      createApps [ 'AppName1', 'AppName2' ], yes
+      appManager.create 'AppName2', { forceNew: yes }
+
+      appManager.on 'AppUnregistered', (name) -> unregisteredAppName = name
+
+      expect(appManager.appControllers.AppName2.instances.length).toBe 2
+
+      appManager.unregister appManager.get 'AppName1'
+      expect(appManager.appControllers.AppName1).toBe undefined
+      expect(unregisteredAppName).toBe 'AppName1'
+
+      appManager.unregister appManager.get 'AppName2'
+      expect(appManager.appControllers.AppName2.instances.length).toBe 1
+      expect(unregisteredAppName).toBe 'AppName2'
+      expect(appManager.appControllers.AppName2).toExist()
+
+      appManager.unregister appManager.get 'AppName2'
+      expect(appManager.appControllers.AppName2).toBe undefined
+      expect(unregisteredAppName).toBe 'AppName2'
+
+
   describe '::get', ->
 
     it 'should return null if there is no appControllers', ->
@@ -52,6 +86,37 @@ describe 'kd.singletons.appManager', ->
     it 'should return app', ->
       appManager.register fooApp = new AppController name: 'FooApp'
       expect(appManager.get('FooApp')).toEqual fooApp
+
+
+  describe '::getFrontApp', ->
+
+    it 'should return the front app instance', ->
+
+      createApps [ 'FrontApp', 'BackApp' ]
+
+      appManager.show 'FrontApp'
+      expect(appManager.getFrontApp().options.name).toBe 'FrontApp'
+
+      appManager.show 'BackApp'
+      expect(appManager.getFrontApp().options.name).toBe 'BackApp'
+
+
+  describe '::getByView', ->
+
+    it 'should return null if the given view doesnt belong to an app instance', ->
+
+      appInstance = appManager.getByView new kd.View
+      expect(appInstance).toBe null
+
+
+    it 'should return the app instance by given app view', ->
+
+      createApps [ 'MyApp' ], yes
+
+      [ appInstance ] = appManager.appControllers.MyApp.instances
+      appInstanceView = appInstance.getView()
+
+      expect(appManager.getByView appInstanceView).toBe appInstance
 
 
   describe '::tell', ->

--- a/client/app/test/applicationmanager.test.coffee
+++ b/client/app/test/applicationmanager.test.coffee
@@ -130,6 +130,48 @@ describe 'kd.singletons.appManager', ->
       expect(kd.warn).toHaveBeenCalled()
 
 
+    it 'should directly call the method of the app if app is created', ->
+
+      isMethodCalled = no
+      methodParam1   = null
+      methodParam2   = null
+
+      createApps [ 'TellApp' ], yes
+
+      AppController::someMethod = (p1, p2) ->
+        isMethodCalled = yes
+        methodParam1   = p1
+        methodParam2   = p2
+
+      appManager.tell 'TellApp', 'someMethod', 'FB', 1907
+
+      kd.utils.defer ->
+        expect(methodParam1).toBe 'FB'
+        expect(methodParam2).toBe 1907
+        expect(isMethodCalled).toBe yes
+
+
+    it 'should create app if app is not created', ->
+
+      isMethodCalled = no
+      methodParam1   = null
+      methodParam2   = null
+
+      registerAppClass AppController, { name: 'NotCreatedApp' }
+
+      AppController::someAnotherMethod = (p1, p2) ->
+        isMethodCalled = yes
+        methodParam1   = p1
+        methodParam2   = p2
+
+      appManager.tell 'NotCreatedApp', 'someAnotherMethod', 2011, '2014'
+
+      kd.utils.defer ->
+        expect(methodParam1).toBe 2011
+        expect(methodParam2).toBe '2014'
+        expect(isMethodCalled).toBe yes
+
+
   describe '::create', ->
 
     it 'should emit AppCouldntBeCreated event when app is not created', (done) ->

--- a/client/app/test/applicationmanager.test.coffee
+++ b/client/app/test/applicationmanager.test.coffee
@@ -9,13 +9,15 @@ KodingAppsController = require '../lib/kodingappscontroller'
 appManager = null
 
 
-describe 'ApplicationManager', ->
+describe 'kd.singletons.appManager', ->
 
 
   beforeEach -> appManager = new ApplicationManager
 
 
-  it 'should work', -> expect(appManager).toBeA ApplicationManager
+  describe 'constructor', ->
+
+    it 'should be instantiated', -> expect(appManager).toBeA ApplicationManager
 
 
   describe '::register', ->
@@ -37,7 +39,8 @@ describe 'ApplicationManager', ->
   describe '::get', ->
 
     it 'should return null if there is no appControllers', ->
-      expect(appManager.get('foo')).toBe.null
+      expect(appManager.get('foo')).toBe null
+
 
     it 'should return app', ->
       appManager.register fooApp = new AppController name: 'FooApp'
@@ -90,6 +93,18 @@ describe 'ApplicationManager', ->
         expect(isRegistered).toBe yes
         expect(isCallbackExecuted).toBe yes
         expect(appManager.appControllers.FakeApp.instances).toInclude createdAppInstance
+        done()
+
+
+    it 'should load app', (done) ->
+
+      globals.config.apps.InternalApp = name: 'InternalApp'
+      expect.spyOn KodingAppsController, 'loadInternalApp'
+
+      appManager.create 'InternalApp', {}
+
+      kd.utils.defer ->
+        expect(KodingAppsController.loadInternalApp).toHaveBeenCalled()
         done()
 
 
@@ -173,7 +188,6 @@ describe 'ApplicationManager', ->
       appManager.quitAll()
 
       expect(Object.keys(appManager.appControllers).length).toBe 0
-
 
 
   describe '::quitByName', ->

--- a/client/app/test/index.coffee
+++ b/client/app/test/index.coffee
@@ -1,3 +1,4 @@
 require './statemachine.test'
 require '../lib/react/test'
 require '../lib/flux/test'
+require './applicationmanager.test'


### PR DESCRIPTION
- [x] `constructor`
- [x] `::register`
- [x] `::unregister`
- [x] `::get`
- [x] `::getByView`
- [x] `::getFrontApp`
- [x] `::tell`
- [x] `::create`
- [x] `::show`
- [x] `::showInstance`
- [x] `::quit`
- [x] `::quitAll`
- [x] `::quitByName`
- [x] `::open`
- [x] `::isAppInternal`
- [x] `::isAppLoaded`
- [x] `::shouldLoadApp`
