### PR TITLE
scripts/sl: Softlayer helper tool

### DIFF
--- a/go/build.sh
+++ b/go/build.sh
@@ -44,6 +44,7 @@ services=(
   koding/workers/appstoragemigrator
   koding/kites/kloud/cleaners/cmd/cleaner
   koding/kites/kloud/scripts/userdebug
+  koding/kites/kloud/scripts/sl
 
   github.com/koding/kite/kitectl
   github.com/canthefason/go-watcher

--- a/go/src/koding/kites/kloud/api/amazon/error.go
+++ b/go/src/koding/kites/kloud/api/amazon/error.go
@@ -69,7 +69,7 @@ type NotFoundError struct {
 
 // Error implements the builtin error interface.
 func (err *NotFoundError) Error() string {
-	return fmt.Sprintf("%s not found after: %s", err.Resource, err.Err)
+	return fmt.Sprintf("%s not found: %s", err.Resource, err.Err)
 }
 
 // IsNotFound returns true if the given error is of *NotFoundError type.

--- a/go/src/koding/kites/kloud/api/sl/filter.go
+++ b/go/src/koding/kites/kloud/api/sl/filter.go
@@ -1,11 +1,5 @@
 package sl
 
-func op(value interface{}) interface{} {
-	return map[string]interface{}{
-		"operation": value,
-	}
-}
-
 // Filter is used for querying Softlayer resources.
 type Filter struct {
 	// ID is the ID of the resource.
@@ -36,6 +30,13 @@ type Filter struct {
 
 	// Fingerprint is a fingerprint of the resource.
 	Fingerprint string
+}
+
+// op is a helper function that wraps given value with {"operation": value}.
+func op(value interface{}) interface{} {
+	return map[string]interface{}{
+		"operation": value,
+	}
 }
 
 // Object returns the objectFilter representation of the filter.

--- a/go/src/koding/kites/kloud/api/sl/filter.go
+++ b/go/src/koding/kites/kloud/api/sl/filter.go
@@ -1,9 +1,10 @@
 package sl
 
-import (
-	"encoding/json"
-	"errors"
-)
+func op(value interface{}) interface{} {
+	return map[string]interface{}{
+		"operation": value,
+	}
+}
 
 // Filter is used for querying Softlayer resources.
 type Filter struct {
@@ -25,41 +26,52 @@ type Filter struct {
 	// By default only parent templates are returned - the ones having
 	// ParentID equal to 0.
 	Children bool
+
+	// Label is the label of the resource.
+	Label string
+
+	// User is a user to which the resource is attached to. In most
+	// cases it's a shorthand for Tags["user"].
+	User string
+
+	// Fingerprint is a fingerprint of the resource.
+	Fingerprint string
 }
 
-// JSON returns the objectFilter JSON representation of the filter.
-func (f *Filter) JSON() (string, error) {
+// Object returns the objectFilter representation of the filter.
+//
+// TODO(rjeczalik): infer from JSON tags
+func (f *Filter) Object() map[string]interface{} {
 	if f == nil {
-		return "", nil
+		return nil
 	}
 	m := make(map[string]interface{})
 	if f.Name != "" {
-		m["name"] = map[string]interface{}{
-			"operation": f.Name,
-		}
+		m["name"] = op(f.Name)
 	}
 	if f.ID != 0 {
-		m["id"] = map[string]interface{}{
-			"operation": f.ID,
-		}
+		m["id"] = op(f.ID)
 	}
 	if f.Datacenter != "" && !f.Children {
+		// If children are also to be collected, then it's not
+		// possible to filter items with objectFilter - parent items
+		// have "datacenters" field and children - "datacenter" one.
+		// Filtering by one of them would remove the other group
+		// from the result set.
 		m["datacenters"] = map[string]interface{}{
-			"name": map[string]interface{}{
-				"operation": f.Datacenter,
-			},
+			"name": op(f.Datacenter),
 		}
 	}
-	// TODO(rjeczalik): research how to support tags
+	if f.Label != "" {
+		m["label"] = op(f.Label)
+	}
+	if f.Fingerprint != "" {
+		m["fingerprint"] = op(f.Fingerprint)
+	}
+	// TODO(rjeczalik): f.Tags - research how to support tags
+	// TODO(rjeczalik): f.User - like above
 	if len(m) == 0 {
-		return "", nil
+		return nil
 	}
-	m = map[string]interface{}{
-		"blockDeviceTemplateGroups": m,
-	}
-	p, err := json.Marshal(m)
-	if err != nil {
-		return "", errors.New("error marshaling filter: " + err.Error())
-	}
-	return string(p), nil
+	return m
 }

--- a/go/src/koding/kites/kloud/api/sl/keys.go
+++ b/go/src/koding/kites/kloud/api/sl/keys.go
@@ -94,8 +94,8 @@ func (k *Key) decode() {
 	}
 }
 
-// KeyMask represents objectMask Softlayer API value for the Key type.
-var KeyMask = []string{
+// keyMask represents objectMask Softlayer API value for the Key type.
+var keyMask = []string{
 	"id",
 	"label",
 	"createDate",

--- a/go/src/koding/kites/kloud/api/sl/keys.go
+++ b/go/src/koding/kites/kloud/api/sl/keys.go
@@ -1,0 +1,193 @@
+package sl
+
+import (
+	"bytes"
+	"crypto/md5"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// Key represents the SoftLayer_Security_Ssh_Key type.
+type Key struct {
+	ID          int       `json:"id,omitempty"`
+	Label       string    `json:"label,omitempty"`
+	CreateDate  time.Time `json:"createDate,omitempty"`
+	Key         string    `json:"key,omitempty"`
+	Fingerprint string    `json:"fingerprint,omitempty"`
+	Note        string    `json:"notes,omitempty"`
+
+	Tags        Tags   `json:"-"`
+	NotTaggable bool   `json:"-"`
+	User        string `json:"-"`
+}
+
+// ParseKey reads the given RSA private key and create a public one for it.
+func ParseKey(pem string) (*Key, error) {
+	p, err := ioutil.ReadFile(pem)
+	if err != nil {
+		return nil, err
+	}
+	key, err := ssh.ParseRawPrivateKey(p)
+	if err != nil {
+		return nil, err
+	}
+	rsaKey, ok := key.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("%q is not a RSA key", pem)
+	}
+	pub, err := ssh.NewPublicKey(&rsaKey.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+	// Compute key fingerprint.
+	var buf bytes.Buffer
+	for _, b := range md5.Sum(pub.Marshal()) {
+		fmt.Fprintf(&buf, "%0.2x:", b)
+	}
+	// Use filename without the ".pem" suffix as the initial label.
+	label := filepath.Base(pem)
+	if strings.HasSuffix(pem, ".pem") {
+		label = label[:len(label)-len(".pem")]
+	}
+	return &Key{
+		Label:       label,
+		Key:         string(bytes.TrimRight(ssh.MarshalAuthorizedKey(pub), "\n")), // trim newline
+		Fingerprint: string(bytes.TrimRight(buf.Bytes(), ":")),                    // trim dangling colon
+		Note:        "{}",
+		Tags:        make(Tags),
+	}, nil
+}
+
+func (k *Key) encode() error {
+	tags := k.Tags
+	if k.User != "" {
+		if tags == nil {
+			tags = make(Tags)
+		}
+		tags["user"] = k.User
+	}
+	if len(tags) == 0 {
+		return nil
+	}
+	p, err := json.Marshal(tags)
+	if err != nil {
+		return err
+	}
+	k.Note = string(p)
+	return nil
+}
+
+func (k *Key) decode() {
+	if err := json.Unmarshal([]byte(k.Note), &k.Tags); err != nil {
+		k.NotTaggable = true
+	}
+	if user, ok := k.Tags["user"]; ok {
+		k.User = user
+		delete(k.Tags, "user")
+	}
+}
+
+// KeyMask represents objectMask Softlayer API value for the Key type.
+var KeyMask = []string{
+	"id",
+	"label",
+	"createDate",
+	"key",
+	"fingerprint",
+	"notes",
+}
+
+// Keys is a helper type for a slice of keys that supports filtering.
+type Keys []*Key
+
+// ByID returns a key with the given ID.
+func (k Keys) ByID(id int) Keys {
+	if id == 0 {
+		return k
+	}
+	for _, key := range k {
+		if key.ID == id {
+			return Keys{key}
+		}
+	}
+	return nil
+}
+
+// ByLabel returns keys that match the given name.
+func (k Keys) ByLabel(name string) (res Keys) {
+	if name == "" {
+		return k
+	}
+	for _, key := range k {
+		if key.Label == name {
+			res = append(res, key)
+		}
+	}
+	return res
+}
+
+// ByUser returns keys attached to the given user.
+func (k Keys) ByUser(user string) (res Keys) {
+	if user == "" {
+		return k
+	}
+	for _, key := range k {
+		if key.User == user {
+			res = append(res, key)
+		}
+	}
+	return res
+}
+
+// ByFingerprint returns those keys, which match the given fingerprint.
+func (k Keys) ByFingerprint(fingerprint string) (res Keys) {
+	if fingerprint == "" {
+		return k
+	}
+	for _, key := range k {
+		if key.Fingerprint == fingerprint {
+			res = append(res, key)
+		}
+	}
+	return res
+}
+
+// ByTags returns those keys, whose tags match the given tags.
+func (k Keys) ByTags(tags Tags) (res Keys) {
+	if len(tags) == 0 {
+		return k
+	}
+	for _, key := range k {
+		if key.Tags.Matches(tags) {
+			res = append(res, key)
+		}
+	}
+	return res
+}
+
+// Filter filters keys by the given filter value.
+//
+// If f is nil, all k are returned.
+func (k Keys) Filter(f *Filter) (res Keys) {
+	if f == nil {
+		return k
+	}
+	return k.ByID(f.ID).
+		ByLabel(f.Label).
+		ByFingerprint(f.Fingerprint).
+		ByUser(f.User).
+		ByTags(f.Tags)
+}
+
+type byCreateDateKey []*Key
+
+func (p byCreateDateKey) Len() int           { return len(p) }
+func (p byCreateDateKey) Less(i, j int) bool { return p[i].CreateDate.After(p[j].CreateDate) }
+func (p byCreateDateKey) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }

--- a/go/src/koding/kites/kloud/api/sl/keys.go
+++ b/go/src/koding/kites/kloud/api/sl/keys.go
@@ -51,13 +51,8 @@ func ParseKey(pem string) (*Key, error) {
 	for _, b := range md5.Sum(pub.Marshal()) {
 		fmt.Fprintf(&buf, "%0.2x:", b)
 	}
-	// Use filename without the ".pem" suffix as the initial label.
-	label := filepath.Base(pem)
-	if strings.HasSuffix(pem, ".pem") {
-		label = label[:len(label)-len(".pem")]
-	}
 	return &Key{
-		Label:       label,
+		Label:       strings.TrimSuffix(filepath.Base(pem), ".pem"),               // trim .pem file extension
 		Key:         string(bytes.TrimRight(ssh.MarshalAuthorizedKey(pub), "\n")), // trim newline
 		Fingerprint: string(bytes.TrimRight(buf.Bytes(), ":")),                    // trim dangling colon
 		Note:        "{}",

--- a/go/src/koding/kites/kloud/api/sl/keys_test.go
+++ b/go/src/koding/kites/kloud/api/sl/keys_test.go
@@ -23,7 +23,7 @@ func TestKeys(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewKey(%q)=%s", pem, err)
 	}
-	key.Label = fmt.Sprintf("test-%s", key.Label)
+	key.Label = fmt.Sprintf("test-%s-%d", key.Label, time.Now().UnixNano())
 	newKey, err := c.CreateKey(key)
 	if err != nil {
 		t.Fatalf("CreateKey(%+v)=%s", key, err)

--- a/go/src/koding/kites/kloud/api/sl/keys_test.go
+++ b/go/src/koding/kites/kloud/api/sl/keys_test.go
@@ -1,0 +1,73 @@
+package sl_test
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"koding/kites/kloud/api/sl"
+)
+
+func TestKeys(t *testing.T) {
+	pem := os.Getenv("KLOUD_USER_PRIVATEKEY")
+	if pem == "" {
+		t.Skip("skipping, KLOUD_USER_PRIVATEKEY is empty")
+	}
+	c, err := sl.NewSoftlayerWithOptions(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := sl.ParseKey(pem)
+	if err != nil {
+		t.Fatalf("NewKey(%q)=%s", pem, err)
+	}
+	key.Label = fmt.Sprintf("test-%s", key.Label)
+	newKey, err := c.CreateKey(key)
+	if err != nil {
+		t.Fatalf("CreateKey(%+v)=%s", key, err)
+	}
+	defer func() {
+		if err := c.DeleteKey(newKey.ID); err != nil {
+			t.Error(err)
+		}
+	}()
+	if newKey.ID == 0 {
+		t.Error("want key.ID != 0")
+	}
+	if newKey.Fingerprint != key.Fingerprint {
+		t.Errorf("want fingerprint=%q; got %q", key.Fingerprint, newKey.Fingerprint)
+	}
+	if newKey.CreateDate.IsZero() {
+		t.Errorf("want %v to be actual date", newKey.CreateDate)
+	}
+	f := &sl.Filter{
+		Label: key.Label,
+	}
+	d := time.Now()
+	keys, err := c.KeysByFilter(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reqDur := time.Now().Sub(d)
+	d = time.Now()
+	xkeys, err := c.XKeysByFilter(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	xreqDur := time.Now().Sub(d)
+	t.Logf("[TEST] filtering took: client-side=%s, server-side=%s", reqDur, xreqDur)
+	if len(keys) != 1 {
+		t.Errorf("want len(keys)=1; got %d", len(keys))
+	}
+	if len(xkeys) != 1 {
+		t.Errorf("want len(xkeys)=1; got %d", len(keys))
+	}
+	if !reflect.DeepEqual(keys[0], newKey) {
+		t.Errorf("want key=%+v; got %+v", newKey, keys[0])
+	}
+	if !reflect.DeepEqual(xkeys[0], newKey) {
+		t.Errorf("want key=%+v; got %+v", newKey, xkeys[0])
+	}
+}

--- a/go/src/koding/kites/kloud/api/sl/softlayer.go
+++ b/go/src/koding/kites/kloud/api/sl/softlayer.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"koding/kites/common"
 	"os"
 	"sort"
 
@@ -24,8 +23,6 @@ import (
 // as the client-side filtering does not scale.
 
 var (
-	defaultLogger = common.NewLogger("softlayer", false)
-
 	// workaround for softlayer-go API
 	nullBuf = &bytes.Buffer{}
 
@@ -355,18 +352,4 @@ func (c *Softlayer) DeleteInstance(id int) error {
 	}
 
 	return nil
-}
-
-func (c *Softlayer) log() logging.Logger {
-	if c.opts.Log != nil {
-		return c.opts.Log
-	}
-	return defaultLogger
-}
-
-func (c *Softlayer) datacenters() []string {
-	if len(c.opts.Datacenters) != 0 {
-		return c.opts.Datacenters
-	}
-	return ProductionDatacenters
 }

--- a/go/src/koding/kites/kloud/api/sl/softlayer.go
+++ b/go/src/koding/kites/kloud/api/sl/softlayer.go
@@ -114,7 +114,7 @@ func NewSoftlayerWithOptions(opts *Options) (*Softlayer, error) {
 // If filter is nil, all templates are returned.
 func (c *Softlayer) KeysByFilter(filter *Filter) (Keys, error) {
 	path := fmt.Sprintf("%s/getSshKeys.json", c.account.GetName())
-	p, err := c.DoRawHttpRequestWithObjectMask(path, KeyMask, "GET", nullBuf)
+	p, err := c.DoRawHttpRequestWithObjectMask(path, keyMask, "GET", nullBuf)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +157,7 @@ func (c *Softlayer) XKeysByFilter(filter *Filter) (Keys, error) {
 	}
 	path := fmt.Sprintf("%s/getSshKeys.json", c.account.GetName())
 	p, err = c.DoRawHttpRequestWithObjectFilterAndObjectMask(
-		path, KeyMask, string(p), "GET", nullBuf,
+		path, keyMask, string(p), "GET", nullBuf,
 	)
 	if err != nil {
 		return nil, err
@@ -251,7 +251,7 @@ func (c *Softlayer) DeleteKey(id int) error {
 // If filter is nil, all templates are returned.
 func (c *Softlayer) TemplatesByFilter(filter *Filter) (Templates, error) {
 	path := fmt.Sprintf("%s/getBlockDeviceTemplateGroups.json", c.account.GetName())
-	p, err := c.DoRawHttpRequestWithObjectMask(path, TemplateMasks, "GET", nullBuf)
+	p, err := c.DoRawHttpRequestWithObjectMask(path, templateMask, "GET", nullBuf)
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +306,7 @@ func (c *Softlayer) XTemplatesByFilter(filter *Filter) (Templates, error) {
 	}
 	path := fmt.Sprintf("%s/getBlockDeviceTemplateGroups.json", c.account.GetName())
 	p, err = c.DoRawHttpRequestWithObjectFilterAndObjectMask(
-		path, TemplateMasks, string(p), "GET", nullBuf,
+		path, templateMask, string(p), "GET", nullBuf,
 	)
 	if err != nil {
 		return nil, err

--- a/go/src/koding/kites/kloud/api/sl/template.go
+++ b/go/src/koding/kites/kloud/api/sl/template.go
@@ -1,7 +1,9 @@
 package sl
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 )
@@ -35,6 +37,21 @@ func (t Tags) Matches(tags Tags) bool {
 	}
 	return len(matches) == len(tags)
 
+}
+
+// String gives key-value tags representation.
+func (t Tags) String() string {
+	if len(t) == 0 {
+		return "[]"
+	}
+	var buf bytes.Buffer
+	fmt.Fprint(&buf, "[")
+	for k, v := range t {
+		fmt.Fprint(&buf, k, "=", v, ",")
+	}
+	p := buf.Bytes()
+	p[len(p)-1] = ']' // replace last dangling commna
+	return string(p)
 }
 
 // TemplateMasks represents objectMasks for the Template struct.
@@ -95,60 +112,57 @@ func (t Templates) ByID(id int) Templates {
 	}
 	for _, template := range t {
 		if template.ID == id {
-			return []*Template{template}
+			return Templates{template}
 		}
 	}
 	return nil
 }
 
 // ByName returns the templates, which names matches the given name.
-func (t Templates) ByName(name string) Templates {
+func (t Templates) ByName(name string) (res Templates) {
 	if name == "" {
 		return t
 	}
-	var named []*Template
 	for _, template := range t {
 		if strings.Contains(template.Name, name) {
-			named = append(named, template)
+			res = append(res, template)
 		}
 	}
-	return named
+	return res
 }
 
 // ByDatacenter returns those templates which are either located
 // in the given datacenter or are available in the given datacenter.
-func (t Templates) ByDatacenter(datacenter string) Templates {
+func (t Templates) ByDatacenter(datacenter string) (res Templates) {
 	if datacenter == "" {
 		return t
 	}
-	var regional []*Template
 	for _, template := range t {
 		if template.Datacenter != nil && template.Datacenter.Name == datacenter {
-			regional = append(regional, template)
+			res = append(res, template)
 			continue
 		}
 		for _, d := range template.Datacenters {
 			if d.Name == datacenter {
-				regional = append(regional, template)
+				res = append(res, template)
 				break
 			}
 		}
 	}
-	return regional
+	return res
 }
 
-// ByTags returns those templates, whose tags matches fully the given tags.
-func (t Templates) ByTags(tags Tags) Templates {
+// ByTags returns those templates, whose tags match fully the given tags.
+func (t Templates) ByTags(tags Tags) (res Templates) {
 	if len(tags) == 0 {
 		return t
 	}
-	var tagged []*Template
 	for _, template := range t {
 		if template.Tags.Matches(tags) {
-			tagged = append(tagged, template)
+			res = append(res, template)
 		}
 	}
-	return tagged
+	return res
 }
 
 // Filter filters the template by the given filter value.
@@ -159,7 +173,10 @@ func (t Templates) Filter(f *Filter) Templates {
 	if !f.Children {
 		t = t.Parent()
 	}
-	return t.ByID(f.ID).ByName(f.Name).ByDatacenter(f.Datacenter).ByTags(f.Tags)
+	return t.ByID(f.ID).
+		ByName(f.Name).
+		ByDatacenter(f.Datacenter).
+		ByTags(f.Tags)
 }
 
 type byCreateDateDesc []*Template

--- a/go/src/koding/kites/kloud/api/sl/template.go
+++ b/go/src/koding/kites/kloud/api/sl/template.go
@@ -54,10 +54,10 @@ func (t Tags) String() string {
 	return string(p)
 }
 
-// TemplateMasks represents objectMasks for the Template struct.
+// templateMasks represents objectMasks for the Template struct.
 //
 // TODO(rjeczalik): infer the list from JSON tags
-var TemplateMasks = []string{
+var templateMask = []string{
 	"id",
 	"parentId",
 	"globalIdentifier",

--- a/go/src/koding/kites/kloud/provider/softlayer/destroy.go
+++ b/go/src/koding/kites/kloud/provider/softlayer/destroy.go
@@ -41,7 +41,7 @@ func (m *Machine) Destroy(ctx context.Context) error {
 
 // IsNotFound returns true if the error is *NotFoundError.
 func isNotFound(err error) bool {
-	if slErr, ok := err.(*sl.APIError); ok {
+	if slErr, ok := err.(*sl.Error); ok {
 		if slErr.Code == "SoftLayer_Exception_NotFound" {
 			return true
 		}

--- a/go/src/koding/kites/kloud/scripts/sl/main.go
+++ b/go/src/koding/kites/kloud/scripts/sl/main.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"koding/kites/kloud/api/sl"
+)
+
+var (
+	username = os.Getenv("SOFTLAYER_USER_NAME")
+	apiKey   = os.Getenv("SOFTLAYER_API_KEY")
+)
+
+// Main is used to globally register each Softlayer resources handler.
+var Main = make(ResourceTree)
+
+// Command represents a single action on a resource.
+type Command interface {
+	Name() string
+	RegisterFlags(*flag.FlagSet)
+	Run(*sl.Softlayer) error
+}
+
+// Resource represents a Softlayer resource.
+type Resource struct {
+	Name        string
+	Description string
+	Commands    map[string]Command
+}
+
+// ResourceTree represents resources and their actions (commands).
+type ResourceTree map[string]*Resource
+
+// Run executes a command on requested resource.
+func (rt ResourceTree) Run(client *sl.Softlayer, args []string) error {
+	var res, cmd string
+	if len(args) == 0 || args[0] == "-help" {
+		fmt.Fprintln(os.Stderr, rt.Usage())
+		return nil
+	}
+
+	res, args = args[0], args[1:]
+	if len(args) == 0 || args[0] == "-help" {
+		fmt.Fprintln(os.Stderr, rt.ResourceUsage(res))
+		return nil
+	}
+
+	cmd, args = args[0], args[1:]
+	resource, ok := rt[res]
+	if !ok {
+		return fmt.Errorf("resource %q not found; see 'sl -help' for details", res)
+	}
+
+	command, ok := resource.Commands[cmd]
+	if !ok {
+		return fmt.Errorf("command %[1]q for %[2]q resource not found; see 'sl %[2]s -help' for details", cmd, res)
+	}
+
+	flags := flag.NewFlagSet("sl "+res+" "+cmd, flag.ContinueOnError)
+	command.RegisterFlags(flags)
+
+	err := flags.Parse(args)
+	if err == flag.ErrHelp {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	return command.Run(client)
+}
+
+// Register adds a resource.
+func (rt ResourceTree) Register(res *Resource) {
+	rt[res.Name] = res
+}
+
+// Usage returns a usage text.
+func (rt ResourceTree) Usage() string {
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, "Usage: sl <resource> <command> [ARGS...]")
+	fmt.Fprintln(&buf)
+	fmt.Fprintln(&buf, "Available resources:")
+	fmt.Fprintln(&buf)
+	w := tabwriter.NewWriter(&buf, 0, 8, 0, '\t', 0)
+	for _, res := range rt.Resources() {
+		fmt.Fprintf(&buf, "\t%s\t%s\n", res.Name, res.Description)
+	}
+	w.Flush()
+	return buf.String()
+}
+
+// ResourceUsage returns a usage text build for the given resource.
+func (rt ResourceTree) ResourceUsage(res string) string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "Usage: sl %s <command> [ARGS...]\n", res)
+	fmt.Fprintln(&buf)
+	fmt.Fprintln(&buf, "Available commands:")
+	fmt.Fprintln(&buf)
+	w := tabwriter.NewWriter(&buf, 0, 8, 0, '\t', 0)
+	for _, cmd := range rt.ResourceCommands(res) {
+		fmt.Fprintf(&buf, "\t%s\t%s\n", cmd.Name(), rt.Description(cmd))
+	}
+	w.Flush()
+	return buf.String()
+}
+
+// Resources returns slice of Softlayer resources, sorted by name.
+func (rt ResourceTree) Resources() []*Resource {
+	var resources []*Resource
+	for _, res := range rt {
+		resources = append(resources, res)
+	}
+	sort.Sort(resByName(resources))
+	return resources
+}
+
+// ResourceCommands returns a slice of commands for the given resource,
+// sorted by name.
+func (rt ResourceTree) ResourceCommands(res string) []Command {
+	var commands []Command
+	for _, cmd := range rt[res].Commands {
+		commands = append(commands, cmd)
+	}
+	sort.Sort(cmdByName(commands))
+	return commands
+}
+
+// Description builds a description text for the given command.
+func (rt ResourceTree) Description(cmd Command) string {
+	var buf bytes.Buffer
+	flags := flag.NewFlagSet(cmd.Name(), 0)
+	cmd.RegisterFlags(flags)
+	flags.VisitAll(func(f *flag.Flag) {
+		fmt.Fprintf(&buf, "-%s <%T> ", f.Name, f.Value.(flag.Getter).Get())
+	})
+	return strings.TrimSpace(buf.String())
+}
+
+func die(v interface{}) {
+	fmt.Fprintln(os.Stderr, v)
+	os.Exit(1)
+}
+
+func main() {
+	if username == "" {
+		die("SOFTLAYER_USER_NAME is not set")
+	}
+	if apiKey == "" {
+		die("SOFTLAYER_API_KEY is not set")
+	}
+	client, err := sl.NewSoftlayer(username, apiKey)
+	if err != nil {
+		die(err)
+	}
+	if err = Main.Run(client, os.Args[1:]); err != nil {
+		die(err)
+	}
+}
+
+type resByName []*Resource
+
+func (p resByName) Len() int           { return len(p) }
+func (p resByName) Less(i, j int) bool { return p[i].Name < p[j].Name }
+func (p resByName) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+type cmdByName []Command
+
+func (p cmdByName) Len() int           { return len(p) }
+func (p cmdByName) Less(i, j int) bool { return p[i].Name() < p[j].Name() }
+func (p cmdByName) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }

--- a/go/src/koding/kites/kloud/scripts/sl/sshkey.go
+++ b/go/src/koding/kites/kloud/scripts/sl/sshkey.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/user"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"koding/kites/kloud/api/sl"
+)
+
+var defaultUser = "root"
+
+func init() {
+	Main.Register(sshkeyResource)
+
+	if u, err := user.Current(); err == nil {
+		defaultUser = u.Username
+	}
+}
+
+var sshkeyResource = &Resource{
+	Name:        "sshkey",
+	Description: "Manages SSH keys.",
+	Commands: map[string]Command{
+		"list": new(sshkeyList),
+		"add":  new(sshkeyAdd),
+		"rm":   new(sshkeyRm),
+	},
+}
+
+// sshkeyList implements a list command
+type sshkeyList struct {
+	pem   string
+	label string
+	user  string
+}
+
+func (*sshkeyList) Name() string {
+	return "list"
+}
+
+func (cmd *sshkeyList) RegisterFlags(f *flag.FlagSet) {
+	f.StringVar(&cmd.pem, "pem", "", "Filters keys by fingerprint computed from the given key.")
+	f.StringVar(&cmd.label, "label", "", "Filters keys by a label.")
+	f.StringVar(&cmd.user, "user", "", "Filters keys by a user.")
+}
+
+func (cmd *sshkeyList) Run(c *sl.Softlayer) error {
+	f := &sl.Filter{
+		Label: cmd.label,
+		User:  cmd.user,
+	}
+	if cmd.pem != "" {
+		key, err := sl.ParseKey(cmd.pem)
+		if err != nil {
+			return err
+		}
+		f.Fingerprint = key.Fingerprint
+	}
+	keys, err := c.KeysByFilter(f)
+	if err != nil {
+		return err
+	}
+	printKeys(keys...)
+	return nil
+}
+
+// sshkeyAdd implements an add command
+type sshkeyAdd struct {
+	pem   string
+	label string
+	user  string
+	tags  string
+}
+
+func (cmd *sshkeyAdd) Name() string {
+	return "add"
+}
+
+func (cmd *sshkeyAdd) RegisterFlags(f *flag.FlagSet) {
+	f.StringVar(&cmd.pem, "pem", "", "Private key file.")
+	f.StringVar(&cmd.label, "label", "", "Label of the key.")
+	f.StringVar(&cmd.user, "user", defaultUser, "Username for which key is created.")
+	f.StringVar(&cmd.tags, "tags", "", "Tags to add for the key.")
+}
+
+func (cmd *sshkeyAdd) Run(c *sl.Softlayer) error {
+	key, err := sl.ParseKey(cmd.pem)
+	if err != nil {
+		return err
+	}
+	if cmd.label != "" {
+		key.Label = cmd.label
+	}
+	if cmd.user != "" {
+		key.User = cmd.user
+	}
+	if cmd.tags != "" {
+		key.Tags = newTags(strings.Split(cmd.tags, ","))
+	}
+	key, err = c.CreateKey(key)
+	if err != nil {
+		return err
+	}
+	printKeys(key)
+	return nil
+}
+
+// sshkeyRm implements a rm command
+type sshkeyRm struct {
+	pem string
+	id  int
+}
+
+func (*sshkeyRm) Name() string {
+	return "rm"
+}
+
+func (cmd *sshkeyRm) RegisterFlags(f *flag.FlagSet) {
+	f.IntVar(&cmd.id, "id", 0, "Remove public key for the given ID.")
+	f.StringVar(&cmd.pem, "pem", "", "Remove public key for the given private key.")
+}
+
+func (cmd *sshkeyRm) Run(c *sl.Softlayer) error {
+	var ids []int
+	if cmd.id != 0 {
+		ids = append(ids, cmd.id)
+	}
+	if cmd.pem != "" {
+		key, err := sl.ParseKey(cmd.pem)
+		if err != nil {
+			return err
+		}
+		f := &sl.Filter{
+			Fingerprint: key.Fingerprint,
+		}
+		keys, err := c.KeysByFilter(f)
+		if err != nil && !sl.IsNotFound(err) {
+			return err
+		}
+		for _, key := range keys {
+			ids = append(ids, key.ID)
+		}
+	}
+	if len(ids) == 0 {
+		return errors.New("no key found to remove")
+	}
+	for _, id := range ids {
+		if err := c.DeleteKey(id); err != nil {
+			return err
+		}
+		fmt.Println("Removed", id)
+	}
+	return nil
+}
+
+func printKeys(keys ...*sl.Key) {
+	w := &tabwriter.Writer{}
+	w.Init(os.Stdout, 0, 8, 0, '\t', 0)
+	fmt.Fprintln(w, "ID\tLabel\tFingerprint\tCreateDate\tUser\tTags")
+	for _, key := range keys {
+		fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%s\n", key.ID, key.Label,
+			key.Fingerprint, key.CreateDate.Format(time.RFC3339), key.User, key.Tags)
+	}
+	w.Flush()
+}
+
+func newTags(kv []string) sl.Tags {
+	if len(kv) == 0 {
+		return nil
+	}
+	t := make(sl.Tags)
+	for _, kv := range kv {
+		if i := strings.IndexRune(kv, '='); i != -1 {
+			t[kv[:i]] = kv[i+1:]
+		} else {
+			t[kv] = ""
+		}
+	}
+	return t
+}


### PR DESCRIPTION
The official slcli lacks couple of features like tagging the keys, which
is going to be needed in future for the packer plugin to lookup the key
to attach to the instance.

This tool is going to be extended also with more debug / maintanance
commands for the Softlayer VMs.

Moreover there're are some minor quirks in the official tool, like
the  sshkey resource refuse to cooperate, in particular the following command:

```
$ slcli sshkey add -k kloud_rsa.pem kloud
```

Fails with:

```
SoftLayerAPIError(SoftLayer_Exception_Public): Unable to generate a
fingerprint. Please ensure the key provided is a valid public key.
```

The scripts/sl works with the kloud_rsa.pem key:

```
$ sl sshkey add -pem kloud_rsa.pem -label kloud
ID  Label   Fingerprint                 CreateDate          User        Tags
445673  slcli   9f:fc:76:92:0b:88:ff:94:e5:e2:d7:5b:67:e5:1a:27 2015-12-21 03:03:44 -0600 -0600 rjeczalik   []
```

/cc @fatih @cihangir @leeola ptal
