### PR TITLE
softlayer: run cloud-init in the same session instead of reboot [part of TMS-1920]

### DIFF
--- a/go/src/koding/kites/kloud/provisioner/softlayer-cloud-init.sh
+++ b/go/src/koding/kites/kloud/provisioner/softlayer-cloud-init.sh
@@ -68,11 +68,18 @@ EOF
 # overwritten by Koding Userdata, to restore original value run dpkg-reconfigure cloud-init
 datasource_list: [ SoftLayer, None ]
 EOF
-	# ensure cloud-init is started on boot
+
+	# ensure cloud-init is started for the first time
 	rm -rf /var/lib/cloud/*
 
-	# reboot instance to let the cloud-init run for the first time
-	reboot
+	# update environment after cloud-init package installation
+	source /etc/environment
+
+	# run cloud-init
+	cloud-init init --local
+	cloud-init init
+	cloud-init modules --mode=config
+	cloud-init modules --mode=final
 }
 
 main 2>&1 | tee -a /var/log/softlayer-cloud-init.log


### PR DESCRIPTION
Gets rid of post-provision timeouts and cuts average build time by 1min.

/cc @cihangir @szkl @leeola 
