### PR TITLE
TEST-11 Fix for invalidCardDetails

### DIFF
--- a/client/test/lib/helpers/helpers.coffee
+++ b/client/test/lib/helpers/helpers.coffee
@@ -521,6 +521,7 @@ module.exports =
         .waitForElementVisible   '.single-plan.' + planType + '.current', 20000
     else
       browser
+        .pause  3000
         .expect.element(upgradePlanButton).to.not.be.enabled
 
 


### PR DESCRIPTION
Added a pause before asserting that the button was disabled, because the speed of test execution has increased.

https://koding.atlassian.net/browse/TEST-11
