### PR TITLE
TEST-23 Tests.teams-EditByPressingTheUpKey_and_deletePost

### DIFF
--- a/client/test/lib/helpers/teamshelpers.coffee
+++ b/client/test/lib/helpers/teamshelpers.coffee
@@ -558,3 +558,42 @@ module.exports =
         .waitForElementVisible    likeButtonUnpressed, 20000
         .pause                    3000
         .assert.elementNotPresent likeButtonPressed
+
+
+  editOrDeletePost: (browser, editPost = no, deletePost = no) ->
+
+    editedmessage       = 'Message after editing'
+    textSelector        = '.ChatItem .SimpleChatListItem.ChatItem-contentWrapper .ChatListItem-itemBodyContainer'
+    menuButton          = '.SimpleChatListItem.ChatItem-contentWrapper:nth-of-type(1) .ButtonWithMenuWrapper button'
+    editButton          = '.ButtonWithMenuItemsList li:nth-child(1)'
+    chatInput           = '.editing .ChatItem-updateMessageForm .ChatInputWidget textarea'
+    editedText          = '.ChatItem .SimpleChatListItem.edited .ChatListItem-itemBodyContainer .ChatItem-contentBody .MessageBody'
+    deleteButton        = '.ButtonWithMenuItemsList li:nth-child(2)'
+    confirmDelete       = '.Modal-DeleteItemPrompt .Modal-buttons .Button--danger'
+    deletedTextSelector = '.Pane-body .ChatList .ChatItem .SimpleChatListItem .ChatListItem-itemBodyContainer'
+
+    browser
+      .waitForElementVisible  textSelector, 20000
+      .moveToElement          textSelector, 10, 10
+      .waitForElementVisible  menuButton, 20000
+      .click                  menuButton
+
+    if editPost
+      browser
+        .waitForElementVisible  editButton, 20000
+        .click                  editButton
+        .waitForElementVisible  chatInput, 20000
+        .clearValue             chatInput
+        .setValue               chatInput, editedmessage
+        .setValue               chatInput, browser.Keys.ENTER
+        .waitForElementVisible  editedText, 20000
+        .assert.containsText    editedText, editedmessage
+
+    if deletePost
+      browser
+        .waitForElementVisible     deleteButton, 20000
+        .click                     deleteButton
+        .waitForElementVisible     confirmDelete, 20000
+        .click                     confirmDelete
+        .pause                     3000 #for the text to be deleted
+        .assert.elementNotPresent  deletedTextSelector

--- a/client/test/lib/teams/teamslikeunlike.coffee
+++ b/client/test/lib/teams/teamslikeunlike.coffee
@@ -32,29 +32,44 @@ module.exports =
   editPost: (browser) ->
 
     message       = helpers.getFakeText()
-    editedmessage = 'Message after editing'
-    textSelector  = '.ChatItem .SimpleChatListItem.ChatItem-contentWrapper .ChatListItem-itemBodyContainer'
-    chatInput     = '.editing .ChatItem-updateMessageForm .ChatInputWidget textarea'
-    menuButton    = '.SimpleChatListItem.ChatItem-contentWrapper:nth-of-type(1) .ButtonWithMenuWrapper button'
-    editButton    = '.ButtonWithMenuItemsList li:nth-child(1)'
-    editedText    = '.ChatItem .SimpleChatListItem.edited .ChatListItem-itemBodyContainer .ChatItem-contentBody .MessageBody'
 
     user = teamsHelpers.loginTeam(browser)
     teamsHelpers.createChannel(browser, user)
     teamsHelpers.sendComment(browser, message)
+    teamsHelpers.editOrDeletePost(browser, yes, no)
+    browser.end()
 
+
+  deletePost: (browser) ->
+  
+    message = helpers.getFakeText()
+  
+    user = teamsHelpers.loginTeam(browser)
+    teamsHelpers.createChannel(browser, user)
+    teamsHelpers.sendComment(browser, message)
+    teamsHelpers.editOrDeletePost(browser, no, yes)
+    browser.end()
+
+
+  editPostUsingUPkey: (browser) ->
+  
+    message           = helpers.getFakeText()
+    chatInputSelector = '.ChatPaneFooter .ChatInputWidget textarea'
+    textSelector      = '.ChatItem .SimpleChatListItem.ChatItem-contentWrapper .ChatListItem-itemBodyContainer'
+    editingSelector   = '.SimpleChatListItem.editing .ChatItem-updateMessageForm.visible .ChatInputWidget textarea'
+    chatItem          = '.Pane-body .ChatList .ChatItem:nth-of-type(3)'
+ 
+    user = teamsHelpers.loginTeam(browser)
+    teamsHelpers.createChannel(browser, user)
+    teamsHelpers.sendComment(browser, message)
+ 
     browser
       .waitForElementVisible  textSelector, 20000
-      .moveToElement          textSelector, 10, 10
-      .waitForElementVisible  menuButton, 20000
-      .click                  menuButton
-      .waitForElementVisible  editButton, 20000
-      .click                  editButton
-      .waitForElementVisible  chatInput, 20000
-      .clearValue             chatInput
-      .setValue               chatInput, editedmessage
-      .setValue               chatInput, browser.Keys.ENTER
-      .waitForElementVisible  editedText, 20000
-      .assert.containsText    editedText, editedmessage
+      .setValue               chatInputSelector, browser.Keys.UP_ARROW
+      .waitForElementVisible  editingSelector, 20000 
+      .clearValue             editingSelector
+      .setValue               editingSelector, 'Message after editing' + browser.Keys.ENTER
+      .waitForElementVisible  chatItem, 20000
+      .pause                  3000 #waiting for text to be changed
+      .assert.containsText    chatItem, 'Message after editing'
       .end()
-


### PR DESCRIPTION
The following tests were added:
- delete post
- edit post using the UP key

Refactored "editPost" test, by creating a helper for edit Post and delete Post.

I've run this PR 3 times on wercker, please see below @didemacet @fatihacet 
![selection_020](https://cloud.githubusercontent.com/assets/7612973/12293384/ebbce732-b9fb-11e5-8fbe-1a24f77e6f10.png)
![selection_021](https://cloud.githubusercontent.com/assets/7612973/12293398/f64283ba-b9fb-11e5-9a51-7b6539880a14.png)
![selection_022](https://cloud.githubusercontent.com/assets/7612973/12293404/f8f3a8b4-b9fb-11e5-81ad-1a2fbd2f6d2d.png)
![selection_023](https://cloud.githubusercontent.com/assets/7612973/12293408/fb81734a-b9fb-11e5-99f6-ca5c0be4cbb4.png)

https://koding.atlassian.net/browse/TEST-23
