### PR TITLE
ACT-433 fix for scrolling to selected message

### DIFF
--- a/client/activity/lib/components/chatinputwidget/tokens/channeltoken.coffee
+++ b/client/activity/lib/components/chatinputwidget/tokens/channeltoken.coffee
@@ -19,13 +19,17 @@ module.exports = ChannelToken =
   getConfig: ->
 
     return {
-      component              : ChannelDropbox
-      getters                :
-        items                : 'dropboxChannels'
-        selectedIndex        : 'channelsSelectedIndex'
-        selectedItem         : 'channelsSelectedItem'
-      horizontalNavigation   : no
-      handleItemConfirmation : (item, query) -> "##{item.get 'name'} "
+      component            : ChannelDropbox
+      getters              :
+        items              : 'dropboxChannels'
+        selectedIndex      : 'channelsSelectedIndex'
+        selectedItem       : 'channelsSelectedItem'
+      horizontalNavigation : no
+      processConfirmedItem : (item, query) ->
+        return {
+          type  : 'text'
+          value : "##{item.get 'name'} "
+        }
     }
 
 

--- a/client/activity/lib/components/chatinputwidget/tokens/commandtoken.coffee
+++ b/client/activity/lib/components/chatinputwidget/tokens/commandtoken.coffee
@@ -14,11 +14,15 @@ module.exports = CommandToken =
   getConfig: ->
 
     return {
-      component              : CommandDropbox
-      getters                :
-        items                : 'dropboxCommands'
-        selectedIndex        : 'commandsSelectedIndex'
-        selectedItem         : 'commandsSelectedItem'
-      horizontalNavigation   : no
-      handleItemConfirmation : (item, query) -> "#{item.get 'name'} #{item.get 'paramPrefix', ''}"
+      component            : CommandDropbox
+      getters              :
+        items              : 'dropboxCommands'
+        selectedIndex      : 'commandsSelectedIndex'
+        selectedItem       : 'commandsSelectedItem'
+      horizontalNavigation : no
+      processConfirmedItem : (item, query) ->
+        return {
+          type  : 'text'
+          value : "#{item.get 'name'} #{item.get 'paramPrefix', ''}"
+        }
     }

--- a/client/activity/lib/components/chatinputwidget/tokens/emojitoken.coffee
+++ b/client/activity/lib/components/chatinputwidget/tokens/emojitoken.coffee
@@ -20,13 +20,16 @@ module.exports = EmojiToken =
   getConfig: ->
 
     return {
-      component              : EmojiDropbox
-      getters                :
-        items                : 'dropboxEmojis'
-        selectedIndex        : 'emojisSelectedIndex'
-        selectedItem         : 'emojisSelectedItem'
-      horizontalNavigation   : yes
-      handleItemConfirmation : (item, query) ->
+      component            : EmojiDropbox
+      getters              :
+        items              : 'dropboxEmojis'
+        selectedIndex      : 'emojisSelectedIndex'
+        selectedItem       : 'emojisSelectedItem'
+      horizontalNavigation : yes
+      processConfirmedItem : (item, query) ->
         EmojiActions.incrementUsageCount item
-        return "#{formatEmojiName item} "
+        return {
+          type  : 'text'
+          value : "#{formatEmojiName item} "
+        }
     }

--- a/client/activity/lib/components/chatinputwidget/tokens/mentiontoken.coffee
+++ b/client/activity/lib/components/chatinputwidget/tokens/mentiontoken.coffee
@@ -26,13 +26,17 @@ module.exports = MentionToken =
         selectedIndex      : 'mentionsSelectedIndex'
         selectedItem       : 'mentionsSelectedItem'
       horizontalNavigation : no
-      handleItemConfirmation : (item, query) ->
+      processConfirmedItem : (item, query) ->
         names = item.get 'names'
         if names
           name = findNameByQuery(names.toJS(), query) ? names.first()
         else
           name = item.getIn ['profile', 'nickname']
-        return "@#{name} "
+
+        return {
+          type  : 'text'
+          value : "@#{name} "
+        }
     }
 
 

--- a/client/activity/lib/components/chatinputwidget/tokens/searchtoken.coffee
+++ b/client/activity/lib/components/chatinputwidget/tokens/searchtoken.coffee
@@ -17,17 +17,21 @@ module.exports = SearchToken =
   getConfig: ->
 
     return {
-      component              : SearchDropbox
-      getters                :
-        items                : 'dropboxSearchItems'
-        selectedIndex        : 'searchSelectedIndex'
-        selectedItem         : 'searchSelectedItem'
-        flags                : 'searchFlags'
-      horizontalNavigation   : no
-      handleItemConfirmation : (item, query) ->
+      component            : SearchDropbox
+      getters              :
+        items              : 'dropboxSearchItems'
+        selectedIndex      : 'searchSelectedIndex'
+        selectedItem       : 'searchSelectedItem'
+        flags              : 'searchFlags'
+      horizontalNavigation : no
+      processConfirmedItem : (item, query) ->
         { initialChannelId, id } = item.get('message').toJS()
-        ChannelActions.loadChannel(initialChannelId).then ({ channel }) ->
-          kd.singletons.router.handleRoute "/Channels/#{channel.name}/#{id}"
+        return {
+          type     : 'command'
+          value    :
+            name   : '/search'
+            params : { initialChannelId, messageId : id }
+        }
     }
 
 

--- a/client/activity/lib/components/chatpane/index.coffee
+++ b/client/activity/lib/components/chatpane/index.coffee
@@ -166,6 +166,7 @@ module.exports = class ChatPane extends React.Component
     return null  unless @props.thread
 
     <Scroller
+      data-is-scroller=yes
       style={{height: 'auto'}}
       ref='scrollContainer'
       onScroll={@bound 'onScroll'}

--- a/client/activity/lib/flux/actions/command.coffee
+++ b/client/activity/lib/flux/actions/command.coffee
@@ -22,6 +22,10 @@ executeCommand = (command, channel) ->
           kd.singletons.router.handleRoute "/Channels/#{channelName}"
       else
         channelActions.unfollowChannel channelId
+    when '/search'
+        { initialChannelId, messageId } = params
+        channelActions.loadChannel(initialChannelId).then ({ channel }) ->
+          kd.singletons.router.handleRoute "/Channels/#{channel.name}/#{messageId}"
 
 
 module.exports = {

--- a/client/app/lib/util/findScrollableParent.coffee
+++ b/client/app/lib/util/findScrollableParent.coffee
@@ -16,7 +16,7 @@ module.exports = findScrollableParent = (element) ->
     if element is document
       continue
 
-    if element.classList.contains 'Scrollable'
+    if element.dataset.isScroller
       return element
 
     style = global.getComputedStyle element

--- a/client/app/lib/util/findScrollableParent.coffee
+++ b/client/app/lib/util/findScrollableParent.coffee
@@ -16,6 +16,9 @@ module.exports = findScrollableParent = (element) ->
     if element is document
       continue
 
+    if element.classList.contains 'Scrollable'
+      return element
+
     style = global.getComputedStyle element
 
     overflowY =

--- a/client/app/lib/util/scrollToElement.coffee
+++ b/client/app/lib/util/scrollToElement.coffee
@@ -8,14 +8,19 @@ findScrollableParent = require 'app/util/findScrollableParent'
 ###
 module.exports = scrollToElement = (element) ->
 
-  $element = $ element
-  $parent = $element.parent()
+  $element  = $ element
+  $parent   = $element.parent()
   $scroller = $ findScrollableParent element
 
-  containerTop = Math.abs $parent.position().top
-  elementTop = $element.position().top
+  scrollableHeight = $scroller.get(0).scrollHeight
+  containerTop     = $parent.position().top
+  containerHeight  = $parent.height()
+  elementTop       = $element.position().top
+
+  heightDelta      = scrollableHeight - containerHeight
   distanceToCenter = (($scroller.height() - $element.height()) / 2)
 
-  scrollTop = containerTop + elementTop - distanceToCenter
+  scrollTop = heightDelta - containerTop + elementTop - distanceToCenter
 
   $scroller.animate { scrollTop }, 347
+


### PR DESCRIPTION
@usirin, can you please review these changes? They contain fix for the bug https://koding.atlassian.net/browse/ACT-433
Also, I added a few changes related to search in `ChatInputWidget`:
- search is treated as usual command like `/invite` and `/leave`. It means that when user clicks on any item in search dropbox, `onCommand` handler of `ChatInputWidget.Container` is called. It gives an ability to move search handling from `SearchToken` into general command action - `activity/fux/actions/command.coffee`
- input is cleared after user is clicked on search item (same behavior as for other commands). When I tested scrolling fix, I noticed that it didn't work and in some cases it really confused me as a user. So I fixed it
