### PR TITLE
TMS-2109 Use Model permissions for existing groups on db

### DIFF
--- a/config/main.dev.coffee
+++ b/config/main.dev.coffee
@@ -1529,9 +1529,15 @@ Configuration = (options={}) ->
         mongorestore -h#{boot2dockerbox} -dkoding dump/koding
         rm -rf ./dump
 
-        echo '#---> UPDATING MONGO DATABASE ACCORDING TO LATEST CHANGES IN CODE (UPDATE PERMISSIONS @chris) <---#'
+        updatePermissions
+
+      }
+
+      function updatePermissions () {
+
+        echo '#---> UPDATING MONGO DATABASE ACCORDING TO LATEST CHANGES IN CODE (UPDATE PERMISSIONS @gokmen) <---#'
         cd #{projectRoot}
-        node #{projectRoot}/scripts/permission-updater  -c #{socialapi.configFilePath} --hard >/dev/null
+        node #{projectRoot}/scripts/permission-updater -c dev --reset
 
       }
 
@@ -1599,6 +1605,9 @@ Configuration = (options={}) ->
       elif [ "$1" == "services" ]; then
         check_service_dependencies
         services
+
+      elif [ "$1" == "updatepermissions" ]; then
+        updatePermissions
 
       elif [ "$1" == "resetdb" ]; then
 

--- a/scripts/permission-updater/main.coffee
+++ b/scripts/permission-updater/main.coffee
@@ -39,10 +39,23 @@ koding.once 'dbClientReady', ->
     console.error err  if err
 
     unless permissionSet?
-      if argv.hard?
+      if argv.hard or argv.reset
         Bongo.dash workQueue, done
       else
         done()
+      return
+
+    if argv.reset
+
+      newSet = new JPermissionSet {}, { privacy: 'public' }
+      workQueue.push ->
+        permissionSet.update {
+          $set:
+            permissions: newSet.permissions
+        }, (err) ->
+          console.log 'Failed to update permissions', err  if err
+          workQueue.fin()
+
       return
 
     console.log "BEFORE", permissionSet.permissions

--- a/workers/social/lib/social/models/group/index.coffee
+++ b/workers/social/lib/social/models/group/index.coffee
@@ -45,9 +45,7 @@ module.exports = class JGroup extends Module
     permissions     :
       'grant permissions'                 : []
       'open group'                        : ['member', 'moderator']
-      'list members'                      :
-        public                            : ['moderator', 'member']
-        private                           : ['moderator', 'member']
+      'list members'                      : ['moderator', 'member']
       'read group activity'               :
         public                            : ['guest', 'member', 'moderator']
         private                           : ['member', 'moderator']
@@ -77,9 +75,7 @@ module.exports = class JGroup extends Module
       'delete channel'          : ['member', 'moderator']
 
       # JTag related permissions
-      'read tags'               :
-        public                  : ['member', 'moderator']
-        private                 : ['member', 'moderator']
+      'read tags'               : ['member', 'moderator']
       'create tags'             : ['member', 'moderator']
       'freetag content'         : ['member', 'moderator']
       'browse content by tag'   : ['member', 'moderator']


### PR DESCRIPTION
for development requirements we are using a blank db which only includes `koding` group and some other base data that we require to run koding. until now permission change was effected manually on that blank db, with this change it will be using the latest permissions defined in the code when one runs `./run resetdb` or `./run buildservices` we may need to do same for production db as well.

https://koding.atlassian.net/browse/TMS-2109
