### PR TITLE
Tests - Fix for invalidCardDetails

### DIFF
--- a/client/test/lib/helpers/helpers.coffee
+++ b/client/test/lib/helpers/helpers.coffee
@@ -504,7 +504,7 @@ module.exports =
 
   submitForm: (browser, validCardDetails = yes) ->
 
-    upgradePlanButton = '.kdmodal-inner .green:not(.paypal)'
+    upgradePlanButton = '.payment-modal .kdmodal-inner .kdmodal-content .payment-form-wrapper [disabled="disabled"]'
     planType          = 'developer'
 
     if validCardDetails
@@ -520,7 +520,7 @@ module.exports =
     else
       browser
         .pause  3000
-        .expect.element(upgradePlanButton).to.not.be.enabled
+        .waitForElementVisible   upgradePlanButton, 20000 
 
 
   selectPlan: (browser, planType = 'developer') ->

--- a/scripts/test-instance/parallel-sets.coffee
+++ b/scripts/test-instance/parallel-sets.coffee
@@ -64,7 +64,7 @@ module.exports = [
   [
     # { name: 'teams teamschannels' }
     { name: 'ide terminal' }
-    # { name: 'pricing invalidcarddetails' }
+    { name: 'pricing invalidcarddetails' }
   ]
 
   [


### PR DESCRIPTION
@didemacet @fatihacet I saw that the 'pricing invalidcarddetails' was disabled for failing and I checked it. It seems that the button that was unabled before changed properties and I changed the selector and tested it on wercker 6 times and it passed from the first try every time.

![selection_030](https://cloud.githubusercontent.com/assets/7612973/12523307/bcb5642c-c15e-11e5-8e54-b7969121d276.png)
