### PR TITLE
GEN-1862 cleaner: list InstanceIDs for cleaned EIPs

### DIFF
--- a/go/src/koding/kites/kloud/cleaners/cmd/cleaner/elasticips.go
+++ b/go/src/koding/kites/kloud/cleaners/cmd/cleaner/elasticips.go
@@ -22,8 +22,8 @@ func (e *ElasticIPs) Run() {
 }
 
 func (e *ElasticIPs) Result() string {
-	return fmt.Sprintf("Released(removed) %d non associated elastic IP addresses",
-		e.nonused.Count())
+	return fmt.Sprintf("Released (removed) %d non associated elastic IP addresses: %v",
+		e.nonused.Count(), e.nonused.InstanceIDs())
 }
 
 func (e *ElasticIPs) Info() *taskInfo {
@@ -51,8 +51,8 @@ func (e *DowngradedElasticIPs) Run() {
 }
 
 func (e *DowngradedElasticIPs) Result() string {
-	return fmt.Sprintf("Released (removed) %d non-paid elastic IP addresses",
-		e.nonpaid.Count())
+	return fmt.Sprintf("Released (removed) %d non-paid elastic IP addresses: %v",
+		e.nonpaid.Count(), e.nonpaid.InstanceIDs())
 }
 
 func (e *DowngradedElasticIPs) Info() *taskInfo {

--- a/go/src/koding/kites/kloud/cleaners/lookup/addresses.go
+++ b/go/src/koding/kites/kloud/cleaners/lookup/addresses.go
@@ -69,6 +69,20 @@ func (a *Addresses) Count() int {
 	return count
 }
 
+func (a *Addresses) InstanceIDs() []string {
+	var ids []string
+
+	for _, addrs := range a.m {
+		for _, addr := range addrs {
+			if id := aws.StringValue(addr.InstanceId); id != "" {
+				ids = append(ids, id)
+			}
+		}
+	}
+
+	return ids
+}
+
 // NotAssociated returns a list of addresses which are not
 // associated
 func (a *Addresses) NotAssociated() *Addresses {


### PR DESCRIPTION
If after deployment we'll be still leaking EIPs, this CL will help troubleshooting the affected instances.

/cc @koding/godevs 
