### PR TITLE
ACT-457 Activity: prepareThreadTitle: channel name bug is fixed

### DIFF
--- a/client/activity/lib/util/getParticipantOrigins.coffee
+++ b/client/activity/lib/util/getParticipantOrigins.coffee
@@ -5,11 +5,14 @@ module.exports = getParticipantOrigins = (channel) ->
 
   { lastMessage, participantsPreview, participantCount } = channel.toJS()
 
+  isLastMessageOwnerLeave = false
+  isLastMessageOwnerLeave = lastMessage.payload?.systemType? and lastMessage.payload?.systemType  == 'leave'
+
   lastMessageOwner = lastMessage?.account
 
-  origins = if lastMessageOwner and not isMyPost(lastMessage) then [lastMessageOwner] else []
+  origins = if lastMessageOwner and not isMyPost(lastMessage) and not isLastMessageOwnerLeave then [lastMessageOwner] else []
   owners  = [whoami()._id]
-  owners.push lastMessageOwner._id  if lastMessageOwner
+  owners.push lastMessageOwner._id  if lastMessageOwner and not isLastMessageOwnerLeave
 
   filtered = participantsPreview.filter (p) ->
     return not (p._id in owners)

--- a/client/activity/lib/util/getParticipantOrigins.coffee
+++ b/client/activity/lib/util/getParticipantOrigins.coffee
@@ -5,12 +5,15 @@ module.exports = getParticipantOrigins = (channel) ->
 
   { lastMessage, participantsPreview, participantCount } = channel.toJS()
 
-  isLastMessageOwnerLeave = false
-  isLastMessageOwnerLeave = lastMessage.payload?.systemType? and lastMessage.payload?.systemType  == 'leave'
+  isLastMessageOwnerLeave = lastMessage.payload?.systemType? and lastMessage.payload?.systemType  is 'leave'
 
   lastMessageOwner = lastMessage?.account
 
-  origins = if lastMessageOwner and not isMyPost(lastMessage) and not isLastMessageOwnerLeave then [lastMessageOwner] else []
+
+  if lastMessageOwner and not isMyPost(lastMessage) and not isLastMessageOwnerLeave
+  then origins = [lastMessageOwner]
+  else origins = []
+
   owners  = [whoami()._id]
   owners.push lastMessageOwner._id  if lastMessageOwner and not isLastMessageOwnerLeave
 


### PR DESCRIPTION
This bug occurs when last message owner left the conversation.
I first decided that message belong to one who left conversation then remove it from where we store (origins variable)

https://koding.atlassian.net/browse/ACT-457
