### PR TITLE
[TMS-2132] Team: Sidebar: Fix collapsed sidebar ui issues and align machine labels

### DIFF
--- a/client/app/lib/components/sidebarmachineslistitem/styl/sidebarmachineslistItem.styl
+++ b/client/app/lib/components/sidebarmachineslistitem/styl/sidebarmachineslistItem.styl
@@ -8,8 +8,7 @@ $transRed   = rgba(233, 72, 53, .25)
   display                   block
   font-size                 $fs-regular
   font-weight               $fw-regular
-  height                    28px
-  line-height               20px
+  line-height               16px
   noTextDeco()
   margin-bottom             8px
   padding                   0px 8px 0px 19px
@@ -23,6 +22,12 @@ $transRed   = rgba(233, 72, 53, .25)
 
   &:hover > .MachineSettings
     opacity                 1
+
+  .SidebarListItem-title
+    rel()
+    top                     50%
+    vendor                  transform, translateY(-50%)
+    height                  18px
 
 .SidebarMachinesListItem
   rel()

--- a/client/app/lib/components/sidebarstacksection/styl/sidebarstacksection.styl
+++ b/client/app/lib/components/sidebarstacksection/styl/sidebarstacksection.styl
@@ -4,6 +4,7 @@
   > .SidebarSection-headerTitle
     margin                  15px 0
     color                   #656565
+    vendor                  transition, all .3s ease
 
   .SidebarStackSection
     h4
@@ -16,6 +17,7 @@
     .SidebarSection-body
       rel()
       left                  13px
+      vendor                transition, all .3s ease
 
       .SidebarMachinesListItem--MainLink
         color               #818181
@@ -55,3 +57,22 @@
 
   &:last-of-type
     margin-bottom           0
+
+#kdmaincontainer
+  &.collapsed
+    .SidebarTeamSection
+
+      > .SidebarSection-headerTitle
+        opacity             0
+
+      .SidebarSection-body
+        left                0
+
+      .SidebarMachinesListItem--MainLink
+        rel()
+        width               100%
+        padding-right       0
+
+        .SidebarListItem-unreadCount
+          right             2px !important
+          top               -2px !important


### PR DESCRIPTION
/cc @gokmen @sinan 

https://koding.atlassian.net/browse/TMS-2132

![screen shot 2016-01-27 at 2 34 11 pm](https://cloud.githubusercontent.com/assets/728733/12613925/66378936-c505-11e5-869c-5ac44c01b68c.png)
![screen shot 2016-01-27 at 2 34 16 pm](https://cloud.githubusercontent.com/assets/728733/12613926/663a41bc-c505-11e5-971b-549d6eaa39eb.png)
![screen shot 2016-01-27 at 2 41 02 pm](https://cloud.githubusercontent.com/assets/728733/12613927/6658ab16-c505-11e5-9a0a-9793926e47cc.png)

![yggollcs3k](https://cloud.githubusercontent.com/assets/728733/12613940/717b0c32-c505-11e5-83f0-1cc080673fac.gif)
