### PR TITLE
[TMS-664] Don't check roles for Stack Catalog modal tabs.

### DIFF
--- a/client/admin/lib/views/customviews/adminappview.coffee
+++ b/client/admin/lib/views/customviews/adminappview.coffee
@@ -12,6 +12,7 @@ module.exports = class AdminAppView extends kd.ModalView
     options.testPath         = 'groups-admin'
     options.useRouter       ?= yes
     options.paneViewClass  or= AdminMainTabPaneView
+    options.checkRoles      ?= yes
 
     super options, data
 
@@ -58,8 +59,8 @@ module.exports = class AdminAppView extends kd.ModalView
 
   createTabs: ->
 
-    group        = @getData()
-    { tabData }  = @getOptions()
+    group                     = @getData()
+    { tabData, checkRoles }   = @getOptions()
 
     items   = []
     myRoles = _globals.config.roles
@@ -73,7 +74,7 @@ module.exports = class AdminAppView extends kd.ModalView
 
         role = if item.role? then item.role else 'admin'
 
-        if role not in myRoles
+        if checkRoles and role not in myRoles
           continue
 
         items.push item

--- a/client/stacks/lib/views/customviews/stackcatalogmodalview.coffee
+++ b/client/stacks/lib/views/customviews/stackcatalogmodalview.coffee
@@ -8,7 +8,8 @@ module.exports = class StackCatalogModalView extends AdminAppView
 
   constructor: (options = {}, data) ->
 
-    options.paneViewClass = StackCatalogMainTabPaneView
+    options.paneViewClass or= StackCatalogMainTabPaneView
+    options.checkRoles     ?= no
 
     super options, data
 


### PR DESCRIPTION
Ignore user roles while stack catalog modal is rendering. Otherwise user who has `member` role can not open `Stack Catalog` modal.

/cc @fatihacet @gokmen @szkl @usirin @sinan 

https://koding.atlassian.net/browse/TMS-664
