### PR TITLE
ACT-349 Chat pane: unread messages label

### DIFF
--- a/client/activity/lib/components/channelinfo/container.coffee
+++ b/client/activity/lib/components/channelinfo/container.coffee
@@ -1,7 +1,8 @@
-kd        = require 'kd'
-View      = require './view'
-React     = require 'kd-react'
-immutable = require 'immutable'
+kd                   = require 'kd'
+View                 = require './view'
+React                = require 'kd-react'
+immutable            = require 'immutable'
+ImmutableRenderMixin = require 'react-immutable-render-mixin'
 
 module.exports = class ChannelInfoContainer extends React.Component
 
@@ -56,3 +57,5 @@ module.exports = class ChannelInfoContainer extends React.Component
       integrationTooltipVisible={@state.integrationTooltipVisible}
       collabTooltipVisible={@state.collabTooltipVisible} />
 
+
+ChannelInfoContainer.include [ ImmutableRenderMixin ]

--- a/client/activity/lib/components/chatlist/index.coffee
+++ b/client/activity/lib/components/chatlist/index.coffee
@@ -1,4 +1,3 @@
-_                      = require 'lodash'
 kd                     = require 'kd'
 React                  = require 'kd-react'
 ReactDOM               = require 'react-dom'
@@ -12,9 +11,6 @@ ActivityFlux           = require 'activity/flux'
 Waypoint               = require 'react-waypoint'
 ImmutableRenderMixin   = require 'react-immutable-render-mixin'
 findScrollableParent   = require 'app/util/findScrollableParent'
-
-debounce = (delay, options, fn) -> _.debounce fn, delay, options
-
 
 module.exports = class ChatList extends React.Component
 
@@ -57,7 +53,7 @@ module.exports = class ChatList extends React.Component
     window.removeEventListener 'resize', @bound 'handleResize'
 
 
-  glance: debounce 1000, {}, ->
+  glance: ->
 
     @props.onGlance()  if kd.singletons.windowController.isFocused()
 

--- a/client/activity/lib/components/chatlist/index.coffee
+++ b/client/activity/lib/components/chatlist/index.coffee
@@ -118,7 +118,10 @@ module.exports = class ChatList extends React.Component
     # put glancer waypoint only if all the unread messages are loaded, and on
     # the screen. Once it enters to the screen, it will glance the channel.
     if index is messages.size - unreadCount and not isMessagesLoading
-      markers.push <Waypoint onEnter={@bound 'onGlancerEnter'} scrollableParent={@scrollableParent} />
+      markers.push <Waypoint
+        onEnter={@bound 'onGlancerEnter'}
+        scrollableParent={@scrollableParent}
+        fireOnRapidScroll=no />
 
     return markers
 

--- a/client/activity/lib/components/chatlist/index.coffee
+++ b/client/activity/lib/components/chatlist/index.coffee
@@ -42,6 +42,7 @@ module.exports = class ChatList extends React.Component
   componentDidMount: ->
 
     kd.singletons.windowController.addFocusListener @bound 'handleFocus'
+    @cacheDateMarkers()
     @scrollableParent = findScrollableParent ReactDOM.findDOMNode this
     window.addEventListener 'resize', @bound 'handleResize'
 
@@ -231,3 +232,5 @@ module.exports = class ChatList extends React.Component
       {@renderChildren()}
     </div>
 
+
+ChatList.include [ ImmutableRenderMixin ]

--- a/client/activity/lib/components/chatpane/container.coffee
+++ b/client/activity/lib/components/chatpane/container.coffee
@@ -104,18 +104,30 @@ module.exports = class ChatPaneContainer extends React.Component
     @isThresholdReached = no
 
 
-  onScroll: ->
-
-    @updateDateMarkersPosition()
-    @updateUnreadMessagesLabel()
-
-
   updateDateMarkersPosition: ->
 
     { view }    = @refs
     { content } = view.refs
 
     content.refs.ChatList.updateDateMarkersPosition()
+
+
+  updateUnreadMessagesLabel: ->
+
+    unreadCount = @channel 'unreadCount'
+    return  unless unreadCount
+
+    messages = @props.thread.get('messages').toList()
+    message  = messages.get messages.size - unreadCount
+    return  unless message
+
+    { view }    = @refs
+    { content } = view.refs
+    element     = helper.getMessageElement message.get 'id'
+    label       = content.refs.UnreadCountLabel
+    position    = getScrollablePosition element
+
+    label.setPosition position
 
 
   onTopThresholdReached: (event) ->
@@ -131,36 +143,37 @@ module.exports = class ChatPaneContainer extends React.Component
     kd.utils.wait 500, => @props.onLoadMore()
 
 
+  onScroll: ->
+
+    @updateDateMarkersPosition()
+    @updateUnreadMessagesLabel()
+
+
   onGlance: -> ActivityFlux.actions.channel.glance @channel 'id'
 
 
-  updateUnreadMessagesLabel: ->
+  onJumpToUnreadMessages: ->
 
     unreadCount = @channel 'unreadCount'
-    return  unless unreadCount
-
-    messages = @props.thread.get('messages').toList()
-    message  = messages.get messages.size - unreadCount
+    messages    = @props.thread.get('messages').toList()
+    message     = messages.get messages.size - unreadCount
     return  unless message
 
-    { view }    = @refs
-    { content } = view.refs
-    element     = helper.getMessageElement message.get 'id'
-    label       = content.refs.unreadCountLabel
-    position    = getScrollablePosition element
-
-    label.setPosition position
+    element = helper.getMessageElement message.get 'id'
+    scrollToElement element, yes
 
 
   render: ->
 
     <ChatPaneView {...@props}
-      ref                   = 'view'
-      selectedMessageId     = { @state.selectedMessageId }
-      onTopThresholdReached = { @bound 'onTopThresholdReached' }
-      onGlance              = { @bound 'onGlance' }
-      onScroll              = { @bound 'onScroll' }
-      isMessagesLoading     = { @isThresholdReached }>
+      ref                    = 'view'
+      selectedMessageId      = { @state.selectedMessageId }
+      isMessagesLoading      = { @isThresholdReached }
+      onTopThresholdReached  = { @bound 'onTopThresholdReached' }
+      onGlance               = { @bound 'onGlance' }
+      onScroll               = { @bound 'onScroll' }
+      onJumpToUnreadMessages = { @bound 'onJumpToUnreadMessages' }
+    >
         {@props.children}
     </ChatPaneView>
 

--- a/client/activity/lib/components/chatpane/container.coffee
+++ b/client/activity/lib/components/chatpane/container.coffee
@@ -58,7 +58,6 @@ module.exports = class ChatPaneContainer extends React.Component
 
     { view } = @refs
 
-    @getViewContent().show()
     scrollTop = @flag 'scrollPosition'
     if scrollTop
       view.scrollToPosition scrollTop
@@ -72,8 +71,6 @@ module.exports = class ChatPaneContainer extends React.Component
 
     { scrollTop } = view.getScrollParams()
     { channel }   = ActivityFlux.actions
-
-    @getViewContent().hide()
 
     kd.utils.defer =>
       channel.setLastSeenTime (@channel 'id'), Date.now()

--- a/client/activity/lib/components/chatpane/styl/chatpane.styl
+++ b/client/activity/lib/components/chatpane/styl/chatpane.styl
@@ -45,6 +45,8 @@
   margin                    0 10px
   borderBox()
   text-align                center
+  fadeOut()
+  pointer()
 
   &.fixedOnTop
     top                     0px

--- a/client/activity/lib/components/chatpane/styl/chatpane.styl
+++ b/client/activity/lib/components/chatpane/styl/chatpane.styl
@@ -47,14 +47,17 @@
   text-align                center
   fadeOut()
   pointer()
+  hidden()
 
   &.fixedOnTop
     top                     0px
     rounded                 0 0 5px 5px
+    visible()
 
   &.fixedOnBottom
     bottom                  0px
     rounded                 5px 5px 0 0
+    visible()
 
   .jumpButton
     fl()

--- a/client/activity/lib/components/chatpane/styl/chatpane.styl
+++ b/client/activity/lib/components/chatpane/styl/chatpane.styl
@@ -35,3 +35,36 @@
 .ChatList
   width                     100%
 
+.ChatPane-unreadMessages
+  abs()
+  z-index                   100
+  kalc                      width, 100% \- 20px
+  bg                        color, #43a1df
+  color                     #fff
+  padding                   0px 5px 3px 5px
+  margin                    0 10px
+  borderBox()
+  text-align                center
+
+  &.fixedOnTop
+    top                     0px
+    rounded                 0 0 5px 5px
+
+  &.fixedOnBottom
+    bottom                  0px
+    rounded                 5px 5px 0 0
+
+  .jumpButton
+    fl()
+    font-size               11px
+    padding-top             1px
+    text-transform          uppercase
+
+  .counterText
+    font-size               14px
+
+  .markAsRead
+    fr()
+    font-size               11px
+    padding-top             1px
+    text-transform          uppercase

--- a/client/activity/lib/components/chatpane/styl/chatpane.styl
+++ b/client/activity/lib/components/chatpane/styl/chatpane.styl
@@ -19,9 +19,7 @@
     dFlex()
     rel()
     > .Scrollable
-      opacity                 0
-      vendor                  transition, opacity .3s ease
-
+      fadeIn()
 .PublicChatPane-footer
 .PrivateChatPane-footer
   abs()

--- a/client/activity/lib/components/chatpane/test/index.coffee
+++ b/client/activity/lib/components/chatpane/test/index.coffee
@@ -1,0 +1,4 @@
+describe 'ChatPane', ->
+
+  require './view'
+  require './unreadmessageslabel'

--- a/client/activity/lib/components/chatpane/test/unreadmessageslabel.coffee
+++ b/client/activity/lib/components/chatpane/test/unreadmessageslabel.coffee
@@ -4,6 +4,7 @@ ReactDOM            = require 'react-dom'
 expect              = require 'expect'
 TestUtils           = require 'react-addons-test-utils'
 UnreadMessagesLabel = require '../unreadmessageslabel'
+ScrollablePosition  = require 'activity/constants/scrollableposition'
 
 describe 'ChatPaneUnreadMessagesLabel', ->
 
@@ -33,37 +34,26 @@ describe 'ChatPaneUnreadMessagesLabel', ->
       counterText = TestUtils.findRenderedDOMComponentWithClass result, 'counterText'
       expect(counterText.props.children).toEqual '3 new messages'
 
-
-  describe '::setPosition', ->
-
     it 'adds a proper css class depending on position', ->
 
       result = TestUtils.renderIntoDocument(
-        <UnreadMessagesLabel unreadCount={1} />
+        <UnreadMessagesLabel unreadCount={1} unreadMessagePosition={ScrollablePosition.ABOVE} />
       )
 
-      result.setPosition 'above'
       container = TestUtils.findRenderedDOMComponentWithClass result, 'ChatPane-unreadMessages'
       expect(container.classList.contains 'fixedOnTop').toBe yes
 
-      result.setPosition 'below'
+      result = TestUtils.renderIntoDocument(
+        <UnreadMessagesLabel unreadCount={1} unreadMessagePosition={ScrollablePosition.BELOW} />
+      )
+
       container = TestUtils.findRenderedDOMComponentWithClass result, 'ChatPane-unreadMessages'
       expect(container.classList.contains 'fixedOnBottom').toBe yes
 
-      result.setPosition 'inside'
-      container = TestUtils.findRenderedDOMComponentWithClass result, 'ChatPane-unreadMessages'
-      expect(container.classList.contains 'out').toBe yes
-
-
-  describe '::close', ->
-
-    it 'hides a component', ->
-
       result = TestUtils.renderIntoDocument(
-        <UnreadMessagesLabel unreadCount={3} />
+        <UnreadMessagesLabel unreadCount={1} unreadMessagePosition={ScrollablePosition.INSIDE} />
       )
 
-      result.close()
       container = TestUtils.findRenderedDOMComponentWithClass result, 'ChatPane-unreadMessages'
       expect(container.classList.contains 'out').toBe yes
 

--- a/client/activity/lib/components/chatpane/test/unreadmessageslabel.coffee
+++ b/client/activity/lib/components/chatpane/test/unreadmessageslabel.coffee
@@ -1,0 +1,102 @@
+kd                  = require 'kd'
+React               = require 'kd-react'
+ReactDOM            = require 'react-dom'
+expect              = require 'expect'
+TestUtils           = require 'react-addons-test-utils'
+UnreadMessagesLabel = require '../unreadmessageslabel'
+
+describe 'ChatPaneUnreadMessagesLabel', ->
+
+  describe '::render', ->
+
+    it 'renders nothing if unread count is 0', ->
+
+      result = TestUtils.renderIntoDocument(
+        <UnreadMessagesLabel unreadCount={0} />
+      )
+
+      expect(result.props.children).toNotExist()
+
+    it 'renders unread count label if unread count > 0', ->
+
+      result = TestUtils.renderIntoDocument(
+        <UnreadMessagesLabel unreadCount={1} />
+      )
+
+      counterText = TestUtils.findRenderedDOMComponentWithClass result, 'counterText'
+      expect(counterText.props.children).toEqual '1 new message'
+
+      result = TestUtils.renderIntoDocument(
+        <UnreadMessagesLabel unreadCount={3} />
+      )
+
+      counterText = TestUtils.findRenderedDOMComponentWithClass result, 'counterText'
+      expect(counterText.props.children).toEqual '3 new messages'
+
+
+  describe '::setPosition', ->
+
+    it 'adds a proper css class depending on position', ->
+
+      result = TestUtils.renderIntoDocument(
+        <UnreadMessagesLabel unreadCount={1} />
+      )
+
+      result.setPosition 'above'
+      container = TestUtils.findRenderedDOMComponentWithClass result, 'ChatPane-unreadMessages'
+      expect(container.classList.contains 'fixedOnTop').toBe yes
+
+      result.setPosition 'below'
+      container = TestUtils.findRenderedDOMComponentWithClass result, 'ChatPane-unreadMessages'
+      expect(container.classList.contains 'fixedOnBottom').toBe yes
+
+      result.setPosition 'inside'
+      container = TestUtils.findRenderedDOMComponentWithClass result, 'ChatPane-unreadMessages'
+      expect(container.classList.contains 'out').toBe yes
+
+
+  describe '::close', ->
+
+    it 'hides a component', ->
+
+      result = TestUtils.renderIntoDocument(
+        <UnreadMessagesLabel unreadCount={3} />
+      )
+
+      result.close()
+      container = TestUtils.findRenderedDOMComponentWithClass result, 'ChatPane-unreadMessages'
+      expect(container.classList.contains 'out').toBe yes
+
+
+  describe '::onJump', ->
+
+    it 'should be called when clicking on component', ->
+
+      props = { unreadCount : 3, onJump : kd.noop }
+      spy   = expect.spyOn props, 'onJump'
+
+      result = TestUtils.renderIntoDocument(
+        <UnreadMessagesLabel {...props} />
+      )
+
+      container = TestUtils.findRenderedDOMComponentWithClass result, 'ChatPane-unreadMessages'
+      TestUtils.Simulate.click container
+
+      expect(spy).toHaveBeenCalled()
+
+
+  describe '::onMarkAsRead', ->
+
+    it 'should be called when clicking on "Mark As Read" button', ->
+
+      props = { unreadCount : 3, onMarkAsRead : kd.noop }
+      spy   = expect.spyOn props, 'onMarkAsRead'
+
+      result = TestUtils.renderIntoDocument(
+        <UnreadMessagesLabel {...props} />
+      )
+
+      button = TestUtils.findRenderedDOMComponentWithClass result, 'markAsRead'
+      TestUtils.Simulate.click button
+
+      expect(spy).toHaveBeenCalled()

--- a/client/activity/lib/components/chatpane/test/view.coffee
+++ b/client/activity/lib/components/chatpane/test/view.coffee
@@ -4,13 +4,13 @@ ReactDOM    = require 'react-dom'
 expect      = require 'expect'
 TestUtils   = require 'react-addons-test-utils'
 toImmutable = require 'app/util/toImmutable'
-ChatPane    = require './view'
+ChatPane    = require '../view'
 ChatList    = require 'activity/components/chatlist'
 ChannelInfo = require 'activity/components/channelinfo'
-mockingjay  = require '../../../../mocks/mockingjay'
+mockingjay  = require '../../../../../mocks/mockingjay'
 
 
-describe 'ChatPane', ->
+describe 'ChatPaneView', ->
 
   getMockThread = (args...) -> toImmutable mockingjay.getMockThread(args...)
 

--- a/client/activity/lib/components/chatpane/unreadmessageslabel.coffee
+++ b/client/activity/lib/components/chatpane/unreadmessageslabel.coffee
@@ -1,0 +1,38 @@
+kd           = require 'kd'
+React        = require 'kd-react'
+ReactDOM     = require 'react-dom'
+formatPlural = kd.utils.formatPlural
+classnames   = require 'classnames'
+
+module.exports = class ChatPaneUnreadMessagesLabel extends React.Component
+
+  @propsTypes =
+    unreadCount : React.PropTypes.number
+
+  @defaultProps =
+    unreadCount : 0
+
+  setPosition: (position) ->
+
+    element = ReactDOM.findDOMNode this
+    return  unless element
+
+    element.className = classnames
+      'ChatPane-unreadMessages' : yes
+      'hidden'                  : position.visible
+      'fixedOnTop'              : position.relativePosition is 'above'
+      'fixedOnBottom'           : position.relativePosition is 'below'
+
+
+  render: ->
+
+    { unreadCount } = @props
+    return null  unless unreadCount > 0
+
+    <div className='ChatPane-unreadMessages fixedOnTop'>
+      <span className='jumpButton'>Jump</span>
+      <span className='counterText'>
+        { "#{unreadCount} new #{formatPlural unreadCount, 'message', no}" }
+      </span>
+      <span className='markAsRead'>Mark As Read (ESC)</span>
+    </div>

--- a/client/activity/lib/components/chatpane/unreadmessageslabel.coffee
+++ b/client/activity/lib/components/chatpane/unreadmessageslabel.coffee
@@ -1,8 +1,9 @@
-kd           = require 'kd'
-React        = require 'kd-react'
-ReactDOM     = require 'react-dom'
-formatPlural = kd.utils.formatPlural
-classnames   = require 'classnames'
+kd                 = require 'kd'
+React              = require 'kd-react'
+ReactDOM           = require 'react-dom'
+formatPlural       = kd.utils.formatPlural
+classnames         = require 'classnames'
+ScrollablePosition = require 'activity/constants/scrollableposition'
 
 module.exports = class ChatPaneUnreadMessagesLabel extends React.Component
 
@@ -32,8 +33,8 @@ module.exports = class ChatPaneUnreadMessagesLabel extends React.Component
     element = ReactDOM.findDOMNode this
     return  unless element
 
-    isAbove = unreadMessagePosition is 'above'
-    isBelow = unreadMessagePosition is 'below'
+    isAbove = unreadMessagePosition is ScrollablePosition.ABOVE
+    isBelow = unreadMessagePosition is ScrollablePosition.BELOW
 
     return @close()  unless isAbove or isBelow
 

--- a/client/activity/lib/components/chatpane/unreadmessageslabel.coffee
+++ b/client/activity/lib/components/chatpane/unreadmessageslabel.coffee
@@ -21,12 +21,15 @@ module.exports = class ChatPaneUnreadMessagesLabel extends React.Component
     element = ReactDOM.findDOMNode this
     return  unless element
 
-    return @close()  if position.visible
+    isAbove = position is 'above'
+    isBelow = position is 'below'
+
+    return @close()  unless isAbove or isBelow
 
     element.className = classnames
       'ChatPane-unreadMessages' : yes
-      'fixedOnTop'              : position.relativePosition is 'above'
-      'fixedOnBottom'           : position.relativePosition is 'below'
+      'fixedOnTop'              : isAbove
+      'fixedOnBottom'           : isBelow
 
 
   close: ->
@@ -55,7 +58,7 @@ module.exports = class ChatPaneUnreadMessagesLabel extends React.Component
     { unreadCount } = @props
     return null  unless unreadCount > 0
 
-    <div className='ChatPane-unreadMessages fixedOnTop' onClick={@bound 'onJump'}>
+    <div className='ChatPane-unreadMessages' onClick={@bound 'onJump'}>
       <span className='jumpButton'>Jump</span>
       <span className='counterText'>
         { "#{unreadCount} new #{formatPlural unreadCount, 'message', no}" }

--- a/client/activity/lib/components/chatpane/unreadmessageslabel.coffee
+++ b/client/activity/lib/components/chatpane/unreadmessageslabel.coffee
@@ -7,21 +7,47 @@ classnames   = require 'classnames'
 module.exports = class ChatPaneUnreadMessagesLabel extends React.Component
 
   @propsTypes =
-    unreadCount : React.PropTypes.number
+    unreadCount  : React.PropTypes.number
+    onJump       : React.PropTypes.func
+    onMarkAsRead : React.PropTypes.func
 
   @defaultProps =
-    unreadCount : 0
+    unreadCount  : 0
+    onJump       : kd.noop
+    onMarkAsRead : kd.noop
 
   setPosition: (position) ->
 
     element = ReactDOM.findDOMNode this
     return  unless element
 
+    return @close()  if position.visible
+
     element.className = classnames
       'ChatPane-unreadMessages' : yes
-      'hidden'                  : position.visible
       'fixedOnTop'              : position.relativePosition is 'above'
       'fixedOnBottom'           : position.relativePosition is 'below'
+
+
+  close: ->
+
+    element = ReactDOM.findDOMNode this
+    return  unless element
+
+    element.classList.add 'out'
+
+
+  onJump: (event) ->
+
+    @close()
+    @props.onJump()
+
+
+  onMarkAsRead: (event) ->
+
+    kd.utils.stopDOMEvent event
+    @close()
+    @props.onMarkAsRead()
 
 
   render: ->
@@ -29,10 +55,10 @@ module.exports = class ChatPaneUnreadMessagesLabel extends React.Component
     { unreadCount } = @props
     return null  unless unreadCount > 0
 
-    <div className='ChatPane-unreadMessages fixedOnTop'>
+    <div className='ChatPane-unreadMessages fixedOnTop' onClick={@bound 'onJump'}>
       <span className='jumpButton'>Jump</span>
       <span className='counterText'>
         { "#{unreadCount} new #{formatPlural unreadCount, 'message', no}" }
       </span>
-      <span className='markAsRead'>Mark As Read (ESC)</span>
+      <span className='markAsRead' onClick={@bound 'onMarkAsRead'}>Mark As Read (ESC)</span>
     </div>

--- a/client/activity/lib/components/chatpane/unreadmessageslabel.coffee
+++ b/client/activity/lib/components/chatpane/unreadmessageslabel.coffee
@@ -7,22 +7,33 @@ classnames   = require 'classnames'
 module.exports = class ChatPaneUnreadMessagesLabel extends React.Component
 
   @propsTypes =
-    unreadCount  : React.PropTypes.number
-    onJump       : React.PropTypes.func
-    onMarkAsRead : React.PropTypes.func
+    unreadCount           : React.PropTypes.number
+    onJump                : React.PropTypes.func
+    onMarkAsRead          : React.PropTypes.func
+    unreadMessagePosition : React.PropTypes.string
 
   @defaultProps =
-    unreadCount  : 0
-    onJump       : kd.noop
-    onMarkAsRead : kd.noop
+    unreadCount           : 0
+    onJump                : kd.noop
+    onMarkAsRead          : kd.noop
+    unreadMessagePosition : null
 
-  setPosition: (position) ->
+
+  componentDidMount: -> @setPosition()
+
+
+  componentDidUpdate: -> @setPosition()
+
+
+  setPosition: ->
+
+    { unreadMessagePosition } = @props
 
     element = ReactDOM.findDOMNode this
     return  unless element
 
-    isAbove = position is 'above'
-    isBelow = position is 'below'
+    isAbove = unreadMessagePosition is 'above'
+    isBelow = unreadMessagePosition is 'below'
 
     return @close()  unless isAbove or isBelow
 

--- a/client/activity/lib/components/chatpane/view.coffee
+++ b/client/activity/lib/components/chatpane/view.coffee
@@ -5,6 +5,7 @@ immutable           = require 'immutable'
 Scroller            = require 'app/components/scroller'
 ChatList            = require 'activity/components/chatlist'
 ChannelInfo         = require 'activity/components/channelinfo'
+UnreadMessagesLabel = require './unreadmessageslabel'
 EmojiPreloaderMixin = require 'activity/components/emojipreloadermixin'
 ScrollableContent   = require 'app/components/scroller/scrollablecontent'
 
@@ -96,6 +97,7 @@ class ChatPaneView extends React.Component
     <div className={kd.utils.curry 'ChatPane', @props.className}>
       <section className="Pane-contentWrapper">
         <section className="Pane-body" ref="ChatPaneBody">
+          <UnreadMessagesLabel ref='unreadCountLabel' unreadCount={@channel 'unreadCount'} />
           {@renderBody()}
           {@props.children}
         </section>

--- a/client/activity/lib/components/chatpane/view.coffee
+++ b/client/activity/lib/components/chatpane/view.coffee
@@ -51,6 +51,9 @@ class ChatPaneView extends React.Component
     scroller.style.opacity = 0
 
 
+  onMarkAsRead: -> @props.onGlance yes
+
+
   renderChannelInfoContainer: ->
 
     return null  unless @props.thread
@@ -103,7 +106,7 @@ class ChatPaneView extends React.Component
             ref='UnreadCountLabel'
             unreadCount={@channel 'unreadCount'}
             onJump={@props.onJumpToUnreadMessages}
-            onMarkAsRead={@props.onGlance}
+            onMarkAsRead={@bound 'onMarkAsRead'}
           />
           {@renderBody()}
           {@props.children}

--- a/client/activity/lib/components/chatpane/view.coffee
+++ b/client/activity/lib/components/chatpane/view.coffee
@@ -39,16 +39,10 @@ class ChatPaneView extends React.Component
   channel: (key) -> @props.thread?.getIn ['channel', key]
 
 
-  show: ->
+  componentDidMount: ->
 
     scroller = ReactDOM.findDOMNode @refs.scroller
-    scroller.style.opacity = 1
-
-
-  hide: ->
-
-    scroller = ReactDOM.findDOMNode @refs.scroller
-    scroller.style.opacity = 0
+    scroller.classList.add 'in'
 
 
   renderChannelInfoContainer: ->

--- a/client/activity/lib/components/chatpane/view.coffee
+++ b/client/activity/lib/components/chatpane/view.coffee
@@ -51,9 +51,6 @@ class ChatPaneView extends React.Component
     scroller.style.opacity = 0
 
 
-  onMarkAsRead: -> @props.onGlance yes
-
-
   renderChannelInfoContainer: ->
 
     return null  unless @props.thread
@@ -106,7 +103,7 @@ class ChatPaneView extends React.Component
             ref='UnreadCountLabel'
             unreadCount={@channel 'unreadCount'}
             onJump={@props.onJumpToUnreadMessages}
-            onMarkAsRead={@bound 'onMarkAsRead'}
+            onMarkAsRead={@props.onMarkAsRead}
           />
           {@renderBody()}
           {@props.children}

--- a/client/activity/lib/components/chatpane/view.coffee
+++ b/client/activity/lib/components/chatpane/view.coffee
@@ -102,6 +102,7 @@ class ChatPaneView extends React.Component
           <UnreadMessagesLabel
             ref='UnreadCountLabel'
             unreadCount={@channel 'unreadCount'}
+            unreadMessagePosition={@props.unreadMessagePosition}
             onJump={@props.onJumpToUnreadMessages}
             onMarkAsRead={@props.onMarkAsRead}
           />

--- a/client/activity/lib/components/chatpane/view.coffee
+++ b/client/activity/lib/components/chatpane/view.coffee
@@ -12,25 +12,27 @@ ScrollableContent   = require 'app/components/scroller/scrollablecontent'
 class ChatPaneView extends React.Component
 
   @propsTypes =
-    thread                : React.PropTypes.instanceOf immutable.Map
-    onInviteClick         : React.PropTypes.func
-    showItemMenu          : React.PropTypes.bool
-    isMessagesLoading     : React.PropTypes.bool
-    onTopThresholdReached : React.PropTypes.func
-    selectedMessageId     : React.PropTypes.string
-    onGlance              : React.PropTypes.func
-    onScroll              : React.PropTypes.func
+    thread                 : React.PropTypes.instanceOf immutable.Map
+    onInviteClick          : React.PropTypes.func
+    showItemMenu           : React.PropTypes.bool
+    isMessagesLoading      : React.PropTypes.bool
+    onTopThresholdReached  : React.PropTypes.func
+    selectedMessageId      : React.PropTypes.string
+    onGlance               : React.PropTypes.func
+    onScroll               : React.PropTypes.func
+    onJumpToUnreadMessages : React.PropTypes.func
 
 
   @defaultProps =
-    thread                : immutable.Map()
-    onInviteClick         : kd.noop
-    showItemMenu          : yes
-    isMessagesLoading     : no
-    onTopThresholdReached : kd.noop
-    selectedMessageId     : ''
-    onGlance              : kd.noop
-    onScroll              : kd.noop
+    thread                 : immutable.Map()
+    onInviteClick          : kd.noop
+    showItemMenu           : yes
+    isMessagesLoading      : no
+    onTopThresholdReached  : kd.noop
+    selectedMessageId      : ''
+    onGlance               : kd.noop
+    onScroll               : kd.noop
+    onJumpToUnreadMessages : kd.noop
 
 
   flag: (key) -> @props.thread?.getIn ['flags', key]
@@ -97,7 +99,12 @@ class ChatPaneView extends React.Component
     <div className={kd.utils.curry 'ChatPane', @props.className}>
       <section className="Pane-contentWrapper">
         <section className="Pane-body" ref="ChatPaneBody">
-          <UnreadMessagesLabel ref='unreadCountLabel' unreadCount={@channel 'unreadCount'} />
+          <UnreadMessagesLabel
+            ref='UnreadCountLabel'
+            unreadCount={@channel 'unreadCount'}
+            onJump={@props.onJumpToUnreadMessages}
+            onMarkAsRead={@props.onGlance}
+          />
           {@renderBody()}
           {@props.children}
         </section>

--- a/client/activity/lib/constants/scrollableposition.coffee
+++ b/client/activity/lib/constants/scrollableposition.coffee
@@ -1,0 +1,5 @@
+module.exports = {
+  'ABOVE'
+  'BELOW'
+  'INSIDE'
+}

--- a/client/activity/lib/index.coffee
+++ b/client/activity/lib/index.coffee
@@ -6,6 +6,7 @@ globals                  = require 'globals'
 getGroup                 = require 'app/util/getGroup'
 checkFlag                = require 'app/util/checkFlag'
 isFeedEnabled            = require 'app/util/isFeedEnabled'
+isKoding                 = require 'app/util/isKoding'
 AppStorage               = require 'app/appstorage'
 AppController            = require 'app/appcontroller'
 KodingAppsController     = require 'app/kodingappscontroller'
@@ -149,7 +150,7 @@ module.exports = class ActivityAppController extends AppController
     unless e.which is keyboardKeys.ESC
       kd.utils.stopDOMEvent e
 
-    if isFeedEnabled()
+    if isKoding()
       switch e.model.name
         when 'prevwindow' then @getView().openPrev()
         when 'nextwindow' then @getView().openNext()

--- a/client/activity/lib/util/getScrollablePosition.coffee
+++ b/client/activity/lib/util/getScrollablePosition.coffee
@@ -1,4 +1,5 @@
-$ = require 'jquery'
+$                    = require 'jquery'
+ScrollablePosition   = require 'activity/constants/scrollableposition'
 findScrollableParent = require 'app/util/findScrollableParent'
 
 ###*
@@ -25,10 +26,10 @@ module.exports = getScrollablePosition = (element) ->
   elementHeight      = $element.outerHeight no
 
   if elementTop - containerTop + elementHeight <= containerHeight and elementTop - containerTop >= 0
-    return 'inside'
+    return ScrollablePosition.INSIDE
 
   if elementTop - containerTop < 0
-    return 'above'
+    return ScrollablePosition.ABOVE
 
   if elementTop - containerTop + elementHeight > containerHeight
-    return 'below'
+    return ScrollablePosition.BELOW

--- a/client/app/lib/util/getScrollablePosition.coffee
+++ b/client/app/lib/util/getScrollablePosition.coffee
@@ -1,6 +1,17 @@
 $ = require 'jquery'
 findScrollableParent = require 'app/util/findScrollableParent'
 
+###*
+ * Get element position in scrollable container
+ * in relation to visible portion of scrollable area.
+ * Return value can be:
+ * - 'inside' (element is in visible area)
+ * - 'above' (element is above visible area)
+ * - 'below' (element is below visible area)
+ *
+ * @param {DOMElement} element
+ * @return {string}
+###
 module.exports = getScrollablePosition = (element) ->
 
   container  = findScrollableParent element
@@ -13,15 +24,11 @@ module.exports = getScrollablePosition = (element) ->
   elementTop         = element.getBoundingClientRect().top
   elementHeight      = $element.outerHeight no
 
-  top = elementTop - containerTop + containerScrollTop
-
   if elementTop - containerTop + elementHeight <= containerHeight and elementTop - containerTop >= 0
-    return { top, visible : yes }
+    return 'inside'
 
   if elementTop - containerTop < 0
-    return { top, visible : no, relativePosition : 'above' }
+    return 'above'
 
   if elementTop - containerTop + elementHeight > containerHeight
-    return { top, visible : no, relativePosition : 'below' }
-
-  return { top, visible : no }  
+    return 'below'

--- a/client/app/lib/util/getScrollablePosition.coffee
+++ b/client/app/lib/util/getScrollablePosition.coffee
@@ -1,0 +1,27 @@
+$ = require 'jquery'
+findScrollableParent = require 'app/util/findScrollableParent'
+
+module.exports = getScrollablePosition = (element) ->
+
+  container  = findScrollableParent element
+  $container = $ container
+  $element   = $ element
+
+  containerTop       = container.getBoundingClientRect().top
+  containerHeight    = $container.outerHeight no
+  containerScrollTop = container.scrollTop
+  elementTop         = element.getBoundingClientRect().top
+  elementHeight      = $element.outerHeight no
+
+  top = elementTop - containerTop + containerScrollTop
+
+  if elementTop - containerTop + elementHeight <= containerHeight and elementTop - containerTop >= 0
+    return { top, visible : yes }
+
+  if elementTop - containerTop < 0
+    return { top, visible : no, relativePosition : 'above' }
+
+  if elementTop - containerTop + elementHeight > containerHeight
+    return { top, visible : no, relativePosition : 'below' }
+
+  return { top, visible : no }  

--- a/client/app/styl/commons/appfn.styl
+++ b/client/app/styl/commons/appfn.styl
@@ -232,6 +232,13 @@ fadeOut()
   &.out
     opacity                 0
 
+fadeIn()
+  opacity                   0
+  vendor                    transition, opacity .347s ease\, margin .347s ease
+
+  &.in
+    opacity                 1
+
 noAnim()
   vendor                    transition, none !important
 


### PR DESCRIPTION
@usirin, can you please review this feature?
https://koding.atlassian.net/browse/ACT-349

http://g.recordit.co/Q7vU2RmbIb.gif

/cc @sinan

Here is a few notes on UX:
- label appears when first unread message is out of the visible scrollable area
  - it appears on top when unread messages are above the visible area
  - it appears on bottom when they are below the visible area
- click on the label scrolls to the first unread message
- click on `Mark As Read` glances the channel
