### PR TITLE
ACT-572 activity: don't remove current channel name from message

### DIFF
--- a/client/activity/lib/flux/getters.coffee
+++ b/client/activity/lib/flux/getters.coffee
@@ -238,12 +238,6 @@ selectedChannelThread = [
       popularMessages = popularMessages or immutable.Map()
       thread = thread.set 'messages', popularMessages
 
-    thread = thread.update 'messages', (messages) ->
-      messages.map (msg) ->
-        msg.update 'body', (body) ->
-          # don't show channel name on post body.
-          body.replace(///\##{channel.get('name')}($|\s)///, '').trim()
-
     return thread
 ]
 


### PR DESCRIPTION
@usirin, can you please review this fix?
https://koding.atlassian.net/browse/ACT-572

The issue happens because of this logic - https://github.com/koding/koding/blob/master/client/activity/lib/flux/getters.coffee#L245. The problem occurs only if you submit a message with current channel name. If message contains another channel name, it looks fine. I think we can delete this logic since we don't automatically add channel names to messages as we did before - https://github.com/koding/koding/commit/bf58bc5892307925af5afd7243cd8bc1ee1751fa#diff-b2c9572941262052c3f9d4302eecafbc
