### PR TITLE
activity: popular channels action fix

### DIFF
--- a/client/activity/lib/flux/actions/channel.coffee
+++ b/client/activity/lib/flux/actions/channel.coffee
@@ -245,6 +245,7 @@ loadPopularChannels = (options = {}) ->
         loadChannel channel.id
 
       Promise.all(promises).then (channels) ->
+        channels = channels.map (item) -> item.channel
         dispatch LOAD_POPULAR_CHANNELS_SUCCESS, { channels }
         resolve { channels }
 


### PR DESCRIPTION
@usirin, @gokhansongul, can you please review this fix?
Without it `PopularChannelIdsStore` is filled in with incorrect data structure. It leads to a problem with not working channels dropbox in chat input widget
