### PR TITLE
ACT-521 activity: avatar area popup toggling fix

### DIFF
--- a/client/app/lib/avatararea/avatararea.coffee
+++ b/client/app/lib/avatararea/avatararea.coffee
@@ -8,6 +8,7 @@ JView              = require '../jview'
 PopupNotifications = require '../notifications/popupnotifications'
 JCustomHTMLView    = require 'app/jcustomhtmlview'
 isKoding           = require 'app/util/isKoding'
+helpers            = require './helpers'
 
 
 module.exports = class AvatarArea extends KDCustomHTMLView
@@ -23,6 +24,33 @@ module.exports = class AvatarArea extends KDCustomHTMLView
     { mainView } = kd.singletons
     account      = @getData()
     {profile} = @getData()
+
+    @profileName = new JCustomHTMLView
+      tagName    : 'a'
+      cssClass   : 'profile'
+      attributes :
+        href     : "/#{profile.nickname}"
+        title    : 'Your profile'
+      pistachio  : '{{ #(profile.firstName) }}'
+    , account
+
+    @accountPopup = new AccountPopup
+
+    @accountIcon = new AvatarAreaIconLink
+      cssClass   : 'acc-dropdown-icon'
+      attributes :
+        title    : 'Account'
+        testpath : 'AvatarAreaIconLink'
+    helpers.makePopupButton @accountIcon, @accountPopup
+
+    @notificationsPopup = new PopupNotifications
+      cssClass : if isKoding() then 'notification-list' else 'notification-list team'
+
+    @notificationsIcon = new AvatarAreaIconLink
+      cssClass   : 'notifications acc-notification-icon'
+      attributes :
+        title    : 'Notifications'
+    helpers.makePopupButton @notificationsIcon, @notificationsPopup
 
     if isKoding()
       @avatar = new AvatarView
@@ -41,36 +69,8 @@ module.exports = class AvatarArea extends KDCustomHTMLView
         size       :
           width    : 25
           height   : 25
-        click      : =>
-          @notificationsIcon.click()
       , account
-
-    @profileName = new JCustomHTMLView
-      tagName    : 'a'
-      cssClass   : 'profile'
-      attributes :
-        href     : "/#{profile.nickname}"
-        title    : 'Your profile'
-      pistachio  : '{{ #(profile.firstName) }}'
-    , account
-
-    @accountPopup = new AccountPopup
-
-    @accountIcon = new AvatarAreaIconLink
-      cssClass   : 'acc-dropdown-icon'
-      attributes :
-        title    : 'Account'
-        testpath : 'AvatarAreaIconLink'
-      delegate   : @accountPopup
-
-    @notificationsPopup = new PopupNotifications
-      cssClass : if isKoding() then 'notification-list' else 'notification-list team'
-
-    @notificationsIcon = new AvatarAreaIconLink
-      cssClass   : 'notifications acc-notification-icon'
-      attributes :
-        title    : 'Notifications'
-      delegate   : @notificationsPopup
+      helpers.makePopupButton @avatar, @notificationsPopup
 
 
     @on 'viewAppended', ->

--- a/client/app/lib/avatararea/avatarareaiconlink.coffee
+++ b/client/app/lib/avatararea/avatarareaiconlink.coffee
@@ -26,39 +26,6 @@ module.exports = class AvatarAreaIconLink extends KDCustomHTMLView
     then @$('.count').addClass "hidden"
     else @$('.count').removeClass "hidden"
 
-  click: do (skipNextClick = no, popupIsHidden = no) -> (event) ->
-
-    kd.utils.stopDOMEvent event
-
-    { mainView } = kd.singletons
-
-    if mainView.hasClass('hover') or mainView.isSidebarCollapsed
-      mainView.resetSidebar()
-
-    return skipNextClick = no  if skipNextClick
-
-    popup = @getDelegate()
-    popup.show()
-
-    popup.once 'AvatarPopupShouldBeHidden', (event) ->
-      popupIsHidden = yes
-
-    popup.once 'ReceivedClickElsewhere', (event) =>
-      skipNextClick = if popupIsHidden then no else @isInside event.target
-      popupIsHidden = no
-      popup.hide()
-
-
-
-  isInside: (target) ->
-
-    itself = @$()[0]
-    count  = @$('.count')[0]
-    cite   = @$('cite')[0]
-    icon   = @$('.icon')[0]
-
-    target in [itself, count, cite, icon]
-
 
   pistachio: ->
     """

--- a/client/app/lib/avatararea/helpers.coffee
+++ b/client/app/lib/avatararea/helpers.coffee
@@ -1,0 +1,39 @@
+kd = require 'kd'
+$  = require 'jquery'
+
+module.exports = helpers =
+
+  makePopupButton: (view, popup) ->
+
+    skipNextClick = no
+    popupIsHidden = no
+
+    view.click = (event) ->
+
+      kd.utils.stopDOMEvent event
+
+      { mainView } = kd.singletons
+
+      if mainView.hasClass('hover') or mainView.isSidebarCollapsed
+        mainView.resetSidebar()
+
+      return skipNextClick = no  if skipNextClick
+
+      popup.show()
+      popupIsHidden = false
+
+      popup.once 'AvatarPopupShouldBeHidden', (event) ->
+        popupIsHidden = yes
+
+      popup.once 'ReceivedClickElsewhere', (event) =>
+        skipNextClick = if popupIsHidden
+        then no
+        else helpers.containsOrEqual view.getElement(), event.target
+
+        popupIsHidden = no
+        popup.hide()
+
+
+  containsOrEqual: (element1, element2) ->
+
+    return element1 is element2 or $.contains element1, element2    


### PR DESCRIPTION
@usirin, can you please review this fix? It's about the problem that notification pane is not closed when you click on user icon second time - https://koding.atlassian.net/browse/ACT-521
The similar issue happens on Koding site (not teams) when you click on arrow to open account dropup. I fixed both problems

http://recordit.co/II3dRYvxpM
