### PR TITLE
ACT-477 activity: submitting message edit fix

### DIFF
--- a/client/activity/lib/components/chatlistitem/styl/chatitem.styl
+++ b/client/activity/lib/components/chatlistitem/styl/chatitem.styl
@@ -9,6 +9,8 @@
     .ChatItem-contentWrapper.editing
       margin-bottom         -10px
 
+  &.is-pending
+    opacity                 0.5
 
   .ChatItem-authorName
     display                 inline-block

--- a/client/activity/lib/components/chatlistitem/view.coffee
+++ b/client/activity/lib/components/chatlistitem/view.coffee
@@ -58,6 +58,7 @@ module.exports = class ChatListItemView extends React.Component
     className         : classnames
       'ChatItem'      : yes
       'is-selected'   : isSelected
+      'is-pending'    : message.get 'isFake'
     'data-message-id' : message.get 'id'
 
 

--- a/client/activity/lib/flux/chatinput/actions/message.coffee
+++ b/client/activity/lib/flux/chatinput/actions/message.coffee
@@ -25,6 +25,7 @@ setLastMessageEditMode = ->
     message.get('typeConstant') isnt 'system'
 
   return  unless lastMessage
+  return  if lastMessage.get 'isFake'
 
   MessageActions.setMessageEditMode lastMessage.get('_id'), channelId
 


### PR DESCRIPTION
@usirin, can you please review this fix. It prevents editing message while it's being saved and makes such pending messages half-transparent
https://koding.atlassian.net/browse/ACT-477

/cc @sinan 

Can you guys take a look at half-transparent feature?
http://recordit.co/XyCbl8PVec
Does it look OK?
