### PR TITLE
[TMS-2103] Sidebar: Sort stacks and machines

### DIFF
--- a/client/app/lib/components/sidebarstacksection/index.coffee
+++ b/client/app/lib/components/sidebarstacksection/index.coffee
@@ -47,14 +47,16 @@ module.exports = class SidebarStackSection extends React.Component
 
     config = @props.stack.get 'config'
 
-    @props.stack.get('machines').map (machine) =>
-      visible = config?.getIn [ 'sidebar', machine.get('uid'), 'visibility' ]
-      <SidebarMachinesListItem
-        key={machine.get '_id'}
-        stack={@props.stack}
-        machine={machine}
-        showInSidebar={visible}
-        />
+    @props.stack.get('machines')
+      .sort (a, b) -> a.get('label').localeCompare(b.get('label')) # Sorting from a to z
+      .map (machine) =>
+        visible = config?.getIn [ 'sidebar', machine.get('uid'), 'visibility' ]
+        <SidebarMachinesListItem
+          key={machine.get '_id'}
+          stack={@props.stack}
+          machine={machine}
+          showInSidebar={visible}
+          />
 
 
   renderStackUpdatedWidget: ->

--- a/client/app/lib/flux/environment/getters.coffee
+++ b/client/app/lib/flux/environment/getters.coffee
@@ -104,8 +104,12 @@ stacks = [
   StacksStore
   machinesWithWorkspaces
   (stacks, machinesWorkspaces) ->
+    # Sort stacks by modifiedAt and type.
     stacks
-      .sortBy (stack) -> stack.get '_id'
+      # Show last updated stacks at the top of list
+      .sort (a, b) -> b.getIn(['meta', 'modifiedAt']).localeCompare(a.getIn(['meta', 'modifiedAt']))
+      # Show group stacks at the top of list
+      .sort (a, b) -> if a.getIn ['config', 'groupStack'] then -1 else 1
       .map (stack) ->
         stack.update 'machines', (machines) ->
           machines.map (id) ->


### PR DESCRIPTION
/cc @koding/frontend 
- [x] Sort machines by machine label
- [x] Short stacks by stack type ( private or group )
- [x] Short stacks by modified date

https://koding.atlassian.net/browse/TMS-2103

@gokmen can we make a session about sorting and creating multiple vm instances in stack template when you're available?
