### PR TITLE
GEN-1541 GEN-1542 Refactor usage of appManager.tell and getFrontApp for IDE instances

### DIFF
--- a/client/app/lib/activity/sidebar/sidebarmachinebox.coffee
+++ b/client/app/lib/activity/sidebar/sidebarmachinebox.coffee
@@ -248,13 +248,14 @@ module.exports = class SidebarMachineBox extends KDView
 
       mainView.activitySidebar.redrawMachineList()
 
-      frontApp      = appManager.getFrontApp()
-      isIDE         = frontApp.options.name is 'IDE'
-      wsData        = frontApp.workspaceData
+      ideApp = environmentDataProvider.getIDEFromUId @machine.uid
+
+      return  unless ideApp
+
+      wsData        = ideApp.workspaceData
       isSameMachine = wsData.machineUId is @machine.uid
 
-      if isIDE and wsData and isSameMachine
-        router.handleRoute "/IDE/#{slug}/#{wsData.slug}"
+      router.handleRoute "/IDE/#{slug}/#{wsData.slug}"
 
 
   watchMachineState: ->

--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -494,8 +494,6 @@ module.exports = class ComputeController extends KDController
 
     destroy = (machine)=>
 
-      @stopCollaborationSession machine.uid
-
       baseKite = machine.getBaseKite( createIfNotExists = no )
       if machine?.provider is 'managed' and baseKite.klientDisable?
       then baseKite.klientDisable().finally -> baseKite.disconnect()
@@ -554,8 +552,6 @@ module.exports = class ComputeController extends KDController
     return  if methodNotSupportedBy machine, 'reinit'
 
     startReinit = =>
-
-      @stopCollaborationSession machine.uid
 
       machine.getBaseKite( createIfNotExists = no ).disconnect()
 
@@ -1100,15 +1096,6 @@ module.exports = class ComputeController extends KDController
     remote.cacheable 'JStackTemplate', baseStackId, (err, template) ->
       return callback err  if err
       return callback null, template
-
-
-  ###*
-   * Automatically kill active collaboration sessions if any
-  ###
-  stopCollaborationSession: (machineUId) ->
-
-    ideApp = envDataProvider.getIDEFromUId machineUId
-    ideApp?.stopCollaborationSession()
 
 
   showBuildLogs: (machine) ->

--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -20,6 +20,7 @@ ComputeStateChecker  = require './computestatechecker'
 ComputeEventListener = require './computeeventlistener'
 ComputeController_UI = require './computecontroller.ui'
 ManagedKiteChecker   = require './managed/managedkitechecker'
+envDataProvider      = require 'app/userenvironmentdataprovider'
 
 require './config'
 
@@ -493,7 +494,7 @@ module.exports = class ComputeController extends KDController
 
     destroy = (machine)=>
 
-      @stopCollaborationSession()
+      @stopCollaborationSession machine.uid
 
       baseKite = machine.getBaseKite( createIfNotExists = no )
       if machine?.provider is 'managed' and baseKite.klientDisable?
@@ -516,7 +517,8 @@ module.exports = class ComputeController extends KDController
             console.warn "couldn't delete workspace:", err  if err
 
           @reset yes, ->
-            kd.singletons.appManager.tell 'IDE', 'quit'
+            ideApp = envDataProvider.getIDEFromUId machine.uid
+            ideApp?.quit()
 
         return
 
@@ -553,7 +555,7 @@ module.exports = class ComputeController extends KDController
 
     startReinit = =>
 
-      @stopCollaborationSession()
+      @stopCollaborationSession machine.uid
 
       machine.getBaseKite( createIfNotExists = no ).disconnect()
 
@@ -1103,9 +1105,10 @@ module.exports = class ComputeController extends KDController
   ###*
    * Automatically kill active collaboration sessions if any
   ###
-  stopCollaborationSession: ->
+  stopCollaborationSession: (machineUId) ->
 
-    kd.singletons.appManager.tell 'IDE', 'stopCollaborationSession'
+    ideApp = envDataProvider.getIDEFromUId machineUId
+    ideApp?.stopCollaborationSession()
 
 
   showBuildLogs: (machine) ->

--- a/client/app/lib/util/showSaveDialog.coffee
+++ b/client/app/lib/util/showSaveDialog.coffee
@@ -1,10 +1,11 @@
-kd = require 'kd'
-KDDialogView = kd.DialogView
-KDFormView = kd.FormView
-KDInputView = kd.InputView
-KDLabelView = kd.LabelView
-KDView = kd.View
-IDEFinderItem = require 'ide/finder/idefinderitem'
+kd              = require 'kd'
+KDView          = kd.View
+KDFormView      = kd.FormView
+KDInputView     = kd.InputView
+KDLabelView     = kd.LabelView
+KDDialogView    = kd.DialogView
+IDEFinderItem   = require 'ide/finder/idefinderitem'
+envDataProvider = require 'app/userenvironmentdataprovider'
 
 
 module.exports = (container, callback = kd.noop, options = {}) ->
@@ -72,5 +73,6 @@ module.exports = (container, callback = kd.noop, options = {}) ->
   # for now we can live with it and assuming appManager.frontApp is IDE in
   # this case is safe because this is save/save-as modal.
   if machine = options.machine
-    { rootPath } = kd.singletons.appManager.getFrontApp().workspaceData
-    finderController.updateMachineRoot machine.uid, rootPath
+    if ideApp = envDataProvider.getIDEFromUId machine.uid
+      { rootPath } = ideApp.workspaceData
+      finderController.updateMachineRoot machine.uid, rootPath

--- a/client/app/lib/workspacesettingspopup.coffee
+++ b/client/app/lib/workspacesettingspopup.coffee
@@ -7,6 +7,7 @@ KDCustomHTMLView = kd.CustomHTMLView
 KDModalViewWithForms = kd.ModalViewWithForms
 GuidesLinksView = require './guideslinksview'
 KodingSwitch = require './commonviews/kodingswitch'
+envDataProvider = require 'app/userenvironmentdataprovider'
 
 
 module.exports = class WorkspaceSettingsPopup extends KDModalViewWithForms
@@ -55,7 +56,8 @@ module.exports = class WorkspaceSettingsPopup extends KDModalViewWithForms
 
           if deleteRelatedFiles
             methodName = 'deleteWorkspaceRootFolder'
-            appManager.tell 'IDE', methodName, machineUId, rootPath
+            ideApp = envDataProvider.getIDEFromUId machineUId
+            ideApp?[methodName]? machineUId, rootPath
 
           @emit 'WorkspaceDeleted', wsId
 

--- a/client/ide/lib/views/chat/idechatmessagepane.coffee
+++ b/client/ide/lib/views/chat/idechatmessagepane.coffee
@@ -239,8 +239,6 @@ module.exports = class IDEChatMessagePane extends PrivateMessagePane
       #   KD.utils.stopDOMEvent event
       #   @getDelegate().showSettingsPane()
 
-    appManager.tell 'IDE', 'getWorkspaceName', @title.bound 'updatePartial'
-
     header.addSubView @chevron = @createMenu()
 
     header.addSubView @link = new KDCustomHTMLView
@@ -303,8 +301,8 @@ module.exports = class IDEChatMessagePane extends PrivateMessagePane
 
     @removeOnboarding()
 
-    appManager = kd.getSingleton 'appManager'
-    appManager.tell 'IDE', 'setMachineUser', [participant.profile.nickname]
+    ideApp = envDataProvider.getIDEFromUId @getOption 'mountedMachineUId'
+    ideApp?.setMachineUser [participant.profile.nickname]
 
 
   refresh: ->

--- a/client/ide/lib/views/contentsearch/idecontentsearchresultview.coffee
+++ b/client/ide/lib/views/contentsearch/idecontentsearchresultview.coffee
@@ -1,8 +1,9 @@
-kd         = require 'kd'
-Encoder    = require 'htmlencode'
-FSHelper   = require 'app/util/fs/fshelper'
-showError  = require 'app/util/showError'
-IDEHelpers = require '../../idehelpers'
+kd              = require 'kd'
+Encoder         = require 'htmlencode'
+FSHelper        = require 'app/util/fs/fshelper'
+showError       = require 'app/util/showError'
+IDEHelpers      = require '../../idehelpers'
+envDataProvider = require 'app/userenvironmentdataprovider'
 
 
 module.exports = class IDEContentSearchResultView extends kd.View
@@ -75,8 +76,7 @@ module.exports = class IDEContentSearchResultView extends kd.View
     lineNumber   = target.getAttribute('data-line-number') or 0
     switchIfOpen = yes
 
-
-    file.fetchContents (err, contents) ->
+    file.fetchContents (err, contents) =>
 
       if err
         console.error err
@@ -84,5 +84,6 @@ module.exports = class IDEContentSearchResultView extends kd.View
 
       fileOptions  = { file, contents, switchIfOpen: yes }
 
-      kd.getSingleton('appManager').tell 'IDE', 'openFile', fileOptions, (editorPane) ->
+      ideApp = envDataProvider.getIDEFromUId @machine.uid
+      ideApp?.openFile fileOptions, (editorPane) ->
         editorPane?.goToLine lineNumber

--- a/client/ide/lib/workspace/panes/ideeditorpane.coffee
+++ b/client/ide/lib/workspace/panes/ideeditorpane.coffee
@@ -6,6 +6,7 @@ IDEPane            = require './idepane'
 AceView            = require 'ace/aceview'
 FSHelper           = require 'app/util/fs/fshelper'
 IDEHelpers         = require '../../idehelpers'
+envDataProvider    = require 'app/userenvironmentdataprovider'
 getColorFromString = require 'app/util/getColorFromString'
 
 
@@ -30,7 +31,8 @@ module.exports = class IDEEditorPane extends IDEPane
     @createEditor()
 
     file.once 'fs.delete.finished', ->
-      kd.getSingleton('appManager').tell 'IDE', 'handleFileDeleted', file
+      ideApp = envDataProvider.getIDEFromUId file.machine.uid
+      ideApp?.handleFileDeleted file
 
     @errorOnSave = no
     file.on [ 'fs.save.failed', 'fs.saveAs.failed' ], @bound 'handleSaveFailed'

--- a/client/ide/lib/workspace/panes/idefinderpane.coffee
+++ b/client/ide/lib/workspace/panes/idefinderpane.coffee
@@ -17,7 +17,6 @@ module.exports = class IDEFinderPane extends IDEPane
 
     appManager  = kd.getSingleton 'appManager'
     computeCtrl = kd.getSingleton 'computeController'
-    ideApp      = appManager.getFrontApp()
 
     appManager.open 'Finder', (finderApp) =>
       fc = @finderController = finderApp.create


### PR DESCRIPTION
/cc @koding/frontend 

As you know we can create a lot of `IDE` instances on the fly and we can want to reach an `IDE` instance in our code base. If we have `machine` or `machine uid` we should not use `appManager.tell` method. Because it returns first created instance and this can pose problems. In this case we should use `envDataProvider.getIDEFromUId`.

This PR contains like these stuffs.

https://koding.atlassian.net/browse/GEN-1541

https://koding.atlassian.net/browse/GEN-1542
