### PR TITLE
GEN-1914 	provider/koding: increase klient timeout for t2.nano instances

### DIFF
--- a/go/src/koding/kites/kloud/klient/klient.go
+++ b/go/src/koding/kites/kloud/klient/klient.go
@@ -96,7 +96,7 @@ func Exists(k *kite.Kite, queryString string) error {
 		return err
 	}
 
-	k.Log.Debug("Querying for Klient: %s", queryString)
+	k.Log.Debug("Checking whether %s exists in Kontrol", queryString)
 
 	// an error indicates a non existing klient or another error.
 	_, err = k.GetKites(query.Query())
@@ -123,7 +123,7 @@ func ConnectTimeout(k *kite.Kite, queryString string, t time.Duration) (*Klient,
 		return nil, err
 	}
 
-	k.Log.Debug("Querying for Klient: %s", queryString)
+	k.Log.Debug("Connecting with timeout=%s to Klient: %s", t, queryString)
 
 	kites, err := k.GetKites(query.Query())
 	if err != nil {
@@ -162,10 +162,11 @@ func (k *Klient) IpAddress() (string, error) {
 func NewWithTimeout(k *kite.Kite, queryString string, t time.Duration) (*Klient, error) {
 	timeout := time.After(t)
 
-	k.Log.Debug("Querying for Klient: %s", queryString)
 	for {
 		select {
 		case <-time.Tick(time.Second * 4):
+			k.Log.Debug("trying to connect to klient: %s", queryString)
+
 			if klient, err := Connect(k, queryString); err == nil {
 				return klient, nil
 			}

--- a/go/src/koding/kites/kloud/main.go
+++ b/go/src/koding/kites/kloud/main.go
@@ -175,6 +175,10 @@ func newKite(conf *Config) *kite.Kite {
 	k.Config = kiteconfig.MustGet()
 	k.Config.Port = conf.Port
 
+	if conf.DebugMode {
+		k.SetLogLevel(kite.DEBUG)
+	}
+
 	if conf.Region != "" {
 		k.Config.Region = conf.Region
 	}

--- a/go/src/koding/kites/kloud/provider/koding/build.go
+++ b/go/src/koding/kites/kloud/provider/koding/build.go
@@ -464,8 +464,8 @@ func (m *Machine) convertInstanceType(data *BuildData) (string, bool) {
 	switch {
 	// Ensure instances for old free users or users that downgraded from paid
 	// plan are converted from t2.micro to t2.nano.
-	case plans.Plans[m.Payment.Plan] == plans.Free && aws.StringValue(data.EC2Data.InstanceType) != "t2.nano":
-		return "t2.nano", true
+	case plans.Plans[m.Payment.Plan] == plans.Free && aws.StringValue(data.EC2Data.InstanceType) != plans.T2Nano.String():
+		return plans.T2Nano.String(), true
 	default:
 		return "", false
 	}

--- a/go/src/koding/kites/kloud/provider/koding/machine.go
+++ b/go/src/koding/kites/kloud/provider/koding/machine.go
@@ -234,6 +234,11 @@ func (m *Machine) Unlock() error {
 }
 
 func (m *Machine) releaseEIP() {
+	// If machine is stopped after unsuccessful start, it does not have
+	// IP updated in its meta - stop here.
+	if m.IpAddress == "" {
+		return
+	}
 	// try to release/delete a public elastic IP, if there is an error we don't
 	// care (the instance might not have an elastic IP, aka a free user.
 	addrs, err := m.Session.AWSClient.AddressesByIP(m.IpAddress)

--- a/go/src/koding/kites/kloud/provider/koding/machine.go
+++ b/go/src/koding/kites/kloud/provider/koding/machine.go
@@ -19,6 +19,17 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
+var (
+	// DefaultKlientTimeout is the max duration of time we try to connect
+	// to a Klient to ensure it's running.
+
+	DefaultKlientTimeout = 5 * time.Minute
+
+	// T2Nano is the same as above with the only difference it applies to
+	// t2.nano instances only.
+	T2NanoKlientTimeout = 8 * time.Minute
+)
+
 type Meta struct {
 	AlwaysOn     bool   `bson:"alwaysOn"`
 	InstanceId   string `structs:"instanceId" bson:"instanceId"`
@@ -187,9 +198,21 @@ func (m *Machine) updateStorageSize(size int) error {
 	})
 }
 
+func (m *Machine) klientTimeout() time.Duration {
+	instanceType, ok := m.Meta["instance_type"].(string)
+
+	// If instance type does not exist in meta we assume
+	// it's t2.nano.
+	if !ok || instanceType == plans.T2Nano.String() {
+		return T2NanoKlientTimeout
+	}
+
+	return DefaultKlientTimeout
+}
+
 func (m *Machine) isKlientReady() bool {
 	m.Log.Debug("All finished, testing for klient connection IP [%s]", m.IpAddress)
-	klientRef, err := klient.NewWithTimeout(m.Session.Kite, m.QueryString, time.Minute*5)
+	klientRef, err := klient.NewWithTimeout(m.Session.Kite, m.QueryString, m.klientTimeout())
 	if err != nil {
 		m.Log.Warning("Connecting to remote Klient instance err: %s", err)
 		return false

--- a/go/src/koding/kites/kloud/provider/koding/start.go
+++ b/go/src/koding/kites/kloud/provider/koding/start.go
@@ -79,7 +79,7 @@ func (m *Machine) Start(ctx context.Context) (err error) {
 	// and revert back to t2.nano. This is lazy auto healing of instances that
 	// were created because there were no capacity for their specific instance
 	// type.
-	if typ := aws.StringValue(instance.InstanceType); typ != "" && typ != meta.InstanceType {
+	if typ := aws.StringValue(instance.InstanceType); typ != "" && meta.InstanceType != "" && typ != meta.InstanceType {
 		m.Log.Warning("instance is using %q. Changing back to %q", typ, meta.InstanceType)
 
 		params := &ec2.ModifyInstanceAttributeInput{


### PR DESCRIPTION
Since we've switched to t2.nano on Jan 5 we started observing timeouts connecting to klient on build or info actions. In the result we started stopping such instances on timeout (`STOP started (inconsistent state)`) and users were starting them back. Waiting couple more minutes on klient instead (for t2.nano instances only) is going to reduce the number of timouts and shorten the time of a build process (stop on timeout + start).

/cc @koding/godevs 

https://koding.atlassian.net/browse/GEN-1914
