### PR TITLE
GEN-1947 social: fix security issue where if a user invited to a team as admin, it becomes admin on koding as well

### DIFF
--- a/workers/social/lib/social/models/user/index.coffee
+++ b/workers/social/lib/social/models/user/index.coffee
@@ -983,7 +983,8 @@ module.exports = class JUser extends jraphical.Module
         return callback null  if not group
 
         roles = ['member']
-        roles.push invitation.role  if invitation?.role
+        if invitation?.role and slug isnt 'koding'
+          roles.push invitation.role
         roles = uniq roles
 
         group.approveMember account, roles, (err) ->


### PR DESCRIPTION
thanks @fatihacet for realizing the issue

https://koding.atlassian.net/browse/GEN-1947
