### PR TITLE
TMS-803 landing: redirect to current url after team login

### DIFF
--- a/client/landing/site.landing/coffee/team/tabs/teamlogintab.coffee
+++ b/client/landing/site.landing/coffee/team/tabs/teamlogintab.coffee
@@ -39,6 +39,14 @@ module.exports = class TeamLoginTab extends kd.TabPaneView
       callback : (formData) =>
         track 'submitted login form'
         mainController.on 'LoginFailed', => @form.button.hideLoader()
+
+        # if current url isn't Team url, login is shown because no route has matched current url.
+        # It may happen when logged out user opens a page which requires user authentication.
+        # Let's redirect to this url after user is logged in
+        { pathname } = location
+        if pathname and pathname.indexOf('/Team') isnt 0
+          formData.redirectTo = location.pathname.substring 1
+
         mainController.login formData, (err) =>
           track 'failed to login'  if err
           @form.button.hideLoader()


### PR DESCRIPTION
@sinan, can you please review this fix?
https://koding.atlassian.net/browse/TMS-803

Currently when logged out user tries to open team logged in page like `/Account/Profile`, `/Channels/[channel_name]/[message_id]` etc., they see login form but original url they wanted to open is kept in browser url field. It happens. Here is the code which handles this case - https://github.com/koding/koding/blob/master/client/landing/site.landing/coffee/core/routes.coffee#L30
Since we know the original url, we can open it once user has successfully logged in
