### PR TITLE
GEN-1981 ide: renaming editor pane

### DIFF
--- a/client/app/lib/util/fs/fsitem.coffee
+++ b/client/app/lib/util/fs/fsitem.coffee
@@ -258,11 +258,17 @@ module.exports = class FSItem extends KDObject
 
     .then =>
       @emit "fs.job.finished"
+      @path = toPath
+      @name = FSHelper.getFileNameFromPath toPath
+      @options.path = toPath
+      @options.name = FSHelper.getFileNameFromPath toPath
+      @emit 'FilePathChanged'
 
 
   rename: (newName, callback)->
 
     @moveOrRename "#{FSHelper.getParentPath @getPath()}/#{newName}", callback
+
 
   move: (newPath, callback)->
 

--- a/client/app/lib/util/fs/fsitem.coffee
+++ b/client/app/lib/util/fs/fsitem.coffee
@@ -258,11 +258,7 @@ module.exports = class FSItem extends KDObject
 
     .then =>
       @emit "fs.job.finished"
-      @path = toPath
-      @name = FSHelper.getFileNameFromPath toPath
-      @options.path = toPath
-      @options.name = FSHelper.getFileNameFromPath toPath
-      @emit 'FilePathChanged', FSHelper.getFileNameFromPath toPath
+
 
 
   rename: (newName, callback)->

--- a/client/app/lib/util/fs/fsitem.coffee
+++ b/client/app/lib/util/fs/fsitem.coffee
@@ -262,7 +262,7 @@ module.exports = class FSItem extends KDObject
       @name = FSHelper.getFileNameFromPath toPath
       @options.path = toPath
       @options.name = FSHelper.getFileNameFromPath toPath
-      @emit 'FilePathChanged'
+      @emit 'FilePathChanged', FSHelper.getFileNameFromPath toPath
 
 
   rename: (newName, callback)->

--- a/client/ide/lib/index.coffee
+++ b/client/ide/lib/index.coffee
@@ -1124,7 +1124,7 @@ class IDEAppController extends AppController
     paneType = paneView?.getOptions().paneType
     tabView  = paneView?.parent
 
-    return  unless paneType is 'terminal' and paneType is 'editor'
+    return  unless paneType is 'terminal' or paneType is 'editor'
 
     tabView.tabHandle.setTitleEditMode yes
 

--- a/client/ide/lib/index.coffee
+++ b/client/ide/lib/index.coffee
@@ -1097,13 +1097,12 @@ class IDEAppController extends AppController
 
 
   showStatusBarMenu: (tabHandle, button) ->
-    console.log 'showStatusBarMenu'
 
     @setActiveTabView tabHandle.getDelegate()
 
     paneView = @getActivePaneView()
     paneType = paneView?.getOptions().paneType or null
-    console.log 'paneType', paneType
+
     delegate = button
     menu     = new IDEStatusBarMenu { paneType, paneView, delegate }
 
@@ -1124,9 +1123,8 @@ class IDEAppController extends AppController
     paneView = @getActivePaneView()
     paneType = paneView?.getOptions().paneType
     tabView  = paneView?.parent
-    # console.log 'paneType ', paneType
-    # console.log 'tabView  ', tabView
-    # return  unless paneType is 'terminal'
+
+    return  unless paneType is 'terminal' and paneType is 'editor'
 
     tabView.tabHandle.setTitleEditMode yes
 

--- a/client/ide/lib/index.coffee
+++ b/client/ide/lib/index.coffee
@@ -1125,7 +1125,6 @@ class IDEAppController extends AppController
     tabView  = paneView?.parent
 
     return  unless paneType in ['terminal', 'editor']
-    # return  unless paneType is 'editor'
 
     tabView.tabHandle.setTitleEditMode yes
 

--- a/client/ide/lib/index.coffee
+++ b/client/ide/lib/index.coffee
@@ -1124,7 +1124,8 @@ class IDEAppController extends AppController
     paneType = paneView?.getOptions().paneType
     tabView  = paneView?.parent
 
-    return  unless paneType is 'terminal' or paneType is 'editor'
+    return  unless paneType is 'terminal'
+    return  unless paneType is 'editor'
 
     tabView.tabHandle.setTitleEditMode yes
 

--- a/client/ide/lib/index.coffee
+++ b/client/ide/lib/index.coffee
@@ -1124,8 +1124,8 @@ class IDEAppController extends AppController
     paneType = paneView?.getOptions().paneType
     tabView  = paneView?.parent
 
-    return  unless paneType is 'terminal'
-    return  unless paneType is 'editor'
+    return  unless paneType in ['terminal', 'editor']
+    # return  unless paneType is 'editor'
 
     tabView.tabHandle.setTitleEditMode yes
 

--- a/client/ide/lib/index.coffee
+++ b/client/ide/lib/index.coffee
@@ -1097,11 +1097,13 @@ class IDEAppController extends AppController
 
 
   showStatusBarMenu: (tabHandle, button) ->
+    console.log 'showStatusBarMenu'
 
     @setActiveTabView tabHandle.getDelegate()
 
     paneView = @getActivePaneView()
     paneType = paneView?.getOptions().paneType or null
+    console.log 'paneType', paneType
     delegate = button
     menu     = new IDEStatusBarMenu { paneType, paneView, delegate }
 
@@ -1122,8 +1124,9 @@ class IDEAppController extends AppController
     paneView = @getActivePaneView()
     paneType = paneView?.getOptions().paneType
     tabView  = paneView?.parent
-
-    return  unless paneType is 'terminal'
+    # console.log 'paneType ', paneType
+    # console.log 'tabView  ', tabView
+    # return  unless paneType is 'terminal'
 
     tabView.tabHandle.setTitleEditMode yes
 

--- a/client/ide/lib/views/statusbar/idestatusbarmenu.coffee
+++ b/client/ide/lib/views/statusbar/idestatusbarmenu.coffee
@@ -81,4 +81,5 @@ module.exports = class IDEStatusBarMenu extends KDContextMenu
       'workspace.searchallfiles' , 'showContentSearch'
       'workspace.findfilebyname' , 'showFileFinder'
       'editor.gotoline'          , 'goToLine'
+      'Rename'                   , 'showRenameTerminalView'
     ]

--- a/client/ide/lib/views/tabview/ideapplicationtabview.coffee
+++ b/client/ide/lib/views/tabview/ideapplicationtabview.coffee
@@ -23,18 +23,18 @@ module.exports = class IDEApplicationTabView extends ApplicationTabView
   removePane_: KDTabView::removePane
 
 
-  removePane: (pane, shouldDetach, quiet = no) ->
+  removePane: (pane, shouldDetach, quiet = no, askforsave = yes) ->
 
     return  unless pane
 
     { aceView }        = pane.getOptions()
     { isFileReadonly } = pane.view
 
-    if quiet or isFileReadonly or not aceView or not aceView.ace.isContentChanged()
+    if quiet or isFileReadonly or not aceView or not aceView.ace.isContentChanged() or not askforsave
       return @removePane_ pane, shouldDetach
 
-    @askForSave pane, aceView
 
+    @askForSave pane, aceView  if askforsave
 
   askForSave: (pane, aceView) ->
 

--- a/client/ide/lib/views/tabview/ideview.coffee
+++ b/client/ide/lib/views/tabview/ideview.coffee
@@ -88,7 +88,7 @@ module.exports = class IDEView extends IDEWorkspaceTabView
 
       { tabHandle, view } = pane
       { options }  = view
-      { machine, paneType } = options
+      { paneType } = options
 
 
       switch paneType
@@ -106,7 +106,7 @@ module.exports = class IDEView extends IDEWorkspaceTabView
 
             ideApp.writeSnapshot()
 
-            @renameEditor paneView, machine, newTitle
+            @renameEditor paneView, newTitle
 
 
         when 'terminal'
@@ -836,7 +836,7 @@ module.exports = class IDEView extends IDEWorkspaceTabView
       showErrorNotification err
 
 
-  renameEditor: (paneView, machine, newTitle) ->
+  renameEditor: (paneView, newTitle) ->
 
     editorHandle = @tabView.getHandleByPane paneView
 

--- a/client/ide/lib/views/tabview/ideview.coffee
+++ b/client/ide/lib/views/tabview/ideview.coffee
@@ -67,6 +67,10 @@ module.exports = class IDEView extends IDEWorkspaceTabView
     @tabView.on 'TabNeedsToBeClosed',       @bound 'closeTabByFile'
     @tabView.on 'GoToLineRequested',        @bound 'goToLine'
 
+    @tabView.on 'CloseRequested', (pane) =>
+      askforsave = no
+      @tabView.removePane pane.parent, null , no, askforsave
+
     @tabView.on 'FileNeedsToBeOpened', (file, contents, callback, emitChange, isActivePane) =>
       @closeUntitledFileIfNotChanged()
       file.initialContents = contents

--- a/client/ide/lib/views/tabview/ideview.coffee
+++ b/client/ide/lib/views/tabview/ideview.coffee
@@ -94,20 +94,8 @@ module.exports = class IDEView extends IDEWorkspaceTabView
       switch paneType
         when 'editor'
           tabHandle.enableContextMenu()
-          paneView       = tabHandle.getOptions().pane
-          handleCallback = @lazyBound 'handleEditorRenamingRequested', tabHandle
-          tabHandle.on 'RenamingRequested', handleCallback
+          tabHandle.on 'RenamingRequested', (newTitle) => view.file.emit 'FilePathChanged', newTitle
           tabHandle.makeEditable()
-
-          view.file.on 'FilePathChanged', (newTitle)=>
-            ideApp = kd.singletons.appManager.frontApp
-
-            return  unless ideApp
-
-            ideApp.writeSnapshot()
-
-            @renameEditor paneView, newTitle
-
 
         when 'terminal'
           tabHandle.enableContextMenu()
@@ -786,21 +774,6 @@ module.exports = class IDEView extends IDEWorkspaceTabView
     unless session.length is DEFAULT_SESSION_NAME_LENGTH
       terminalHandle.setTitle session
 
-
-  handleEditorRenamingRequested: (tabHandle, newTitle) ->
-
-    paneView = tabHandle.getOptions().pane
-    editorPane = paneView.view
-    nodeData = editorPane.getFile()
-
-    newTitle = Encoder.XSSEncode newTitle
-    return  if newTitle is nodeData.name
-    return  unless FSHelper.isValidFileName newTitle
-
-    nodeData.rename newTitle, (err)=>
-      if err then console.log 'err', err
-      tabHandle.setTitle newTitle
-
   handleTerminalRenamingRequested: (tabHandle, newTitle) ->
 
     paneView     = tabHandle.getOptions().pane
@@ -834,14 +807,6 @@ module.exports = class IDEView extends IDEWorkspaceTabView
 
     .catch (err) ->
       showErrorNotification err
-
-
-  renameEditor: (paneView, newTitle) ->
-
-    editorHandle = @tabView.getHandleByPane paneView
-
-    editorHandle.setTitle newTitle
-
 
   renameTerminal: (paneView, machine, newTitle) ->
 

--- a/client/ide/lib/views/tabview/ideview.coffee
+++ b/client/ide/lib/views/tabview/ideview.coffee
@@ -94,7 +94,12 @@ module.exports = class IDEView extends IDEWorkspaceTabView
       switch paneType
         when 'editor'
           tabHandle.enableContextMenu()
-          tabHandle.on 'RenamingRequested', (newTitle) => pane.view.file.emit 'FilePathChanged', newTitle
+          tabHandle.on 'RenamingRequested', (newTitle) =>
+            pane.view.file.rename newTitle, (err)=>
+              if err then @notify null, null, err
+              @emit 'NodeRenamed', pane.view.file, newTitle
+
+              pane.view.file.emit 'FilePathChanged', newTitle
           tabHandle.makeEditable()
 
         when 'terminal'
@@ -287,6 +292,9 @@ module.exports = class IDEView extends IDEWorkspaceTabView
 
       ace.on 'FindAndReplaceViewRequested', (withReplaceMode) ->
         appManager.tell 'IDE', 'showFindReplaceView', withReplaceMode
+
+      editorPane.once 'CloseRequested', =>
+        @tabView.removePane editorPane.parent
 
       ace.editor.scrollToRow 0
       editorPane.goToLine 1

--- a/client/ide/lib/views/tabview/ideview.coffee
+++ b/client/ide/lib/views/tabview/ideview.coffee
@@ -90,7 +90,11 @@ module.exports = class IDEView extends IDEWorkspaceTabView
       { paneType } = options
 
       switch paneType
-        when 'editor' then tabHandle.enableContextMenu()
+        when 'editor'
+          tabHandle.enableContextMenu()
+          handleCallback = @lazyBound 'handleEditorRenamingRequested', tabHandle
+          tabHandle.on 'RenamingRequested', handleCallback
+          tabHandle.makeEditable()
         when 'terminal'
           tabHandle.enableContextMenu()
 
@@ -767,6 +771,12 @@ module.exports = class IDEView extends IDEWorkspaceTabView
     ###
     unless session.length is DEFAULT_SESSION_NAME_LENGTH
       terminalHandle.setTitle session
+
+
+  handleEditorRenamingRequested: (tabHandle, newTitle) ->
+    # console.log 'tabHandle ', tabHandle
+    tabHandle.setTitle newTitle
+    @emit 'NodeRenamed', tabHandle, newTitle
 
 
   handleTerminalRenamingRequested: (tabHandle, newTitle) ->

--- a/client/ide/lib/views/tabview/ideview.coffee
+++ b/client/ide/lib/views/tabview/ideview.coffee
@@ -1,27 +1,27 @@
-$                     = require 'jquery'
-kd                    = require 'kd'
-nick                  = require 'app/util/nick'
-FSFile                = require 'app/util/fs/fsfile'
-KDView                = kd.View
-Encoder               = require 'htmlencode'
-FSHelper              = require 'app/util/fs/fshelper'
-IDEHelpers            = require '../../idehelpers'
-KDModalView           = kd.ModalView
-IDEEditorPane         = require '../../workspace/panes/ideeditorpane'
-IDETailerPane         = require '../../workspace/panes/idetailerpane'
-KDContextMenu         = kd.ContextMenu
-KDTabPaneView         = kd.TabPaneView
-IDEPreviewPane        = require '../../workspace/panes/idepreviewpane'
-IDEDrawingPane        = require '../../workspace/panes/idedrawingpane'
-IDETerminalPane       = require '../../workspace/panes/ideterminalpane'
-generatePassword      = require 'app/util/generatePassword'
-KDCustomHTMLView      = kd.CustomHTMLView
-KDSplitViewPanel      = kd.SplitViewPanel
-ProximityNotifier     = require './splithandleproximitynotifier'
-IDEWorkspaceTabView   = require '../../workspace/ideworkspacetabview'
-IDEApplicationTabView = require './ideapplicationtabview.coffee'
-showErrorNotification = require 'app/util/showErrorNotification'
-
+$                       = require 'jquery'
+kd                      = require 'kd'
+nick                    = require 'app/util/nick'
+FSFile                  = require 'app/util/fs/fsfile'
+KDView                  = kd.View
+Encoder                 = require 'htmlencode'
+FSHelper                = require 'app/util/fs/fshelper'
+IDEHelpers              = require '../../idehelpers'
+KDModalView             = kd.ModalView
+IDEEditorPane           = require '../../workspace/panes/ideeditorpane'
+IDETailerPane           = require '../../workspace/panes/idetailerpane'
+KDContextMenu           = kd.ContextMenu
+KDTabPaneView           = kd.TabPaneView
+IDEPreviewPane          = require '../../workspace/panes/idepreviewpane'
+IDEDrawingPane          = require '../../workspace/panes/idedrawingpane'
+IDETerminalPane         = require '../../workspace/panes/ideterminalpane'
+generatePassword        = require 'app/util/generatePassword'
+KDCustomHTMLView        = kd.CustomHTMLView
+KDSplitViewPanel        = kd.SplitViewPanel
+ProximityNotifier       = require './splithandleproximitynotifier'
+IDEWorkspaceTabView     = require '../../workspace/ideworkspacetabview'
+IDEApplicationTabView   = require './ideapplicationtabview.coffee'
+showErrorNotification   = require 'app/util/showErrorNotification'
+environmentDataProvider = require 'app/userenvironmentdataprovider'
 
 HANDLE_PROXIMITY_DISTANCE   = 100
 DEFAULT_SESSION_NAME_LENGTH = 24
@@ -96,6 +96,13 @@ module.exports = class IDEView extends IDEWorkspaceTabView
           handleCallback = @lazyBound 'handleEditorRenamingRequested', tabHandle
           tabHandle.on 'RenamingRequested', handleCallback
           tabHandle.makeEditable()
+
+          view.file.on 'FilePathChanged', =>
+            ideApp = kd.singletons.appManager.frontApp
+
+            return  unless ideApp
+
+            ideApp.writeSnapshot()
         when 'terminal'
           tabHandle.enableContextMenu()
 
@@ -778,19 +785,15 @@ module.exports = class IDEView extends IDEWorkspaceTabView
 
     paneView = tabHandle.getOptions().pane
     editorPane = paneView.view
-    nodeData = editorPane.file
-
+    nodeData = editorPane.getFile()
 
     newTitle = Encoder.XSSEncode newTitle
     return  if newTitle is nodeData.name
     return  unless FSHelper.isValidFileName newTitle
 
     nodeData.rename newTitle, (err)=>
-      if err then console.log 'errr'
-
+      if err then console.log 'err', err
       tabHandle.setTitle newTitle
-      @emit 'NodeRenamed', nodeData, newTitle
-
 
   handleTerminalRenamingRequested: (tabHandle, newTitle) ->
 

--- a/client/ide/lib/views/tabview/ideview.coffee
+++ b/client/ide/lib/views/tabview/ideview.coffee
@@ -88,21 +88,27 @@ module.exports = class IDEView extends IDEWorkspaceTabView
 
       { tabHandle, view } = pane
       { options }  = view
-      { paneType } = options
+      { machine, paneType } = options
+
 
       switch paneType
         when 'editor'
           tabHandle.enableContextMenu()
+          paneView       = tabHandle.getOptions().pane
           handleCallback = @lazyBound 'handleEditorRenamingRequested', tabHandle
           tabHandle.on 'RenamingRequested', handleCallback
           tabHandle.makeEditable()
 
-          view.file.on 'FilePathChanged', =>
+          view.file.on 'FilePathChanged', (newTitle)=>
             ideApp = kd.singletons.appManager.frontApp
 
             return  unless ideApp
 
             ideApp.writeSnapshot()
+
+            @renameEditor paneView, machine, newTitle
+
+
         when 'terminal'
           tabHandle.enableContextMenu()
 
@@ -828,6 +834,13 @@ module.exports = class IDEView extends IDEWorkspaceTabView
 
     .catch (err) ->
       showErrorNotification err
+
+
+  renameEditor: (paneView, machine, newTitle) ->
+
+    editorHandle = @tabView.getHandleByPane paneView
+
+    editorHandle.setTitle newTitle
 
 
   renameTerminal: (paneView, machine, newTitle) ->

--- a/client/ide/lib/views/tabview/ideview.coffee
+++ b/client/ide/lib/views/tabview/ideview.coffee
@@ -94,7 +94,7 @@ module.exports = class IDEView extends IDEWorkspaceTabView
       switch paneType
         when 'editor'
           tabHandle.enableContextMenu()
-          tabHandle.on 'RenamingRequested', (newTitle) => view.file.emit 'FilePathChanged', newTitle
+          tabHandle.on 'RenamingRequested', (newTitle) => pane.view.file.emit 'FilePathChanged', newTitle
           tabHandle.makeEditable()
 
         when 'terminal'

--- a/client/ide/lib/views/tabview/ideview.coffee
+++ b/client/ide/lib/views/tabview/ideview.coffee
@@ -110,7 +110,7 @@ module.exports = class IDEView extends IDEWorkspaceTabView
 
     @tabView.on 'PaneRemoved', ({ pane, handle }) ->
       { options : { paneType } } = pane.view
-      handle.off 'RenamingRequested'  if paneType is 'terminal' and 'editor'
+      handle.off 'RenamingRequested'  if paneType in ['terminal','editor']
 
 
     # This is a custom event for IDEApplicationTabView

--- a/client/ide/lib/views/tabview/ideview.coffee
+++ b/client/ide/lib/views/tabview/ideview.coffee
@@ -293,8 +293,7 @@ module.exports = class IDEView extends IDEWorkspaceTabView
       ace.on 'FindAndReplaceViewRequested', (withReplaceMode) ->
         appManager.tell 'IDE', 'showFindReplaceView', withReplaceMode
 
-      editorPane.once 'CloseRequested', =>
-        @tabView.removePane editorPane.parent
+
 
       ace.editor.scrollToRow 0
       editorPane.goToLine 1

--- a/client/ide/lib/workspace/panes/ideeditorpane.coffee
+++ b/client/ide/lib/workspace/panes/ideeditorpane.coffee
@@ -138,7 +138,7 @@ module.exports = class IDEEditorPane extends IDEPane
 
       deleteFilePath = @file.getOptions().path
 
-      [node] = @file.treeController.selectedNodes
+      [ node ] = @file.treeController.selectedNodes
 
       parent            = node.getData()
       contents          = ace.getContents()
@@ -151,10 +151,10 @@ module.exports = class IDEEditorPane extends IDEPane
       @file.once 'fs.saveAs.finished',   ace.bound 'saveAsFinished'
       @file.emit 'file.requests.saveAs', contents, name, parent.path
 
-      ace.emit 'AceDidSaveAs', name, parent.path # ????
+      ace.emit 'AceDidSaveAs', name, parent.path
 
       @file.on 'fs.saveAs.finished', (newFile) =>
-        {tabView} = @getDelegate()
+        { tabView } = @getDelegate()
 
         return  if tabView.willClose
 
@@ -162,7 +162,7 @@ module.exports = class IDEEditorPane extends IDEPane
 
         @file.path = deleteFilePath
 
-        @file.remove kd.log, false
+        @file.remove kd.noop
 
 
   updateContent: (content, isSaved = no) ->

--- a/client/ide/lib/workspace/panes/ideeditorpane.coffee
+++ b/client/ide/lib/workspace/panes/ideeditorpane.coffee
@@ -107,7 +107,6 @@ module.exports = class IDEEditorPane extends IDEPane
     contents          = @getContent()
     oldCursorPosition = @getCursor()
     @file.machine     = parent.machine
-    parent.path       = parentPath
 
     @file.path = deleteFilePath
 
@@ -118,10 +117,8 @@ module.exports = class IDEEditorPane extends IDEPane
 
     return  if tabView.willClose
 
-    @emit 'CloseRequested'
+    tabView.emit 'CloseRequested', this
     @getDelegate().openSavedFile newFile, contents
-
-    @file.remove kd.noop
 
 
   bindFileSyncEvents: ->
@@ -558,4 +555,6 @@ module.exports = class IDEEditorPane extends IDEPane
     super
 
 
-  updateAceViewDelegate: (ideView) -> @aceView?.setDelegate ideView
+  updateAceViewDelegate: (ideView) ->
+    @aceView?.setDelegate ideView
+    @setDelegate ideView

--- a/client/ide/lib/workspace/panes/ideeditorpane.coffee
+++ b/client/ide/lib/workspace/panes/ideeditorpane.coffee
@@ -49,10 +49,6 @@ module.exports = class IDEEditorPane extends IDEPane
     @getFileModifiedDate (date) => @lastModifiedDate = date
 
 
-  setFile: (file) ->
-    @file = file
-
-
   getFileModifiedDate: (callback = noop) ->
 
     path        = FSHelper.plainPath @file.path

--- a/client/ide/lib/workspace/panes/ideeditorpane.coffee
+++ b/client/ide/lib/workspace/panes/ideeditorpane.coffee
@@ -134,7 +134,7 @@ module.exports = class IDEEditorPane extends IDEPane
         @contentChangedWarning?.destroy()
         @contentChangedWarning = null
 
-    @file.on 'FilePathChanged', (name) =>
+    @file.once 'FilePathChanged', (name) =>
 
       deleteFilePath = @file.getOptions().path
 
@@ -143,17 +143,14 @@ module.exports = class IDEEditorPane extends IDEPane
       parent            = node.getData()
       contents          = ace.getContents()
       oldCursorPosition = ace.editor.getCursorPosition()
+      @file.machine     = parent.machine
+      parent.path       = @file.getOptions().parentPath
 
-      @file.machine = parent.machine
-
-      parent.path = @file.getOptions().parentPath
-
-      @file.once 'fs.saveAs.finished',   ace.bound 'saveAsFinished'
       @file.emit 'file.requests.saveAs', contents, name, parent.path
-
+      @file.once 'fs.saveAs.finished',   ace.bound 'saveAsFinished'
       ace.emit 'AceDidSaveAs', name, parent.path
 
-      @file.on 'fs.saveAs.finished', (newFile) =>
+      @file.once 'fs.saveAs.finished', (newFile) =>
         { tabView } = @getDelegate()
 
         return  if tabView.willClose

--- a/client/ide/lib/workspace/panes/ideeditorpane.coffee
+++ b/client/ide/lib/workspace/panes/ideeditorpane.coffee
@@ -96,6 +96,7 @@ module.exports = class IDEEditorPane extends IDEPane
 
 
   updateFilePath: (name)->
+
     ace = @getAce()
     deleteFilePath = @file.getOptions().path
 

--- a/client/ide/lib/workspace/panes/ideeditorpane.coffee
+++ b/client/ide/lib/workspace/panes/ideeditorpane.coffee
@@ -104,14 +104,14 @@ module.exports = class IDEEditorPane extends IDEPane
     [ node ] = @file.treeController.selectedNodes
 
     parent            = node.getData()
-    contents          = ace.getContents()
-    oldCursorPosition = ace.editor.getCursorPosition()
+    contents          = @getContent()
+    oldCursorPosition = @getCursor
     @file.machine     = parent.machine
     parent.path       = parentPath
 
     @file.path = deleteFilePath
 
-    path = parentPath + '/' + name
+    path = "#{parentPath}/#{name}"
     newFile = FSHelper.createFileInstance { path, machine: parent.machine }
 
     { tabView } = @getDelegate()

--- a/client/ide/lib/workspace/panes/ideeditorpane.coffee
+++ b/client/ide/lib/workspace/panes/ideeditorpane.coffee
@@ -105,7 +105,7 @@ module.exports = class IDEEditorPane extends IDEPane
 
     parent            = node.getData()
     contents          = @getContent()
-    oldCursorPosition = @getCursor
+    oldCursorPosition = @getCursor()
     @file.machine     = parent.machine
     parent.path       = parentPath
 

--- a/client/ide/lib/workspace/panes/ideeditorpane.coffee
+++ b/client/ide/lib/workspace/panes/ideeditorpane.coffee
@@ -134,6 +134,36 @@ module.exports = class IDEEditorPane extends IDEPane
         @contentChangedWarning?.destroy()
         @contentChangedWarning = null
 
+    @file.on 'FilePathChanged', (name) =>
+
+      deleteFilePath = @file.getOptions().path
+
+      [node] = @file.treeController.selectedNodes
+
+      parent            = node.getData()
+      contents          = ace.getContents()
+      oldCursorPosition = ace.editor.getCursorPosition()
+
+      @file.machine = parent.machine
+
+      parent.path = @file.getOptions().parentPath
+
+      @file.once 'fs.saveAs.finished',   ace.bound 'saveAsFinished'
+      @file.emit 'file.requests.saveAs', contents, name, parent.path
+
+      ace.emit 'AceDidSaveAs', name, parent.path # ????
+
+      @file.on 'fs.saveAs.finished', (newFile) =>
+        {tabView} = @getDelegate()
+
+        return  if tabView.willClose
+
+        @getDelegate().openSavedFile newFile, contents
+
+        @file.path = deleteFilePath
+
+        @file.remove kd.log, false
+
 
   updateContent: (content, isSaved = no) ->
 

--- a/client/ide/lib/workspace/panes/ideeditorpane.coffee
+++ b/client/ide/lib/workspace/panes/ideeditorpane.coffee
@@ -49,6 +49,10 @@ module.exports = class IDEEditorPane extends IDEPane
     @getFileModifiedDate (date) => @lastModifiedDate = date
 
 
+  setFile: (file) ->
+    @file = file
+
+
   getFileModifiedDate: (callback = noop) ->
 
     path        = FSHelper.plainPath @file.path


### PR DESCRIPTION
Added Rename menu item to editor pane. It's still in WIP, i need some helps:

I am not able to save new file name. I think, in this file `ide/lib/views/tabview/ideview.coffee` at line 761, `tabHandle` should have information about the file path? 

/cc @sinan @fatihacet 

https://koding.atlassian.net/browse/GEN-1981
