### PR TITLE
TMS-2303 TMS-2301 TMS-2302 TMS-2299 server: attach group to notification events

### DIFF
--- a/workers/social/lib/social/models/collaboration.coffee
+++ b/workers/social/lib/social/models/collaboration.coffee
@@ -79,7 +79,7 @@ module.exports = class Collaboration extends Base
       return callback err  if err
 
       machineUId = machine.uid
-      data =  { machineUId, workspaceId }
+      data =  { machineUId, workspaceId, group: client?.context?.group }
 
       notifyByUsernames options.target, 'CollaborationInvitation', data
 

--- a/workers/social/lib/social/models/sharedmachine.coffee
+++ b/workers/social/lib/social/models/sharedmachine.coffee
@@ -25,7 +25,7 @@ module.exports = class SharedMachine extends bongo.Base
     setUsers client, uid, options, (err) ->
       return callback err  if err
 
-      notifyByUsernames options.target, 'SharedMachineInvitation', { uid }
+      notifyByUsernames options.target, 'SharedMachineInvitation', { uid, group: client?.context?.group }
       notifyOwner client, options
       callback()
 
@@ -44,6 +44,7 @@ module.exports = class SharedMachine extends bongo.Base
   notifyOwner = (client, options) ->
 
     { nickname } = client.connection.delegate.profile
+    options.group = client?.context?.group
     notifyByUsernames [ nickname ], 'MachineShareListUpdated', options
 
 

--- a/workers/social/lib/social/models/workspace.coffee
+++ b/workers/social/lib/social/models/workspace.coffee
@@ -186,6 +186,7 @@ module.exports = class JWorkspace extends Module
             nickname : delegate.profile.nickname
             workspace: ws
             eventName: 'WorkspaceRemoved'
+            group    : client?.context?.group
 
           notifyUsers options, callback
 


### PR DESCRIPTION
This PR attaches group to notification events as context, so that clientside can check to see if the notification is intended for logged-in group.

/cc @usirin 

https://koding.atlassian.net/browse/TMS-2299

https://koding.atlassian.net/browse/TMS-2302

https://koding.atlassian.net/browse/TMS-2301

https://koding.atlassian.net/browse/TMS-2303
