### PR TITLE
TMS-1993 klient: fs.write, added WriteAt functionality

### DIFF
--- a/go/src/koding/klient/fs/fs.go
+++ b/go/src/koding/klient/fs/fs.go
@@ -213,6 +213,10 @@ type writeFileParams struct {
 	//
 	// The current hashing algorithm is md5
 	LastContentHash string
+
+	// Offset optionally writes the given data at the offset location, using
+	// file.WriteAt(data,offset) instead of file.Write(data)
+	Offset int64
 }
 
 func WriteFile(r *kite.Request) (interface{}, error) {
@@ -221,7 +225,7 @@ func WriteFile(r *kite.Request) (interface{}, error) {
 		return nil, errors.New("{ path: [string] }")
 	}
 
-	return writeFile(params.Path, params.Content, params.DoNotOverwrite, params.Append, params.LastContentHash)
+	return writeFile(params)
 }
 
 func UniquePath(r *kite.Request) (interface{}, error) {

--- a/go/src/koding/klient/fs/fs_test.go
+++ b/go/src/koding/klient/fs/fs_test.go
@@ -571,6 +571,42 @@ func TestWriteFile(t *testing.T) {
 			string(buf), string(expectedContents),
 		)
 	}
+
+	// Write some test data
+	err = ioutil.WriteFile(testFile.Name(), []byte("foobaz"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = remote.Tell("writeFile", struct {
+		Path    string
+		Content []byte
+		Offset  int64
+	}{
+		Path:    testFile.Name(),
+		Content: []byte("bar"),
+		Offset:  3,
+	})
+
+	if err != nil {
+		t.Errorf(
+			"writeFile returned an error with an offset. %s",
+			err.Error(),
+		)
+	}
+
+	buf, err = ioutil.ReadFile(testFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(buf) != "foobar" {
+		t.Errorf(
+			"writeFile was given an offset, but did not offset the data correctly. wanted:%s, got:%s",
+			"foobar",
+			string(buf),
+		)
+	}
 }
 
 func TestUniquePath(t *testing.T) {


### PR DESCRIPTION
As an optimization for KD's Fuse optations, WriteAt has been implemented
to allow for partial writes. non-offset usage of the fs.writeFile method
remain the same, no tests were modified - only writeAt tests added.
