### PR TITLE
default stack change flow is confusing

### DIFF
--- a/client/app/lib/components/sidebarstacksection/sidebardifferentstackresources.coffee
+++ b/client/app/lib/components/sidebarstacksection/sidebardifferentstackresources.coffee
@@ -11,17 +11,23 @@ module.exports = class SidebarDifferentStackResources extends React.Component
   @defaultProps =
     className   : 'SidebarStackWidgets --DifferentStackResources'
 
-
+  # this is at best a notification, we shouldn't put this on
+  # top of the sidebar as a forcing function. if we do, there should be "hide this" option
+  # i'd argue that we should remove this completely for now.
+  # users should go to stack catalogue, select whatever stack they like.
+  # on top of that, we say "go re-init your default stack", re-init means
+  # re-init the current one, this action changes the current with the new
+  # default thereby it's very confusing.
   render: ->
 
     <section className={classnames 'SidebarSection', @props.className}>
       <div className='SidebarSection-body'>
         <p>
-          You have different resources in your stacks.
-          Please re-initialize your stacks.
+          Team admin has changed the default stack.
+          Please save your changes and go to Stack Catalog, and reinitialize.
         </p>
         <Link href='/Stacks'>
-          Show Stacks
+          Stack Catalog
         </Link>
       </div>
     </section>


### PR DESCRIPTION
  # this is at best a notification, we shouldn't put this on
  # top of the sidebar as a forcing function. if we do, there should be "hide this" option
  # i'd argue that we should remove this completely for now.
  # users should go to stack catalog, select whatever stack they like.
  # on top of that, we say "go re-init your default stack", re-init means
  # re-init the current one, this action changes the current with the new
  # default thereby it's very confusing.

cc @sinan

https://koding.atlassian.net/browse/TMS-2343
