### PR TITLE
TMS-803 Redirect after login for solo pages

### DIFF
--- a/client/landing/site.landing/coffee/core/utils.coffee
+++ b/client/landing/site.landing/coffee/core/utils.coffee
@@ -358,6 +358,9 @@ module.exports = utils = {
   # Redirect to this url after user is logged in
   getLoginRedirectPath: (loginRoute) ->
 
+    { redirectTo } = kd.utils.parseQuery()
+    return redirectTo.substring 1  if redirectTo
+
     { pathname } = location
     if pathname and pathname.indexOf(loginRoute) is -1
       return pathname.substring 1

--- a/client/landing/site.landing/coffee/core/utils.coffee
+++ b/client/landing/site.landing/coffee/core/utils.coffee
@@ -346,9 +346,20 @@ module.exports = utils = {
 
   removeLastUsedProvider: -> delete window.localStorage.lastUsedProvider
 
+
   createTeamTitlePhrase: (title) ->
+
     # doesn't duplicate the word `the` if the title already has it in the beginning
     # doesn't duplicate the word `team` if the title already has it at the end
     "#{if title.search(/^the/i) < 0 then 'the' else ''} #{title} #{if title.search(/team$/i) < 0 then 'team' else ''}"
+
+  # if current url isn't loginRoute, login is shown because no route has matched current url.
+  # It may happen when logged out user opens a page which requires user authentication.
+  # Redirect to this url after user is logged in
+  getLoginRedirectPath: (loginRoute) ->
+
+    { pathname } = location
+    if pathname and pathname.indexOf(loginRoute) is -1
+      return pathname.substring 1
 
 }

--- a/client/landing/site.landing/coffee/core/utils.coffee
+++ b/client/landing/site.landing/coffee/core/utils.coffee
@@ -353,7 +353,8 @@ module.exports = utils = {
     # doesn't duplicate the word `team` if the title already has it at the end
     "#{if title.search(/^the/i) < 0 then 'the' else ''} #{title} #{if title.search(/team$/i) < 0 then 'team' else ''}"
 
-  # if current url isn't loginRoute, login is shown because no route has matched current url.
+  # If current url contains redirectTo query parameter, use it to redirect after login.
+  # If current url isn't loginRoute, login is shown because no route has matched current url.
   # It may happen when logged out user opens a page which requires user authentication.
   # Redirect to this url after user is logged in
   getLoginRedirectPath: (loginRoute) ->

--- a/client/landing/site.landing/coffee/login/AppView.coffee
+++ b/client/landing/site.landing/coffee/login/AppView.coffee
@@ -563,6 +563,8 @@ module.exports = class LoginView extends JView
       @loginForm.tfcode.show()
       @loginForm.tfcode.setFocus()
 
+    formData.redirectTo = utils.getLoginRedirectPath '/Login'
+
     mainController.login formData
 
 

--- a/client/landing/site.landing/coffee/login/AppView.coffee
+++ b/client/landing/site.landing/coffee/login/AppView.coffee
@@ -564,7 +564,6 @@ module.exports = class LoginView extends JView
       @loginForm.tfcode.setFocus()
 
     formData.redirectTo = utils.getLoginRedirectPath '/Login'
-
     mainController.login formData
 
 

--- a/client/landing/site.landing/coffee/team/tabs/teamlogintab.coffee
+++ b/client/landing/site.landing/coffee/team/tabs/teamlogintab.coffee
@@ -40,12 +40,7 @@ module.exports = class TeamLoginTab extends kd.TabPaneView
         track 'submitted login form'
         mainController.on 'LoginFailed', => @form.button.hideLoader()
 
-        # if current url isn't Team url, login is shown because no route has matched current url.
-        # It may happen when logged out user opens a page which requires user authentication.
-        # Let's redirect to this url after user is logged in
-        { pathname } = location
-        if pathname and pathname.indexOf('/Team') isnt 0
-          formData.redirectTo = location.pathname.substring 1
+        formData.redirectTo = utils.getLoginRedirectPath '/Team'
 
         mainController.login formData, (err) =>
           track 'failed to login'  if err

--- a/servers/lib/crawler/index.coffee
+++ b/servers/lib/crawler/index.coffee
@@ -13,7 +13,7 @@ notFoundError = (name) ->
 
 
 fetchProfileContent = (models, options, callback) ->
-  { client, name } = options
+  { client, name, currentUrl } = options
   { JAccount, SocialChannel } = models
   JAccount.one { 'profile.nickname': name }, (err, account) ->
     return callback err  if err
@@ -24,12 +24,12 @@ fetchProfileContent = (models, options, callback) ->
 
       { content, index } = response
 
-      return callback null, profile account, content, index
+      return callback null, profile account, content, index, currentUrl
 
 
 fetchPostContent = (models, options, callback) ->
   { SocialMessage } = models
-  { client, entrySlug } = options
+  { client, entrySlug, currentUrl } = options
 
   options = { slug: entrySlug, replyLimit: 25 }
   SocialMessage.bySlug client, options, (err, activity) ->
@@ -46,7 +46,7 @@ fetchPostContent = (models, options, callback) ->
         body     : "#{activityContent.body}"
         shareUrl : "#{uri.address}/Activity/Post/#{activityContent.slug}"
         index    : activityContent.body.length > 500 or activity.repliesCount >= 3
-      fullPage = feed.putContentIntoFullPage content, '', graphMeta
+      fullPage = feed.putContentIntoFullPage content, '', graphMeta, currentUrl
       callback null, fullPage
 
 
@@ -163,7 +163,7 @@ module.exports =
 
       { query } = req
       page = getPage query
-      options = { section, entrySlug, client, page, isProfile, name }
+      options = { section, entrySlug, client, page, isProfile, name, currentUrl: req.originalUrl }
       fetchContent models, options, (err, content) ->
         return handleError err, res, content  if err or not content
         return res.status(200).send content

--- a/servers/lib/crawler/staticpages/profile.coffee
+++ b/servers/lib/crawler/staticpages/profile.coffee
@@ -2,7 +2,7 @@
 { getAvatarImageUrl }      = require './activity'
 { getSidebar }             = require './feed'
 
-module.exports = (account, statusUpdates, index) ->
+module.exports = (account, statusUpdates, index, currentUrl) ->
   getGraphMeta = require './graphmeta'
   analytics    = require './analytics'
 
@@ -18,7 +18,7 @@ module.exports = (account, statusUpdates, index) ->
   </head>
   <body itemscope itemtype="http://schema.org/WebPage" class="super profile">
     <div id="kdmaincontainer" class="kdview with-sidebar">
-      #{getSidebar()}
+      #{getSidebar currentUrl}
       #{putContent(account, statusUpdates)}
     </div>
     #{analytics()}


### PR DESCRIPTION
@sinan, can you please review these changes? They fix problems of redirection after login on solo site (koding.com). There are 2 cases handled by this logic:
- login form is shown when logged out user opens a page which requires user to be logged in. For example, `/Account/Profile`, `/My-Machines` etc.
- logged out user clicks on `Login` button on activity page, does log in and after that user is redirected to the same activity page

https://koding.atlassian.net/browse/TMS-803
I decided not to create one more bug for activity page case since TMS-803 has pretty similar description and we already has https://koding.atlassian.net/browse/GEN-1643 for solo site marked as duplicate. So if you don't mind, let's fix all the cases via TMS-803
