### PR TITLE
kloud: workaround querying vlan that have no primary subnet info

### DIFF
--- a/go/src/koding/kites/kloud/api/sl/vlan.go
+++ b/go/src/koding/kites/kloud/api/sl/vlan.go
@@ -84,6 +84,10 @@ func (v VLANs) ByDatacenter(datacenter string) (res VLANs) {
 	for _, vlan := range v {
 		if vlan.Subnet.Datacenter.Name == datacenter {
 			res = append(res, vlan)
+			continue
+		}
+		if len(vlan.Subnets) != 0 && vlan.Subnets[0].Datacenter.Name == datacenter {
+			res = append(res, vlan)
 		}
 	}
 	return res

--- a/go/src/koding/kites/kloud/provider/softlayer/build.go
+++ b/go/src/koding/kites/kloud/provider/softlayer/build.go
@@ -94,9 +94,15 @@ func (m *Machine) build(ctx context.Context) error {
 
 	m.Meta["sourceImage"] = imageID
 
+	hostname := m.Username // using username as a hostname
+	if _, err := strconv.Atoi(hostname); err == nil {
+		// hostname cannot be a number, use m.Uid instead
+		hostname = m.Uid
+	}
+
 	//Create a template for the virtual guest (changing properties as needed)
 	virtualGuestTemplate := datatypes.SoftLayer_Virtual_Guest_Template{
-		Hostname:          m.Username,  // this is correct, we use the username as hostname
+		Hostname:          hostname,
 		Domain:            "koding.io", // this is just a placeholder
 		StartCpus:         1,
 		MaxMemory:         1024,
@@ -169,7 +175,7 @@ func (m *Machine) build(ctx context.Context) error {
 	}
 
 	if err = m.Session.SLClient.InstanceSetTags(obj.Id, sl.Tags(tags)); err != nil {
-		return err
+		m.Log.Warning("couldn't set tags during build: %s", err)
 	}
 
 	m.QueryString = protocol.Kite{ID: kiteID}.String()

--- a/go/src/koding/kites/kloud/scripts/sl/vlan.go
+++ b/go/src/koding/kites/kloud/scripts/sl/vlan.go
@@ -77,13 +77,23 @@ func (cmd *vlanList) Run(ctx context.Context) error {
 	return nil
 }
 
+func datacenter(v *sl.VLAN) string {
+	if v.Subnet.Datacenter.Name != "" {
+		return v.Subnet.Datacenter.Name
+	}
+	if len(v.Subnets) != 0 {
+		return v.Subnets[0].Datacenter.Name
+	}
+	return ""
+}
+
 func printVlans(vlans sl.VLANs) {
 	w := &tabwriter.Writer{}
 	w.Init(os.Stdout, 0, 8, 0, '\t', 0)
 	fmt.Fprintln(w, "ID\tInternal ID\tTotal\tAvailable\tInstances\tDatacenter\tTags")
 	for _, v := range vlans {
 		fmt.Fprintf(w, "%d\t%d\t%d\t%d\t%d\t%s\t%s\n", v.ID, v.InternalID, v.Subnet.Total,
-			v.Subnet.Available, v.InstanceCount, v.Subnet.Datacenter.Name, v.Tags)
+			v.Subnet.Available, v.InstanceCount, datacenter(v), v.Tags)
 	}
 	w.Flush()
 }


### PR DESCRIPTION
Some datacenters in Softlayer does not have primary subnet info. This makes vlan balancing broken on current production.

Nothing than can't be work-arounded, instead of relying on kloud to balance vlan, we're going to set the vlanID directly in jMachine.

/cc @koding/godevs 
