### PR TITLE
[TMS-2371] Stack Catalog: Onboarding: Fix Safari issue

### DIFF
--- a/client/stacks/lib/views/stacks/basestacktemplatesview.coffee
+++ b/client/stacks/lib/views/stacks/basestacktemplatesview.coffee
@@ -49,13 +49,15 @@ module.exports = class BaseStackTemplatesView extends kd.View
   createOnboardingView: (options = {}) ->
 
     @initialView.hide()
-    @scrollView.addSubView onboardingView = new OnboardingView options
+    @onboardingView?.destroy()
 
-    onboardingView.on 'StackOnboardingCompleted', (template) =>
-      onboardingView.destroy()
+    @scrollView.addSubView @onboardingView = new OnboardingView options
+
+    @onboardingView.on 'StackOnboardingCompleted', (template) =>
+      @onboardingView.destroy()
       @showEditor { inEditMode: no, showHelpContent: yes }, template
 
-    onboardingView.on 'ScrollTo', (direction = 'top') =>
+    @onboardingView.on 'ScrollTo', (direction = 'top') =>
       duration = 500
       top      = if direction is 'top' then 0 else @scrollView.getScrollHeight()
 


### PR DESCRIPTION
/cc @koding/frontend 

https://koding.atlassian.net/browse/TMS-2371

Guys, actually this pr is a workaround. As far as i understand `lazyrouter.bind` calls `handle` \*  function 3 times for Safari and calls 2 times other browsers. I investigated why it works like this but i could not find the root cause. What do you think?

*: https://github.com/koding/koding/blob/master/client/app/lib/util/routeHandler.coffee#L35
The Issue: http://recordit.co/L9yCeHI97D
