### PR TITLE
TMS-2319 klientctl: Increased ulimit to klient default

### DIFF
--- a/go/src/koding/klientctl/install.go
+++ b/go/src/koding/klientctl/install.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/codegangsta/cli"
 	"koding/klientctl/logging"
+
+	"github.com/codegangsta/cli"
 	"github.com/leeola/service"
 )
 
@@ -251,6 +252,7 @@ func (k klientSh) Format() string {
 
 	return fmt.Sprintf(
 		`#!/bin/sh
+ulimit -n 5000
 %sKITE_HOME=%s %s --kontrol-url=%s
 `,
 		sudoCmd, k.KiteHome, k.KlientBinPath, k.KontrolURL,


### PR DESCRIPTION
`ulimit -n 100000` is what koding.com and klient have been using, but
is too big for OSX. Setting to 5k instead.

https://koding.atlassian.net/browse/TMS-2319
