### PR TITLE
TMS-2307 klient: Added PublicIPRetry, and PublicIP host rotation

### DIFF
--- a/go/src/koding/klient/app/register.go
+++ b/go/src/koding/klient/app/register.go
@@ -14,7 +14,9 @@ import (
 )
 
 func (k *Klient) register(useTunnel bool) error {
-	ip, err := publicip.PublicIP()
+	// Attempt to get the IP, and retry up to 10 times with 5 second pauses between
+	// retries.
+	ip, err := publicip.PublicIPRetry(10, 5*time.Second, k.log)
 	if err != nil {
 		return err
 	}

--- a/go/src/koding/klient/info/publicip/publicip.go
+++ b/go/src/koding/klient/info/publicip/publicip.go
@@ -19,6 +19,7 @@ var echoSites = []string{
 	// In the future, maybe koding.com/-/echoip first?
 	"http://echoip.com",
 	"http://api.ipify.org",
+	"ifconfig.co",
 }
 
 // PublicIP returns an IP that is supposed to be Public.

--- a/go/src/koding/klient/info/publicip/publicip.go
+++ b/go/src/koding/klient/info/publicip/publicip.go
@@ -19,7 +19,11 @@ var echoSites = []string{
 	// In the future, maybe koding.com/-/echoip first?
 	"http://echoip.com",
 	"http://api.ipify.org",
-	"ifconfig.co",
+	"http://ifconfig.co",
+}
+
+var defaultClient = &http.Client{
+	Timeout: 5 * time.Second,
 }
 
 // PublicIP returns an IP that is supposed to be Public.
@@ -29,7 +33,7 @@ func PublicIP() (net.IP, error) {
 
 // publicIP requests a URL and returns a netIP for the response.
 func publicIP(host string) (net.IP, error) {
-	resp, err := http.Get(host)
+	resp, err := defaultClient.Get(host)
 	if err != nil {
 		return nil, err
 	}

--- a/go/src/koding/klient/info/publicip/publicip.go
+++ b/go/src/koding/klient/info/publicip/publicip.go
@@ -19,7 +19,7 @@ var echoSites = []string{
 	// In the future, maybe koding.com/-/echoip first?
 	"http://echoip.com",
 	"http://api.ipify.org",
-	"http://ifconfig.co",
+	"http://ipinfo.io/ip",
 }
 
 var defaultClient = &http.Client{

--- a/go/src/koding/klient/info/publicip/publicip.go
+++ b/go/src/koding/klient/info/publicip/publicip.go
@@ -2,18 +2,33 @@ package publicip
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
+	"time"
+
+	"github.com/koding/kite"
 )
 
-// The site PublicIP() uses to get the public IP from.
-const publicEcho string = "http://echoip.com"
+// The sites that PublicIP() uses to get the public IP from.
+//
+// Note that the site must return *only* the IP characters.
+var echoSites = []string{
+	// In the future, maybe koding.com/-/echoip first?
+	"http://echoip.com",
+	"http://api.ipify.org",
+}
 
 // PublicIP returns an IP that is supposed to be Public.
 func PublicIP() (net.IP, error) {
-	resp, err := http.Get(publicEcho)
+	return publicIP(echoSites[0])
+}
+
+// publicIP requests a URL and returns a netIP for the response.
+func publicIP(host string) (net.IP, error) {
+	resp, err := http.Get(host)
 	if err != nil {
 		return nil, err
 	}
@@ -30,4 +45,45 @@ func PublicIP() (net.IP, error) {
 	}
 
 	return n, nil
+}
+
+// PublicIPRetry fetches the public IP, retrying as many times as requested.
+// An *optional* logger is provided, to log retry progress.
+func PublicIPRetry(maxRetries int, retryPause time.Duration, log kite.Logger) (net.IP, error) {
+	return publicIPRetry(echoSites, maxRetries, retryPause, log)
+}
+
+func publicIPRetry(hosts []string, maxRetries int, retryPause time.Duration, log kite.Logger) (net.IP, error) {
+	if maxRetries <= 0 {
+		return nil, errors.New("PublicIPRetry: maxRetries must be larger than 0")
+	}
+
+	var (
+		ip  net.IP
+		err error
+	)
+
+	for i := 0; i < maxRetries; i++ {
+		host := hosts[i%len(hosts)]
+		ip, err = publicIP(host)
+
+		// If there's no error, we successfully got the IP.
+		if err == nil {
+			return ip, nil
+		}
+
+		if log != nil {
+			log.Warning(
+				"Retrying fetch of PublicIP due to error. delay:%s, err:%s",
+				retryPause, err,
+			)
+		}
+
+		if retryPause > 0 {
+			// Pause before retrying.
+			time.Sleep(retryPause)
+		}
+	}
+
+	return nil, err
 }

--- a/go/src/koding/klient/info/publicip/publicip_test.go
+++ b/go/src/koding/klient/info/publicip/publicip_test.go
@@ -1,0 +1,80 @@
+package publicip
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestPublicIPRetry(t *testing.T) {
+	var callCount int
+	var eventualSuccessReq int
+	successTS := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			fmt.Fprint(w, "0.1.2.3")
+		}))
+	defer successTS.Close()
+
+	failTS := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+		}))
+	defer failTS.Close()
+
+	eventualSuccessTS := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			if callCount > eventualSuccessReq {
+				fmt.Fprint(w, "0.1.2.3")
+			}
+		}))
+	defer eventualSuccessTS.Close()
+
+	Convey("Given a max of valid and invalid hosts", t, func() {
+		callCount = 0
+
+		hosts := []string{
+			failTS.URL,
+			successTS.URL,
+			failTS.URL,
+		}
+
+		Convey("It should return the first succeeding host", func() {
+			ip, err := publicIPRetry(hosts, 10, 0, nil)
+			So(err, ShouldBeNil)
+			So(ip, ShouldNotBeNil)
+			So(ip.String(), ShouldEqual, "0.1.2.3")
+			So(callCount, ShouldEqual, 2)
+		})
+
+		Convey("It should only return an error after exceeding maxRetries", func() {
+			ip, err := publicIPRetry(hosts, 1, 0, nil)
+			So(err, ShouldNotBeNil)
+			So(ip, ShouldBeNil)
+			So(callCount, ShouldEqual, 1)
+		})
+	})
+
+	Convey("Given eventually succeeding hosts", t, func() {
+		callCount = 0
+		eventualSuccessReq = 3
+
+		hosts := []string{
+			failTS.URL,
+			eventualSuccessTS.URL,
+			failTS.URL,
+		}
+
+		Convey("It should repeat the entire hosts list until success within maxRetries", func() {
+			ip, err := publicIPRetry(hosts, 10, 0, nil)
+			So(err, ShouldBeNil)
+			So(ip, ShouldNotBeNil)
+			So(ip.String(), ShouldEqual, "0.1.2.3")
+			So(callCount, ShouldEqual, 5)
+		})
+	})
+}


### PR DESCRIPTION
The 2nd host and host rotation helps to ensure that if one of
the IP providers _(even us, eventually)_  is down, Klient can still
start and potentially run normally.

This does not "fix" the panic, due to the panic being intended.
The panic behavior (Seen here:
https://github.com/koding/koding/blob/master/go/src/koding/klient/app/klient.go#L386)
Is not inherently bad. Klient cannot do much if it cannot get its IP,
and if it is failing to even communicate, restarting (after a panic)
is a reasonable response.

This PR mainly focuses on the reliance to echoip, and a single provider.

https://koding.atlassian.net/browse/TMS-2307
