### PR TITLE
GEN-2038 Markup optimization

### DIFF
--- a/client/app/lib/components/sidebarchannelssection/styl/sidebarchannelssection.styl
+++ b/client/app/lib/components/sidebarchannelssection/styl/sidebarchannelssection.styl
@@ -3,15 +3,13 @@ $fs-channels = 20px
 .SidebarChannelsSection .SidebarListItem
   margin                    0
 
-.SidebarChannelsSection .SidebarListItem-icon
-  height                    28px
-  vertical-align            top
-  display                   inline-block
-  margin-right              3px
-  rel()
-
   &:before
+    height                  28px
+    vertical-align          top
+    margin-right            3px
     content                 '#'
     font-size               $fs-small
     color                   $gray-10
     text-shadow             none
+    dIBlock()
+    rel()

--- a/client/app/lib/components/sidebarlist/sidebarlistitem.coffee
+++ b/client/app/lib/components/sidebarlist/sidebarlistitem.coffee
@@ -52,7 +52,6 @@ module.exports = class SidebarListItem extends React.Component
   render: ->
 
     <Link className={@getClassName()} href={@props.href} onClick={@bound 'onClick'}>
-      <cite className='SidebarListItem-icon' />
       <span className='SidebarListItem-title'>{@props.title}</span>
       {@renderUnreadCount()}
     </Link>

--- a/client/ide/lib/styl/ide.styl
+++ b/client/ide/lib/styl/ide.styl
@@ -599,7 +599,7 @@ body.ide .dark .ide-files-tab .kdtabhandle.close-handle .icon
     display                 block
     float                   right
 
-  p
+  li
     color                   #D4CFC9
     padding                 5px 20px
     clear                   both

--- a/client/ide/lib/styl/ide.styl
+++ b/client/ide/lib/styl/ide.styl
@@ -723,16 +723,17 @@ body.ide .dark .ide-files-tab .kdtabhandle.close-handle .icon
       pointer()
       fr()
 
-      cite
-        display             block
+      &:before
+        dBlock()
+        content             ''
 
-      &.shortcuts cite
+      &.shortcuts:before
         r-sprite            'ide', 'keyboard'
 
       &.github cite
         r-sprite            'ide', 'github'
 
-      &.help cite
+      &.help:before
         margin-top          -1px
         r-sprite            'ide', 'help'
 

--- a/client/ide/lib/styl/ide.styl
+++ b/client/ide/lib/styl/ide.styl
@@ -588,7 +588,7 @@ body.ide .dark .ide-files-tab .kdtabhandle.close-handle .icon
     styleScrollBars         rgba(255,255,255,.25)
 
     > .kdscrollview > *
-      min-width             250px
+      min-width             248px
 
   .settings-header
     color                   text-color-green

--- a/client/ide/lib/views/statusbar/idestatusbar.coffee
+++ b/client/ide/lib/views/statusbar/idestatusbar.coffee
@@ -48,12 +48,12 @@ module.exports = class IDEStatusBar extends KDView
       callback : @bound 'handleSessionEnd'
 
     @addSubView new KDCustomHTMLView
-      partial  : '<cite></cite>'
+      tagName  : 'i'
       cssClass : 'icon help'
       click    : -> new HelpSupportModal
 
     @addSubView new KDCustomHTMLView
-      partial  : '<cite></cite>'
+      tagName  : 'i'
       cssClass : 'icon shortcuts'
       click    : (event) =>
         kd.utils.stopDOMEvent event

--- a/client/ide/lib/workspace/panes/settings/ideeditorsettingsview.coffee
+++ b/client/ide/lib/workspace/panes/settings/ideeditorsettingsview.coffee
@@ -144,32 +144,34 @@ module.exports = class IDEEditorSettingsView extends IDESettingsView
 
     """
       <div class="settings-header">Editor Settings</div>
-      <p>Enable autosave                        {{> @useAutosave}}</p>
-      <p>Use soft tabs                          {{> @useSoftTabs}}</p>
-      <p>Line numbers                           {{> @showGutter}}</p>
-      <p>
-        <span title="Remove pane when last tab closed">
-          Remove pane when last tab closed
-        </span>
-        {{> @enableAutoRemovePane}}
-      </p>
-      <p>Use word wrapping                      {{> @useWordWrap}}</p>
-      <p>Show print margin                      {{> @showPrintMargin}}</p>
-      <p>Highlight active line                  {{> @highlightActiveLine}}</p>
-      <p>Show invisibles                        {{> @showInvisibles}}</p>
-      <p>Use scroll past end                    {{> @scrollPastEnd}}</p>
-      <p>
-        <span title="Trim trailing whitespaces on save">
-          Trim trailing whitespaces on save
-        </span>
-        {{> @trimTrailingWhitespaces}}
-      </p>
-      <p>Enable autocomplete             {{> @enableAutocomplete}}</p>
-      <p>Enable emmet                    {{> @enableEmmet}}</p>
-      <p>Enable snippets                 {{> @enableSnippets}}</p>
-      <p>Enable brace, tag completion    {{> @enableBraceCompletion}}
-      <p class="with-select">Key binding {{> @keyboardHandler}}</p>
-      <p class="with-select">Font size   {{> @fontSize}}</p>
-      <p class="with-select">Theme       {{> @theme}}</p>
-      <p class="with-select">Tab size    {{> @tabSize}}</p>
+      <ul>
+        <li>Enable autosave                        {{> @useAutosave}}</li>
+        <li>Use soft tabs                          {{> @useSoftTabs}}</li>
+        <li>Line numbers                           {{> @showGutter}}</li>
+        <li>
+          <span title="Remove pane when last tab closed">
+            Remove pane when last tab closed
+          </span>
+          {{> @enableAutoRemovePane}}
+        </li>
+        <li>Use word wrapping                      {{> @useWordWrap}}</li>
+        <li>Show print margin                      {{> @showPrintMargin}}</li>
+        <li>Highlight active line                  {{> @highlightActiveLine}}</li>
+        <li>Show invisibles                        {{> @showInvisibles}}</li>
+        <li>Use scroll past end                    {{> @scrollPastEnd}}</li>
+        <li>
+          <span title="Trim trailing whitespaces on save">
+            Trim trailing whitespaces on save
+          </span>
+          {{> @trimTrailingWhitespaces}}
+        </li>
+        <li>Enable autocomplete             {{> @enableAutocomplete}}</li>
+        <li>Enable emmet                    {{> @enableEmmet}}</li>
+        <li>Enable snippets                 {{> @enableSnippets}}</li>
+        <li>Enable brace, tag completion    {{> @enableBraceCompletion}}</li>
+        <li class="with-select">Key binding {{> @keyboardHandler}}</li>
+        <li class="with-select">Font size   {{> @fontSize}}</li>
+        <li class="with-select">Theme       {{> @theme}}</li>
+        <li class="with-select">Tab size    {{> @tabSize}}</li>
+      <ul>
     """

--- a/client/ide/lib/workspace/panes/settings/ideterminalsettingsview.coffee
+++ b/client/ide/lib/workspace/panes/settings/ideterminalsettingsview.coffee
@@ -52,10 +52,12 @@ module.exports = class IDETerminalSettingsView extends IDESettingsView
   pistachio: ->
     """
       <div class="settings-header">Terminal Settings</div>
-      <p class="with-select">Font        {{> @font}}</p>
-      <p class="with-select">Font size   {{> @fontSize}}</p>
-      <p class="with-select">Theme       {{> @theme}}</p>
-      <p class="with-select">Scrollback  {{> @scrollback}}</p>
-      <p>Use visual bell                 {{> @visualBell}}</p>
-      <p>Blinking cursor                 {{> @blinkingCursor}}</p>
+      <ul>
+        <li class="with-select">Font        {{> @font}}</li>
+        <li class="with-select">Font size   {{> @fontSize}}</li>
+        <li class="with-select">Theme       {{> @theme}}</li>
+        <li class="with-select">Scrollback  {{> @scrollback}}</li>
+        <li>Use visual bell                 {{> @visualBell}}</li>
+        <li>Blinking cursor                 {{> @blinkingCursor}}</li>
+      </ul>
     """


### PR DESCRIPTION
`before:`
![](http://g.recordit.co/9MGWgI8c7a.gif)

`fixed version`
![](http://take.ms/cispV)

`before:`
![](http://g.recordit.co/nb2niPoL03.gif)

`after: used i elements instead of div and deleted unnecessary cite elements.`
![](http://g.recordit.co/bJ7Qpor7EU.gif)

`before:`
![](http://g.recordit.co/7c6RclknO8.gif)

`after: using li elements instead of p for listing`
![](http://g.recordit.co/zw67ED3az9.gif)

`before:`
![](http://g.recordit.co/Xg9HDnoO3z.gif)

`after: deleted unnecessary cite elements for icons`
![](http://g.recordit.co/7hk3rKcjdB.gif)

/cc @sinan @gokmen @fatihacet 
