### PR TITLE
api/sl: list instances via vlan pagination

### DIFF
--- a/go/src/koding/kites/kloud/api/sl/datacenter.go
+++ b/go/src/koding/kites/kloud/api/sl/datacenter.go
@@ -60,6 +60,13 @@ type LocaleTimezone struct {
 // filtering capabilities.
 type Datacenters []*Datacenter
 
+func (d Datacenters) Err() error {
+	if len(d) == 0 {
+		return errNotFound
+	}
+	return nil
+}
+
 // ByID filters the datacenters by id.
 func (d Datacenters) ByID(id int) Datacenters {
 	if id == 0 {

--- a/go/src/koding/kites/kloud/api/sl/instance.go
+++ b/go/src/koding/kites/kloud/api/sl/instance.go
@@ -21,7 +21,7 @@ type TagReference struct {
 }
 
 // instanceMask represents objectMask for the Instance struct.
-var instanceMask = ObjectMask((*Instance)(nil))
+var instanceMask = ObjectMask((*Instance)(nil), "networkVlans.virtualGuests")
 
 // Instance represents a Softlayer_Virtual_Guest resource.
 type Instance struct {
@@ -71,6 +71,13 @@ func (e *InstanceEntry) decode() {
 // Instances is a conveniance type for a list of instances that supports
 // filtering.
 type Instances []*Instance
+
+func (i Instances) Err() error {
+	if len(i) == 0 {
+		return errNotFound
+	}
+	return nil
+}
 
 // ByID filters the instances by ID.
 func (i Instances) ByID(id int) Instances {
@@ -131,6 +138,13 @@ func (i Instances) Swap(j, k int)      { i[j], i[k] = i[k], i[j] }
 // InstanceEntries is a conveniance type for a list of instance entries
 // that support filtering.
 type InstanceEntries []*InstanceEntry
+
+func (e InstanceEntries) Err() error {
+	if len(e) == 0 {
+		return errNotFound
+	}
+	return nil
+}
 
 // ByID filters the instance entries by ID.
 func (e InstanceEntries) ByID(id int) InstanceEntries {

--- a/go/src/koding/kites/kloud/api/sl/keys.go
+++ b/go/src/koding/kites/kloud/api/sl/keys.go
@@ -95,6 +95,13 @@ var keyMask = ObjectMask((*Key)(nil))
 // Keys is a helper type for a slice of keys that supports filtering.
 type Keys []*Key
 
+func (k Keys) Err() error {
+	if len(k) == 0 {
+		return errNotFound
+	}
+	return nil
+}
+
 // ByID returns a key with the given ID.
 func (k Keys) ByID(id int) Keys {
 	if id == 0 {

--- a/go/src/koding/kites/kloud/api/sl/objectmask.go
+++ b/go/src/koding/kites/kloud/api/sl/objectmask.go
@@ -13,6 +13,6 @@ var objectMask = &object.Builder{
 //
 // ObjectMask assumes each field we want to read from Softlayer API has
 // API name set in its json tag.
-func ObjectMask(v interface{}) []string {
-	return objectMask.Build(v).Keys()
+func ObjectMask(v interface{}, ignored ...string) []string {
+	return objectMask.Build(v, ignored...).Keys()
 }

--- a/go/src/koding/kites/kloud/api/sl/softlayer.go
+++ b/go/src/koding/kites/kloud/api/sl/softlayer.go
@@ -326,6 +326,25 @@ func (c *Softlayer) InstanceEntriesByFilter(filter *Filter) (InstanceEntries, er
 	return *req.Resource.(*InstanceEntries), nil
 }
 
+// InstancesInVlan fetches all instances within the VLAN given by the id.
+func (c *Softlayer) InstancesInVlan(id int) (Instances, error) {
+	req := &ResourceRequest{
+		Name:       "Vlan",
+		Path:       fmt.Sprintf("SoftLayer_Network_Vlan/%d/getObject.json", id),
+		ObjectMask: vlanInstancesMask,
+		Resource:   &VLAN{},
+	}
+	if err := c.get(req); err != nil {
+		return nil, err
+	}
+
+	i := Instances(req.Resource.(*VLAN).Instances)
+	if err := i.Err(); err != nil {
+		return nil, err
+	}
+	return i, nil
+}
+
 // XInstancesByFilter queries for keys, which are filtered on the server side
 // with the given filter.
 //

--- a/go/src/koding/kites/kloud/api/sl/template.go
+++ b/go/src/koding/kites/kloud/api/sl/template.go
@@ -132,6 +132,13 @@ func (t *Template) decode() {
 // filtering.
 type Templates []*Template
 
+func (t Templates) Err() error {
+	if len(t) == 0 {
+		return errNotFound
+	}
+	return nil
+}
+
 // Parent returns those templates, which have ParentID equal to 0.
 func (t Templates) Parent() Templates {
 	var parents []*Template


### PR DESCRIPTION
Official softlayer tool has problems listing vms:

```
~ $ slcli vm list
SoftLayerAPIError(SOAP-ENV:Server): Internal Error
```

This CL adds instance pagination via vlans, that is we obtain vm list from `Softlayer_Vlan` endpoint and not from `Softlayer_Virtual_Guests` one. It's a bit of hack, but works.

To list instances pick a vlan ID from `sl vlan list` and list vms for it, e.g.:

```
~ $ sl instance list -vlan 1171487
ID              Datacenter      Hostname                Tags
16171141        tok02           4xposed                 [koding-env=production,koding-domain=u4ks8e8d2a45.4xposed.koding.io,koding-user=4xposed,koding-machineid=56c7b4a6816fa94fc876f2fd]
16171527        tok02           adnbox                  [koding-env=production,koding-domain=uaks9b29acd7.adnbox.koding.io,koding-user=adnbox,koding-machineid=56c7b986816fa94fc876f31f]
16171541        tok02           aessaidi                [koding-env=production,koding-domain=uaks5241edc8.aessaidi.koding.io,koding-machineid=56c7b994816fa94fc876f321,koding-user=aessaidi]
16170781        tok02           alejoescobar            [koding-user=alejoescobar,koding-env=production,koding-machineid=56c7b23d816fa94fc876f2d7,koding-domain=uaksb2cd2c6c.alejoescobar.koding.io]
16170591        tok02           allenwyma               [koding-user=allenwyma,koding-machineid=56c7b0ef816fa94fc876f2cc,koding-domain=uaks8fdf4c60.allenwyma.koding.io,koding-env=production]
16170941        tok02           anhstein                [koding-domain=uaks9eb3cb93.anhstein.koding.io,koding-user=anhstein,koding-env=production,koding-machineid=56c7b35a816fa94fc876f2e8]
...
```

/cc @cihangir @sent-hil 
