### PR TITLE
TMS-829 IDE: Stack script notifications

### DIFF
--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -1102,7 +1102,7 @@ module.exports = class ComputeController extends KDController
       return callback null, template
 
 
-  showBuildLogs: (machine) ->
+  showBuildLogs: (machine, enableLineParser) ->
 
     # Not supported for Koding Group
     return  if isKoding()
@@ -1116,6 +1116,7 @@ module.exports = class ComputeController extends KDController
       description:
         "Your Koding Stack has successfully been initialized. The log here
          describes each executed step of the Stack creation process."
+      enableLineParser
     }
 
 

--- a/client/ide/lib/index.coffee
+++ b/client/ide/lib/index.coffee
@@ -445,14 +445,14 @@ class IDEAppController extends AppController
   ###
   tailFile: (options, callback = kd.noop) ->
 
-    { file, contents, targetTabView, description, emitChange } = options
+    { file, contents, targetTabView, description, emitChange, enableLineParser } = options
 
     targetTabView = @ideViews.first.tabView  unless targetTabView
 
     @setActiveTabView targetTabView
 
     @activeTabView.emit 'FileNeedsToBeTailed', {
-      file, contents, description, callback, emitChange
+      file, contents, description, callback, emitChange, enableLineParser
     }
 
 
@@ -1263,7 +1263,7 @@ class IDEAppController extends AppController
       else
         mainView.activitySidebar.selectWorkspace data
 
-      computeController.showBuildLogs machine  if initial
+      computeController.showBuildLogs machine, yes  if initial
 
       @emit 'IDEReady'
 

--- a/client/ide/lib/views/tabview/ideview.coffee
+++ b/client/ide/lib/views/tabview/ideview.coffee
@@ -319,7 +319,7 @@ module.exports = class IDEView extends IDEWorkspaceTabView
 
   tailFile: (options) ->
 
-    { file, content, callback, emitChange, description } = options
+    { file, content, callback, emitChange, description, enableLineParser } = options
 
     callback   ?= kd.noop
     emitChange ?= yes
@@ -335,7 +335,7 @@ module.exports = class IDEView extends IDEWorkspaceTabView
 
       content   or= ''
       tailerPane  = new IDETailerPane {
-        file, content, description, delegate: this, ideViewHash: @hash
+        file, content, description, delegate: this, ideViewHash: @hash, enableLineParser
       }
 
       paneOptions =

--- a/client/ide/lib/workspace/panes/idetailerpane.coffee
+++ b/client/ide/lib/workspace/panes/idetailerpane.coffee
@@ -1,8 +1,9 @@
-kd                 = require 'kd'
-FSFile             = require 'app/util/fs/fsfile'
-IDEPane            = require './idepane'
-AceView            = require 'ace/aceview'
-IDEAce             = require '../../views/ace/ideace'
+kd                      = require 'kd'
+FSFile                  = require 'app/util/fs/fsfile'
+IDEPane                 = require './idepane'
+AceView                 = require 'ace/aceview'
+IDEAce                  = require '../../views/ace/ideace'
+IDETailerPaneLineParser = require './idetailerpanelineparser'
 
 
 module.exports = class IDETailerPane extends IDEPane
@@ -25,6 +26,7 @@ module.exports = class IDETailerPane extends IDEPane
 
     @scrollToBottom()
     @getEditor().insert "\n#{newLine}"
+    IDETailerPaneLineParser.process newLine
 
 
   createEditor: ->

--- a/client/ide/lib/workspace/panes/idetailerpane.coffee
+++ b/client/ide/lib/workspace/panes/idetailerpane.coffee
@@ -21,12 +21,19 @@ module.exports = class IDETailerPane extends IDEPane
 
     @createEditor()
 
+    @enableLineParser = options.enableLineParser
+    unless @enableLineParser
+      # enable line parser with a delay to let the editor
+      # be filled in with existent file data since we don't
+      # need to run any parser action on existent content
+      kd.utils.wait 500, => @enableLineParser = yes
+
 
   handleFileUpdate: (newLine) ->
 
     @scrollToBottom()
     @getEditor().insert "\n#{newLine}"
-    IDETailerPaneLineParser.process newLine
+    IDETailerPaneLineParser.process newLine  if @enableLineParser
 
 
   createEditor: ->

--- a/client/ide/lib/workspace/panes/idetailerpanelineparser.coffee
+++ b/client/ide/lib/workspace/panes/idetailerpanelineparser.coffee
@@ -1,0 +1,30 @@
+kd                 = require 'kd'
+KDNotificationView = kd.NotificationView
+
+showDoneNotification = -> showNotification 'Provisioning Completed'
+
+
+showNotification = (message, duration = 2000) ->
+
+  new KDNotificationView
+    title    : message
+    duration : duration
+
+
+config = [
+  { template : '_KD_DONE_', fn : showDoneNotification }
+  { template : /^_KD_NOTIFY_@(.+)@$/, fn : showNotification }
+]
+
+
+module.exports = IDETailerPaneLineParser =
+
+  process: (line) ->
+
+    line = line.trim()
+    for { template, fn } in config
+      if template instanceof RegExp
+        match = line.match template
+        return fn.apply null, match.slice 1  if match
+      else if line is template
+        return fn()


### PR DESCRIPTION
@gokmen, can you please review these changes?
https://koding.atlassian.net/browse/TMS-829

The main idea is implemented in `IDETailerPaneLineParser`. There is a `config` object which describes all parser templates. Each template has either a string or regexp and a function to execute a code for template. A string template is used for simple cases when you exactly know that you're looking for a specific constant string. For example, `_KD_DONE_`. Regexp template is used when it's necessary to analyze a line and probably extract params from it. Extracted params are passed to execution function as arguments.
Actually all templates can be described with regexp but it's better to use strings where possible to improve performance.
So if you want to add a new template, you need to:
- describe a statement to match template in the line - string or regexp
- add a function with a code which should be called when template is matched

When a stack is re-initialized and VM is re-built, parser starts immediately right after `IDETailerPane` is created. In other cases (for example, when user has refreshed the page or opened the file manually), I added a 500ms delay for parser to avoid parser actions when editor is being filled in with existent file content
