### PR TITLE
[TMS-2222] Add Plan & Billing tab to Team Settings modal

### DIFF
--- a/client/admin/lib/index.coffee
+++ b/client/admin/lib/index.coffee
@@ -48,7 +48,7 @@ module.exports = class AdminAppController extends AppController
         }
         { slug : 'APIAccess',      title : 'API Access',        viewClass : AdminAPIView             }
         { slug : 'Logs',           title : 'Team Logs',         viewClass : LogsView                 }
-        { slug : 'Plan-Billing',   title : 'Plan & Billing',    viewClass : GroupPlanBillingView     }
+        # { slug : 'Plan-Billing',   title : 'Plan & Billing',    viewClass : GroupPlanBillingView     }
       ]
     koding     :
       title    : 'Koding Administration'

--- a/client/admin/lib/index.coffee
+++ b/client/admin/lib/index.coffee
@@ -13,6 +13,7 @@ TopicModerationView        = require './views/moderation/topicmoderationview'
 OnboardingAdminView        = require './views/onboarding/onboardingadminview'
 AdminInvitationsView       = require './views/invitations/admininvitationsview'
 GroupPermissionsView       = require './views/permissions/grouppermissionsview'
+GroupPlanBillingView       = require './views/plan-billing/groupplanbillingview'
 GroupsBlockedUserView      = require './views/members/groupsblockeduserview'
 AdminIntegrationsView      = require './views/integrations/adminintegrationsview'
 GroupGeneralSettingsView   = require './views/general/groupgeneralsettingsview'
@@ -47,6 +48,7 @@ module.exports = class AdminAppController extends AppController
         }
         { slug : 'APIAccess',      title : 'API Access',        viewClass : AdminAPIView             }
         { slug : 'Logs',           title : 'Team Logs',         viewClass : LogsView                 }
+        { slug : 'Plan-Billing',   title : 'Plan & Billing',    viewClass : GroupPlanBillingView     }
       ]
     koding     :
       title    : 'Koding Administration'

--- a/client/admin/lib/styl/app.group.admin.styl
+++ b/client/admin/lib/styl/app.group.admin.styl
@@ -1484,6 +1484,7 @@ Admin main styles
     &.members
     &.invitations
     &.integrations
+    &.plan-billing
       padding-top           40px
 
   .breadcrumb
@@ -1492,3 +1493,106 @@ Admin main styles
 
     .active
       font-weight           regular
+
+
+.AppModal--admin
+  .plan-billing
+    .kdtabhandle
+      a
+        noTextDeco()
+
+    .billing-info
+      > .kdview
+        padding-top         20px
+
+      section
+        margin-bottom       40px
+
+        .kdheaderview
+          font-size         14px
+          color             #787878
+          line-height       30px
+          padding           0 0 17px
+
+          span
+            margin          0
+
+          .kdbutton
+            fr()
+
+        .subscription
+          color             #434343
+          font-size         14px
+          line-height       20px
+          margin-top        15px
+
+        .listview-wrapper
+          margin-top        20px
+          font-size         14px
+
+        .payment-method
+          .billing-link
+            padding-left    0
+            float           none
+            height          30px
+            cf()
+
+          .credit-card-title
+            line-height     23px
+            height          23px
+            fl()
+
+          .icon
+            display         block
+            margin-right    5px
+            fl()
+
+            &.visa
+              r-sprite              'pricing', 'visa'
+            &.american-express
+              r-sprite              'pricing', 'american-express'
+            &.mastercard
+              r-sprite              'pricing', 'mastercard'
+            &.discover
+              r-sprite              'pricing', 'discover'
+
+    .teams-plan
+      .kdlistitemview
+        display             table
+        height              95px
+        border-bottom       2px solid #ECECEC
+
+        > *
+          display           table-cell
+          vertical-align    middle
+
+        .plan-name
+          width             120px
+          color             #7B7B7B
+          rel()
+          top               -10px
+
+        .plan-info
+          strong
+            color           #595959
+            font-weight     bold
+
+          i
+            color           #A59999
+            dBlock()
+            font-style      italic
+            font-size       14px
+
+        .button
+          width             120px
+          text-align        center
+
+          .kdview
+            color           #9F9F9F
+            text-transform  uppercase
+            margin-top      70px
+            font-size       14px
+
+            &.upgrade
+              color         #749DCE
+              cursor        pointer

--- a/client/admin/lib/views/plan-billing/groupbillinginfo.coffee
+++ b/client/admin/lib/views/plan-billing/groupbillinginfo.coffee
@@ -1,0 +1,5 @@
+kd              = require 'kd'
+AccountBilling  = require 'account/views/accountbilling'
+
+
+module.exports = class GroupBillingInfo extends AccountBilling

--- a/client/admin/lib/views/plan-billing/groupplanbillingview.coffee
+++ b/client/admin/lib/views/plan-billing/groupplanbillingview.coffee
@@ -1,0 +1,54 @@
+kd              = require 'kd'
+KDView          = kd.View
+KDTabView       = kd.TabView
+KDTabPaneView   = kd.TabPaneView
+
+GroupTeamsPlan    = require './groupteamsplan'
+GroupBillingInfo  = require './groupbillinginfo'
+GroupUsage        = require './groupusage'
+
+AdminSubTabHandleView = require 'admin/views/customviews/adminsubtabhandleview'
+
+
+module.exports = class GroupPlanBillingView extends KDView
+
+  PANE_NAMES_BY_ROUTE =
+    'Teams-Plan'    : 'Teams Plan'
+    'Billing-Info'  : 'Billing Info'
+    'Usage'         : 'Usage'
+
+
+  constructor: (options = {}, data) ->
+
+    options.cssClass = kd.utils.curry 'plan-biling-view', options.cssClass
+
+    super options, data
+
+    @createTabView()
+
+
+  createTabView: ->
+
+    rootPath = '/Admin/Plan-Billing'
+
+    @addSubView @tabView = new KDTabView
+      hideHandleCloseIcons : yes
+      tabHandleClass       : AdminSubTabHandleView
+
+    @tabView.addPane teamsTabView   = new KDTabPaneView
+      name    : PANE_NAMES_BY_ROUTE['Teams-Plan']
+      route   : "#{rootPath}/Teams-Plan"
+    @tabView.addPane billingView    = new KDTabPaneView
+      name    : PANE_NAMES_BY_ROUTE['Billing-Info']
+      route   : "#{rootPath}/Billing-Info"
+    @tabView.addPane usageView      = new KDTabPaneView
+      name    : PANE_NAMES_BY_ROUTE['Usage']
+      route   : "#{rootPath}/Usage"
+
+    teamsTabView.addSubView @teamsPlan    = new GroupTeamsPlan
+    billingView.addSubView  @billingInfo  = new GroupBillingInfo
+    billingView.addSubView  @usage        = new GroupUsage
+
+    @tabView.showPaneByIndex 0
+
+    @on 'SubTabRequested', (action, identifier) => @tabView.showPaneByName PANE_NAMES_BY_ROUTE[action]

--- a/client/admin/lib/views/plan-billing/groupplanitemview.coffee
+++ b/client/admin/lib/views/plan-billing/groupplanitemview.coffee
@@ -1,0 +1,39 @@
+kd              = require 'kd'
+JView           = require 'app/jview'
+KDView          = kd.View
+globals         = require 'globals'
+KDListItemView  = kd.ListItemView
+
+
+module.exports = class GroupPlanItemView extends KDListItemView
+
+  JView.mixin @prototype
+
+
+  constructor: (options = {}, data) ->
+
+    super options, data
+
+    { currentGroup }  = globals
+    isCurrent         = currentGroup.config?.plan is data.name
+    text              = if isCurrent then 'current' else 'upgrade'
+
+    @button = new KDView
+      partial   : text
+      cssClass  : text
+      click     : ->
+        return  if isCurrent
+
+
+  pistachio: ->
+
+    plan = @getData()
+
+    return """
+      <div class='plan-name'>#{plan.name}</div>
+      <div class='plan-info'>
+        <strong>max #{plan.member} member(s)</strong>
+        <i>Limited to #{plan.maxInstance} instance(s)</i>
+      </div>
+      <div class='button'>{{> @button}}</div>
+    """

--- a/client/admin/lib/views/plan-billing/groupteamsplan.coffee
+++ b/client/admin/lib/views/plan-billing/groupteamsplan.coffee
@@ -1,0 +1,52 @@
+kd                    = require 'kd'
+KDView                = kd.View
+GroupPlanItemView     = require './groupplanitemview'
+KDListViewController  = kd.ListViewController
+
+
+module.exports = class GroupTeamsPlan extends KDView
+
+
+  constructor: (options = {}, data) ->
+
+    options.listItemClass     or= GroupPlanItemView
+    options.fetcherMethodName or= 'list'
+
+    super options, data
+
+    @createListController()
+    @fetchPlans()
+
+
+  createListController: ->
+
+    @listController       = new KDListViewController
+      viewOptions         :
+        wrapper           : yes
+        itemClass         : @getOptions().listItemClass
+      useCustomScrollView : yes
+      noItemFoundWidget   : new kd.CustomHTMLView
+        cssClass          : 'hidden no-item-found'
+        partial           : 'No plan available.'
+      startWithLazyLoader : yes
+      lazyLoaderOptions   :
+        spinnerOptions    :
+          size            : width: 28
+
+    @addSubView @listController.getView()
+
+    @listController.on 'AllItemsAddedToList', => @listController.lazyLoader.hide()
+
+
+  fetchPlans: ->
+
+    { computeController } = kd.singletons
+
+    computeController.fetchTeamPlans (plans) =>
+
+      Object.keys(plans).forEach (key) =>
+
+        plan      = plans[key]
+        plan.name = key
+
+        @listController.addItem plan

--- a/client/admin/lib/views/plan-billing/groupusage.coffee
+++ b/client/admin/lib/views/plan-billing/groupusage.coffee
@@ -1,0 +1,5 @@
+kd      = require 'kd'
+KDView  = kd.View
+
+
+module.exports = class GroupUsage extends KDView

--- a/workers/social/lib/social/models/computeproviders/computeprovider.coffee
+++ b/workers/social/lib/social/models/computeproviders/computeprovider.coffee
@@ -188,9 +188,8 @@ module.exports = class ComputeProvider extends Base
       callback null, PLANS
 
 
-  @fetchTeamPlans = permit
-    advanced : [{ permission: 'sudoer', superadmin: yes }]
-    success  : (client, callback) ->
+  @fetchTeamPlans = permit 'create machines',
+    success: (client, callback) ->
       callback null, teamutils.TEAMPLANS
 
 

--- a/workers/social/lib/social/models/computeproviders/computeprovider.test.coffee
+++ b/workers/social/lib/social/models/computeproviders/computeprovider.test.coffee
@@ -202,14 +202,6 @@ runTests = -> describe 'workers.social.models.computeproviders.computeprovider',
 
       expectAccessDenied ComputeProvider, 'fetchTeamPlans', done
 
-    it 'should fail if user doesnt have permission', (done) ->
-
-      withConvertedUser ({ client }) ->
-
-        ComputeProvider.fetchTeamPlans client, (err, plans) ->
-          expect(err).to.exist
-          expect(err.message).to.be.equal 'Access denied'
-          done()
 
     it 'should be able to fetch team plans for koding admins', (done) ->
 


### PR DESCRIPTION
/cc @koding/frontend 

https://koding.atlassian.net/browse/TMS-2222

Foot note: `UPGARDE` and `CURRENT` texts or buttons don't have any action for now. Also `Billing Info` shows payment info & history of current user. Because it is extended from `AccountBilling` component. This view or working logic will be changed when back-end side is ready. 
##### Routes:
- `/Admin/Plan-Billing/Billing-Info`
- `/Admin/Plan-Billing/Teams-Plan`
- `/Admin/Plan-Billing/Usage`

Also can someone add `wip` label? As far as i know back-end side is not ready or i can close `Plan & Billing` navigation item from `Team Settings`. Which is the best way to handle this situation? What do you think?

![screen shot 2016-02-23 at 4 12 03 pm](https://cloud.githubusercontent.com/assets/728733/13254174/eba8f0b6-da48-11e5-8e50-d31d6db5d5af.png)
![screen shot 2016-02-23 at 4 12 09 pm](https://cloud.githubusercontent.com/assets/728733/13254175/ebacddfc-da48-11e5-96e1-143aa333cf72.png)
