### PR TITLE
[TMS-2409] Stack Catalog: Crendetials: Fix slipped warning text issue

### DIFF
--- a/client/app/lib/stacks/credentiallistitem.coffee
+++ b/client/app/lib/stacks/credentiallistitem.coffee
@@ -57,9 +57,11 @@ module.exports = class CredentialListItem extends kd.ListItemView
   setVerified: (state, reason) ->
 
     if state
+      @unsetClass 'failed'
       @warningView.hide()
       @getDelegate().emit 'ItemSelected', this
     else
+      @setClass 'failed'
       @warningView.updatePartial if reason
         "Failed to verify: #{reason}"
       else

--- a/client/stacks/lib/styl/app.stacks.styl
+++ b/client/stacks/lib/styl/app.stacks.styl
@@ -503,6 +503,11 @@ Stacks main styles
 .AppModal--admin .stacks-v2
 
   .credential-list
+    .credential-item
+      &.failed
+        .buttons
+          top               26px !important
+
     .buttons
       width                 400px
 


### PR DESCRIPTION
/cc @fatihacet @gokmen 

https://koding.atlassian.net/browse/TMS-2409
#### Issue

<img width="782" alt="or" src="https://cloud.githubusercontent.com/assets/728733/13303736/b1aa26ca-db59-11e5-8e4a-61cd12874766.png">
#### After

![e](https://cloud.githubusercontent.com/assets/728733/13303738/b8e2f4da-db59-11e5-9f0e-c925e79d3338.png)
![e1](https://cloud.githubusercontent.com/assets/728733/13303739/b908f40a-db59-11e5-974a-c573be955648.png)
![e2](https://cloud.githubusercontent.com/assets/728733/13303740/b9148f7c-db59-11e5-8e3b-af4ca89d8c98.png)
