### PR TITLE
TMS-2397 Stack credential: remove interpolation characters replacement of __rawContent

### DIFF
--- a/client/stacks/lib/views/stacks/variablesview.coffee
+++ b/client/stacks/lib/views/stacks/variablesview.coffee
@@ -116,7 +116,6 @@ module.exports = class VariablesView extends StackBaseEditorTabView
       @_providedData = {}
       @setState 'INVALID'
     else
-      content = helper.encodeRawContent content
       @_providedData = _.extend converted.contentObject, { __rawContent : content }
       @handleDataChange()
 
@@ -155,27 +154,7 @@ module.exports = class VariablesView extends StackBaseEditorTabView
         { meta } = data
         if (Object.keys meta).length
           content = if rawContent = meta.__rawContent
-          then helper.decodeRawContent rawContent
+          then rawContent
           else (jsonToYaml meta).content
 
-          @getAce().setContent content
-
-
-  helper =
-
-    encodeRawContent: (content) ->
-
-      content
-        .replace '$', encodeURIComponent('$'), 'g'
-        .replace '{', encodeURIComponent('{'), 'g'
-        .replace '}', encodeURIComponent('}'), 'g'
-
-
-    decodeRawContent: (content) ->
-
-      _.unescape(
-        content
-          .replace encodeURIComponent('$'), '$', 'g'
-          .replace encodeURIComponent('{'), '{', 'g'
-          .replace encodeURIComponent('}'), '}', 'g'
-      )
+          @getAce().setContent _.unescape content


### PR DESCRIPTION
@gokmen, please review this fix for https://koding.atlassian.net/browse/TMS-2397. It removes that tricky replacement helper after Rafal's changes in https://koding.atlassian.net/browse/TMS-2452
