### PR TITLE
[TMS-2461] Collaboration: Prevent to race condition

### DIFF
--- a/client/ide/lib/collaborationcontroller.coffee
+++ b/client/ide/lib/collaborationcontroller.coffee
@@ -152,6 +152,9 @@ module.exports = CollaborationController =
     @removeParticipant username
     @removeWorkspaceSnapshot username
 
+    @unwatchParticipant username
+    @removeParticipantPermissions username
+
     options = {
       username
       machineUId : @mountedMachineUId
@@ -387,8 +390,6 @@ module.exports = CollaborationController =
       { nickname } = account.profile
 
       @statusBar.removeParticipantAvatar nickname
-      @unwatchParticipant nickname
-      @removeParticipantPermissions nickname
 
 
   participantAdded: (participant) ->


### PR DESCRIPTION
/cc @koding/frontend 

https://koding.atlassian.net/browse/TMS-2461

We were getting `delete of null` error message when participant leaves from session. Because we were calling 2 methods about `rtm` things from wrong places and in wrong times. I fixed this stuff with this pr.
#### Error

![jabba - c2 a0koding 7c ide 2016-02-26 19-01-54](https://cloud.githubusercontent.com/assets/728733/13475056/7724df7a-e0c9-11e5-9ae0-76f650883f53.png)
