### PR TITLE
ide: destroy split view on clearing layout

### DIFF
--- a/client/ide/lib/workspace/idelayoutmanager.coffee
+++ b/client/ide/lib/workspace/idelayoutmanager.coffee
@@ -307,7 +307,7 @@ module.exports = class IDELayoutManager extends KDObject
     ideView         = new IDEView
     ideApp.ideViews = []  # Reset `ideViews`s array
 
-    splitView.detach()
+    splitView.destroy()
 
     parentView.addSubView ideView
 


### PR DESCRIPTION
@GokhanTurunc, can you please take a look at this fix? I think I found the root cause of https://koding.atlassian.net/browse/TMS-2486. Currently if ide layout is cleared, old split view is not destroyed but detached. From what I see in the code it's not used elsewhere in the code after it's detached. However, it keep listening to window resize events. After collaboration session is ended, we call `windowController.notifyWindowResizeListeners()` (https://github.com/koding/koding/blob/master/client/ide/lib/index.coffee#L106) and it leads to call of `saveLayoutSize()` by detached split view (https://github.com/koding/koding/blob/master/client/ide/lib/index.coffee#L307) which, in its turn, throws exception since it's called on destroyed app.
If we destroy split view while clearing layour, it stops listening to window resize event and no exception happens.
If detaching split view is implemented on purpose and my change may break something, I'll revert it and implement a defensive check (`return  if @isDestroyed`) as you suggested in https://koding.atlassian.net/browse/TMS-2486?focusedCommentId=28475&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-28475 which is also a good solution

/cc @fatihacet
