### PR TITLE
stackplan: interpolate user_data only for build stack requests

### DIFF
--- a/go/src/koding/kites/kloud/provider/aws/apply.go
+++ b/go/src/koding/kites/kloud/provider/aws/apply.go
@@ -189,7 +189,7 @@ func (s *Stack) destroy(ctx context.Context, username, groupname, stackID string
 		}
 	}
 
-	if _, err := s.InjectAWSData(ctx, username); err != nil {
+	if _, err := s.InjectAWSData(ctx, username, false); err != nil {
 		return err
 	}
 
@@ -315,7 +315,7 @@ func (s *Stack) apply(ctx context.Context, username, groupname, stackID string) 
 		}
 	}
 
-	kiteIDs, err := s.InjectAWSData(ctx, username)
+	kiteIDs, err := s.InjectAWSData(ctx, username, true)
 	if err != nil {
 		return err
 	}

--- a/go/src/koding/kites/kloud/provider/aws/plan.go
+++ b/go/src/koding/kites/kloud/provider/aws/plan.go
@@ -89,7 +89,7 @@ func (s *Stack) Plan(ctx context.Context) (interface{}, error) {
 
 	s.Log.Debug("Injecting AWS data")
 
-	if _, err := s.InjectAWSData(ctx, s.Req.Username); err != nil {
+	if _, err := s.InjectAWSData(ctx, s.Req.Username, true); err != nil {
 		return nil, err
 	}
 

--- a/go/src/koding/kites/kloud/provider/aws/stackplan.go
+++ b/go/src/koding/kites/kloud/provider/aws/stackplan.go
@@ -42,7 +42,7 @@ func (s *Stack) SetAwsRegion(region string) error {
 	return t.Flush()
 }
 
-func (s *Stack) InjectAWSData(ctx context.Context, username string) (stackplan.KiteMap, error) {
+func (s *Stack) InjectAWSData(ctx context.Context, username string, expandUserData bool) (stackplan.KiteMap, error) {
 	t := s.Builder.Template
 
 	sess, ok := session.FromContext(ctx)
@@ -140,7 +140,7 @@ func (s *Stack) InjectAWSData(ctx context.Context, username string) (stackplan.K
 		//
 		//   https://github.com/hashicorp/terraform/issues/4084
 		//
-		if cmd, ok := instance["user_data"].(string); ok {
+		if cmd, ok := instance["user_data"].(string); ok && expandUserData {
 			userCfg.UserData = fmt.Sprintf("${base64encode(null_resource.%s.triggers.user_data)}", resourceName)
 
 			nullRes, ok := t.Resource["null_resource"].(map[string]interface{})


### PR DESCRIPTION
It fixes stack destroy issues without the need to save the template - it's not possible to save broken template, as plan request will fail (it validates the stack template). The only exception to this guarantee are `${var.useInput_*}` variables, as kloud is ignoring them during plan validation. So it's enough to not interpolate user_data on destroy, as it's the only place where userInput variables may be inserted.

/cc @koding/godevs
