### PR TITLE
TMS-2275 cleaner: delete jMachine documents for terminated instances

### DIFF
--- a/go/src/koding/kites/kloud/cleaners/cmd/cleaner/cleaner.go
+++ b/go/src/koding/kites/kloud/cleaners/cmd/cleaner/cleaner.go
@@ -19,12 +19,13 @@ import (
 )
 
 type Cleaner struct {
-	AWS      *lookup.Lookup
-	MongoDB  *lookup.MongoDB
-	Postgres *lookup.Postgres
-	DNS      *dnsclient.Route53
-	DNSDev   *dnsclient.Route53
-	Domains  dnsstorage.Storage
+	AWS            *lookup.Lookup
+	MongoDB        *lookup.MongoDB
+	SandboxMongoDB *lookup.MongoDB
+	Postgres       *lookup.Postgres
+	DNS            *dnsclient.Route53
+	DNSDev         *dnsclient.Route53
+	Domains        dnsstorage.Storage
 
 	Hook   Hook
 	Log    logging.Logger
@@ -65,7 +66,7 @@ func NewCleaner(conf *Config) *Cleaner {
 
 	m := lookup.NewMongoDB(conf.MongoURL)
 
-	l, err := lookup.NewAWS(opts, m.DB)
+	l, err := lookup.NewAWS(opts)
 	if err != nil {
 		panic(err)
 	}
@@ -106,15 +107,16 @@ func NewCleaner(conf *Config) *Cleaner {
 	}
 
 	return &Cleaner{
-		AWS:      l,
-		MongoDB:  m,
-		Postgres: p,
-		DNS:      dns,
-		DNSDev:   dnsdev,
-		Domains:  domains,
-		Hook:     hook,
-		Log:      common.NewLogger("cleaner", conf.Debug),
-		Config:   conf,
+		AWS:            l,
+		MongoDB:        m,
+		SandboxMongoDB: lookup.NewMongoDB(conf.SandboxMongoURL),
+		Postgres:       p,
+		DNS:            dns,
+		DNSDev:         dnsdev,
+		Domains:        domains,
+		Hook:           hook,
+		Log:            common.NewLogger("cleaner", conf.Debug),
+		Config:         conf,
 	}
 }
 

--- a/go/src/koding/kites/kloud/cleaners/cmd/cleaner/cleaner.go
+++ b/go/src/koding/kites/kloud/cleaners/cmd/cleaner/cleaner.go
@@ -63,11 +63,12 @@ func NewCleaner(conf *Config) *Cleaner {
 		MaxResults:  int64(conf.MaxResults),
 	}
 
-	l, err := lookup.NewAWS(opts)
+	m := lookup.NewMongoDB(conf.MongoURL)
+
+	l, err := lookup.NewAWS(opts, m.DB)
 	if err != nil {
 		panic(err)
 	}
-	m := lookup.NewMongoDB(conf.MongoURL)
 
 	dnsOpts := &dnsclient.Options{
 		Creds:      creds,

--- a/go/src/koding/kites/kloud/cleaners/cmd/cleaner/main.go
+++ b/go/src/koding/kites/kloud/cleaners/cmd/cleaner/main.go
@@ -23,7 +23,8 @@ type Config struct {
 	}
 
 	// MongoDB
-	MongoURL string `required:"true"`
+	MongoURL        string `required:"true"`
+	SandboxMongoURL string `required:"true"`
 
 	// Postgres
 	Postgres struct {
@@ -223,6 +224,7 @@ func (c *Cleaner) collectAndProcess() error {
 		//},
 		&TestVMS{
 			Instances: artifacts.Instances,
+			MongoDB:   c.SandboxMongoDB.DB,
 		},
 		&TestDomains{
 			DNS: c.DNSDev,

--- a/go/src/koding/kites/kloud/cleaners/cmd/cleaner/testvms.go
+++ b/go/src/koding/kites/kloud/cleaners/cmd/cleaner/testvms.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"koding/db/mongodb"
 	"koding/kites/kloud/cleaners/lookup"
 	"strings"
 	"time"
@@ -9,6 +10,7 @@ import (
 
 type TestVMS struct {
 	Instances *lookup.MultiInstances
+	MongoDB   *mongodb.MongoDB
 
 	testInstances *lookup.MultiInstances
 }
@@ -26,6 +28,7 @@ func (t *TestVMS) Run() {
 	}
 
 	t.testInstances.TerminateAll()
+	t.testInstances.DeleteDocs(t.MongoDB)
 }
 
 func (t *TestVMS) Result() string {

--- a/go/src/koding/kites/kloud/cleaners/lookup/lookup.go
+++ b/go/src/koding/kites/kloud/cleaners/lookup/lookup.go
@@ -1,7 +1,6 @@
 package lookup
 
 import (
-	"koding/db/mongodb"
 	"koding/kites/kloud/api/amazon"
 
 	"github.com/koding/logging"
@@ -15,13 +14,12 @@ type Lookup struct {
 	values  []string
 	clients *amazon.Clients
 	log     logging.Logger
-	db      *mongodb.MongoDB
 }
 
 // NewAWS gives new Lookup client.
 //
 // When opts.Log is nil, defaultLogger is used instead.
-func NewAWS(opts *amazon.ClientOptions, db *mongodb.MongoDB) (*Lookup, error) {
+func NewAWS(opts *amazon.ClientOptions) (*Lookup, error) {
 	optsCopy := *opts
 	if optsCopy.Log == nil {
 		optsCopy.Log = defaultLogger
@@ -33,7 +31,6 @@ func NewAWS(opts *amazon.ClientOptions, db *mongodb.MongoDB) (*Lookup, error) {
 	return &Lookup{
 		clients: clients,
 		log:     optsCopy.Log,
-		db:      db,
 	}, nil
 }
 
@@ -44,7 +41,7 @@ func (l *Lookup) FetchIpAddresses() *Addresses {
 
 // FetchInstances fetches all instances from all regions
 func (l *Lookup) FetchInstances() *MultiInstances {
-	return NewMultiInstances(l.clients, l.db, l.log)
+	return NewMultiInstances(l.clients, l.log)
 }
 
 // FetchVolumes fetches all instances from all regions

--- a/go/src/koding/kites/kloud/cleaners/lookup/lookup.go
+++ b/go/src/koding/kites/kloud/cleaners/lookup/lookup.go
@@ -1,6 +1,7 @@
 package lookup
 
 import (
+	"koding/db/mongodb"
 	"koding/kites/kloud/api/amazon"
 
 	"github.com/koding/logging"
@@ -14,12 +15,13 @@ type Lookup struct {
 	values  []string
 	clients *amazon.Clients
 	log     logging.Logger
+	db      *mongodb.MongoDB
 }
 
 // NewAWS gives new Lookup client.
 //
 // When opts.Log is nil, defaultLogger is used instead.
-func NewAWS(opts *amazon.ClientOptions) (*Lookup, error) {
+func NewAWS(opts *amazon.ClientOptions, db *mongodb.MongoDB) (*Lookup, error) {
 	optsCopy := *opts
 	if optsCopy.Log == nil {
 		optsCopy.Log = defaultLogger
@@ -31,6 +33,7 @@ func NewAWS(opts *amazon.ClientOptions) (*Lookup, error) {
 	return &Lookup{
 		clients: clients,
 		log:     optsCopy.Log,
+		db:      db,
 	}, nil
 }
 
@@ -41,7 +44,7 @@ func (l *Lookup) FetchIpAddresses() *Addresses {
 
 // FetchInstances fetches all instances from all regions
 func (l *Lookup) FetchInstances() *MultiInstances {
-	return NewMultiInstances(l.clients, l.log)
+	return NewMultiInstances(l.clients, l.db, l.log)
 }
 
 // FetchVolumes fetches all instances from all regions

--- a/go/src/koding/kites/kloud/cleaners/lookup/multiinstances.go
+++ b/go/src/koding/kites/kloud/cleaners/lookup/multiinstances.go
@@ -173,7 +173,7 @@ func (m *MultiInstances) TerminateAll() {
 	wg.Wait()
 }
 
-// TerminateAll terminates all instances
+// StopAll stops all instances.
 func (m *MultiInstances) StopAll() {
 	if len(m.m) == 0 {
 		return


### PR DESCRIPTION
This CL makes the cleaner delete jMachines document for deleted instance on sandbox environment. Even thought the code is generic to always remove a doc if it can find one, we terminate a EC2 instance on production only if it does not exist in Mongo or is not tagged (so-called ghost instances). So the only documents that will eventually get deleted are those for sandbox instances.

/cc @koding/godevs 

https://koding.atlassian.net/browse/TMS-2275
