### PR TITLE
TMS-2510 fuseklient: on rename don't remove from memory till remote op. succeeds

### DIFF
--- a/go/src/koding/fuseklient/dir.go
+++ b/go/src/koding/fuseklient/dir.go
@@ -209,11 +209,6 @@ func (d *Dir) MoveEntry(oldName, newName string, newDir *Dir) (Node, error) {
 		return nil, err
 	}
 
-	removedEntry, err := d.removeChild(oldName)
-	if err != nil {
-		return nil, err
-	}
-
 	oldPath := d.GetPathForEntry(oldName)
 	newPath := newDir.GetPathForEntry(newName)
 
@@ -228,6 +223,11 @@ func (d *Dir) MoveEntry(oldName, newName string, newDir *Dir) (Node, error) {
 	}
 
 	newEntry, err := newDir.initializeChild(e)
+	if err != nil {
+		return nil, err
+	}
+
+	removedEntry, err := d.removeChild(oldName)
 	if err != nil {
 		return nil, err
 	}

--- a/go/src/koding/fuseklient/dir_test.go
+++ b/go/src/koding/fuseklient/dir_test.go
@@ -713,6 +713,7 @@ func newFakeTransport() *fakeTransport {
 			"fs.createDirectory": true,
 			"fs.remove":          true,
 			"fs.readFile":        map[string]interface{}{"content": c},
+			"fs.getDiskInfo":     transport.GetDiskInfoRes{},
 			"fs.getInfo": transport.GetInfoRes{
 				Exists:   true,
 				IsDir:    true,
@@ -742,21 +743,6 @@ func newFakeTransport() *fakeTransport {
 			},
 		},
 	}
-}
-
-func newErrorTransport(m string, e error) *errorTransport {
-	f := newFakeTransport()
-
-	return &errorTransport{
-		fakeTransport: f,
-		ErrorResponses: map[string]error{
-			m: e,
-		},
-	}
-}
-
-func newWriteErrTransport() *errorTransport {
-	return newErrorTransport("fs.writeFile", fuse.EIO)
 }
 
 func newDir() *Dir {

--- a/go/src/koding/fuseklient/kodingnetworkfs.go
+++ b/go/src/koding/fuseklient/kodingnetworkfs.go
@@ -507,6 +507,10 @@ func (k *KodingNetworkFS) SetInodeAttributes(ctx context.Context, op *fuseops.Se
 		if *op.Size == 0 {
 			if file, ok := entry.(*File); ok {
 				file.WriteAt([]byte{}, 0)
+
+				if err := file.Flush(); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/go/src/koding/fuseklient/kodingnetworkfs_test.go
+++ b/go/src/koding/fuseklient/kodingnetworkfs_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/fuse/fuseutil"
+	"github.com/koding/kite"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -44,6 +45,202 @@ func TestKodingNetworkFSPrefetch(t *testing.T) {
 	defer _unmount(k)
 
 	fusetest.RunAllTests(t, k.MountPath)
+}
+
+func TestRemoteError(t *testing.T) {
+	Convey("Given folder is mounted, but remote return errs", t, func() {
+		var (
+			rNode fuseops.InodeID = 1
+
+			err = &kite.Error{
+				Type:    "timeout",
+				Message: `No response to "method"`,
+			}
+			f = newFakeTransport()
+		)
+
+		Convey("Rename", func() {
+			e := newErrorTransport("fs.rename", err)
+			e.fakeTransport = f
+
+			k := newknfs(e)
+
+			Convey("It should return when trying to rename entry", func() {
+				op := &fuseops.RenameOp{
+					OldParent: rNode,
+					NewParent: rNode,
+					OldName:   "file", // file is returned part of ReadDir() resp.
+					NewName:   "renamed",
+				}
+				So(k.Rename(context.TODO(), op), ShouldEqual, syscall.ECONNREFUSED)
+
+				Convey("It should not rename file in memory", func() {
+					So(len(k.liveNodes), ShouldEqual, 1)
+
+					rootDir, _ := k.liveNodes[rNode].(*Dir)
+					_, err := rootDir.FindEntry("renamed")
+					So(err, ShouldEqual, fuse.ENOENT)
+
+					_, err = rootDir.FindEntry("file")
+					So(err, ShouldBeNil)
+				})
+			})
+		})
+
+		Convey("SetInodeAttributes", func() {
+			e := newErrorTransport("fs.writeFile", err)
+			e.fakeTransport = f
+
+			k := newknfs(e)
+
+			// add file to inodes so it can fetched in below op
+			rootDir, _ := k.liveNodes[rNode].(*Dir)
+			file, err := rootDir.FindEntryFile("file")
+			So(err, ShouldBeNil)
+			k.liveNodes[2] = file
+
+			Convey("It should return err when trying to truncate file", func() {
+				var size uint64 = 0
+
+				op := &fuseops.SetInodeAttributesOp{
+					Inode: 2,
+					Size:  &size,
+				}
+				So(k.SetInodeAttributes(context.TODO(), op), ShouldEqual, syscall.ECONNREFUSED)
+			})
+		})
+
+		Convey("Unlink", func() {
+			e := newErrorTransport("fs.remove", err)
+			e.fakeTransport = f
+
+			k := newknfs(e)
+
+			Convey("It should return when trying to remove file", func() {
+				op := &fuseops.UnlinkOp{
+					Parent: rNode,
+					Name:   "file", // file is returned part of ReadDir() resp.
+				}
+				So(k.Unlink(context.TODO(), op), ShouldEqual, syscall.ECONNREFUSED)
+
+				Convey("It should not remove file from memory", func() {
+					So(len(k.liveNodes), ShouldEqual, 1)
+
+					rootDir, _ := k.liveNodes[rNode].(*Dir)
+					_, err := rootDir.FindEntry("file")
+					So(err, ShouldBeNil)
+				})
+			})
+		})
+
+		Convey("MkDir", func() {
+			e := newErrorTransport("fs.createDirectory", err)
+			e.fakeTransport = f
+
+			k := newknfs(e)
+
+			Convey("It should return when trying to make dir", func() {
+				op := &fuseops.MkDirOp{
+					Parent: rNode,
+					Name:   "newdir",
+				}
+				So(k.MkDir(context.TODO(), op), ShouldEqual, syscall.ECONNREFUSED)
+
+				Convey("It should not add dir to memory", func() {
+					So(len(k.liveNodes), ShouldEqual, 1)
+
+					rootDir, _ := k.liveNodes[rNode].(*Dir)
+					_, err := rootDir.FindEntry("newdir")
+					So(err, ShouldEqual, fuse.ENOENT)
+				})
+			})
+		})
+
+		Convey("RmDir", func() {
+			e := newErrorTransport("fs.remove", err)
+			e.fakeTransport = f
+
+			k := newknfs(e)
+
+			Convey("It should return when trying remove dir", func() {
+				op := &fuseops.RmDirOp{
+					Parent: rNode,
+					Name:   "folder", // folder is returned part of ReadDir() resp.
+				}
+				So(k.RmDir(context.TODO(), op), ShouldEqual, syscall.ECONNREFUSED)
+
+				Convey("It should not remove file from memory", func() {
+					So(len(k.liveNodes), ShouldEqual, 1)
+
+					rootDir, _ := k.liveNodes[rNode].(*Dir)
+					_, err := rootDir.FindEntry("folder")
+					So(err, ShouldBeNil)
+				})
+			})
+		})
+
+		Convey("CreateFile", func() {
+			e := newErrorTransport("fs.writeFile", err)
+			e.fakeTransport = f
+
+			k := newknfs(e)
+
+			Convey("It should return err when trying to create file", func() {
+				op := &fuseops.CreateFileOp{
+					Parent: rNode,
+					Name:   "newfile",
+				}
+				So(k.CreateFile(context.TODO(), op), ShouldEqual, syscall.ECONNREFUSED)
+
+				Convey("It should not add file to memory", func() {
+					So(len(k.liveNodes), ShouldEqual, 1)
+
+					rootDir, _ := k.liveNodes[rNode].(*Dir)
+					_, err := rootDir.FindEntry("newfile")
+					So(err, ShouldEqual, fuse.ENOENT)
+				})
+			})
+		})
+
+		Convey("Write", func() {
+			e := newErrorTransport("fs.writeFile", err)
+			e.fakeTransport = f
+
+			k := newknfs(e)
+
+			// add file to inodes so it can fetched in below op
+			rootDir, _ := k.liveNodes[rNode].(*Dir)
+			file, err := rootDir.FindEntryFile("file")
+			So(err, ShouldBeNil)
+
+			k.liveNodes[2] = file
+
+			op := &fuseops.WriteFileOp{
+				Inode:  2,
+				Offset: 0,
+				Data:   []byte("overwritten"),
+			}
+			So(k.WriteFile(context.TODO(), op), ShouldBeNil)
+
+			Convey("FlushFile", func() {
+				Convey("It should return err when flushing file", func() {
+					op := &fuseops.FlushFileOp{
+						Inode: 2,
+					}
+					So(k.FlushFile(context.TODO(), op), ShouldEqual, syscall.ECONNREFUSED)
+				})
+			})
+
+			Convey("SyncFile", func() {
+				Convey("It should return err when syncing file", func() {
+					op := &fuseops.SyncFileOp{
+						Inode: 2,
+					}
+					So(k.SyncFile(context.TODO(), op), ShouldEqual, syscall.ECONNREFUSED)
+				})
+			})
+		})
+	})
 }
 
 func TestKodingNetworkFSAdditional(tt *testing.T) {

--- a/go/src/koding/fuseklient/transport/remotetransport.go
+++ b/go/src/koding/fuseklient/transport/remotetransport.go
@@ -181,7 +181,7 @@ func (r *RemoteTransport) relativePath(path string) string {
 func (r *RemoteTransport) trip(methodName string, req interface{}, res interface{}) error {
 	raw, err := r.Client.TellWithTimeout(methodName, r.TellTimeout, req)
 	if err != nil {
-		if isKiteConnectionErr(err) {
+		if IsKiteConnectionErr(err) {
 			return syscall.ECONNREFUSED
 		}
 		return err
@@ -192,12 +192,12 @@ func (r *RemoteTransport) trip(methodName string, req interface{}, res interface
 
 ///// Kite error checkers
 
-func isKiteMethodNotFoundErr(err error) bool {
+func IsKiteMethodNotFoundErr(err error) bool {
 	kiteErr, ok := err.(*kite.Error)
 	return ok && kiteErr.Type != "methodNotFound"
 }
 
-func isKiteConnectionErr(err error) bool {
+func IsKiteConnectionErr(err error) bool {
 	kiteError, ok := err.(*kite.Error)
 	switch {
 	case !ok:


### PR DESCRIPTION
Aside from couple changes [here](https://github.com/koding/koding/pull/7066/files#diff-77e221458a06468037d396583b2bcd2dR230) and [here](https://github.com/koding/koding/pull/7066/files#diff-6238b41bb00eb0c5ed2deeed4ce2b7e8R511), this PR is mostly about tests.
