### PR TITLE
TMS-2511 kite: remove adding 'nbf' to token generated from kontrol to avoid  dealing with clock drift problems in VMs

### DIFF
--- a/go/src/github.com/koding/kite/kontrol/kontrol.go
+++ b/go/src/github.com/koding/kite/kontrol/kontrol.go
@@ -372,7 +372,6 @@ func generateToken(aud, username, issuer, privateKey string) (string, error) {
 	tkn.Claims["sub"] = username                                     // Subject
 	tkn.Claims["aud"] = aud                                          // Audience
 	tkn.Claims["exp"] = time.Now().UTC().Add(ttl).Add(leeway).Unix() // Expiration Time
-	tkn.Claims["nbf"] = time.Now().UTC().Add(-leeway).Unix()         // Not Before
 	tkn.Claims["iat"] = time.Now().UTC().Unix()                      // Issued At
 	tkn.Claims["jti"] = tknID.String()                               // JWT ID
 


### PR DESCRIPTION
@gokmen one time my VM date had drifted couple minutes behind. This caused kd klient to remote VM connections to not be valid till the VM date caught up to the nbf token time.

According to the [spec](https://tools.ietf.org/html/rfc7519#section-4.1.5):

```
Implementers MAY
   provide for some small leeway, usually no more than a few minutes, to
   account for clock skew.  Its value MUST be a number containing a
   NumericDate value.  Use of this claim is OPTIONAL.
```

But I don't think setting this value gives us anything. @cihangir mentioned you were checking this on the client side, so just want to make sure removing this doesn't cause problems.

https://koding.atlassian.net/browse/TMS-2511
