### PR TITLE
TMS-829 Stack script notification

### DIFF
--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -1105,7 +1105,7 @@ module.exports = class ComputeController extends KDController
       return callback null, template
 
 
-  showBuildLogs: (machine) ->
+  showBuildLogs: (machine, tailOffset) ->
 
     # Not supported for Koding Group
     return  if isKoding()
@@ -1122,6 +1122,7 @@ module.exports = class ComputeController extends KDController
         Your Koding Stack has successfully been initialized. The log here
         describes each executed step of the Stack creation process.
       "
+      tailOffset
     }
 
 

--- a/client/ide/lib/index.coffee
+++ b/client/ide/lib/index.coffee
@@ -50,6 +50,8 @@ class IDEAppController extends AppController
 
   {noop, warn} = kd
 
+  INITIAL_BUILD_LOGS_TAIL_OFFSET = 15
+
   @options = require './ideappcontrolleroptions'
 
   constructor: (options = {}, data) ->
@@ -437,14 +439,14 @@ class IDEAppController extends AppController
   ###
   tailFile: (options, callback = kd.noop) ->
 
-    { file, contents, targetTabView, description, emitChange } = options
+    { file, contents, targetTabView, description, emitChange, tailOffset } = options
 
     targetTabView = @ideViews.first.tabView  unless targetTabView
 
     @setActiveTabView targetTabView
 
     @activeTabView.emit 'FileNeedsToBeTailed', {
-      file, contents, description, callback, emitChange
+      file, contents, description, callback, emitChange, tailOffset
     }
 
 
@@ -1255,7 +1257,7 @@ class IDEAppController extends AppController
       else
         mainView.activitySidebar.selectWorkspace data
 
-      computeController.showBuildLogs machine  if initial
+      computeController.showBuildLogs machine, INITIAL_BUILD_LOGS_TAIL_OFFSET  if initial
 
       @emit 'IDEReady'
 

--- a/client/ide/lib/views/tabview/ideview.coffee
+++ b/client/ide/lib/views/tabview/ideview.coffee
@@ -319,7 +319,7 @@ module.exports = class IDEView extends IDEWorkspaceTabView
 
   tailFile: (options) ->
 
-    { file, content, callback, emitChange, description } = options
+    { file, content, callback, emitChange, description, tailOffset } = options
 
     callback   ?= kd.noop
     emitChange ?= yes
@@ -335,7 +335,7 @@ module.exports = class IDEView extends IDEWorkspaceTabView
 
       content   or= ''
       tailerPane  = new IDETailerPane {
-        file, content, description, delegate: this, ideViewHash: @hash
+        file, content, description, delegate: this, ideViewHash: @hash, tailOffset
       }
 
       paneOptions =

--- a/client/ide/lib/workspace/panes/idetailerpane.coffee
+++ b/client/ide/lib/workspace/panes/idetailerpane.coffee
@@ -1,8 +1,9 @@
-kd                 = require 'kd'
-FSFile             = require 'app/util/fs/fsfile'
-IDEPane            = require './idepane'
-AceView            = require 'ace/aceview'
-IDEAce             = require '../../views/ace/ideace'
+kd                      = require 'kd'
+FSFile                  = require 'app/util/fs/fsfile'
+IDEPane                 = require './idepane'
+AceView                 = require 'ace/aceview'
+IDEAce                  = require '../../views/ace/ideace'
+IDETailerPaneLineParser = require './idetailerpanelineparser'
 
 
 module.exports = class IDETailerPane extends IDEPane
@@ -25,6 +26,7 @@ module.exports = class IDETailerPane extends IDEPane
 
     @scrollToBottom()
     @getEditor().insert "\n#{newLine}"
+    IDETailerPaneLineParser.process newLine
 
 
   createEditor: ->

--- a/client/ide/lib/workspace/panes/idetailerpane.coffee
+++ b/client/ide/lib/workspace/panes/idetailerpane.coffee
@@ -31,7 +31,7 @@ module.exports = class IDETailerPane extends IDEPane
 
   createEditor: ->
 
-    { file, description, descriptionView } = @getOptions()
+    { file, description, descriptionView, tailOffset } = @getOptions()
 
     unless file instanceof FSFile
       throw new TypeError 'File must be an instance of FSFile'
@@ -73,8 +73,9 @@ module.exports = class IDETailerPane extends IDEPane
 
       kite = @file.machine.getBaseKite()
       kite.tail
-        path  : @file.getPath()
-        watch : @bound 'handleFileUpdate'
+        path       : @file.getPath()
+        watch      : @bound 'handleFileUpdate'
+        lineOffset : tailOffset
 
       ace.editor.renderer.setScrollMargin 0, 15, 0, 0
 

--- a/client/ide/lib/workspace/panes/idetailerpanelineparser.coffee
+++ b/client/ide/lib/workspace/panes/idetailerpanelineparser.coffee
@@ -1,0 +1,30 @@
+kd                 = require 'kd'
+KDNotificationView = kd.NotificationView
+
+showDoneNotification = -> showNotification 'Provisioning Completed'
+
+
+showNotification = (message, duration = 2000) ->
+
+  new KDNotificationView
+    title    : message
+    duration : duration
+
+
+config = [
+  { template : '_KD_DONE_', fn : showDoneNotification }
+  { template : /^_KD_NOTIFY_@(.+)@$/, fn : showNotification }
+]
+
+
+module.exports = IDETailerPaneLineParser =
+
+  process: (line) ->
+
+    line = line.trim()
+    for { template, fn } in config
+      if template instanceof RegExp
+        match = line.match template
+        return fn.apply null, match.slice 1  if match
+      else if line is template
+        return fn()


### PR DESCRIPTION
@gokmen, can you please review this? This PR is a duplicate of https://github.com/koding/koding/pull/6834 which I have to close because I accidentally deleted all my remote branches while re-generating my github user token.
Please take a look at https://github.com/koding/koding/commit/c60a70f567870c96fbd0518213f6375d174bf396 - it's usage of tail offset parameter instead of delaying file parsing as it was implemented before. I request 15 last lines of the logs file when it's opened right after VM has been initialized in order to compensate possible loss of lines at this moment. Also, if stack script is simple and it's already completed by the moment build logs are opened, these last lines help to trigger script completion notification if it exists in the script.
In other cases file is tailed without fetching last lines

https://koding.atlassian.net/browse/TMS-829
