### PR TITLE
TMS-2496 stackplan: team admin has no sude but must be able to delete machine and destroy user stack

### DIFF
--- a/go/src/koding/kites/kloud/provider/aws/apply.go
+++ b/go/src/koding/kites/kloud/provider/aws/apply.go
@@ -164,7 +164,7 @@ func (s *Stack) destroy(ctx context.Context, username, groupname, stackID string
 	}
 	defer tfKite.Close()
 
-	contentID := username + "-" + stackID
+	contentID := groupname + "-" + stackID
 	s.Log.Debug("Building template %s", contentID)
 
 	if err := s.Builder.BuildTemplate(s.Builder.Stack.Template, contentID); err != nil {
@@ -277,7 +277,7 @@ func (s *Stack) apply(ctx context.Context, username, groupname, stackID string) 
 	}
 	defer tfKite.Close()
 
-	contentID := username + "-" + stackID
+	contentID := groupname + "-" + stackID
 	s.Log.Debug("Building template: %s", contentID)
 
 	if err := s.Builder.BuildTemplate(s.Builder.Stack.Template, contentID); err != nil {

--- a/go/src/koding/kites/kloud/provider/aws/stackplan.go
+++ b/go/src/koding/kites/kloud/provider/aws/stackplan.go
@@ -177,6 +177,7 @@ func (s *Stack) InjectAWSData(ctx context.Context, username string, expandUserDa
 		// will be replaced with the kitekeys we create below
 		userCfg.KiteKey = fmt.Sprintf("${lookup(var.%s, count.index)}", kiteKeyName)
 
+		// TODO(rjeczalik): do not compute userdata for destroy operations, it's a nop
 		userdata, err := sess.Userdata.Create(userCfg)
 		if err != nil {
 			return nil, err

--- a/go/src/koding/kites/kloud/provider/vagrant/apply.go
+++ b/go/src/koding/kites/kloud/provider/vagrant/apply.go
@@ -165,7 +165,7 @@ func (s *Stack) destroy(ctx context.Context, username, groupname, stackID string
 	}
 	defer tfKite.Close()
 
-	contentID := username + "-" + stackID
+	contentID := groupname + "-" + stackID
 	s.Log.Debug("Building template: %s", contentID)
 
 	if err := s.Builder.BuildTemplate(s.Builder.Stack.Template, contentID); err != nil {
@@ -262,7 +262,7 @@ func (s *Stack) apply(ctx context.Context, username, groupname, stackID string) 
 	}
 	defer tfKite.Close()
 
-	contentID := username + "-" + stackID
+	contentID := groupname + "-" + stackID
 	s.Log.Debug("Building template: %s", contentID)
 
 	if err := s.Builder.BuildTemplate(s.Builder.Stack.Template, contentID); err != nil {

--- a/go/src/koding/kites/kloud/stackplan/builder.go
+++ b/go/src/koding/kites/kloud/stackplan/builder.go
@@ -195,13 +195,17 @@ func (b *Builder) BuildMachines(ctx context.Context) error {
 		// TODO(arslan): add custom type with custom methods for type
 		// []*Machineuser
 		for _, user := range machine.Users {
-			// we only going to select users that are allowed
-			if user.Sudo && user.Owner {
+			// we only going to select users that are allowed:
+			//
+			//   - team member that owns vm (sudo + owner)
+			//   - team admin that owns all vms (owner + !permanent)
+			//
+			// A shared user is (owner + permanent).
+			if (user.Sudo || !user.Permanent) && user.Owner {
 				validUsers[user.Id.Hex()] = user
 			} else {
 				// return early, we don't tolerate nonvalid inputs to apply
-				return fmt.Errorf("machine '%s' is not valid. Aborting apply",
-					machine.ObjectId.Hex())
+				return fmt.Errorf("machine '%s' is not valid. Aborting apply", machine.ObjectId.Hex())
 			}
 		}
 	}


### PR DESCRIPTION
/cc @koding/godevs 

username cannot be used for a contentID since stack can be destroyed be
an admin - when that happens Terraform fails to lookup existing
stackplan state file uploaded to S3, which makes the resources not
being deleted.

https://koding.atlassian.net/browse/TMS-2496
