### PR TITLE
[GEN-2157] Keep initial content and match it with changed content

### DIFF
--- a/client/ace/lib/aceview.coffee
+++ b/client/ace/lib/aceview.coffee
@@ -128,7 +128,10 @@ module.exports = class AceView extends JView
         file.emit 'file.requests.save', contents
 
     @ace.on 'FileContentChanged', =>
-      @ace.contentChanged = yes
+      @ace.contentChanged = @ace.isCurrentContentChanged()
+
+      return  unless @ace.contentChanged
+
       @setActiveTabHandleClass 'modified'
       @getDelegate().quitOptions =
         message : 'You have unsaved changes. You will lose them if you close this tab.'

--- a/client/stacks/lib/views/customviews/stackcatalogmodalview.coffee
+++ b/client/stacks/lib/views/customviews/stackcatalogmodalview.coffee
@@ -23,5 +23,5 @@ module.exports = class StackCatalogModalView extends AdminAppView
 
     { mainView } = activePane
 
-    unless mainView?.defineStackView?.isStackChanged
+    unless mainView?.defineStackView?.isStackChanged()
       @destroy()

--- a/client/stacks/lib/views/stacks/editors/basestackeditorview.coffee
+++ b/client/stacks/lib/views/stacks/editors/basestackeditorview.coffee
@@ -54,13 +54,10 @@ module.exports = class BaseStackEditorView extends IDEEditorPane
       if targetContentType is 'json'
         ace.setContent JSON.stringify(JSON.parse(content), null, '\t'), no
 
-      @initialContent = ace.getContents()
+      ace.lastSavedContents = ace.getContents()
 
       kd.utils.defer =>
         @getEditorSession().setScrollTop 0
-
-      ace.on 'FileContentChanged', =>
-        ace.contentChanged = ace.getContents() isnt @initialContent
 
       @emit 'EditorReady'
 

--- a/client/stacks/lib/views/stacks/editors/basestackeditorview.coffee
+++ b/client/stacks/lib/views/stacks/editors/basestackeditorview.coffee
@@ -54,8 +54,13 @@ module.exports = class BaseStackEditorView extends IDEEditorPane
       if targetContentType is 'json'
         ace.setContent JSON.stringify(JSON.parse(content), null, '\t'), no
 
+      @initialContent = ace.getContents()
+
       kd.utils.defer =>
         @getEditorSession().setScrollTop 0
+
+      ace.on 'FileContentChanged', =>
+        ace.contentChanged = ace.getContents() isnt @initialContent
 
       @emit 'EditorReady'
 

--- a/client/stacks/lib/views/stacks/editors/stacktemplateeditorview.coffee
+++ b/client/stacks/lib/views/stacks/editors/stacktemplateeditorview.coffee
@@ -30,6 +30,8 @@ module.exports = class StackTemplateEditorView extends BaseStackEditorView
     ace.editor.session.insert position, content
     ace.contentChanged = no
 
+    @initialContent = ace.getContents()
+
 
   createEditor: ->
 

--- a/client/stacks/lib/views/stacks/editors/stacktemplateeditorview.coffee
+++ b/client/stacks/lib/views/stacks/editors/stacktemplateeditorview.coffee
@@ -30,8 +30,6 @@ module.exports = class StackTemplateEditorView extends BaseStackEditorView
     ace.editor.session.insert position, content
     ace.contentChanged = no
 
-    @initialContent = ace.getContents()
-
 
   createEditor: ->
 


### PR DESCRIPTION
/cc @gokmen @fatihacet 

https://koding.atlassian.net/browse/GEN-2157

/fyi @gokmen I had to create `@changedContents` list and fill it with key-values. Older version was working simple because `isContentChanged` method of editors was not working correctly. So I reverted my changes from before https://github.com/GokhanTurunc/koding/commit/ad713af4407968f48b28301904b46b0750e3b95c
#### Before

![nuakkdyw7h](https://cloud.githubusercontent.com/assets/728733/13669578/248df558-e6cd-11e5-84d2-4d2f2719c3d4.gif)
#### After

![3ovemj2mj7](https://cloud.githubusercontent.com/assets/728733/13669562/082e1564-e6cd-11e5-90ab-f5c6d5a53a39.gif)
