### PR TITLE
TMS-2562 Admin: hide Mount button if machine is not accessible

### DIFF
--- a/client/admin/lib/views/resources/resourcemachineitem.coffee
+++ b/client/admin/lib/views/resources/resourcemachineitem.coffee
@@ -2,6 +2,7 @@ kd               = require 'kd'
 
 showError        = require 'app/util/showError'
 MachinesListItem = require 'app/environment/machineslistitem'
+Machine          = require 'app/providers/machine'
 
 
 module.exports   = class ResourceMachineItem extends MachinesListItem
@@ -23,6 +24,14 @@ module.exports   = class ResourceMachineItem extends MachinesListItem
     labelOptions = partial: label
 
     @labelLink.addSubView new kd.CustomHTMLView labelOptions
+
+    { State } = Machine
+    return  if machine.status.state in [
+      State.NotInitialized
+      State.Building
+      State.Terminating
+      State.Terminated
+    ]
 
     @labelLink.addSubView new kd.ButtonView
       title    : if mounted then 'Mounted' else 'Mount'

--- a/client/admin/lib/views/resources/resourcemachineitem.coffee
+++ b/client/admin/lib/views/resources/resourcemachineitem.coffee
@@ -2,7 +2,7 @@ kd               = require 'kd'
 
 showError        = require 'app/util/showError'
 MachinesListItem = require 'app/environment/machineslistitem'
-Machine          = require 'app/providers/machine'
+{ State }        = require 'app/providers/machine'
 
 
 module.exports   = class ResourceMachineItem extends MachinesListItem
@@ -25,13 +25,7 @@ module.exports   = class ResourceMachineItem extends MachinesListItem
 
     @labelLink.addSubView new kd.CustomHTMLView labelOptions
 
-    { State } = Machine
-    return  if machine.status.state in [
-      State.NotInitialized
-      State.Building
-      State.Terminating
-      State.Terminated
-    ]
+    return  unless machine.status.state is State.Running
 
     @labelLink.addSubView new kd.ButtonView
       title    : if mounted then 'Mounted' else 'Mount'


### PR DESCRIPTION
@gokmen, can you please review this fix? I hide `Mount` button if machine is not accessible at the moment (not yet initialized, is building, terminating or terminated) so there is no sense to admin to attach to it.
Another way to handle this case is to show a text (fox example, `N/A`) instead of `Mount` button. Maybe it will be a better UX

https://koding.atlassian.net/browse/TMS-2562
