### PR TITLE
Collaboration Permission Flow

### DIFF
--- a/client/ide/lib/collaborationcontroller.coffee
+++ b/client/ide/lib/collaborationcontroller.coffee
@@ -878,7 +878,6 @@ module.exports = CollaborationController =
 
           @stateMachine.transition 'Active'
           @updateSessionStartingProgress 90
-          @makeReadOnly()  if @getMyPermission() isnt 'edit'
 
           kd.utils.wait 2000, =>
             @updateSessionStartingProgress 100
@@ -1402,3 +1401,21 @@ module.exports = CollaborationController =
 
     openFolders = @finderPane.getOpenFolders()
     @rtm.getFromModel('commonStore').set 'openFolders', openFolders
+
+
+  requestEditPermission: ->
+
+    return  if @requestEditPermissionView
+
+    @requestEditPermissionView = new kd.CustomHTMLView
+      cssClass : 'ide-warning-view system-notification in'
+      partial  : "REQUEST ACCESS: You don't have permissions to make changes. <a href='#'>Ask for permission.</a> <a href='#' class='close'></a>"
+      click    : (e) =>
+        kd.utils.stopDOMEvent e
+        if e.target.classList.contains 'close'
+          @requestEditPermissionView.destroy()
+
+    @getView().addSubView @requestEditPermissionView
+
+    @requestEditPermissionView.once 'KDObjectWillBeDestroyed', =>
+      @requestEditPermissionView = null

--- a/client/ide/lib/collaborationcontroller.coffee
+++ b/client/ide/lib/collaborationcontroller.coffee
@@ -253,16 +253,11 @@ module.exports = CollaborationController =
 
   setWatchMap: ->
 
-    if @myWatchMap.values().length
-      @emit 'WatchMapIsReady'
-      return
+    return @emit 'WatchMapIsReady'  if @amIHost
 
-    @listChatParticipants (accounts) =>
-      accounts.forEach (account) =>
-        { nickname } = account.profile
-        @myWatchMap.set nickname, nickname
-
-      @emit 'WatchMapIsReady'
+    host = @collaborationHost
+    @myWatchMap.set host, host
+    @emit 'WatchMapIsReady'
 
 
   activateRealtimeManagerForHost: ->
@@ -411,7 +406,6 @@ module.exports = CollaborationController =
       return  if nickname is nick()
 
       @statusBar.createParticipantAvatar nickname, no
-      @watchParticipant nickname
 
       if @amIHost
         @setParticipantPermission nickname

--- a/client/ide/lib/index.coffee
+++ b/client/ide/lib/index.coffee
@@ -1655,6 +1655,12 @@ class IDEAppController extends AppController
     @finderPane.makeReadOnly()
 
     appView.setClass 'read-only'
+    appView.on 'click', @bound 'readOnlyNotifierCallback_'
+
+
+  readOnlyNotifierCallback_: ->
+
+    @requestEditPermission()
 
 
   makeEditable: ->
@@ -1666,6 +1672,8 @@ class IDEAppController extends AppController
     @finderPane.makeEditable()
 
     appView.unsetClass 'read-only'
+    appView.off 'click', @bound 'readOnlyNotifierCallback_'
+    @requestEditPermissionView?.destroy()
 
 
   deleteWorkspaceRootFolder: (machineUId, rootPath) ->

--- a/client/ide/lib/index.coffee
+++ b/client/ide/lib/index.coffee
@@ -1648,18 +1648,24 @@ class IDEAppController extends AppController
 
   makeReadOnly: ->
 
+    appView = @getView()
+
     ideView.isReadOnly = yes  for ideView in @ideViews
     @forEachSubViewInIDEViews_ (pane) -> pane.makeReadOnly()
     @finderPane.makeReadOnly()
-    @getView().setClass 'read-only'
+
+    appView.setClass 'read-only'
 
 
   makeEditable: ->
 
+    appView = @getView()
+
     ideView.isReadOnly = no  for ideView in @ideViews
     @forEachSubViewInIDEViews_ (pane) -> pane.makeEditable()
     @finderPane.makeEditable()
-    @getView().unsetClass 'read-only'
+
+    appView.unsetClass 'read-only'
 
 
   deleteWorkspaceRootFolder: (machineUId, rootPath) ->

--- a/client/ide/lib/styl/ide.styl
+++ b/client/ide/lib/styl/ide.styl
@@ -1286,6 +1286,7 @@ body.ide .kddialogview.save-as-dialog
   .nfinder .chevron
   .kdtabhandle .close-tab
   .kdtabhandle .options
+  .general-handles
     hidden()
 
   ul ul li.selected

--- a/client/ide/lib/views/tabview/ideview.coffee
+++ b/client/ide/lib/views/tabview/ideview.coffee
@@ -486,14 +486,14 @@ module.exports = class IDEView extends IDEWorkspaceTabView
 
   click: ->
 
-    super
-
     appManager = kd.getSingleton 'appManager'
 
     appManager.tell 'IDE', 'setActiveTabView', @tabView
     appManager.tell 'IDE', 'setFindAndReplaceViewDelegate'
 
     @updateStatusBar()
+
+    super
 
 
   openSavedFile: (file, content) ->


### PR DESCRIPTION
- [x] Remove default `edit` permission from participants.
- [x] Start participants with `read` permission.
- [x] Show `Request Permission` notification when participant wants to take an action.
- [x] Implement `Send Permission Request`
- [x] Show `Permission Requested` avatar popup on host.
- [x] Implement `Deny Permission Request` on host.
- [x] Implement `Permission Request Rejected` on participant and show permission denied notification.
- [x] Implement `Grant Permission` action on host.
- [x] Implement `Permission Request Granted` on participant and show permission granted notification.
- [x] Give all access to permission granted user.
- [x] Highlight permission granted user avatar on host and all participants.
- [x] Make sure that avatars highlighted on refresh for users who has `edit` permission.
- [x] Add `Make Presenter` avatar menu item for host.
- [x] Add `Remove Permission` avatar menu item for host.
- [x] Implement `Make Presenter` action.
- [x] Implement `Remove Permission` action.
