### PR TITLE
TMS-2573 Admin: close Teams Settings modal when opening VM settings modal

### DIFF
--- a/client/admin/lib/views/resources/resourcemachineitem.coffee
+++ b/client/admin/lib/views/resources/resourcemachineitem.coffee
@@ -73,3 +73,18 @@ module.exports   = class ResourceMachineItem extends MachinesListItem
 
     @sidebarToggle = new kd.CustomHTMLView
 
+
+  destroyModal: ->
+
+    if modal = helper.findParentModal @parent
+      modal.destroy()
+
+
+  helper =
+
+    findParentModal: (view) ->
+
+      return  unless view
+      return view  if view instanceof kd.ModalView
+
+      helper.findParentModal view.parent


### PR DESCRIPTION
@gokmen, can you please review this fix? I made it similar to how `VM Settings` is opened in `My Stacks` list, i.e. fist we close current modal and then open `VM Settings` modal.
However, I think this approach has one disadvantage - once user opens `VM Settings`, they can't easily return back to the place where they open `VM Settings` from since the initial modal is already closed.
The other way to fix this issue is to open `VM Settings` above the initial modal. In this case user can close `VM Settings` and they will see what they saw before opening it. But I'm not sure that it's a good UX to show 2 modals one above another.

I just wanted share my thoughts about it so we can discuss the problem here if makes sense.
http://recordit.co/KRxeU8y47l

https://koding.atlassian.net/browse/TMS-2573
