### PR TITLE
TMS-2515 klient: fix for hostFromClient

### DIFF
--- a/go/src/koding/klient/remote/remote.go
+++ b/go/src/koding/klient/remote/remote.go
@@ -155,6 +155,13 @@ func (r *Remote) hostFromClient(k *kite.Client) (string, error) {
 
 	host, _, err := net.SplitHostPort(u.Host)
 	if err != nil {
+		// we try if u.Host is just a host without a port and not
+		// e.g. ill-formatted ipv6 address.
+		_, _, e := net.SplitHostPort(net.JoinHostPort(u.Host, "80"))
+		if e == nil {
+			return u.Host, nil
+		}
+
 		return "", err
 	}
 


### PR DESCRIPTION
Fixes the following klient error:

```
016-03-16 11:33:17 [klient] ERROR [remote][GetMachines] Unable to extract host from *kite.Client. err:missing port in address ffcef00a9d62.rafal.koding.me
```

/cc @koding/godevs 

https://koding.atlassian.net/browse/TMS-2515
