### PR TITLE
TMS-2434 klient/vagrant, provider/vagrant: expose klient port to vagrant host for connecting from IDE via localhost

### DIFF
--- a/go/src/koding/kites/kloud/api/vagrantapi/vagrantapi.go
+++ b/go/src/koding/kites/kloud/api/vagrantapi/vagrantapi.go
@@ -46,6 +46,7 @@ type Create struct {
 	FilePath       string           // always absolute for response values
 	ProvisionData  string           // base64-json-encoded userdata.Value
 	Hostname       string           // hostname of the box
+	Username       string           // owner of the box
 	Box            string           // box type
 	Memory         int              // memory in MiB
 	Cpus           int              // number of cores
@@ -191,6 +192,20 @@ func (k *Klient) cmd(queryString, method, boxPath string) error {
 // Create calls vagrant.create method on a kite given by the queryString.
 func (k *Klient) Create(queryString string, req *Create) (resp *Create, err error) {
 	resp = &Create{}
+
+	// Share the host kite with quest kite.
+	if req.Username != "" {
+		share := map[string]interface{}{
+			"username":  req.Username,
+			"permanent": true,
+		}
+
+		if _, err := k.send(queryString, "klient.share", share, nil); err != nil {
+			if !strings.Contains(err.Error(), "user is already in the shared list") {
+				k.Log.Error("failed to share %q with %q: %s", queryString, req.Username, err)
+			}
+		}
+	}
 
 	url, err := k.send(queryString, "vagrant.create", req, resp)
 	if err != nil {

--- a/go/src/koding/kites/kloud/api/vagrantapi/vagrantapi.go
+++ b/go/src/koding/kites/kloud/api/vagrantapi/vagrantapi.go
@@ -37,21 +37,21 @@ const (
 // ForwardedPort represents a single config.vm.network "forwarded_port" rule
 // in a Vagrantfile.
 type ForwardedPort struct {
-	GuestPort int
-	HostPort  int
+	GuestPort int `json:"guest,omitempty"`
+	HostPort  int `json:"host,omitempty"`
 }
 
 // Create represents vagrant.create request and response.
 type Create struct {
-	FilePath       string // always absolute for response values
-	ProvisionData  string // base64-json-encoded userdata.Value
-	Hostname       string // hostname of the box
-	Box            string // box type
-	Memory         int    // memory in MiB
-	Cpus           int    // number of cores
-	CustomScript   string // custom sh script, plain text
-	HostURL        string // host kite URL
-	ForwardedPorts []*ForwardedPort
+	FilePath       string           // always absolute for response values
+	ProvisionData  string           // base64-json-encoded userdata.Value
+	Hostname       string           // hostname of the box
+	Box            string           // box type
+	Memory         int              // memory in MiB
+	Cpus           int              // number of cores
+	CustomScript   string           // custom sh script, plain text
+	HostURL        string           // host kite URL
+	ForwardedPorts []*ForwardedPort `json:"forwarded_ports,omitempty"`
 }
 
 // Command represents vagrant.{up,halt,destroy} requests.

--- a/go/src/koding/kites/kloud/api/vagrantapi/vagrantapi.go
+++ b/go/src/koding/kites/kloud/api/vagrantapi/vagrantapi.go
@@ -34,16 +34,24 @@ const (
 	StateSaved      = State("saved")
 )
 
+// ForwardedPort represents a single config.vm.network "forwarded_port" rule
+// in a Vagrantfile.
+type ForwardedPort struct {
+	GuestPort int
+	HostPort  int
+}
+
 // Create represents vagrant.create request and response.
 type Create struct {
-	FilePath      string // always absolute for response values
-	ProvisionData string // base64-json-encoded userdata.Value
-	Hostname      string // hostname of the box
-	Box           string // box type
-	Memory        int    // memory in MiB
-	Cpus          int    // number of cores
-	CustomScript  string // custom sh script, plain text
-	HostURL       string // host kite URL
+	FilePath       string // always absolute for response values
+	ProvisionData  string // base64-json-encoded userdata.Value
+	Hostname       string // hostname of the box
+	Box            string // box type
+	Memory         int    // memory in MiB
+	Cpus           int    // number of cores
+	CustomScript   string // custom sh script, plain text
+	HostURL        string // host kite URL
+	ForwardedPorts []*ForwardedPort
 }
 
 // Command represents vagrant.{up,halt,destroy} requests.

--- a/go/src/koding/kites/kloud/provider/vagrant/stackplan.go
+++ b/go/src/koding/kites/kloud/provider/vagrant/stackplan.go
@@ -188,10 +188,12 @@ func (s *Stack) InjectVagrantData(ctx context.Context, username string) (string,
 			ports = make([]interface{}, 0)
 		}
 		ports = append(ports, &vagrantapi.ForwardedPort{
+			HostPort:  56790,
 			GuestPort: 56789,
 		})
 
 		box["forwarded_ports"] = ports
+		box["username"] = username
 
 		tunnel := s.newTunnel(resourceName)
 

--- a/go/src/koding/kites/kloud/provider/vagrant/stackplan.go
+++ b/go/src/koding/kites/kloud/provider/vagrant/stackplan.go
@@ -14,6 +14,7 @@ import (
 
 	"koding/db/models"
 	"koding/db/mongodb/modelhelper"
+	"koding/kites/kloud/api/vagrantapi"
 	"koding/kites/kloud/contexthelper/session"
 	"koding/kites/kloud/machinestate"
 	puser "koding/kites/kloud/scripts/provisionklient/userdata"
@@ -181,6 +182,16 @@ func (s *Stack) InjectVagrantData(ctx context.Context, username string) (string,
 		if _, ok := box["box"]; !ok {
 			box["box"] = "${var.vagrant_box}"
 		}
+
+		ports, ok := box["forwarded_ports"].([]interface{})
+		if !ok {
+			ports = make([]interface{}, 0)
+		}
+		ports = append(ports, &vagrantapi.ForwardedPort{
+			GuestPort: 56789,
+		})
+
+		box["forwarded_ports"] = ports
 
 		tunnel := s.newTunnel(resourceName)
 

--- a/go/src/koding/kites/terraformplugins/vagrant/config.go
+++ b/go/src/koding/kites/terraformplugins/vagrant/config.go
@@ -153,6 +153,10 @@ func newCreateReq(d *schema.ResourceData) (*vagrantapi.Create, error) {
 				}
 			}
 
+			if port.HostPort == 0 {
+				port.HostPort = port.GuestPort
+			}
+
 			c.ForwardedPorts = append(c.ForwardedPorts, &port)
 		}
 	}

--- a/go/src/koding/kites/terraformplugins/vagrant/config.go
+++ b/go/src/koding/kites/terraformplugins/vagrant/config.go
@@ -108,6 +108,11 @@ func newCreateReq(d *schema.ResourceData) (*vagrantapi.Create, error) {
 		return nil, errors.New("invalid request: hostname field is missing")
 	}
 
+	c.Username, ok = d.Get("username").(string)
+	if !ok {
+		return nil, errors.New("invalid request: hostname field is missing")
+	}
+
 	c.Memory, ok = d.Get("memory").(int)
 	if !ok {
 		return nil, errors.New("invalid request: memory field is missing")

--- a/go/src/koding/kites/terraformplugins/vagrant/resource_vagrant_instance.go
+++ b/go/src/koding/kites/terraformplugins/vagrant/resource_vagrant_instance.go
@@ -43,6 +43,11 @@ func resourceVagrantBuild() *schema.Resource {
 				Optional:    true,
 				Description: "Hostname of the Vagrant machine. Defaults to klient's username",
 			},
+			"username": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Username of the Vagrant machine.",
+			},
 			"memory": &schema.Schema{
 				Type:        schema.TypeInt,
 				Optional:    true,

--- a/go/src/koding/kites/terraformplugins/vagrant/resource_vagrant_instance.go
+++ b/go/src/koding/kites/terraformplugins/vagrant/resource_vagrant_instance.go
@@ -58,6 +58,24 @@ func resourceVagrantBuild() *schema.Resource {
 				Optional:    true,
 				Description: "Custom script to be executed inside the Vagrant box after the main provisioning is finished.",
 			},
+			"forwarded_ports": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"host": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Host value of the forwarded port.",
+						},
+						"guest": {
+							Type:        schema.TypeInt,
+							Required:    true,
+							Description: "Guest port to forward.",
+						},
+					},
+				},
+			},
 
 			"registerURL": &schema.Schema{
 				Type:        schema.TypeString,

--- a/go/src/koding/kites/tunnelproxy/client.go
+++ b/go/src/koding/kites/tunnelproxy/client.go
@@ -155,8 +155,13 @@ func NewClient(opts *ClientOptions) (*Client, error) {
 		optsCopy.Log = common.NewLogger("tunnelclient", optsCopy.Debug)
 	}
 
+	k := kite.New(ClientKiteName, ClientKiteVersion)
+	if optsCopy.Debug {
+		k.SetLogLevel(kite.DEBUG)
+	}
+
 	c := &Client{
-		kite:          kite.New(ClientKiteName, ClientKiteVersion),
+		kite:          k,
 		opts:          &optsCopy,
 		tunnelKiteURL: optsCopy.tunnelKiteURL(),
 		stateChanges:  make(chan *tunnel.ClientStateChange, 128),
@@ -481,6 +486,7 @@ func (c *Client) tryRegister() error {
 		TunnelName:  c.opts.TunnelName,
 		LocalRoutes: c.opts.LocalRoutes,
 	}
+
 	kiteResp, err := client.TellWithTimeout("register", c.opts.timeout(), req)
 	if err != nil {
 		return c.handleReg(nil, err)

--- a/go/src/koding/kites/tunnelproxy/client.go
+++ b/go/src/koding/kites/tunnelproxy/client.go
@@ -87,6 +87,9 @@ type ClientOptions struct {
 	// LocalRoutes is sent with RegisterRequest.
 	LocalRoutes map[string]string
 
+	// StateChanges, when non-nil, listens on tunnel connection state transtions.
+	StateChanges chan<- *tunnel.ClientStateChange
+
 	Debug  bool           // whether to use debug logging
 	Log    logging.Logger // overwrites logger used with custom one
 	Config *config.Config // configures kite.Kite to connect to tunnelserver
@@ -301,6 +304,10 @@ func (c *Client) eventloop() {
 	for {
 		select {
 		case ch := <-c.stateChanges:
+			if c.opts.StateChanges != nil {
+				c.opts.StateChanges <- ch
+			}
+
 			c.opts.Log.Debug("handling transition: %s", ch)
 
 			switch ch.Current {

--- a/go/src/koding/kites/tunnelproxy/client.go
+++ b/go/src/koding/kites/tunnelproxy/client.go
@@ -84,6 +84,9 @@ type ClientOptions struct {
 	// port on which it received connection.
 	LocalAddr string
 
+	// LocalRoutes is sent with RegisterRequest.
+	LocalRoutes map[string]string
+
 	Debug  bool           // whether to use debug logging
 	Log    logging.Logger // overwrites logger used with custom one
 	Config *config.Config // configures kite.Kite to connect to tunnelserver
@@ -475,7 +478,8 @@ func (c *Client) tryRegister() error {
 	defer client.Close()
 
 	req := &RegisterRequest{
-		TunnelName: c.opts.TunnelName,
+		TunnelName:  c.opts.TunnelName,
+		LocalRoutes: c.opts.LocalRoutes,
 	}
 	kiteResp, err := client.TellWithTimeout("register", c.opts.timeout(), req)
 	if err != nil {

--- a/go/src/koding/kites/tunnelproxy/server.go
+++ b/go/src/koding/kites/tunnelproxy/server.go
@@ -536,13 +536,11 @@ func (s *Server) vhostRoutes(vhost string) map[string]string {
 }
 
 func (s *Server) localRoute(r *http.Request) string {
-	ips := map[string]struct{}{
-		parseIP(r.RemoteAddr):                    {},
-		parseIP(r.Header.Get("X-Real-IP")):       {},
-		parseIP(r.Header.Get("X-Forwarded-For")): {},
+	if isWebsocketConn(r) {
+		return ""
 	}
 
-	delete(ips, "")
+	ips := extractIPs(r)
 
 	if len(ips) == 0 {
 		return ""

--- a/go/src/koding/kites/tunnelproxy/server.go
+++ b/go/src/koding/kites/tunnelproxy/server.go
@@ -59,7 +59,8 @@ type Server struct {
 	record    *dnsclient.Record
 	callbacks *callbacks
 
-	mu       sync.Mutex // protects services and tunnels
+	mu       sync.Mutex // protects routes, services and tunnels
+	routes   map[string]map[string]string
 	services map[int]net.Listener
 	tunnels  *Tunnels
 
@@ -119,6 +120,7 @@ func NewServer(opts *ServerOptions) (*Server, error) {
 		DNS:      dns,
 		opts:     &optsCopy,
 		record:   dnsclient.ParseRecord("", optsCopy.ServerAddr),
+		routes:   make(map[string]map[string]string),
 		services: make(map[int]net.Listener),
 		tunnels:  newTunnels(),
 	}
@@ -139,6 +141,12 @@ type RegisterRequest struct {
 
 	// Username on behalf which handle the registration request.
 	Username string `json:"username,omitempty"`
+
+	// LocalRoutes forwards tunnel connections to the endpoint on localhost.
+	// If both local server of the tunnel and the client are within the
+	// same network, all HTTP requests are going to be redirected to
+	// use local interfece instead.
+	LocalRoutes map[string]string // maps publicIP to local address
 }
 
 // RegisterResult represents response value for register method.
@@ -200,17 +208,18 @@ func (res *RegisterServicesResult) Err() (err error) {
 	return err
 }
 
-func (s *Server) addClient(ident, name, vhost string) {
+func (s *Server) addClient(ident, name, vhost string, routes map[string]string) {
 	s.opts.Log.Debug("%s: adding vhost=%s", ident, vhost)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	s.tunnels.addClient(ident, name, vhost)
+	s.routes[vhost] = routes
 	s.Server.AddHost(vhost, ident)
 }
 
-func (s *Server) delClient(ident string) {
+func (s *Server) delClient(ident, vhost string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -234,6 +243,7 @@ func (s *Server) delClient(ident string) {
 	}
 
 	s.tunnels.delClient(ident)
+	delete(s.routes, vhost)
 }
 
 func (s *Server) addClientService(ident string, tun *Tunnel) error {
@@ -422,10 +432,10 @@ func (s *Server) Register(r *kite.Request) (interface{}, error) {
 		Ident:       utils.RandString(32),
 	}
 
-	s.addClient(res.Ident, req.TunnelName, res.VirtualHost)
+	s.addClient(res.Ident, req.TunnelName, res.VirtualHost, req.LocalRoutes)
 
 	s.Server.OnDisconnect(res.Ident, func() error {
-		s.delClient(res.Ident)
+		s.delClient(res.Ident, res.VirtualHost)
 		return nil
 	})
 
@@ -511,6 +521,66 @@ func (s *Server) listen(network, addr string) (net.Listener, error) {
 	return nil, errors.New("unable to find available port")
 }
 
+func (s *Server) vhostRoutes(vhost string) map[string]string {
+	s.mu.Lock()
+	routes, ok := s.routes[vhost]
+	if !ok {
+		host, port, err := net.SplitHostPort(vhost)
+		if err == nil && (port == "80" || port == "443") {
+			routes, ok = s.routes[host]
+		}
+	}
+	s.mu.Unlock()
+
+	return routes
+}
+
+func (s *Server) localRoute(r *http.Request) string {
+	ips := map[string]struct{}{
+		parseIP(r.RemoteAddr):                    {},
+		parseIP(r.Header.Get("X-Real-IP")):       {},
+		parseIP(r.Header.Get("X-Forwarded-For")): {},
+	}
+
+	delete(ips, "")
+
+	if len(ips) == 0 {
+		return ""
+	}
+
+	routes := s.vhostRoutes(strings.ToLower(r.Host))
+
+	if len(routes) == 0 {
+		return ""
+	}
+
+	for ip := range ips {
+		route, ok := routes[ip]
+		if !ok {
+			continue
+		}
+
+		r.URL.Scheme = "http"
+		r.URL.Host = route
+
+		return r.URL.String()
+	}
+
+	return ""
+}
+
+func (s *Server) tunnelHandler() http.HandlerFunc {
+	base := forward("/klient", s.Server)
+	return func(w http.ResponseWriter, r *http.Request) {
+		if url := s.localRoute(r); url != "" {
+			http.Redirect(w, r, url, 307)
+			return
+		}
+
+		base(w, r)
+	}
+}
+
 // NewServerKite creates a server kite for the given server.
 func NewServerKite(s *Server, name, version string) (*kite.Kite, error) {
 	k := kite.New(name, version)
@@ -550,7 +620,7 @@ func NewServerKite(s *Server, name, version string) (*kite.Kite, error) {
 	k.HandleFunc("registerServices", s.RegisterServices)
 	k.HandleHTTPFunc("/healthCheck", artifact.HealthCheckHandler(name))
 	k.HandleHTTPFunc("/version", artifact.VersionHandler())
-	k.HandleHTTP("/{rest:.*}", forward("/klient", s.Server))
+	k.HandleHTTP("/{rest:.*}", s.tunnelHandler())
 
 	if s.opts.RegisterURL == nil {
 		s.opts.RegisterURL = k.RegisterURL(false)

--- a/go/src/koding/kites/tunnelproxy/tunnelproxy.go
+++ b/go/src/koding/kites/tunnelproxy/tunnelproxy.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/hashicorp/go-multierror"
@@ -173,6 +175,39 @@ func splitHostPort(addr string) (string, int, error) {
 	}
 
 	return host, int(n), nil
+}
+
+func extractIPs(r *http.Request) map[string]struct{} {
+	ips := map[string]struct{}{
+		parseIP(r.RemoteAddr):              {},
+		parseIP(r.Header.Get("X-Real-IP")): {},
+	}
+
+	for _, ip := range r.Header["X-Forwarded-For"] {
+		ips[parseIP(ip)] = struct{}{}
+	}
+
+	delete(ips, "")
+
+	return ips
+}
+
+func isWebsocketConn(r *http.Request) bool {
+	return r.Method == "GET" && headerContains(r.Header["Connection"], "upgrade") &&
+		headerContains(r.Header["Upgrade"], "websocket")
+}
+
+// headerContains is a copy of tokenListContainsValue from gorilla/websocket/util.go
+func headerContains(header []string, value string) bool {
+	for _, h := range header {
+		for _, v := range strings.Split(h, ",") {
+			if strings.EqualFold(strings.TrimSpace(v), value) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 type callbacks struct {

--- a/go/src/koding/kites/tunnelproxy/tunnelproxy.go
+++ b/go/src/koding/kites/tunnelproxy/tunnelproxy.go
@@ -144,6 +144,23 @@ func host(addr string) string {
 	return addr
 }
 
+func parseIP(ip string) string {
+	if ip == "" {
+		return ""
+	}
+
+	host, _, err := net.SplitHostPort(ip)
+	if err == nil {
+		ip = host
+	}
+
+	if net.ParseIP(ip) != nil {
+		return ip
+	}
+
+	return ""
+}
+
 func splitHostPort(addr string) (string, int, error) {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {

--- a/go/src/koding/klient/app/klient.go
+++ b/go/src/koding/klient/app/klient.go
@@ -320,7 +320,6 @@ func (k *Klient) RegisterMethods() {
 
 	// Tunnel
 	k.kite.HandleFunc("tunnel.info", k.tunnel.Info)
-	k.kite.HandleFunc("tunnel.route", k.tunnel.Route)
 
 	// Docker
 	// k.kite.HandleFunc("docker.create", k.docker.Create)

--- a/go/src/koding/klient/storage/bolt.go
+++ b/go/src/koding/klient/storage/bolt.go
@@ -6,24 +6,32 @@ import (
 	"github.com/boltdb/bolt"
 )
 
-const DataBucket = "userdata"
+var DataBucket = []byte("userdata")
 
 // boltdb satisfies https://godoc.org/github.com/koding/cache#Cache interface
 type boltdb struct {
+	bucketName []byte
 	*bolt.DB
 }
 
 // NewBoltStorage returns a new boltdb
 func NewBoltStorage(db *bolt.DB) (*boltdb, error) {
+	return NewBoltStorageBucket(db, nil)
+}
+
+// NewBoltStorageBucket returns a new boltdb with a custom bucket name.
+func NewBoltStorageBucket(db *bolt.DB, bucketName []byte) (*boltdb, error) {
 	if db == nil {
 		return nil, errors.New("boltDB reference is nil")
 	}
 
-	b := &boltdb{}
-	b.DB = db
+	b := &boltdb{
+		bucketName: bucketName,
+		DB:         db,
+	}
 
 	if err := b.Update(func(tx *bolt.Tx) error {
-		_, err := tx.CreateBucketIfNotExists([]byte(DataBucket))
+		_, err := tx.CreateBucketIfNotExists(b.bucket())
 		if err != nil {
 			return err
 		}
@@ -35,10 +43,18 @@ func NewBoltStorage(db *bolt.DB) (*boltdb, error) {
 	return b, nil
 }
 
+func (b *boltdb) bucket() []byte {
+	if b.bucketName != nil {
+		return b.bucketName
+	}
+
+	return DataBucket
+}
+
 // Set adds the given key/value pair to the db
 func (b *boltdb) Set(key, value string) error {
 	return b.DB.Update(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte(DataBucket))
+		b := tx.Bucket(b.bucket())
 		return b.Put([]byte(key), []byte(value))
 	})
 }
@@ -47,7 +63,7 @@ func (b *boltdb) Set(key, value string) error {
 func (b *boltdb) Get(key string) (string, error) {
 	var res string
 	if err := b.DB.View(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte(DataBucket))
+		b := tx.Bucket(b.bucket())
 		v := b.Get([]byte(key))
 		res = string(v)
 		return nil
@@ -65,7 +81,7 @@ func (b *boltdb) Get(key string) (string, error) {
 // Delete deletes the value associated with the given key
 func (b *boltdb) Delete(key string) error {
 	return b.DB.Update(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte(DataBucket))
+		b := tx.Bucket(b.bucket())
 		return b.Delete([]byte(key))
 	})
 }

--- a/go/src/koding/klient/tunnel/storage.go
+++ b/go/src/koding/klient/tunnel/storage.go
@@ -1,27 +1,10 @@
 package tunnel
 
 import (
-	"encoding/json"
-	"errors"
+	"koding/klient/storage"
 
 	"github.com/boltdb/bolt"
 )
-
-type Storage interface {
-	Options() (*Options, error)
-	SetOptions(*Options) error
-}
-
-func newStorage(opts *Options) Storage {
-	b, err := newBoltStorage(opts.DB)
-	if err == nil {
-		return b
-	}
-
-	opts.Log.Warning("tunnel: unable to open BoltDB: %s", err)
-
-	return newMemStorage()
-}
 
 var (
 	// dbBucket is the bucket name used to retrieve and store the resolved
@@ -30,78 +13,25 @@ var (
 	dbOptions = []byte("options")
 )
 
-type boltStorage struct {
-	db *bolt.DB
+type Storage struct {
+	db *storage.EncodingStorage
 }
 
-func newBoltStorage(db *bolt.DB) (*boltStorage, error) {
-	if db == nil {
-		return nil, errors.New("no local database")
+func NewStorage(db *bolt.DB) *Storage {
+	return &Storage{
+		db: storage.NewEncodingStorage(db, dbBucket),
 	}
-	b := &boltStorage{
-		db: db,
-	}
-
-	if err := b.init(); err != nil {
-		return nil, err
-	}
-
-	return b, nil
 }
 
-func (b *boltStorage) init() error {
-	return b.db.Update(func(tx *bolt.Tx) (err error) {
-		if tx.Bucket(dbBucket) == nil {
-			_, err = tx.CreateBucket(dbBucket)
-		}
-		return err
-	})
-}
-
-func (b *boltStorage) Options() (*Options, error) {
+func (s *Storage) Options() (*Options, error) {
 	var opts Options
-	err := b.db.View(func(tx *bolt.Tx) error {
-		p := tx.Bucket(dbBucket).Get(dbOptions)
-		if len(p) == 0 {
-			return errors.New("not found")
-		}
-
-		return json.Unmarshal(p, &opts)
-	})
-
-	if err != nil {
+	if err := s.db.GetValue("options", &opts); err != nil {
 		return nil, err
 	}
 
 	return &opts, nil
 }
 
-func (b *boltStorage) SetOptions(opts *Options) error {
-	p, err := json.Marshal(opts)
-	if err != nil {
-		return err
-	}
-
-	return b.db.Update(func(tx *bolt.Tx) error {
-		return tx.Bucket(dbBucket).Put(dbOptions, p)
-	})
-}
-
-type memStorage struct {
-	opts *Options
-}
-
-func newMemStorage() *memStorage {
-	return &memStorage{
-		opts: &Options{},
-	}
-}
-
-func (m *memStorage) Options() (*Options, error) {
-	return m.opts.copy(), nil
-}
-
-func (m *memStorage) SetOptions(opts *Options) error {
-	m.opts = opts.copy()
-	return nil
+func (s *Storage) SetOptions(opts *Options) error {
+	return s.db.SetValue("options", opts)
 }

--- a/go/src/koding/klient/tunnel/tunnel.go
+++ b/go/src/koding/klient/tunnel/tunnel.go
@@ -213,9 +213,13 @@ func (t *Tunnel) Start(opts *Options, registerURL *url.URL) (*url.URL, error) {
 		return registerURL, nil
 	}
 
-	t.opts.Log.Debug("starting tunnel client: %# v", opts)
+	clientOpts := t.clientOptions()
 
-	client, err := tunnelproxy.NewClient(t.clientOptions())
+	t.opts.Log.Debug("starting tunnel client")
+	t.opts.Log.Debug("tunnel.Options=%+v", opts)
+	t.opts.Log.Debug("tunnelproxy.ClientOptions=%+v", clientOpts)
+
+	client, err := tunnelproxy.NewClient(clientOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/go/src/koding/klient/tunnel/tunnel.go
+++ b/go/src/koding/klient/tunnel/tunnel.go
@@ -27,7 +27,7 @@ var (
 
 // Tunnel
 type Tunnel struct {
-	db     Storage
+	db     *Storage
 	opts   *Options
 	client *tunnelproxy.Client
 
@@ -122,7 +122,7 @@ func New(opts *Options) *Tunnel {
 	optsCopy := *opts
 
 	t := &Tunnel{
-		db:   newStorage(&optsCopy),
+		db:   NewStorage(optsCopy.DB),
 		opts: &optsCopy,
 	}
 

--- a/go/src/koding/klient/tunnel/vbox.go
+++ b/go/src/koding/klient/tunnel/vbox.go
@@ -1,0 +1,241 @@
+package tunnel
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"koding/klient/vagrant"
+	"koding/tools/util"
+
+	"github.com/koding/kite"
+)
+
+func (t *Tunnel) Info(r *kite.Request) (interface{}, error) {
+	return nil, nil // TODO
+}
+
+func (t *Tunnel) Route(r *kite.Request) (interface{}, error) {
+	return nil, nil // TODO
+}
+
+type Ports []*vagrant.ForwardedPort
+
+func (p Ports) String() string {
+	if len(p) == 0 {
+		return "[]"
+	}
+
+	var buf bytes.Buffer
+
+	fmt.Fprintf(&buf, "[%+v", p[0])
+
+	for _, p := range p[1:] {
+		fmt.Fprintf(&buf, ",%+v", p)
+	}
+
+	buf.WriteRune(']')
+
+	return buf.String()
+}
+
+// localRoute gives route of the local HTTP server (kite server).
+//
+// If the kite server runs inside a VirtualBox machine, localRoute
+// returns a route to the forwarded port on the host network.
+func (t *Tunnel) localRoute() map[string]string {
+	ok, err := vagrant.IsVagrant()
+	if err != nil {
+		t.opts.Log.Error("failure checking local route: %s", err)
+
+		return nil
+	}
+
+	if !ok {
+		return map[string]string{
+			t.opts.PublicIP.String(): t.opts.LocalAddr,
+		}
+	}
+
+	_, port, err := parseHostPort(t.opts.LocalAddr)
+	if err != nil {
+		t.opts.Log.Error("ill-formed local address: %s", err)
+
+		return nil
+	}
+
+	ports, err := t.forwardedPorts()
+	if err != nil {
+		t.opts.Log.Error("failure checking local route: %s", err)
+
+		return nil
+	}
+
+	t.opts.Log.Debug("forwarded ports: %+v", Ports(ports))
+
+	// cache forwarded ports
+	t.mu.Lock()
+	t.ports = ports
+	t.mu.Unlock()
+
+	var localAddr string
+
+	for _, p := range ports {
+		if p.GuestPort == port {
+			localAddr = net.JoinHostPort("127.0.0.1", strconv.Itoa(p.HostPort))
+			break
+		}
+	}
+
+	if localAddr == "" {
+		t.opts.Log.Error("unable to find forwarded host port for %d: %+v", port, ports)
+
+		return nil
+	}
+
+	return map[string]string{
+		t.opts.PublicIP.String(): localAddr,
+	}
+}
+
+func (t *Tunnel) gateways() (map[string]string, error) {
+	routes, err := util.ParseRoutes()
+	if err != nil {
+		return nil, err
+	}
+
+	gateways := make(map[string]string)
+
+	for _, r := range routes {
+		if !begins(r.Iface, "eth") {
+			continue
+		}
+
+		if r.Gateway == nil {
+			continue
+		}
+
+		gateways[r.Iface] = r.Gateway.String()
+	}
+
+	if len(gateways) == 0 {
+		return nil, errors.New("no interfaces found")
+	}
+
+	return gateways, nil
+}
+
+func (t *Tunnel) dialHostKite(addr string) (*kite.Client, error) {
+	hostKiteURL := &url.URL{
+		Scheme: "http",
+		Host:   addr,
+		Path:   "/kite",
+	}
+
+	k := kite.New("klienttunnel", "0.0.1")
+	k.Config = t.opts.Config.Copy()
+
+	if t.opts.Debug {
+		k.SetLogLevel(kite.DEBUG)
+	}
+
+	client := k.NewClient(hostKiteURL.String())
+	client.Auth = &kite.Auth{
+		Type: "kiteKey",
+		Key:  k.Config.KiteKey,
+	}
+
+	if err := client.DialTimeout(7 * time.Second); err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
+func (t *Tunnel) forwardedPorts() ([]*vagrant.ForwardedPort, error) {
+	if t.opts.TunnelName == "" {
+		return nil, errors.New("failue checking local route: missing tunnel name")
+	}
+
+	// If we're a kite inside vagrant, we call host kite asking
+	// about forwarded ports. TunnelName is assigned by the host
+	// kite and is equal to jMachines.Uid for the given vagrant
+	// vm. The VirtualBox machine name is always prefixed by
+	// the jMachines.Uid.
+	gateways, err := t.gateways()
+	if err != nil {
+		return nil, fmt.Errorf("failure reading routing table: %s", err)
+	}
+
+	addr, ok := gateways["eth0"]
+	if !ok {
+		for _, a := range gateways {
+			addr = a // pick first non-eth0 interface (eth1?)
+			break
+		}
+	}
+
+	// NOTE(rjeczalik): we assume host kite is on port 56789 (all installer
+	// scripts use it as default one) and the host kite listens on all
+	// interfaces.
+	addr = net.JoinHostPort(addr, "56789")
+
+	client, err := t.dialHostKite(addr)
+	if err != nil {
+		return nil, fmt.Errorf("failure dialing host kite %q: %s", addr, err)
+	}
+	defer client.Close()
+
+	req := &vagrant.ForwardedPortsRequest{
+		Name: t.opts.TunnelName,
+	}
+
+	resp, err := client.TellWithTimeout("vagrant.listForwardedPorts", 15*time.Second, req)
+	if err != nil {
+		return nil, fmt.Errorf("failure calling listForwardedPorts: %s", err)
+	}
+
+	var ports []*vagrant.ForwardedPort
+	if err := resp.Unmarshal(&ports); err != nil {
+		return nil, fmt.Errorf("failure reading response: %s", err)
+	}
+
+	if len(ports) == 0 {
+		return nil, errors.New("no forwarded ports found")
+	}
+
+	return ports, nil
+}
+
+func parseHostPort(addr string) (string, int, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", 0, err
+	}
+
+	n, err := strconv.ParseUint(port, 10, 16)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return host, int(n), nil
+}
+
+func begins(s string, substrs ...string) bool {
+	if s == "" {
+		return true
+	}
+
+	for _, substr := range substrs {
+		if strings.HasPrefix(s, substr) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/go/src/koding/klient/vagrant/handlers.go
+++ b/go/src/koding/klient/vagrant/handlers.go
@@ -76,6 +76,7 @@ type ForwardedPort struct {
 }
 
 type VagrantCreateOptions struct {
+	Username       string           `json:"username"`
 	Hostname       string           `json:"hostname"`
 	Box            string           `json:"box,omitempty"`
 	Memory         int              `json:"memory,omitempty"`
@@ -459,7 +460,7 @@ func (h *Handlers) vboxForwardedPorts(name string) (ports []*ForwardedPort, err 
 		}
 
 		if i := strings.IndexRune(line, '='); i != -1 {
-			line = line[:i]
+			line = line[i+1:]
 		}
 
 		if s, err := strconv.Unquote(line); err == nil {

--- a/go/src/koding/klient/vagrant/handlers.go
+++ b/go/src/koding/klient/vagrant/handlers.go
@@ -4,8 +4,14 @@
 package vagrant
 
 import (
+	"bufio"
+	"bytes"
 	"errors"
+	"fmt"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -65,8 +71,8 @@ type Info struct {
 }
 
 type ForwardedPort struct {
-	GuestPort int `json:"guestPort"`
-	HostPort  int `json:"hostPort"`
+	GuestPort int `json:"guest,omitempty"`
+	HostPort  int `json:"host,omitempty"`
 }
 
 type VagrantCreateOptions struct {
@@ -77,7 +83,7 @@ type VagrantCreateOptions struct {
 	ProvisionData  string           `json:"provisionData"`
 	CustomScript   string           `json:"customScript,omitempty"`
 	FilePath       string           `json:"filePath"`
-	ForwardedPorts []*ForwardedPort `json:"forwardedPorts,omitempty"`
+	ForwardedPorts []*ForwardedPort `json:"forwarded_ports,omitempty"`
 }
 
 type vagrantFunc func(r *kite.Request, v *vagrantutil.Vagrant) (interface{}, error)
@@ -273,12 +279,52 @@ func (h *Handlers) Status(r *kite.Request) (interface{}, error) {
 	return h.withPath(r, fn)
 }
 
-// Version retursn the Vagrant version of the system
+// Version returns the Vagrant version of the system
 func (h *Handlers) Version(r *kite.Request) (interface{}, error) {
 	fn := func(r *kite.Request, v *vagrantutil.Vagrant) (interface{}, error) {
 		return v.Version()
 	}
 	return h.withPath(r, fn)
+}
+
+type ForwardedPortsRequest struct {
+	Name string `json:"name"`
+}
+
+func (req *ForwardedPortsRequest) Valid() error {
+	if req.Name == "" {
+		return errors.New("box name is empty")
+	}
+
+	return nil
+}
+
+// ForwardedPorts lists all forwarded port rules for the given box.
+func (h *Handlers) ForwardedPorts(r *kite.Request) (interface{}, error) {
+	if r.Args == nil {
+		return nil, errors.New("no arguments")
+	}
+
+	var req ForwardedPortsRequest
+	if err := r.Args.One().Unmarshal(&req); err != nil {
+		return nil, err
+	}
+
+	if err := req.Valid(); err != nil {
+		return nil, err
+	}
+
+	name, err := h.vboxLookupName(req.Name)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find box %q: %s", req.Name, err)
+	}
+
+	ports, err := h.vboxForwardedPorts(name)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read forwarded ports for box %q: %s", name, err)
+	}
+
+	return ports, nil
 }
 
 func (h *Handlers) boxAdd(v *vagrantutil.Vagrant, box, filePath string) {
@@ -362,6 +408,92 @@ func (h *Handlers) boxWait(filePath string) error {
 	wait := make(chan error, 1)
 	queue <- wait
 	return <-wait
+}
+
+func (h *Handlers) vboxLookupName(partial string) (fullName string, err error) {
+	p, err := exec.Command("VBoxManage", "list", "vms").Output()
+	if err != nil {
+		return "", err
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(p))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if i := strings.IndexRune(line, ' '); i != -1 {
+			line = line[:i]
+		}
+		if s, err := strconv.Unquote(line); err == nil {
+			line = s
+		}
+
+		if strings.HasPrefix(line, partial) {
+			if fullName != "" {
+				return "", fmt.Errorf("multiple boxes found for %q: %q, %q", partial, fullName, line)
+			}
+
+			fullName = line
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+
+	if fullName == "" {
+		return "", fmt.Errorf("no box found for %q", partial)
+	}
+
+	return fullName, nil
+}
+
+func (h *Handlers) vboxForwardedPorts(name string) (ports []*ForwardedPort, err error) {
+	p, err := exec.Command("VBoxManage", "showvminfo", name, "--machinereadable").Output()
+	if err != nil {
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(p))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "Forwarding") {
+			continue
+		}
+
+		if i := strings.IndexRune(line, '='); i != -1 {
+			line = line[:i]
+		}
+
+		if s, err := strconv.Unquote(line); err == nil {
+			line = s
+		}
+
+		// forwarding rule is in format "tcp56788,tcp,,56788,,56789", where
+		// 56788 is host port and 56789 a guest one.
+		v := strings.Split(line, ",")
+
+		if len(v) != 6 || v[3] == "" || v[5] == "" {
+			h.log.Debug("forwarding rule is ill-formatted: %s", line)
+			continue
+		}
+
+		hostPort, err := strconv.Atoi(v[3])
+		if err != nil {
+			h.log.Debug("forwarding rule: parsing host port error: %s", err)
+			continue
+		}
+
+		guestPort, err := strconv.Atoi(v[5])
+		if err != nil {
+			h.log.Debug("forwarding rule: parsing guest port error: %s", err)
+			continue
+		}
+
+		ports = append(ports, &ForwardedPort{GuestPort: guestPort, HostPort: hostPort})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return ports, nil
 }
 
 func (h *Handlers) init() {
@@ -462,4 +594,50 @@ func (fns OutputFuncs) Output(line string) {
 	for _, fn := range fns {
 		fn(line)
 	}
+}
+
+var vboxModules = []string{
+	"vboxguest",
+	"vboxsf",
+	"vboxvideo",
+}
+
+func IsVagrant() (bool, error) {
+	if runtime.GOOS != "linux" {
+		return false, nil // TODO(rjeczalik): Windows support
+	}
+
+	p, err := exec.Command("lsmod").Output()
+	if err != nil {
+		return false, errors.New("IsVagrant error: " + err.Error())
+	}
+
+	for {
+		// a single line of lsmod output is in format:
+		//
+		//  module             249035  2 modules
+		//
+		// if at least one VirtualBox module is loaded into kernel,
+		// it means it's a vagrant box.
+		i := bytes.IndexByte(p, ' ')
+		if i == -1 {
+			break
+		}
+
+		module := string(p[:i])
+
+		for _, vboxModule := range vboxModules {
+			if module == vboxModule {
+				return true, nil
+			}
+		}
+
+		if i = bytes.IndexByte(p, '\n'); i == -1 {
+			break
+		}
+
+		p = p[i+1:]
+	}
+
+	return false, nil
 }

--- a/go/src/koding/klient/vagrant/template.go
+++ b/go/src/koding/klient/vagrant/template.go
@@ -44,7 +44,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "{{.Box}}"
   config.vm.hostname = "{{.Hostname}}"
 
-{{range _, $f := {{.ForwardedPorts}}
+{{range $_, $f := .ForwardedPorts}}
   config.vm.network "forwarded_port", guest: {{$f.GuestPort}}, host: {{$f.HostPort}}, auto_correct: true
 {{end}}
 

--- a/go/src/koding/klient/vagrant/template.go
+++ b/go/src/koding/klient/vagrant/template.go
@@ -29,7 +29,7 @@ date > /etc/vagrant_provisioned_at
 wget -q --retry-connrefused --tries 5 https://s3.amazonaws.com/kodingdev-provision/provisionklient.gz || die "downloading provisionklient failed"
 gzip -d -f provisionklient.gz || die "unarchiving provisionklient failed"
 chmod +x provisionklient
-./provisionklient -data '{{ .ProvisionData }}'
+./provisionklient -data '{{.ProvisionData}}'
 
 cat >user-script.sh <<EOF
 {{ .CustomScript }}
@@ -41,12 +41,16 @@ chmod +x user-script.sh
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "{{ .Box }}"
-  config.vm.hostname = "{{ .Hostname }}"
+  config.vm.box = "{{.Box}}"
+  config.vm.hostname = "{{.Hostname}}"
+
+{{range _, $f := {{.ForwardedPorts}}
+  config.vm.network "forwarded_port", guest: {{$f.GuestPort}}, host: {{$f.HostPort}}, auto_correct: true
+{{end}}
 
   config.vm.provider "virtualbox" do |vb|
     # Use VBoxManage to customize the VM. For example to change memory:
-    vb.customize ["modifyvm", :id, "--memory", "{{ .Memory }}", "--cpus", "{{ .Cpus }}"]
+    vb.customize ["modifyvm", :id, "--memory", "{{.Memory}}", "--cpus", "{{.Cpus}}"]
   end
 
   config.vm.provision "shell", inline: $script

--- a/go/src/koding/tools/util/net.go
+++ b/go/src/koding/tools/util/net.go
@@ -1,0 +1,83 @@
+package util
+
+import (
+	"bufio"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"runtime"
+	"strings"
+)
+
+// Route represents a single routing entry.
+type Route struct {
+	Iface   string
+	Dest    net.IP
+	Gateway net.IP
+}
+
+// String implements the fmt.Stringer interface.
+func (r *Route) String() string {
+	return fmt.Sprintf("%s: %s -> %s", r.Iface, r.Dest, r.Gateway)
+}
+
+func ipFromHex(s string) (net.IP, error) {
+	if s == "00000000" {
+		return nil, nil
+	}
+
+	p, err := hex.DecodeString(s)
+	if err != nil {
+		return nil, err
+	}
+
+	return net.IPv4(p[3], p[2], p[1], p[0]), nil
+}
+
+// ParseRoutes reads system routing information and list gateway
+// addresses for each available interface.
+//
+// TODO(rjeczalik): add support for darwin and windows.
+func ParseRoutes() ([]*Route, error) {
+	if runtime.GOOS != "linux" {
+		return nil, errors.New("routes not implemented")
+	}
+
+	f, err := os.Open("/proc/net/route")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var routes []*Route
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		s := strings.Fields(scanner.Text())
+		if len(s) < 3 || s[0] == "Iface" || s[0] == "*" || len(s[1]) != 8 || len(s[2]) != 8 {
+			continue
+		}
+
+		r := &Route{
+			Iface: s[0],
+		}
+
+		if r.Dest, err = ipFromHex(s[1]); err != nil {
+			continue
+		}
+
+		if r.Gateway, err = ipFromHex(s[2]); err != nil {
+			continue
+		}
+
+		routes = append(routes, r)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return routes, nil
+}

--- a/go/src/koding/tools/util/net_test.go
+++ b/go/src/koding/tools/util/net_test.go
@@ -1,0 +1,22 @@
+package util_test
+
+import (
+	"testing"
+
+	"koding/tools/util"
+)
+
+func TestRoutes(t *testing.T) {
+	r, err := util.ParseRoutes()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(r) == 0 {
+		t.Fatal("no routes parsed")
+	}
+
+	for i, r := range r {
+		t.Logf("[%d] routes: %s", i, r)
+	}
+}


### PR DESCRIPTION
/cc @koding/godevs 
- [x] terraform plugins: forwarded_ports resource
- [x] kloud: forward port for klient kite
- [x] klient: send local port to tunnelserver (if a vagrant klient)
- [x] tunnelserver: redirect when public ip matches the one registered for local port
- [x] klient/tunnel: add tunnel.info

https://koding.atlassian.net/browse/TMS-2434
