### PR TITLE
AccountSessionListWrapper: Do not listen ItemDeleted event from list controller anymore

### DIFF
--- a/client/account/lib/accountsessionlistwrapper.coffee
+++ b/client/account/lib/accountsessionlistwrapper.coffee
@@ -26,7 +26,7 @@ module.exports = class AccountSessionListWrapper extends KDView
       fetcherMethod     : (query, options, callback) ->
         whoami().fetchMySessions options, (err, sessions)  -> callback err, sessions
 
-    @listController.on 'ItemDeleted', (item) ->
+    @listController.getListView().on 'ItemWasRemoved', (item) ->
       session  = item.getData()
       clientId = kookies.get 'clientId'
 


### PR DESCRIPTION
Based on that commit https://github.com/koding/koding/pull/7268/commits/b050921cbe31e481b83f2f089dc1f632dc1c692c but this pr can be merged without it.

/cc @gokmen @sinan @gokhansongul 
