### PR TITLE
TMS-2599 provider/vagrant, klient/tunnel: add support for TCP tunnels

### DIFF
--- a/go/src/koding/kites/e2etest/tunnelproxy_test.go
+++ b/go/src/koding/kites/e2etest/tunnelproxy_test.go
@@ -179,11 +179,21 @@ func testTunnelserverTCP(t *testing.T, serverURL *url.URL) {
 		t.Fatal("expected virtualHost to be non-empty")
 	}
 
-	if err := client.RegisterService("echo1", echo1.Addr().String()); err != nil {
+	echo1service := &tunnelproxy.Service{
+		Name:      "echo1",
+		LocalAddr: echo1.Addr().String(),
+	}
+
+	if err := client.RegisterService(echo1service); err != nil {
 		t.Fatalf("RegisterService(echo1)=%s", err)
 	}
 
-	if err := client.RegisterService("echo2", echo2.Addr().String()); err != nil {
+	echo2service := &tunnelproxy.Service{
+		Name:      "echo2",
+		LocalAddr: echo2.Addr().String(),
+	}
+
+	if err := client.RegisterService(echo2service); err != nil {
 		t.Fatalf("RegisterService(echo2)=%s", err)
 	}
 
@@ -260,10 +270,11 @@ func testWithTunnelserver(t *testing.T, test func(*testing.T, *url.URL)) {
 		Config:          serverCfg,
 		ServerAddr:      serverURL.Host,
 		RegisterURL:     serverURL,
-		TCPRangeFrom:    30000,
-		TCPRangeTo:      30100,
+		TCPRangeFrom:    10000,
+		TCPRangeTo:      50000,
 		Log:             Test.Log.New("tunnelserver"),
 		Debug:           true,
+		Test:            true,
 	}
 
 	server, err := tunnelproxy.NewServer(serverOpts)

--- a/go/src/koding/kites/terraformplugins/vagrant/config.go
+++ b/go/src/koding/kites/terraformplugins/vagrant/config.go
@@ -37,7 +37,6 @@ func newConfig() error {
 
 	config.Environment = Environment
 	config.Region = Region
-	config.Transport = kiteconfig.XHRPolling
 
 	return nil
 }
@@ -64,10 +63,16 @@ func NewClient() (*Client, error) {
 	k := kite.New(Name, Version)
 	k.Config = config.Copy()
 
+	if debug {
+		k.SetLogLevel(kite.DEBUG)
+	}
+
 	c := &Client{
 		Kite: k,
 		Log:  common.NewLogger(Name, debug),
 	}
+
+	c.Log.Debug("starting provider-vagrant in debug mode")
 
 	c.Vagrant = &vagrantapi.Klient{
 		Kite:  k,

--- a/go/src/koding/kites/tunnelproxy/server.go
+++ b/go/src/koding/kites/tunnelproxy/server.go
@@ -7,6 +7,8 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
+	"os/user"
 	"sort"
 	"strconv"
 	"strings"
@@ -62,6 +64,7 @@ type Server struct {
 	opts      *ServerOptions
 	record    *dnsclient.Record
 	callbacks *callbacks
+	privateIP string
 
 	mu       sync.Mutex        // protects idents, services and tunnels
 	idents   map[string]string // maps vhost to ident
@@ -81,6 +84,7 @@ func NewServer(opts *ServerOptions) (*Server, error) {
 		if err != nil {
 			return nil, err
 		}
+
 		optsCopy.ServerAddr = ip
 	}
 
@@ -120,7 +124,16 @@ func NewServer(opts *ServerOptions) (*Server, error) {
 	if !optsCopy.NoCNAME {
 		id, err := instanceID()
 		if err != nil {
-			return nil, err
+			if optsCopy.Test {
+				username := os.Getenv("USER")
+				if u, err := user.Current(); err == nil {
+					username = u.Username
+				}
+
+				id = "koding-" + username
+			} else {
+				return nil, err
+			}
 		}
 
 		optsCopy.BaseVirtualHost = strings.TrimPrefix(id, "i-") + "." + optsCopy.BaseVirtualHost
@@ -159,13 +172,21 @@ func NewServer(opts *ServerOptions) (*Server, error) {
 	optsCopy.Log.Debug("Server options: %# v", &optsCopy)
 
 	s := &Server{
-		Server:   server,
-		DNS:      dns,
-		opts:     &optsCopy,
-		record:   dnsclient.ParseRecord("", optsCopy.ServerAddr),
-		idents:   make(map[string]string),
-		services: make(map[int]net.Listener),
-		tunnels:  newTunnels(),
+		Server:    server,
+		DNS:       dns,
+		opts:      &optsCopy,
+		privateIP: "0.0.0.0",
+		record:    dnsclient.ParseRecord("", optsCopy.ServerAddr),
+		idents:    make(map[string]string),
+		services:  make(map[int]net.Listener),
+		tunnels:   newTunnels(),
+	}
+
+	// Do not bind to private address for testing.
+	if !s.opts.Test {
+		if ip, err := privateIP(); err == nil {
+			s.privateIP = ip
+		}
 	}
 
 	return s, nil
@@ -266,6 +287,10 @@ func (s *Server) addClient(ident, name, vhost string, services map[string]*Tunne
 
 	err := new(multierror.Error)
 	for _, tun := range toList(services, vhost) {
+		if tun.Name != "kite" && tun.Name != "kites" {
+			s.opts.Log.Warning("unsupported %q service added during initial registration", tun.Name)
+		}
+
 		e := s.tunnels.addClientService(ident, tun)
 		if e != nil {
 			e = multierror.Append(e, err)
@@ -399,11 +424,22 @@ func (s *Server) delClientService(ident, name string) {
 }
 
 func (s *Server) addr(port int) string {
-	return net.JoinHostPort(host(s.opts.ServerAddr), strconv.Itoa(port))
+	return net.JoinHostPort(s.privateIP, strconv.Itoa(port))
 }
 
-// RegisterServices
+// RegisterServices creates a port-routed TCP tunnel for each requested service.
 func (s *Server) RegisterServices(r *kite.Request) (interface{}, error) {
+	resp, err := s.registerServices(r)
+	if err != nil {
+		s.opts.Log.Error("error serving RegisterServices for %q: %s", r.Username, err)
+
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func (s *Server) registerServices(r *kite.Request) (interface{}, error) {
 	var req RegisterServicesRequest
 
 	if r.Args == nil {
@@ -426,6 +462,9 @@ func (s *Server) RegisterServices(r *kite.Request) (interface{}, error) {
 		VirtualHost: vhost,
 		Services:    make(map[string]*Tunnel, len(services)),
 	}
+
+	s.opts.Log.Debug("received RegisterServices request for %q: %+v", r.Username, services)
+
 	for _, service := range services {
 		// During initial registration klient sends details about port
 		// (and eventual forwarded ports) for kite and kites services,
@@ -458,6 +497,8 @@ func (s *Server) RegisterServices(r *kite.Request) (interface{}, error) {
 		return nil, err
 	}
 
+	s.opts.Log.Debug("registered services for %q: %+v", r.Username, res)
+
 	return res, nil
 }
 
@@ -467,6 +508,17 @@ func (s *Server) vhost(req *RegisterRequest) string {
 
 // Register creates a virtual host and DNS record for the user.
 func (s *Server) Register(r *kite.Request) (interface{}, error) {
+	resp, err := s.register(r)
+	if err != nil {
+		s.opts.Log.Error("error serving Register for %q: %s", r.Username, err)
+
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func (s *Server) register(r *kite.Request) (interface{}, error) {
 	var req RegisterRequest
 
 	if r.Args != nil {
@@ -490,9 +542,9 @@ func (s *Server) Register(r *kite.Request) (interface{}, error) {
 		req.TunnelName = utils.RandString(12)
 	}
 
-	s.opts.Log.Debug("received register request: %# v", &req)
-
 	vhost := s.vhost(&req)
+
+	s.opts.Log.Debug("received register request: %s", TunnelsByName(toList(req.Services, vhost)))
 
 	// By default all addresses are routed by default with wildcard
 	// CNAME. If it is disabled explicitly, we're inserting A records
@@ -583,13 +635,17 @@ func (s *Server) listen(network, addr string) (net.Listener, error) {
 			port = from
 		}
 
-		l, err := net.Listen(network, net.JoinHostPort(host, strconv.Itoa(port)))
+		addr := net.JoinHostPort(host, strconv.Itoa(port))
+
+		l, err := net.Listen(network, addr)
 		if err == nil {
 			s.lastMu.Lock()
 			s.last = port
 			s.lastMu.Unlock()
 
 			return l, nil
+		} else {
+			s.opts.Log.Debug("unable to listen on %q: %s", addr, err)
 		}
 
 		port++

--- a/go/src/koding/klient/tunnel/storage.go
+++ b/go/src/koding/klient/tunnel/storage.go
@@ -1,6 +1,7 @@
 package tunnel
 
 import (
+	"koding/kites/tunnelproxy"
 	"koding/klient/storage"
 
 	"github.com/boltdb/bolt"
@@ -9,8 +10,7 @@ import (
 var (
 	// dbBucket is the bucket name used to retrieve and store the resolved
 	// address
-	dbBucket  = []byte("klienttunnel")
-	dbOptions = []byte("options")
+	dbBucket = []byte("klienttunnel")
 )
 
 type Storage struct {
@@ -34,4 +34,17 @@ func (s *Storage) Options() (*Options, error) {
 
 func (s *Storage) SetOptions(opts *Options) error {
 	return s.db.SetValue("options", opts)
+}
+
+func (s *Storage) Services() (tunnelproxy.Services, error) {
+	srvc := make(tunnelproxy.Services)
+	if err := s.db.GetValue("services", &srvc); err != nil {
+		return nil, err
+	}
+
+	return srvc, nil
+}
+
+func (s *Storage) SetServices(srvc tunnelproxy.Services) error {
+	return s.db.SetValue("services", srvc)
 }

--- a/go/src/koding/klient/tunnel/tunnel.go
+++ b/go/src/koding/klient/tunnel/tunnel.go
@@ -3,7 +3,6 @@
 package tunnel
 
 import (
-	"errors"
 	"net"
 	"net/url"
 	"strconv"
@@ -13,6 +12,7 @@ import (
 
 	"koding/kites/tunnelproxy"
 	"koding/klient/info/publicip"
+	"koding/klient/storage"
 	"koding/klient/tunnel/tlsproxy"
 	"koding/klient/vagrant"
 
@@ -22,27 +22,20 @@ import (
 	"github.com/koding/tunnel"
 )
 
-var (
-	// ErrKeyNotFound
-	ErrKeyNotFound = errors.New("key not found")
-
-	// ErrNoDatabase
-	ErrNoDatabase = errors.New("local database is not available")
-)
-
 type Tunnel struct {
 	db     *Storage
 	client *tunnelproxy.Client
 
 	// Cached routes, in case host kite goes down.
-	mu    sync.Mutex // protects ports and opts
-	ports []*vagrant.ForwardedPort
-	opts  *Options
+	mu       sync.Mutex // protects ports, opts and services
+	ports    []*vagrant.ForwardedPort
+	opts     *Options
+	services tunnelproxy.Services
 
-	// Used to wait for first successful
-	// tunnel server registration.
-	register sync.WaitGroup
-	once     sync.Once
+	// Used to wait for first successful tunnel server registration.
+	register     sync.WaitGroup
+	once         sync.Once
+	onceServices sync.Once
 
 	state        tunnel.ClientState
 	stateChanges chan *tunnel.ClientStateChange
@@ -168,17 +161,19 @@ func New(opts *Options) (*Tunnel, error) {
 
 func (t *Tunnel) clientOptions() *tunnelproxy.ClientOptions {
 	return &tunnelproxy.ClientOptions{
-		TunnelName:      t.opts.TunnelName,
-		TunnelKiteURL:   t.opts.TunnelKiteURL,
-		LastVirtualHost: t.opts.VirtualHost,
-		LocalAddr:       t.opts.LocalAddr,
-		Services:        t.services(),
-		Config:          t.opts.Config,
-		Timeout:         t.opts.Timeout,
-		OnRegister:      t.updateOptions,
-		Debug:           t.opts.Debug,
-		NoProxy:         t.opts.NoProxy,
-		StateChanges:    t.stateChanges,
+		TunnelName:         t.opts.TunnelName,
+		TunnelKiteURL:      t.opts.TunnelKiteURL,
+		LastVirtualHost:    t.opts.VirtualHost,
+		LocalAddr:          t.opts.LocalAddr,
+		Services:           t.buildServices(),
+		Config:             t.opts.Config,
+		Timeout:            t.opts.Timeout,
+		OnRegister:         t.updateOptions,
+		OnRegisterServices: t.updateServices,
+		PublicIP:           t.opts.PublicIP.String(),
+		Debug:              t.opts.Debug,
+		NoProxy:            t.opts.NoProxy,
+		StateChanges:       t.stateChanges,
 	}
 }
 
@@ -206,6 +201,9 @@ func (t *Tunnel) updateOptions(reg *tunnelproxy.RegisterResult) {
 			t.ports = nil
 		}
 	}
+
+	t.onceServices.Do(t.initServices)
+	t.restoreServices()
 	t.mu.Unlock()
 
 	if err := t.db.SetOptions(t.opts); err != nil {
@@ -213,6 +211,107 @@ func (t *Tunnel) updateOptions(reg *tunnelproxy.RegisterResult) {
 	}
 
 	t.once.Do(t.register.Done)
+}
+
+func (t *Tunnel) initServices() {
+	if !t.isVagrant {
+		return // no ssh service for non-vagrant kites (e.g. managed ones)
+	}
+
+	s, err := t.db.Services()
+	if err == storage.ErrKeyNotFound {
+		s = tunnelproxy.Services{
+			"ssh": &tunnelproxy.Service{
+				LocalAddr: "127.0.0.1:22",
+			},
+		}
+
+		err = t.db.SetServices(s)
+	}
+
+	if err != nil {
+		t.opts.Log.Warning("tunnel: unable to init services: %s", err)
+		return
+	}
+}
+
+func (t *Tunnel) updateServices(reg *tunnelproxy.RegisterServicesResult) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if err := reg.Err(); err != nil {
+		t.opts.Log.Debug("failed to register all of the services: %s", err)
+	}
+
+	var updated int
+	for name, tun := range reg.Services {
+		if tun.Err() != nil {
+			continue
+		}
+
+		service, ok := t.services[name]
+		if !ok {
+			service = &tunnelproxy.Service{}
+			t.services[name] = service
+		}
+
+		service.RemoteAddr = net.JoinHostPort(host(tun.VirtualHost), strconv.Itoa(tun.Port))
+
+		updated++
+	}
+
+	// ignore nop updates
+	if updated != 0 {
+		if err := t.db.SetServices(t.services); err != nil {
+			t.opts.Log.Warning("tunnel: unable to update services: %s", err)
+		}
+	}
+}
+
+func (t *Tunnel) restoreServices() {
+	services, err := t.db.Services()
+	if err != nil {
+		t.opts.Log.Warning("tunnel: unable to read services: %s", err)
+		return
+	}
+
+	// update forwarded ports if there are any
+	if len(t.ports) != 0 {
+		t.opts.Log.Debug("updating forwarded ports for services: %+v", t.ports)
+
+		for _, s := range services {
+			_, localPort, err := splitHostPort(s.RemoteAddr)
+			if err != nil || localPort <= 0 {
+				t.opts.Log.Warning("tunne: skipping %+v service, missing local address: %s", s, err)
+				continue
+			}
+
+			t.opts.Log.Debug("updating forwarded ports for %q service", s.Name)
+
+			for _, p := range t.ports {
+				if p.GuestPort == localPort {
+					t.opts.Log.Debug("found forwarded port for %q service: %+v", s.Name, p)
+
+					s.ForwardedPort = p.HostPort
+					break
+				}
+			}
+		}
+	}
+
+	// TODO(rjeczalik): add vagrant.forwardPort to host klient and call
+	// it for each services that does not have forwarded port; required
+	// in order to add tunnel.add
+
+	if err := t.client.RestoreServices(services); err != nil {
+		t.opts.Log.Error("tunnel: unable to restore %d services: %s", len(services), err)
+	}
+
+	t.services = services
+
+	if err := t.db.SetServices(services); err != nil {
+		t.opts.Log.Warning("tunnel: unable to update services: %s", err)
+	}
 }
 
 // buildOptions finalizes build of tunnel options; the contructed options
@@ -257,11 +356,11 @@ func (t *Tunnel) Start(opts *Options, registerURL *url.URL) (*url.URL, error) {
 		}
 	}
 
-	if t.opts.LastReachable {
+	clientOpts := t.clientOptions()
+
+	if t.opts.LastReachable && !t.isVagrant {
 		return registerURL, nil
 	}
-
-	clientOpts := t.clientOptions()
 
 	t.opts.Log.Debug("starting tunnel client")
 	t.opts.Log.Debug("tunnel.Options=%+v", opts)
@@ -283,6 +382,28 @@ func (t *Tunnel) Start(opts *Options, registerURL *url.URL) (*url.URL, error) {
 	t.opts.Log.Info("tunnel: connected as %q", u.Host)
 
 	return &u, nil
+}
+
+func host(hostport string) string {
+	if host, _, err := net.SplitHostPort(hostport); err == nil {
+		return host
+	}
+
+	return hostport
+}
+
+func splitHostPort(addr string) (string, int, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", 0, err
+	}
+
+	n, err := strconv.ParseUint(port, 10, 16)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return host, int(n), nil
 }
 
 func guessTunnelName(vhost string) string {

--- a/go/src/koding/klient/tunnel/vbox.go
+++ b/go/src/koding/klient/tunnel/vbox.go
@@ -55,13 +55,22 @@ type InfoResponse struct {
 	Ports map[string]*Port `json:"ports,omitempty"`
 }
 
+const (
+	StateNotStarted   = "NotStarted"
+	StateStarted      = "Started"
+	StateConnecting   = "Connecting"
+	StateConnected    = "Connected"
+	StateDisconnected = "Disconnected"
+	StateClosed       = "Closed"
+)
+
 var stateNames = map[tunnel.ClientState]string{
-	tunnel.ClientUnknown:      "NotStarted",
-	tunnel.ClientStarted:      "Started",
-	tunnel.ClientConnecting:   "Connecting",
-	tunnel.ClientConnected:    "Connected",
-	tunnel.ClientDisconnected: "Disconnected",
-	tunnel.ClientClosed:       "Closed",
+	tunnel.ClientUnknown:      StateNotStarted,
+	tunnel.ClientStarted:      StateStarted,
+	tunnel.ClientConnecting:   StateConnected,
+	tunnel.ClientConnected:    StateConnected,
+	tunnel.ClientDisconnected: StateDisconnected,
+	tunnel.ClientClosed:       StateClosed,
 }
 
 func (t *Tunnel) Info(r *kite.Request) (interface{}, error) {

--- a/go/src/koding/klient/tunnel/vbox.go
+++ b/go/src/koding/klient/tunnel/vbox.go
@@ -171,11 +171,11 @@ func (t *Tunnel) hostPort(guestPort int) int {
 	return 0
 }
 
-// serices gives route infromation of tunnelclient kite services.
+// buildServices gives route infromation of tunnelclient kite services.
 //
 // If the kite server runs inside a VirtualBox machine, localRoute
 // returns a route to the forwarded port on the host network.
-func (t *Tunnel) services() map[string]*tunnelproxy.Tunnel {
+func (t *Tunnel) buildServices() map[string]*tunnelproxy.Tunnel {
 	ok, err := vagrant.IsVagrant()
 	if err != nil {
 		t.opts.Log.Error("failure checking local route: %s", err)


### PR DESCRIPTION
- [x] provider/vagrant: tunnel.info on check
- [x] klient/vagrant: store tunnels in db
- [x] klient/vagrant: ssh tunnel on create

https://koding.atlassian.net/browse/TMS-2599
