### PR TITLE
GEN-2279 TMS-2635 Reinit ignore follow events on destroy

### DIFF
--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -715,7 +715,7 @@ module.exports = class ComputeController extends KDController
       (@errorHandler call, 'buildStack', stack) err
 
 
-  destroyStack: (stack, callback) ->
+  destroyStack: (stack, callback, followEvents = yes) ->
 
     # TMS-1919: This only takes a stack instance so it's ok
     # for multiple stacks ~ GG
@@ -729,7 +729,7 @@ module.exports = class ComputeController extends KDController
         name    : 'InProgress'
         message : "This stack is currently #{state.toLowerCase()}."
 
-    stack.machines.forEach (machineId) =>
+    if followEvents then stack.machines.forEach (machineId) =>
       return  unless machine = @findMachineFromMachineId machineId
 
       @eventListener.triggerState machine,
@@ -745,7 +745,7 @@ module.exports = class ComputeController extends KDController
 
       stack.destroy callback
       actions.reinitStack stack._id
-      @eventListener.addListener 'apply', stackId
+      @eventListener.addListener 'apply', stackId  if followEvents
 
     .timeout globals.COMPUTECONTROLLER_TIMEOUT
 
@@ -1289,5 +1289,8 @@ module.exports = class ComputeController extends KDController
           if template and not groupStack
           then @createDefaultStack no, template
           else @createDefaultStack()
+
+        , followEvents = no
+
     , ->
       callback new Error 'Stack is not reinitialized'

--- a/client/app/lib/providers/computestatechecker.coffee
+++ b/client/app/lib/providers/computestatechecker.coffee
@@ -94,8 +94,10 @@ module.exports = class ComputeStateChecker extends KDObject
         computeController.eventListener
           .triggerState machine, { status: response.State }
 
-        computeController.eventListener.followUpcomingEvents
-          _id: machineId, { status: { state: response.State } }
+        computeController.eventListener.followUpcomingEvents {
+          _id    : machineId
+          status : { state: response.State }
+        }
 
         unless machine.status.state is response.State
           kd.info "csc: machine (#{machineId}) state changed: ", response.State


### PR DESCRIPTION
Following the destroy events on reinit causing some unneeded behaviour on ui which doesn't need to be since all the operations is handled in the background and since the required documents already destroyed.

https://koding.atlassian.net/browse/TMS-2635

https://koding.atlassian.net/browse/GEN-2279
