### PR TITLE
TMS-2732 kloud: add a reson of failed authentication to the response

### DIFF
--- a/client/app/lib/stacks/credentiallistitem.coffee
+++ b/client/app/lib/stacks/credentiallistitem.coffee
@@ -85,8 +85,12 @@ module.exports = class CredentialListItem extends kd.ListItemView
       .verify this
       .timeout 10000
       .then (response) =>
-        @setVerified response?[identifier]
-
+        if status = response?[identifier]
+          if message = status.message
+            message = message.split('\n')[..-2].join ''
+          @setVerified status.verified, message
+        else
+          @setVerified no
       .catch (err) =>
         @setVerified no, err.message
 

--- a/go/src/koding/kites/kloud/kloud/stackmethods.go
+++ b/go/src/koding/kites/kloud/kloud/stackmethods.go
@@ -57,6 +57,13 @@ type AuthenticateRequest struct {
 	GroupName string `json:"groupName"`
 }
 
+type AuthenticateResult struct {
+	Verified bool   `json:"verified"`
+	Message  string `json:"message,omitempty"`
+}
+
+type AuthenticateResponse map[string]*AuthenticateResult
+
 // Valid implements the Validator interface.
 func (req *AuthenticateRequest) Valid() error {
 	if len(req.Identifiers) == 0 {


### PR DESCRIPTION
/cc @gokmen 

it responds with `{"stackid": {"verified": true}}` or `{{"stackid": {"verified": false, "message": "error"}}` for authenticate requests instead of `{"stackid": bool}`; you could push your changes here, since I believe this PR is not backward-compatible

https://koding.atlassian.net/browse/TMS-2732
