### PR TITLE
TMS-2703 kloud: don't mark terminated machines as non-initialized

### DIFF
--- a/go/src/koding/kites/kloud/provider/aws/start.go
+++ b/go/src/koding/kites/kloud/provider/aws/start.go
@@ -26,9 +26,6 @@ func (m *Machine) Start(ctx context.Context) (err error) {
 		// AWS. Probably it was deleted and the state was not updated (possible
 		// due a human interaction or a non kloud interaction done somewhere
 		// else.)
-		if err := m.MarkAsNotInitialized(); err != nil {
-			return err
-		}
 
 		return errors.New("instance is not available anymore.")
 	}


### PR DESCRIPTION
/cc @gokmen 

https://koding.atlassian.net/browse/TMS-2703
