### PR TITLE
TMS-2740 Fix multiple render issues

### DIFF
--- a/client/app/lib/notificationcontroller.coffee
+++ b/client/app/lib/notificationcontroller.coffee
@@ -98,7 +98,10 @@ module.exports = class NotificationController extends KDObject
         @once 'EmailConfirmed', displayEmailConfirmedNotification.bind this, modal
         modal.on 'KDObjectWillBeDestroyed', deleteUserCookie.bind this
 
-    @on 'MachineListUpdated', ({ machineUId, action, permanent }) ->
+    @on 'MachineListUpdated', (data = {}) ->
+
+      { machineUId, action, permanent } = data
+
       switch action
         when 'removed'
           if (ideInstance = envDataProvider.getIDEFromUId machineUId) and permanent

--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -1102,7 +1102,7 @@ module.exports = class ComputeController extends KDController
           showError err, 'Failed to fix permissions'
 
 
-  checkMachinePermissions: (machine) ->
+  checkMachinePermissions: ->
 
     { groupsController } = kd.singletons
 

--- a/workers/social/lib/social/models/computeproviders/machine.coffee
+++ b/workers/social/lib/social/models/computeproviders/machine.coffee
@@ -367,9 +367,10 @@ module.exports = class JMachine extends Module
 
   addUsers: (options, callback) ->
 
-    { targets, asOwner, permanent, group } = options
+    { targets, asOwner, permanent, group, inform } = options
 
-    users = @users.slice 0
+    users   = @users.slice 0
+    inform ?= yes
 
     for user in targets
       users = addUser users, { user, asOwner, permanent }
@@ -379,7 +380,8 @@ module.exports = class JMachine extends Module
         'Machine sharing is limited up to 50 users.'
     else
       @update { $set: { users } }, (err) =>
-        informAccounts
+
+        if inform then informAccounts
           users       : targets
           machineUId  : @getAt('uid')
           action      : 'added'


### PR DESCRIPTION
Since MachineListUpdate notification was sending for each machine in `JMachine::addUsers` this was causing to have multiple permission fix modal and unnecessary notifications over pubnub. This prevents that and sends one update for each stack that is assigned after a member kicked by an admin. So, the admin who requested the kick will get the `MachineListUpdated` notification once for each stack instead of each machines.

https://koding.atlassian.net/browse/TMS-2740
