### PR TITLE
TMS-2770 ComputeController: no need to call stack.destroy it'll be handled by kloud

### DIFF
--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -748,9 +748,11 @@ module.exports = class ComputeController extends KDController
 
     .then (res) =>
 
-      stack.destroy callback
       actions.reinitStack stack._id
       @eventListener.addListener 'apply', stackId  if followEvents
+      callback? null
+
+      return res
 
     .timeout globals.COMPUTECONTROLLER_TIMEOUT
 


### PR DESCRIPTION
https://koding.atlassian.net/browse/TMS-2770
