### PR TITLE
GEN-2300 DataDog: disable work with api if there are no datadog keys in config

### DIFF
--- a/workers/social/lib/social/models/datadog.coffee
+++ b/workers/social/lib/social/models/datadog.coffee
@@ -17,10 +17,11 @@ module.exports = class DataDog extends Base
         sendMetrics    : (signature Object, Function)
 
 
-  { api_key, app_key }   = KONFIG.datadog
-  DogApi                 = new dogapi {
-    api_key, app_key
-  }
+  try
+    { api_key, app_key }   = KONFIG.datadog
+    DogApi = new dogapi { api_key, app_key }
+  catch
+    console.warn 'DataDog disabled because of missing configuration'
 
 
   Events =
@@ -118,6 +119,8 @@ module.exports = class DataDog extends Base
       Tracker  = require './tracker'
       Tracker.track nickname, { subject : ev.text }, data.tags
 
+    return callback null  unless DogApi
+
     DogApi.add_event { title, text, tags }, (err, res, status) ->
 
       if err?
@@ -162,6 +165,8 @@ module.exports = class DataDog extends Base
       points = [[now, points]]
 
       metrics.push { metric, tags, points }
+
+    return callback null  unless DogApi
 
     DogApi.add_metrics { series: metrics }, (err) ->
 


### PR DESCRIPTION
@gokmen, here is the changes we were talking about on Slack. I checked it on my dev VM without datadog keys and everything worked fine

https://koding.atlassian.net/browse/GEN-2300
