### PR TITLE
TMS-2660 TMS-2785 TMS-2786 klient, kd: delivery, wercker, local provisionner

### DIFF
--- a/client/app/lib/providers/managed/installkdmodal.coffee
+++ b/client/app/lib/providers/managed/installkdmodal.coffee
@@ -57,12 +57,14 @@ module.exports = class InstallKdModal extends kd.ModalView
 
 
   updateContentViews: (token) ->
+    kontrolUrl = ''
+    channel = 'p'
 
-    kontrolUrl = if globals.config.environment in ['dev', 'default', 'sandbox']
-    then "export KONTROLURL=#{KodingKontrol.getKontrolUrl()}; "
-    else ''
+    if globals.config.environment in ['dev', 'default', 'sandbox']
+      kontrolUrl = "export KONTROLURL=#{KodingKontrol.getKontrolUrl()}; "
+      channel = 'd'
 
-    cmd = "#{kontrolUrl}curl -sL https://kodi.ng/d/kd | bash -s #{token}"
+    cmd = "#{kontrolUrl}curl -sL https://kodi.ng/#{channel}/kd | bash -s #{token}"
 
     @loader.destroy()
     @code.addSubView @input = new kd.InputView

--- a/client/app/lib/providers/managed/installkdmodal.coffee
+++ b/client/app/lib/providers/managed/installkdmodal.coffee
@@ -64,7 +64,7 @@ module.exports = class InstallKdModal extends kd.ModalView
       kontrolUrl = "export KONTROLURL=#{KodingKontrol.getKontrolUrl()}; "
       channel = 'd'
 
-    cmd = "#{kontrolUrl}curl -sL https://kodi.ng/#{channel}/kd | bash -s #{token}"
+    cmd = "#{kontrolUrl}curl -sL https://kodi.ng/c/#{channel}/kd | bash -s #{token}"
 
     @loader.destroy()
     @code.addSubView @input = new kd.InputView

--- a/client/stacks/lib/views/kodingutilitiesview.coffee
+++ b/client/stacks/lib/views/kodingutilitiesview.coffee
@@ -27,10 +27,14 @@ module.exports = class KodingUtilitiesView extends kd.CustomScrollView
       cmd = if err
         "<a href='#'>Failed to generate your command, click to try again!</a>"
       else
-        kontrolUrl = if globals.config.environment in ['dev', 'default', 'sandbox']
-        then "export KONTROLURL=#{globals.config.newkontrol.url}; "
-        else ''
-        "#{kontrolUrl}curl -sL https://kodi.ng/d/kd | bash -s #{token}"
+        kontrolUrl = ''
+        channel = 'p'
+
+        if globals.config.environment in ['dev', 'default', 'sandbox']
+          kontrolUrl = "export KONTROLURL=#{globals.config.newkontrol.url}; "
+          channel = 'd'
+
+        "#{kontrolUrl}curl -sL https://kodi.ng/#{channel}/kd | bash -s #{token}"
 
       @kdInstallView?.destroy()
       @wrapper.addSubView @kdInstallView = new kd.CustomHTMLView

--- a/client/stacks/lib/views/kodingutilitiesview.coffee
+++ b/client/stacks/lib/views/kodingutilitiesview.coffee
@@ -34,7 +34,7 @@ module.exports = class KodingUtilitiesView extends kd.CustomScrollView
           kontrolUrl = "export KONTROLURL=#{globals.config.newkontrol.url}; "
           channel = 'd'
 
-        "#{kontrolUrl}curl -sL https://kodi.ng/#{channel}/kd | bash -s #{token}"
+        "#{kontrolUrl}curl -sL https://kodi.ng/c/#{channel}/kd | bash -s #{token}"
 
       @kdInstallView?.destroy()
       @wrapper.addSubView @kdInstallView = new kd.CustomHTMLView

--- a/deployment/nginx.coffee
+++ b/deployment/nginx.coffee
@@ -312,11 +312,21 @@ module.exports.create = (KONFIG, environment)->
         proxy_connect_timeout 1;
       }
 
-      # redirect /d/* to koding-dl S3 bucket; used to distributed
-      # // kd/klient installers
-      location ~^/d/(.*)$ {
-        proxy_pass            "https://s3.amazonaws.com/koding-dl/$1";
-        proxy_set_header      X-Host          $host; # for customisation
+      # redirect /d/kd to KD installer for development channel
+      location /d/kd {
+        proxy_pass            "https://s3.amazonaws.com/koding-kd/development/install-kd.sh";
+        proxy_set_header      X-Host          $host;
+        proxy_set_header      X-Real-IP       $remote_addr;
+        proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_connect_timeout 1;
+
+        resolver 8.8.8.8;
+      }
+
+      # redirect /p/kd to KD installer for production channel
+      location /p/kd {
+        proxy_pass            "https://s3.amazonaws.com/koding-kd/production/install-kd.sh";
+        proxy_set_header      X-Host          $host;
         proxy_set_header      X-Real-IP       $remote_addr;
         proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_connect_timeout 1;

--- a/deployment/nginx.coffee
+++ b/deployment/nginx.coffee
@@ -312,8 +312,20 @@ module.exports.create = (KONFIG, environment)->
         proxy_connect_timeout 1;
       }
 
+      # redirect /d/* to koding-dl S3 bucket; used to distributed
+      # // kd/klient installers
+      location ~^/d/(.*)$ {
+        proxy_pass            "https://s3.amazonaws.com/koding-dl/$1";
+        proxy_set_header      X-Host          $host; # for customisation
+        proxy_set_header      X-Real-IP       $remote_addr;
+        proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_connect_timeout 1;
+
+        resolver 8.8.8.8;
+      }
+
       # redirect /d/kd to KD installer for development channel
-      location ~ ^/d/kd$ {
+      location ~ ^/c/d/kd$ {
         proxy_pass            "https://s3.amazonaws.com/koding-kd/development/install-kd.sh";
         proxy_set_header      X-Host          $host;
         proxy_set_header      X-Real-IP       $remote_addr;
@@ -324,7 +336,7 @@ module.exports.create = (KONFIG, environment)->
       }
 
       # redirect /p/kd to KD installer for production channel
-      location ~ ^/p/kd$ {
+      location ~ ^/c/p/kd$ {
         proxy_pass            "https://s3.amazonaws.com/koding-kd/production/install-kd.sh";
         proxy_set_header      X-Host          $host;
         proxy_set_header      X-Real-IP       $remote_addr;

--- a/deployment/nginx.coffee
+++ b/deployment/nginx.coffee
@@ -325,7 +325,7 @@ module.exports.create = (KONFIG, environment)->
       }
 
       # redirect /d/kd to KD installer for development channel
-      location ~ ^/c/d/kd$ {
+      location /c/d/kd {
         proxy_pass            "https://s3.amazonaws.com/koding-kd/development/install-kd.sh";
         proxy_set_header      X-Host          $host;
         proxy_set_header      X-Real-IP       $remote_addr;
@@ -336,7 +336,7 @@ module.exports.create = (KONFIG, environment)->
       }
 
       # redirect /p/kd to KD installer for production channel
-      location ~ ^/c/p/kd$ {
+      location /c/p/kd {
         proxy_pass            "https://s3.amazonaws.com/koding-kd/production/install-kd.sh";
         proxy_set_header      X-Host          $host;
         proxy_set_header      X-Real-IP       $remote_addr;

--- a/deployment/nginx.coffee
+++ b/deployment/nginx.coffee
@@ -313,7 +313,7 @@ module.exports.create = (KONFIG, environment)->
       }
 
       # redirect /d/kd to KD installer for development channel
-      location /d/kd {
+      location ~ ^/d/kd$ {
         proxy_pass            "https://s3.amazonaws.com/koding-kd/development/install-kd.sh";
         proxy_set_header      X-Host          $host;
         proxy_set_header      X-Real-IP       $remote_addr;
@@ -324,7 +324,7 @@ module.exports.create = (KONFIG, environment)->
       }
 
       # redirect /p/kd to KD installer for production channel
-      location /p/kd {
+      location ~ ^/p/kd$ {
         proxy_pass            "https://s3.amazonaws.com/koding-kd/production/install-kd.sh";
         proxy_set_header      X-Host          $host;
         proxy_set_header      X-Real-IP       $remote_addr;

--- a/go/src/koding/fuseklient/Readme.md
+++ b/go/src/koding/fuseklient/Readme.md
@@ -6,7 +6,7 @@ Library that integrates [Fuse](https://github.com/bazil/fuse) and [Klient](https
 
     # ----- Download kd from <your team>.koding.com -----
     # kd is the cli to interact with klient and fuseklient
-    curl -L kodi.ng/d/kd | bash -s <token>
+    curl -L kodi.ng/c/p/kd | bash -s <token>
 
     # Mount the remote machine on `folder1`
     kd mount <machine name> ./folder

--- a/go/src/koding/kd/Readme.markdown
+++ b/go/src/koding/kd/Readme.markdown
@@ -31,7 +31,7 @@ registered to koding.com
 
     # ----- Download kd from <your team>.koding.com -----
     # kd is the cli to interact with klient and fuseklient
-    curl -L kodi.ng/d/kd | bash -s <token>
+    curl -L kodi.ng/c/p/kd | bash -s <token>
 
     # Mount the remote VM on `folder`
     kd mount <name> ./folder

--- a/go/src/koding/klient/app/klient.go
+++ b/go/src/koding/klient/app/klient.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"sync"
 	"time"
@@ -500,8 +499,6 @@ func (k *Klient) Run() {
 	// are not interested in it
 	isKoding, _ := info.CheckKoding()
 
-	k.startUpdater()
-
 	if (protocol.Environment == "managed" || protocol.Environment == "devmanaged") && isKoding {
 		k.log.Error("Managed Klient is attempting to run on a Koding provided VM")
 		panic(errors.New("This binary of Klient cannot run on a Koding provided VM"))
@@ -547,6 +544,9 @@ func (k *Klient) Run() {
 
 	k.log.Info("Using version: '%s' querystring: '%s'", k.config.Version, k.kite.Id)
 
+	// start our updater in the background
+	go k.updater.Run()
+
 	k.kite.Run()
 }
 
@@ -561,17 +561,6 @@ func (k *Klient) register(registerURL *url.URL) error {
 	k.kite.RegisterHTTPForever(registerURL)
 
 	return nil
-}
-
-func (k *Klient) startUpdater() {
-	// TODO: Re-enable
-	if runtime.GOOS == "darwin" {
-		k.log.Warning("Updater is disabled on darwin")
-		return
-	}
-
-	// start our updater in the background
-	go k.updater.Run()
 }
 
 func (k *Klient) Close() {

--- a/go/src/koding/klient/app/update.go
+++ b/go/src/koding/klient/app/update.go
@@ -97,7 +97,7 @@ func (u *Updater) checkAndUpdate() error {
 	latestKlientURL := &url.URL{
 		Scheme: "https",
 		Host:   "s3.amazonaws.com",
-		Path:   path.Join("/koding-klient", protocol.Environment, latestVer, file),
+		Path:   path.Join("/koding-klient", protocol.Environment, l, file),
 	}
 
 	return u.updateBinary(latestKlientURL.String())

--- a/go/src/koding/klient/install.sh
+++ b/go/src/koding/klient/install.sh
@@ -34,7 +34,7 @@ get_init_dir() {
 get_init_file() {
 	case "${init_tool}" in
 		launchctl)
-			echo "${init_dir}/com.koding.klient.plist"
+			echo "${init_dir}/klient.plist"
 			;;
 		*)
 			echo "${init_dir}/klient"
@@ -83,7 +83,7 @@ does_service_exist() {
 			sudo chkconfig --list "klient" &>/dev/null && return 0
 			;;
 		launchctl)
-			sudo launchctl list "com.koding.klient" &>/dev/null && return 0
+			sudo launchctl list "klient" &>/dev/null && return 0
 			;;
 		*)
 			;;
@@ -94,7 +94,7 @@ does_service_exist() {
 stop_klient() {
 	if [ ${is_macosx} -eq 1 ]; then
 		# try to stop old klient.plist
-		sudo launchctl unload -w "${init_dir}/klient.plist" &>/dev/null || true
+		sudo launchctl unload -w "${init_dir}/com.koding.klient.plist" &>/dev/null || true
 	else
 		# try to stop old upstart klient
 		sudo stop klient &>/dev/null || true
@@ -248,7 +248,7 @@ Copyright (C) 2012-2016 Koding Inc., all rights reserved.
 <plist version="1.0">
 <dict>
 	<key>Label</key>
-	<string>com.koding.klient</string>
+	<string>klient</string>
 
 	<key>WorkingDirectory</key>
 	<string>/opt/kite/klient</string>

--- a/go/src/koding/klient/install.sh
+++ b/go/src/koding/klient/install.sh
@@ -94,7 +94,7 @@ does_service_exist() {
 stop_klient() {
 	if [ ${is_macosx} -eq 1 ]; then
 		# try to stop old klient.plist
-		sudo launchctl unload -w "${init_dir}/com.koding.klient.plist" &>/dev/null || true
+		sudo launchctl unload -w "${init_dir}/com.koding.klient.plist" &>/dev/null && rm -v "${init_dir}/com.koding.klient.plist" || true
 	else
 		# try to stop old upstart klient
 		sudo stop klient &>/dev/null || true

--- a/go/src/koding/klientctl/checkupdate.go
+++ b/go/src/koding/klientctl/checkupdate.go
@@ -63,8 +63,8 @@ type CheckUpdate struct {
 // NewCheckUpdate is the required initializer for CheckUpdate.
 func NewCheckUpdate() *CheckUpdate {
 	return &CheckUpdate{
-		LocalVersion:       config.Version,
-		Location:           S3UpdateLocation,
+		LocalVersion:       config.VersionNum(),
+		Location:           config.S3KlientctlLatest,
 		RandomSeededNumber: rand.Intn(3),
 		ForceCheck:         false,
 	}

--- a/go/src/koding/klientctl/clifactories.go
+++ b/go/src/koding/klientctl/clifactories.go
@@ -83,7 +83,7 @@ func RepairCommandFactory(c *cli.Context, log logging.Logger, cmdName string) ct
 	// the command struct is responsible for verifying valid opts.
 	opts := repair.Options{
 		MountName: c.Args().First(),
-		Version:   config.Version,
+		Version:   config.VersionNum(),
 	}
 
 	return &repair.Command{

--- a/go/src/koding/klientctl/clifactories.go
+++ b/go/src/koding/klientctl/clifactories.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/codegangsta/cli"
 	"github.com/koding/logging"
+	"github.com/koding/service"
 )
 
 // MountCommandFactory creates a mount.Command instance and runs it with
@@ -95,7 +96,7 @@ func RepairCommandFactory(c *cli.Context, log logging.Logger, cmdName string) ct
 		Helper:        ctlcli.CommandHelper(c, cmdName),
 		// Used to create our KlientService instance. Really needs to be improved in
 		// the future, once it has proper access to a config package
-		ServiceConstructor: newService,
+		ServiceConstructor: func() (service.Service, error) { return newService(nil) },
 	}
 }
 

--- a/go/src/koding/klientctl/config.go
+++ b/go/src/koding/klientctl/config.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"runtime"
 	"time"
 )
 
@@ -17,23 +16,6 @@ const (
 
 	// KlientctlBinName is the bin named that will be stored in the KlientctlDirectory.
 	KlientctlBinName = "kd"
-
-	// KontrolURL is the url to connect to authenticate local klient and get
-	// list of machines.
-	KontrolURL = "https://koding.com/kontrol/kite"
-
-	osName = runtime.GOOS
-
-	// S3UpdateLocation is publically accessible url to check for new updates.
-	S3UpdateLocation = "https://koding-kd.s3.amazonaws.com/latest-version.txt"
-
-	// S3KlientPath is publically accessible url for latest version of klient.
-	// Each OS has its own version of binary, identifiable by OS suffix.
-	S3KlientPath = "https://koding-kd.s3.amazonaws.com/klient-" + osName
-
-	// S3KlientctlPath is publically accessible url for latest version of
-	// klientctl. Each OS has its own version of binary, identifiable by suffix.
-	S3KlientctlPath = "https://koding-kd.s3.amazonaws.com/klientctl-" + osName
 
 	// CommandAttempts is the number of attempts to try commands like start, stop
 	// etc.

--- a/go/src/koding/klientctl/config/config.go
+++ b/go/src/koding/klientctl/config/config.go
@@ -3,7 +3,11 @@ package config
 
 import (
 	"fmt"
+	"net/url"
+	"path"
 	"path/filepath"
+	"runtime"
+	"strconv"
 )
 
 const (
@@ -22,11 +26,6 @@ const (
 	// to the given klient.
 	KiteHome = "/etc/kite"
 
-	// Version is the current version of klientctl. This number is used
-	// by CheckUpdate to determine if current version is behind or equal to latest
-	// version on S3 bucket.
-	Version = 35
-
 	// SSHDefaultKeyDir is the default directory that stores users ssh key pairs.
 	SSHDefaultKeyDir = ".ssh"
 
@@ -35,9 +34,65 @@ const (
 )
 
 var (
+	// Version is the current version of klientctl. This number is used
+	// by CheckUpdate to determine if current version is behind or equal to latest
+	// version on S3 bucket.
+	Version = "35"
+
+	// Environment is the target channel of klientctl. This value is used
+	// to register with Kontrol and to install klient.
+	Environment = "production"
+
 	// KiteVersion is the version identifier used to connect to Kontrol.
-	KiteVersion = fmt.Sprintf("0.0.%d", Version)
+	KiteVersion = fmt.Sprintf("0.0.%s", Version)
 
 	// KiteKeyPath is the full path to kite.key.
 	KiteKeyPath = filepath.Join(KiteHome, "kite.key")
+
+	// KontrolURL is the url to connect to authenticate local klient and get
+	// list of machines.
+	KontrolURL = "https://koding.com/kontrol/kite"
+
+	// S3KlientLatest is URL to the latest version of the klient.
+	S3KlientLatest = "https://koding-klient.s3.amazonaws.com/" + Environment + "/latest-version.txt"
+
+	// S3KlientctlLatest is URL to the latest version of the klientctl.
+	S3KlientctlLatest = "https://koding-kd.s3.amazonaws.com/" + Environment + "/latest-version.txt"
 )
+
+func dirURL(s string) string {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	u.Path = path.Dir(u.Path)
+	return u.String()
+}
+
+func VersionNum() int {
+	version, err := strconv.ParseUint(Version, 10, 32)
+	if err != nil {
+		return 0
+	}
+
+	return int(version)
+}
+
+func S3Klient(version int) string {
+	s3dir := dirURL(S3KlientLatest)
+
+	// TODO(rjeczalik): klient uses a URL without $GOOS_$GOARCH suffix for
+	// auto-updates. Remove the special case when a redirect is deployed
+	// to the suffixed file.
+	if runtime.GOOS == "linux" {
+		return fmt.Sprintf("%[1]s/%[2]d/klient-0.1.%[2]d.gz", s3dir, version)
+	}
+
+	return fmt.Sprintf("%[1]s/%[2]d/klient-0.1.%[2]d.%[3]s_%[4]s.gz",
+		s3dir, version, runtime.GOOS, runtime.GOARCH)
+}
+
+func S3Klientctl(version int) string {
+	return fmt.Sprintf("%s/klientctl-0.1.%d.%s_%s.gz", dirURL(S3KlientctlLatest),
+		version, runtime.GOOS, runtime.GOARCH)
+}

--- a/go/src/koding/klientctl/config/config.go
+++ b/go/src/koding/klientctl/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -59,6 +60,19 @@ var (
 	// S3KlientctlLatest is URL to the latest version of the klientctl.
 	S3KlientctlLatest = "https://koding-kd.s3.amazonaws.com/" + Environment + "/latest-version.txt"
 )
+
+func init() {
+	if os.Getenv("KD_DEBUG") == "1" {
+		// For debugging kd build.
+		fmt.Println("Version", Version)
+		fmt.Println("Environment", Environment)
+		fmt.Println("KiteVersion", KiteVersion)
+		fmt.Println("KiteKeyPath", KiteKeyPath)
+		fmt.Println("KontrolURL", KontrolURL)
+		fmt.Println("S3KlientLatest", S3KlientLatest)
+		fmt.Println("S3KlientctlLatest", S3KlientctlLatest)
+	}
+}
 
 func dirURL(s string) string {
 	u, err := url.Parse(s)

--- a/go/src/koding/klientctl/install-kd.sh
+++ b/go/src/koding/klientctl/install-kd.sh
@@ -3,10 +3,6 @@
 readonly releaseChannel="%RELEASE_CHANNEL%"
 
 installFuseOnDarwinOnly () {
-  if [ ! "$(uname -s)" = "Darwin" ]; then
-    return
-  fi
-
   # check if osxfuse is installed already
   if [ -d "/Library/Filesystems/osxfusefs.fs" ]; then
     return
@@ -151,7 +147,7 @@ case "$platform" in
     echo "Downloading kd..."
 
 
-	sudo curl -SLo /usr/local/bin/kd.gz "https://koding-kd.s3.amazonaws.com/${releaseChannel}/kd-0.1.${version}.${platform}_amd64.gz"
+  sudo curl -SLo /usr/local/bin/kd.gz "https://koding-kd.s3.amazonaws.com/${releaseChannel}/kd-0.1.${version}.${platform}_amd64.gz"
     err=$?; if [ "$err" -ne 0 ]; then
       cat << EOF
 Error: Failed to download kd binary. Please check your internet
@@ -160,20 +156,27 @@ EOF
       exit 1
     fi
 
-	if ! sudo gzip -d -f /usr/local/bin/kd.gz; then
-		echo "Error: Failed to extract kd binary." 2>&1
-		exit 1
-	fi
+  if ! sudo gzip -d -f /usr/local/bin/kd.gz; then
+    echo "Error: Failed to extract kd binary." 2>&1
+    exit 1
+  fi
 
-	sudo rm -f /usr/local/bin/kd.gz
-    sudo chmod +x /usr/local/bin/kd
+  sudo rm -f /usr/local/bin/kd.gz
+  sudo chmod +x /usr/local/bin/kd
 
-    echo "Created /usr/local/bin/kd"
+  echo "Created /usr/local/bin/kd"
+
+  if [[ "$platform" == "darwin" ]]; then
+    # Ensure old klient is not running.
+    sudo launchctl unload -w /Library/LaunchDaemons/com.koding.klient &>/dev/null || true
+    rm -f /Library/LaunchDaemons/com.koding.klient &>/dev/null || true
 
     # Check if fuse is needed, and install it if it is.
     installFuseOnDarwinOnly
-    echo ""
-    ;;
+  fi
+
+  echo
+  ;;
   windows|linux)
     cat << EOF
 Error: This platform is not supported at this time.
@@ -215,7 +218,7 @@ isVirtualbox=$(VBoxHeadless -h 2>&1 | grep -c 'Oracle VM VirtualBox Headless Int
 isVagrant=$(vagrant version 2>&1 | grep -c 'Installed Version:')
 
 if [[ $isVirtualbox -eq 0 && $isVagrant -eq 0 ]]; then
-	cat << EOF
+  cat << EOF
 No VirtualBox nor Vagrant is present on your system. In order to use local provisioning
 with Vagrant provider ensure they are installed:
 
@@ -225,7 +228,7 @@ with Vagrant provider ensure they are installed:
 EOF
 
 elif [[ $isVirtualbox -eq 0 ]]; then
-	cat << EOF
+  cat << EOF
 No VirtualBox is present on your system. In order to use local provisioning
 with Vagrant provider ensure it is installed:
 
@@ -234,7 +237,7 @@ with Vagrant provider ensure it is installed:
 EOF
 
 elif [[ $isVagrant -eq 0 ]]; then
-	cat << EOF
+  cat << EOF
 No Vagrant is present on your system. In order to use local provisioning
 with Vagrant provider ensure it is installed:
 

--- a/go/src/koding/klientctl/install-kd.sh
+++ b/go/src/koding/klientctl/install-kd.sh
@@ -210,3 +210,36 @@ Please run the following command for more information:
     kd -h
 
 EOF
+
+isVirtualbox=$(VBoxManage -h 2>&1 | grep -c 'Oracle VM VirtualBox Headless Interface')
+isVagrant=$(vagrant version 2>&1 | grep -c 'Installed Version:')
+
+if [[ $isVirtualbox -eq 0 && $isVagrant -eq 0 ]]; then
+	cat << EOF
+No VirtualBox nor Vagrant is present on your system. In order to use local provisioning
+with Vagrant provider ensure they are installed:
+
+  * VirtualBox 5.0+ (https://www.virtualbox.org/wiki/Downloads)
+  * Vagrant 1.7.4+ (https://www.vagrantup.com/downloads.html)
+
+EOF
+
+elif [[ $isVirtualbox -eq 0 ]]; then
+	cat << EOF
+No VirtualBox is present on your system. In order to use local provisioning
+with Vagrant provider ensure it is installed:
+
+  * VirtualBox 5.0+ (https://www.virtualbox.org/wiki/Downloads)
+
+EOF
+
+elif [[ $isVagrant -eq 0 ]]; then
+	cat << EOF
+No Vagrant is present on your system. In order to use local provisioning
+with Vagrant provider ensure it is installed:
+
+  * Vagrant 1.7.4+ (https://www.vagrantup.com/downloads.html)
+
+EOF
+
+fi

--- a/go/src/koding/klientctl/install-kd.sh
+++ b/go/src/koding/klientctl/install-kd.sh
@@ -211,7 +211,7 @@ Please run the following command for more information:
 
 EOF
 
-isVirtualbox=$(VBoxManage -h 2>&1 | grep -c 'Oracle VM VirtualBox Headless Interface')
+isVirtualbox=$(VBoxHeadless -h 2>&1 | grep -c 'Oracle VM VirtualBox Headless Interface')
 isVagrant=$(vagrant version 2>&1 | grep -c 'Installed Version:')
 
 if [[ $isVirtualbox -eq 0 && $isVagrant -eq 0 ]]; then

--- a/go/src/koding/klientctl/install-kd.sh
+++ b/go/src/koding/klientctl/install-kd.sh
@@ -151,7 +151,7 @@ case "$platform" in
     echo "Downloading kd..."
 
 
-	sudo curl -SLo /usr/local/bin/kd.gz "https://koding-kd.s3.amazonaws.com/${releaseChannel}/klientctl-0.1.${version}.${platform}_amd64.gz"
+	sudo curl -SLo /usr/local/bin/kd.gz "https://koding-kd.s3.amazonaws.com/${releaseChannel}/kd-0.1.${version}.${platform}_amd64.gz"
     err=$?; if [ "$err" -ne 0 ]; then
       cat << EOF
 Error: Failed to download kd binary. Please check your internet

--- a/go/src/koding/klientctl/install.go
+++ b/go/src/koding/klientctl/install.go
@@ -3,25 +3,91 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"html/template"
 	"io/ioutil"
-	"koding/klientctl/config"
-	"koding/klientctl/metrics"
 	"net/http"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
 
-	"github.com/koding/logging"
+	"koding/klientctl/config"
+	"koding/klientctl/metrics"
 
 	"github.com/codegangsta/cli"
-	"github.com/leeola/service"
+	"github.com/koding/logging"
+	"github.com/koding/service"
 )
+
+type ServiceOptions struct {
+	Username   string
+	KontrolURL string
+}
+
+var defaultServiceOpts = &ServiceOptions{
+	Username:   username(),
+	KontrolURL: config.KontrolURL,
+}
+
+var klientShTmpl = template.Must(template.New("").Parse(`#!/bin/bash
+
+# Koding Service Connector
+# Copyright (C) 2012-2016 Koding Inc., all rights reserved.
+
+# source environment
+for src in /etc/{environment,profile,bashrc}; do
+	[[ -f ${src} ]] && source ${src}
+done
+
+isOSX=$(uname -v | grep -Ec '^Darwin Kernel.*')
+
+if [[ ${isOSX} -ne 0 ]]; then
+	# wait under OS-X till network is ready
+	. /etc/rc.common
+
+	CheckForNetwork
+
+	while [ "${NETWORKUP}" != "-YES-" ]; do
+		sleep 5
+		NETWORKUP=
+		CheckForNetwork
+	done
+fi
+
+# configure environment
+
+ulimit -n 5000
+
+# start klient
+
+{{if .KontrolURL}}
+export KITE_KONTROL_URL=${KITE_KONTROL_URL:-{{.KontrolURL}}}
+{{else}}
+export KITE_KONTROL_URL=${KITE_KONTROL_URL:-https://koding.com/kontrol/kite}
+{{end}}
+{{if .User}}
+export USERNAME=${USERNAME:-{{.User}}}
+{{end}}
+{{if .KlientBinPath}}
+export KLIENT_BIN=${KLIENT_BIN:-{{.KlientBinPath}}}
+{{else}}
+export KLIENT_BIN=${KLIENT_BIN:-/opt/kite/klient/klient}
+{{end}}
+export HOME=$(eval cd ~${USERNAME}; pwd)
+export PATH=$PATH:/usr/local/bin
+
+sudo -E -u "${USERNAME}" ${KLIENT_BIN} -kontrol-url "${KITE_KONTROL_URL}"
+`))
 
 // newService provides a preconfigured (based on klientctl's config)
 // service object to install, uninstall, start and stop Klient.
-func newService() (service.Service, error) {
+func newService(opts *ServiceOptions) (service.Service, error) {
+	if opts == nil {
+		opts = defaultServiceOpts
+	}
+
 	// TODO: Add hosts's username
 	svcConfig := &service.Config{
 		Name:        "klient",
@@ -29,8 +95,16 @@ func newService() (service.Service, error) {
 		Description: "Koding Service Connector",
 		Executable:  filepath.Join(KlientDirectory, "klient.sh"),
 		Option: map[string]interface{}{
-			"LogStderr": true,
-			"LogStdout": true,
+			"LogStderr":     true,
+			"LogStdout":     true,
+			"After":         "network.target",
+			"RequiredStart": "$network",
+			"Environment": map[string]string{
+				"USERNAME":         opts.Username,
+				"KITE_USERNAME":    "",
+				"KITE_KONTROL_URL": opts.KontrolURL,
+				"KITE_HOME":        config.KiteHome,
+			},
 		},
 	}
 
@@ -119,7 +193,7 @@ func InstallCommandFactory(c *cli.Context, log logging.Logger, _ string) int {
 	// TODO: Accept `kd install --user foo` flag to replace the
 	// environ checking.
 	klientSh := klientSh{
-		User:          sudoUserFromEnviron(os.Environ()),
+		User:          username(),
 		KiteHome:      config.KiteHome,
 		KlientBinPath: klientBinPath,
 		KontrolURL:    kontrolURL,
@@ -193,8 +267,13 @@ func InstallCommandFactory(c *cli.Context, log logging.Logger, _ string) int {
 		return 1
 	}
 
+	opts := &ServiceOptions{
+		Username:   klientSh.User,
+		KontrolURL: klientSh.KontrolURL,
+	}
+
 	// Create our interface to the OS specific service
-	s, err := newService()
+	s, err := newService(opts)
 	if err != nil {
 		log.Error("Error creating Service. err:%s", err)
 		fmt.Println(GenericInternalNewCodeError)
@@ -215,7 +294,11 @@ func InstallCommandFactory(c *cli.Context, log logging.Logger, _ string) int {
 	// Note that the service may error if it is already running, so
 	// we're ignoring any starting errors here. We will verify the
 	// connection below, anyway.
-	s.Start()
+	if err = s.Start(); err != nil {
+		log.Error("Error starting %s: %s", config.KlientName, err)
+		fmt.Println(FailedStartKlient)
+		return 1
+	}
 
 	fmt.Println("Verifying installation...")
 	err = WaitUntilStarted(config.KlientAddress, CommandAttempts, CommandWaitTime)
@@ -274,34 +357,30 @@ type klientSh struct {
 }
 
 // Format returns the klient.sh struct formatted for the actual file.
-func (k klientSh) Format() string {
-	// sudoCmd is used to run the bin as the given user. However,
-	// we only do that if the user value of klientSh is non-zeroed.
-	var sudoCmd string
+func (k klientSh) Format() (string, error) {
+	var buf bytes.Buffer
 
-	if k.User != "" {
-		sudoCmd = fmt.Sprintf("sudo -u %s ", k.User)
+	if err := klientShTmpl.Execute(&buf, &k); err != nil {
+		return "", nil
 	}
 
-	return fmt.Sprintf(
-		`#!/bin/sh
-ulimit -n 5000
-%sKITE_HOME=%s %s --kontrol-url=%s
-`,
-		sudoCmd, k.KiteHome, k.KlientBinPath, k.KontrolURL,
-	)
+	return buf.String(), nil
 }
 
 // Create writes the result of Format() to the given path.
-func (k klientSh) Create(p string) error {
+func (k klientSh) Create(file string) error {
+	p, err := k.Format()
+	if err != nil {
+		return err
+	}
+
 	// perm -rwr-xr-x, same as klient
-	return ioutil.WriteFile(p, []byte(k.Format()), 0755)
+	return ioutil.WriteFile(file, []byte(p), 0755)
 }
 
 // sudoUserFromEnviron extracts the SUDO_USER environment variable value from
 // the given slice, if any.
 func sudoUserFromEnviron(envs []string) string {
-	var user string
 	for _, s := range envs {
 		env := strings.Split(s, "=")
 
@@ -310,9 +389,21 @@ func sudoUserFromEnviron(envs []string) string {
 		}
 
 		if env[0] == "SUDO_USER" {
-			user = env[1]
-			break
+			return env[1]
 		}
 	}
-	return user
+
+	return ""
+}
+
+func username() string {
+	if s := sudoUserFromEnviron(os.Environ()); s != "" {
+		return s
+	}
+
+	if u, err := user.Current(); err == nil {
+		return u.Username
+	}
+
+	return ""
 }

--- a/go/src/koding/klientctl/klient/klient.go
+++ b/go/src/koding/klientctl/klient/klient.go
@@ -62,6 +62,9 @@ type KlientOptions struct {
 
 	// Version, as passed to the second argument to `kite.New()`.
 	Version string
+
+	// Environment for the kite.Config.Environemnt.
+	Environment string
 }
 
 // NewKlientOptions returns KlientOptions initialized to default values.
@@ -71,6 +74,7 @@ func NewKlientOptions() KlientOptions {
 		KiteKeyPath: filepath.Join(config.KiteHome, "kite.key"),
 		Name:        config.Name,
 		Version:     config.KiteVersion,
+		Environment: config.Environment,
 	}
 }
 
@@ -92,7 +96,8 @@ func CreateKlientClient(opts KlientOptions) (*kite.Client, error) {
 		return nil, errors.New("CreateKlientClient: Address is required")
 	}
 
-	k := kite.New("klientctl", opts.Version)
+	k := kite.New(opts.Name, opts.Version)
+	k.Config.Environment = opts.Environment
 	c := k.NewClient(opts.Address)
 
 	// If a key path is declared, load it and setup auth.

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -74,7 +74,7 @@ func main() {
 
 	app := cli.NewApp()
 	app.Name = config.Name
-	app.Version = fmt.Sprintf("%d", config.Version)
+	app.Version = config.Version
 
 	app.Commands = []cli.Command{
 		cli.Command{

--- a/go/src/koding/klientctl/mount.go
+++ b/go/src/koding/klientctl/mount.go
@@ -161,7 +161,7 @@ func (c *MountCommand) Run() (int, error) {
 		"no-prefetch-meta": c.Options.NoPrefetchMeta,
 		"prefetch-all":     c.Options.PrefetchAll,
 		"no-watch":         c.Options.NoWatch,
-		"version":          config.Version,
+		"version":          config.VersionNum(),
 	}
 	metrics.TrackMount(c.Options.Name, c.Options.LocalPath, o)
 

--- a/go/src/koding/klientctl/repair/command.go
+++ b/go/src/koding/klientctl/repair/command.go
@@ -18,7 +18,7 @@ import (
 	"koding/mountcli"
 
 	"github.com/koding/logging"
-	"github.com/leeola/service"
+	"github.com/koding/service"
 )
 
 type Options struct {

--- a/go/src/koding/klientctl/restart.go
+++ b/go/src/koding/klientctl/restart.go
@@ -16,7 +16,7 @@ func RestartCommand(c *cli.Context, log logging.Logger, _ string) int {
 		return 1
 	}
 
-	s, err := newService()
+	s, err := newService(nil)
 	if err != nil {
 		log.Error("Error creating Service. err:%s", err)
 		fmt.Println(GenericInternalNewCodeError)

--- a/go/src/koding/klientctl/run.go
+++ b/go/src/koding/klientctl/run.go
@@ -14,6 +14,7 @@ import (
 	"koding/klientctl/metrics"
 	"koding/mountcli"
 
+	_ "github.com/coreos/go-log/log"
 	"github.com/koding/logging"
 
 	"github.com/codegangsta/cli"
@@ -121,7 +122,7 @@ func (r *RunCommand) runOnRemote(localPath string, cmdWithArgsStr string) (*Exec
 	}
 
 	// track metrics
-	metrics.TrackRun(machine, config.Version)
+	metrics.TrackRun(machine, config.VersionNum())
 
 	return r.runOnMachine(machine, fullCmdPath, cmdWithArgsStr)
 }

--- a/go/src/koding/klientctl/run.go
+++ b/go/src/koding/klientctl/run.go
@@ -14,7 +14,6 @@ import (
 	"koding/klientctl/metrics"
 	"koding/mountcli"
 
-	_ "github.com/coreos/go-log/log"
 	"github.com/koding/logging"
 
 	"github.com/codegangsta/cli"

--- a/go/src/koding/klientctl/ssh.go
+++ b/go/src/koding/klientctl/ssh.go
@@ -42,7 +42,7 @@ func SSHCommandFactory(c *cli.Context, log logging.Logger, _ string) int {
 
 	// track metrics
 	go func() {
-		metrics.TrackSSH(mountName, config.Version)
+		metrics.TrackSSH(mountName, config.VersionNum())
 	}()
 
 	err = cmd.Run(mountName)
@@ -61,7 +61,7 @@ func SSHCommandFactory(c *cli.Context, log logging.Logger, _ string) int {
 
 	// track metrics
 	if err != nil {
-		metrics.TrackSSHFailed(mountName, err.Error(), config.Version)
+		metrics.TrackSSHFailed(mountName, err.Error(), config.VersionNum())
 	}
 
 	log.Error("SSHCommand.Run returned err:%s", err)

--- a/go/src/koding/klientctl/ssh.go
+++ b/go/src/koding/klientctl/ssh.go
@@ -19,6 +19,8 @@ func SSHCommandFactory(c *cli.Context, log logging.Logger, _ string) int {
 		return 1
 	}
 
+	mountName := c.Args()[0]
+
 	cmd, err := ssh.NewSSHCommand(log, true)
 
 	// TODO: Refactor SSHCommand instance to require no initialization,
@@ -34,11 +36,9 @@ func SSHCommandFactory(c *cli.Context, log logging.Logger, _ string) int {
 			fmt.Println(GenericInternalError)
 		}
 
-		metrics.TrackSSHFailed(mountName, err.Error(), config.Version)
+		metrics.TrackSSHFailed(mountName, err.Error(), config.VersionNum())
 		return 1
 	}
-
-	mountName := c.Args()[0]
 
 	// track metrics
 	go func() {

--- a/go/src/koding/klientctl/start.go
+++ b/go/src/koding/klientctl/start.go
@@ -16,7 +16,7 @@ func StartCommand(c *cli.Context, log logging.Logger, _ string) int {
 		return 1
 	}
 
-	s, err := newService()
+	s, err := newService(nil)
 	if err != nil {
 		log.Error("Error creating Service. err:%s", err)
 		fmt.Println(GenericInternalNewCodeError)

--- a/go/src/koding/klientctl/status.go
+++ b/go/src/koding/klientctl/status.go
@@ -24,8 +24,8 @@ func init() {
 			Timeout: 4 * time.Second,
 		},
 		LocalKiteAddress:  config.KlientAddress,
-		RemoteKiteAddress: KontrolURL,
-		RemoteHTTPAddress: S3UpdateLocation,
+		RemoteKiteAddress: config.KontrolURL,
+		RemoteHTTPAddress: config.S3KlientctlLatest,
 	}
 }
 

--- a/go/src/koding/klientctl/stop.go
+++ b/go/src/koding/klientctl/stop.go
@@ -17,7 +17,7 @@ func StopCommand(c *cli.Context, log logging.Logger, _ string) int {
 		return 1
 	}
 
-	s, err := newService()
+	s, err := newService(nil)
 	if err != nil {
 		log.Error("Error creating Service. err:%s", err)
 		fmt.Println(GenericInternalError)

--- a/go/src/koding/klientctl/uninstall.go
+++ b/go/src/koding/klientctl/uninstall.go
@@ -143,7 +143,7 @@ func (u *Uninstall) Uninstall() (string, int) {
 func UninstallCommand(c *cli.Context, log logging.Logger, _ string) (string, int) {
 	warnings := []string{}
 
-	s, err := newService()
+	s, err := newService(nil)
 	if err != nil {
 		log.Warning("Failed creating Service for uninstall. err:%s", err)
 		warnings = append(warnings, FailedUninstallingKlientWarn)

--- a/go/src/koding/klientctl/unmount.go
+++ b/go/src/koding/klientctl/unmount.go
@@ -246,7 +246,7 @@ func (c *UnmountCommand) Unmount(name, path string) error {
 	}
 
 	// track metrics
-	metrics.TrackUnmount(name, config.Version)
+	metrics.TrackUnmount(name, config.VersionNum())
 
 	return nil
 }

--- a/scripts/deploy-kd.sh
+++ b/scripts/deploy-kd.sh
@@ -60,3 +60,14 @@ cp -f "${REPO_PATH}/go/src/koding/klientctl/install-kd.sh" install-kd.sh
 sed -i -e "s|\%RELEASE_CHANNEL\%|${CHANNEL}|g" install-kd.sh
 s3cmd del $S3DIR/install-kd.sh
 s3cmd -P put install-kd.sh $S3DIR/install-kd.sh
+
+# Update production bucket - koding-dl
+# TODO(rjeczalik): remove koding-dl and add routes:
+#
+#   - kodi.ng/d/kd -> koding-kd/development/install-kd.sh
+#   - kodi.ng/p/kd -> koding-kd/production/install-kd.sh
+#
+if [[ "$CHANNEL" == "production" ]]; then
+	s3cmd del "s3://koding-dl/kd"
+	s3cmd -P put install-kd.sh "s3://koding-dl/kd"
+fi

--- a/scripts/deploy-kd.sh
+++ b/scripts/deploy-kd.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REPO_PATH=$(git rev-parse --show-toplevel)
+
+# configure s3cmd
+cat > $HOME/.s3cfg <<EOF
+[default]
+access_key=$S3_KEY_ID
+secret_key=$S3_KEY_SECRET
+EOF
+
+export S3DIR="s3://koding-kd/$CHANNEL"
+
+# fetch the latest build number since wercker doesn't provide one
+s3cmd get $S3DIR/latest-version.txt version
+
+export OLDBUILDNO=$(cat version)
+export NEWBUILDNO=$(($OLDBUILDNO+1))
+
+echo "New version will be: $NEWBUILDNO"
+rm -f version
+
+KONTROL_URL="https://koding.com/kontrol/kite"
+if [[ "$CHANNEL" == "development" ]]; then
+	KONTROL_URL="https://sandbox.koding.com/kontrol/kite"
+fi
+
+kd-build() {
+	GOOS="${1:-}" GOARCH=amd64 go build -v -ldflags "-X koding/klientctl/config.Version 0.1.$NEWBUILDNO -X koding/klientctl/config.Environment $CHANNEL -X koding/klientctl/config.KontrolURL $KONTROL_URL" -o kd koding/klientctl
+}
+
+# build klient binary for linux
+kd-build
+
+# validate klient version
+[[ $(./kd -version) == "kd version 0.1.$NEWBUILDNO" ]]
+
+# prepare klient.gz
+gzip -9 -N kd
+mv kd.gz kd-0.1.$NEWBUILDNO.linux_amd64.gz
+
+kd-build darwin
+gzip -9 -N kd
+mv kd.gz kd-0.1.$NEWBUILDNO.darwin_amd64.gz
+
+#  Copy files to S3.
+s3cmd -P put *.gz  $S3DIR/
+
+# Update latest-version.txt with the latest version
+s3cmd del $S3DIR/latest-version.txt
+echo $NEWBUILDNO > latest-version.txt
+s3cmd -P put latest-version.txt $S3DIR/latest-version.txt
+
+#  Update install-kd.sh file
+cp -f "${REPO_PATH}/go/src/koding/klientctl/install-kd.sh" install-kd.sh
+sed -i -e "s|\%RELEASE_CHANNEL\%|${CHANNEL}|g" install-kd.sh
+s3cmd del $S3DIR/install-kd.sh
+s3cmd -P put install-kd.sh $S3DIR/install-kd.sh

--- a/scripts/deploy-kd.sh
+++ b/scripts/deploy-kd.sh
@@ -27,15 +27,17 @@ if [[ "$CHANNEL" == "development" ]]; then
 	KONTROL_URL="https://sandbox.koding.com/kontrol/kite"
 fi
 
+# NOTE(rjeczalik): kd expects the version to be a single digit, while klient
+# expect semver - making a note until this is made consistent.
 kd-build() {
-	GOOS="${1:-}" GOARCH=amd64 go build -v -ldflags "-X koding/klientctl/config.Version 0.1.$NEWBUILDNO -X koding/klientctl/config.Environment $CHANNEL -X koding/klientctl/config.KontrolURL $KONTROL_URL" -o kd koding/klientctl
+	GOOS="${1:-}" GOARCH=amd64 go build -v -ldflags "-X koding/klientctl/config.Version $NEWBUILDNO -X koding/klientctl/config.Environment $CHANNEL -X koding/klientctl/config.KontrolURL $KONTROL_URL" -o kd koding/klientctl
 }
 
 # build klient binary for linux
 kd-build
 
 # validate klient version
-[[ $(./kd -version) == "kd version 0.1.$NEWBUILDNO" ]]
+[[ $(./kd -version) == "kd version $NEWBUILDNO" ]]
 
 # prepare klient.gz
 gzip -9 -N kd

--- a/scripts/deploy-kd.sh
+++ b/scripts/deploy-kd.sh
@@ -60,14 +60,3 @@ cp -f "${REPO_PATH}/go/src/koding/klientctl/install-kd.sh" install-kd.sh
 sed -i -e "s|\%RELEASE_CHANNEL\%|${CHANNEL}|g" install-kd.sh
 s3cmd del $S3DIR/install-kd.sh
 s3cmd -P put install-kd.sh $S3DIR/install-kd.sh
-
-# Update production bucket - koding-dl
-# TODO(rjeczalik): remove koding-dl and add routes:
-#
-#   - kodi.ng/d/kd -> koding-kd/development/install-kd.sh
-#   - kodi.ng/p/kd -> koding-kd/production/install-kd.sh
-#
-if [[ "$CHANNEL" == "production" ]]; then
-	s3cmd del "s3://koding-dl/kd"
-	s3cmd -P put install-kd.sh "s3://koding-dl/kd"
-fi

--- a/scripts/deploy-klient.sh
+++ b/scripts/deploy-klient.sh
@@ -11,6 +11,10 @@ access_key=$S3_KEY_ID
 secret_key=$S3_KEY_SECRET
 EOF
 
+if [[ -z "$KLIENT_CHANNEL" ]]; then
+	KLIENT_CHANNEL=${CHANNEL:-}
+fi
+
 export S3DIR="s3://koding-klient/$KLIENT_CHANNEL"
 
 # fetch the latest build number since wercker doesn't provide one

--- a/wercker.yml
+++ b/wercker.yml
@@ -257,22 +257,32 @@ deploy:
         key-secret: $S3_KEY_SECRET
         opts: "--no-mime-magic --guess-mime-type"
 
-  s3-klientkite-production:
+  s3-klient-production:
     - script:
-        name: deploy klient to production channel
+        name: deploy klient and kd to production channel
         code: $WERCKER_ROOT/scripts/deploy-klient.sh
 
-  s3-klientkite-development:
+  s3-klient-development:
     - script:
-        name: deploy klient to development channel
+        name: deploy klient and kd to development channel
         code: $WERCKER_ROOT/scripts/deploy-klient.sh
 
-  s3-klientkite-managed:
+  s3-kd-production:
+    - script:
+        name: deploy klient and kd to production channel
+        code: $WERCKER_ROOT/scripts/deploy-kd.sh
+
+  s3-kd-development:
+    - script:
+        name: deploy klient and kd to development channel
+        code: $WERCKER_ROOT/scripts/deploy-kd.sh
+
+  s3-klient-managed:
     - script:
         name: deploy klient to managed channel
         code: $WERCKER_ROOT/scripts/deploy-klient.sh
 
-  s3-klientkite-devmanaged:
+  s3-klient-devmanaged:
     - script:
         name: deploy klient to devmanaged channel
         code: $WERCKER_ROOT/scripts/deploy-klient.sh

--- a/wercker.yml
+++ b/wercker.yml
@@ -259,22 +259,22 @@ deploy:
 
   s3-klient-production:
     - script:
-        name: deploy klient and kd to production channel
+        name: deploy klient to production channel
         code: $WERCKER_ROOT/scripts/deploy-klient.sh
 
   s3-klient-development:
     - script:
-        name: deploy klient and kd to development channel
+        name: deploy klient to development channel
         code: $WERCKER_ROOT/scripts/deploy-klient.sh
 
   s3-kd-production:
     - script:
-        name: deploy klient and kd to production channel
+        name: deploy kd to production channel
         code: $WERCKER_ROOT/scripts/deploy-kd.sh
 
   s3-kd-development:
     - script:
-        name: deploy klient and kd to development channel
+        name: deploy kd to development channel
         code: $WERCKER_ROOT/scripts/deploy-kd.sh
 
   s3-klient-managed:


### PR DESCRIPTION
- [x] klientctl: download klient binary from original klient S3 bucket
- [x] klientctl: updater - use binary from configured distribution channel
- [x] klientctl: deploy kd to production / development
- [x] wercker: reconfigure targets
- [x] klientctl/service: rework service to install klient that works with vagrant (envs etc.)
- [x] klientctl/service: add extra vagrant param, ensure virtualbox and vagrant are installed
- [x] klient: add os-x autoupdater
- [x] nginx: update kodi.ng routes to point to channels.

https://koding.atlassian.net/browse/TMS-2786

https://koding.atlassian.net/browse/TMS-2785

https://koding.atlassian.net/browse/TMS-2660
