### PR TITLE
TMS-2791 fuseklient: fix bug where renaming file broken ops on nested file/dirs

### DIFF
--- a/go/src/koding/fuseklient/content.go
+++ b/go/src/koding/fuseklient/content.go
@@ -36,7 +36,7 @@ type ContentReadWriter struct {
 
 	// Path is the full path on locally mounted folder. Note it does not contain.
 	// the remote path prefix, that's in transport.
-	Path string
+	Path *string
 
 	// Size is the size of file on local. Note this can differ from remote if
 	// file was written to, but not yet synced to remote.
@@ -55,7 +55,7 @@ type ContentReadWriter struct {
 }
 
 // NewContentReadWriter is the required initializer for ContentReadWriter.
-func NewContentReadWriter(t remote, path string, size int64) *ContentReadWriter {
+func NewContentReadWriter(t remote, path *string, size int64) *ContentReadWriter {
 	return &ContentReadWriter{
 		remote:    t,
 		Path:      path,
@@ -91,7 +91,7 @@ func (c *ContentReadWriter) ReadAt(p []byte, offset int64) (int, error) {
 		return copied, nil
 	}
 
-	resp, err := c.remote.ReadFileAt(c.Path, offset, c.BlockSize)
+	resp, err := c.remote.ReadFileAt(*c.Path, offset, c.BlockSize)
 	if err != nil {
 		return 0, err
 	}
@@ -118,7 +118,7 @@ func (c *ContentReadWriter) ReadAll() error {
 
 	var offset int64 = 0
 	for offset < c.Size {
-		resp, err := c.remote.ReadFileAt(c.Path, offset, c.BlockSize)
+		resp, err := c.remote.ReadFileAt(*c.Path, offset, c.BlockSize)
 		if err != nil {
 			return err
 		}
@@ -219,5 +219,5 @@ func (c *ContentReadWriter) writeAt(content []byte, offset int64) int {
 // writeContentToRemote saves specified byte slice to remote.
 func (c *ContentReadWriter) writeContentToRemote(content []byte) error {
 	c.isDirty = false
-	return c.remote.WriteFile(c.Path, content)
+	return c.remote.WriteFile(*c.Path, content)
 }

--- a/go/src/koding/fuseklient/content_test.go
+++ b/go/src/koding/fuseklient/content_test.go
@@ -27,7 +27,7 @@ func TestContentReadWriterCreate(t *testing.T) {
 
 			So(cr.Create(), ShouldBeNil)
 
-			resp, err := rt.ReadFile(cr.Path)
+			resp, err := rt.ReadFile(*cr.Path)
 			So(err, ShouldBeNil)
 
 			So(resp.Content, ShouldResemble, []byte("Hello"))
@@ -64,7 +64,7 @@ func TestContentReadWriterSave(t *testing.T) {
 			So(cr.WriteAt(dftCnt, 0), ShouldBeNil)
 			So(cr.Save(false), ShouldBeNil)
 
-			resp, err := rt.ReadFile(cr.Path)
+			resp, err := rt.ReadFile(*cr.Path)
 			So(err, ShouldBeNil)
 
 			So(resp.Content, ShouldResemble, dftCnt)
@@ -198,7 +198,8 @@ func newContentReader() (*ContentReadWriter, transport.Transport, error) {
 		return nil, nil, err
 	}
 
-	cr := NewContentReadWriter(rt, "1", int64(len(dftCnt)))
+	sz := "1"
+	cr := NewContentReadWriter(rt, &sz, int64(len(dftCnt)))
 	rt, ok := cr.remote.(*transport.RemoteTransport)
 	if !ok {
 		return nil, nil, fmt.Errorf(

--- a/go/src/koding/fuseklient/file.go
+++ b/go/src/koding/fuseklient/file.go
@@ -22,7 +22,7 @@ type File struct {
 func NewFile(n *Entry) *File {
 	return &File{
 		Entry:   n,
-		content: NewContentReadWriter(n.Transport, n.Path, int64(n.Attrs.Size)),
+		content: NewContentReadWriter(n.Transport, &n.Path, int64(n.Attrs.Size)),
 	}
 }
 

--- a/go/src/koding/fusetest/dir.go
+++ b/go/src/koding/fusetest/dir.go
@@ -190,39 +190,39 @@ func testRename(t *testing.T, mountDir string) {
 			So(os.IsNotExist(err), ShouldBeTrue)
 
 			statDirCheck(newPath)
+		})
 
-			Convey("It should update path of contents inside old dir", func() {
-				file1 := path.Join(oldPath, "file1")
-				err := ioutil.WriteFile(file1, []byte("Hello World!"), 0700)
-				So(err, ShouldBeNil)
+		Convey("It should update path of contents inside old dir", func() {
+			file1 := path.Join(oldPath, "file1")
+			err := ioutil.WriteFile(file1, []byte("Hello World!"), 0700)
+			So(err, ShouldBeNil)
 
-				dir1 := path.Join(oldPath, "dir1")
-				So(os.Mkdir(dir1, 0700), ShouldBeNil)
+			dir1 := path.Join(oldPath, "dir1")
+			So(os.Mkdir(dir1, 0700), ShouldBeNil)
 
-				file2 := path.Join(dir1, "file2")
-				err = ioutil.WriteFile(file2, []byte("Hello World!"), 0700)
-				So(err, ShouldBeNil)
+			file2 := path.Join(dir1, "file2")
+			err = ioutil.WriteFile(file2, []byte("Hello World!"), 0700)
+			So(err, ShouldBeNil)
 
-				dir2 := path.Join(dir1, "dir2")
-				So(os.Mkdir(dir2, 0700), ShouldBeNil)
+			dir2 := path.Join(dir1, "dir2")
+			So(os.Mkdir(dir2, 0700), ShouldBeNil)
 
-				So(os.Rename(oldPath, newPath), ShouldBeNil)
+			So(os.Rename(oldPath, newPath), ShouldBeNil)
 
-				_, err = os.Stat(oldPath)
-				So(os.IsNotExist(err), ShouldBeTrue)
+			_, err = os.Stat(oldPath)
+			So(os.IsNotExist(err), ShouldBeTrue)
 
-				_, err = os.Stat(path.Join(newPath, "dir1"))
-				So(err, ShouldBeNil)
+			_, err = os.Stat(path.Join(newPath, "dir1"))
+			So(err, ShouldBeNil)
 
-				_, err = os.Stat(path.Join(newPath, "file1"))
-				So(err, ShouldBeNil)
+			_, err = os.Stat(path.Join(newPath, "file1"))
+			So(err, ShouldBeNil)
 
-				_, err = os.Stat(path.Join(newPath, "dir1", "dir2"))
-				So(err, ShouldBeNil)
+			_, err = os.Stat(path.Join(newPath, "dir1", "dir2"))
+			So(err, ShouldBeNil)
 
-				_, err = os.Stat(path.Join(newPath, "dir1", "file2"))
-				So(err, ShouldBeNil)
-			})
+			_, err = os.Stat(path.Join(newPath, "dir1", "file2"))
+			So(err, ShouldBeNil)
 		})
 
 		Convey("It should update path of contents inside old dir", func() {

--- a/go/src/koding/fusetest/dir.go
+++ b/go/src/koding/fusetest/dir.go
@@ -189,7 +189,8 @@ func testRename(t *testing.T, mountDir string) {
 			_, err := os.Stat(oldPath)
 			So(os.IsNotExist(err), ShouldBeTrue)
 
-			statDirCheck(newPath)
+			_, err = statDirCheck(newPath)
+			So(err, ShouldBeNil)
 		})
 
 		Convey("It should update path of contents inside old dir", func() {

--- a/go/src/koding/fusetest/dir.go
+++ b/go/src/koding/fusetest/dir.go
@@ -190,6 +190,39 @@ func testRename(t *testing.T, mountDir string) {
 			So(os.IsNotExist(err), ShouldBeTrue)
 
 			statDirCheck(newPath)
+
+			Convey("It should update path of contents inside old dir", func() {
+				file1 := path.Join(oldPath, "file1")
+				err := ioutil.WriteFile(file1, []byte("Hello World!"), 0700)
+				So(err, ShouldBeNil)
+
+				dir1 := path.Join(oldPath, "dir1")
+				So(os.Mkdir(dir1, 0700), ShouldBeNil)
+
+				file2 := path.Join(dir1, "file2")
+				err = ioutil.WriteFile(file2, []byte("Hello World!"), 0700)
+				So(err, ShouldBeNil)
+
+				dir2 := path.Join(dir1, "dir2")
+				So(os.Mkdir(dir2, 0700), ShouldBeNil)
+
+				So(os.Rename(oldPath, newPath), ShouldBeNil)
+
+				_, err = os.Stat(oldPath)
+				So(os.IsNotExist(err), ShouldBeTrue)
+
+				_, err = os.Stat(path.Join(newPath, "dir1"))
+				So(err, ShouldBeNil)
+
+				_, err = os.Stat(path.Join(newPath, "file1"))
+				So(err, ShouldBeNil)
+
+				_, err = os.Stat(path.Join(newPath, "dir1", "dir2"))
+				So(err, ShouldBeNil)
+
+				_, err = os.Stat(path.Join(newPath, "dir1", "file2"))
+				So(err, ShouldBeNil)
+			})
 		})
 
 		Convey("It should update path of contents inside old dir", func() {

--- a/go/src/koding/fusetest/fusetest.go
+++ b/go/src/koding/fusetest/fusetest.go
@@ -320,7 +320,7 @@ func (f *Fusetest) CheckLocalFileContents(file, contents string) error {
 }
 
 func (f *Fusetest) fullCachePath(entry string) string {
-	return filepath.Join(f.Opts.CachePath, filepath.Base(f.TestDir), entry)
+	return filepath.Join(f.Opts.CachePath, entry)
 }
 
 func (f *Fusetest) fullMountPath(entry string) string {

--- a/go/src/koding/fusetest/fusetest_misc.go
+++ b/go/src/koding/fusetest/fusetest_misc.go
@@ -144,6 +144,8 @@ func (f *Fusetest) TestCpOutToIn() {
 			contents, err := f.Remote.ReadFile(in)
 			So(err, ShouldBeNil)
 			So(contents, ShouldEqual, "Hello World!")
+
+			So(f.CheckLocalFileContents(filepath.Join(dirName, "in"), string("Hello World!")), ShouldBeNil)
 		})
 	})
 }


### PR DESCRIPTION
This fixes where if you did `mv dir1/ dir2/`, then any non-cached operations on the new dir, ie `cat dir2/file`, `echo 1 > dir2/file` would return `Input/Output error`. This is because we're caching the entire path from mount to file/dir inside file/dir respectively.

To fix, on rename op, I'm fetching all nested file/dir and updating the path. In addition I changed path to be a pointer so changes are reflected anything that's also reliant on path, ie File#content.

I also fixed couple bugs in fusetest and added a test case. On diff. note I think we need to separate out fuseklient integration tests into its own package. Currently fusetest is both fuseklient integration test and kd acceptance tests.
