### PR TITLE
klient: remove KITE_KONTROL_URL from plist

### DIFF
--- a/go/src/koding/klient/install.sh
+++ b/go/src/koding/klient/install.sh
@@ -269,8 +269,6 @@ Copyright (C) 2012-2016 Koding Inc., all rights reserved.
 			<string>$(whoami)</string>
 			<key>KITE_USERNAME</key>
 			<string>${username}</string>
-			<key>KITE_KONTROL_URL</key>
-			<string>${kontrolurl}</string>
 			<key>KITE_HOME</key>
 			<string>/etc/kite</string>
 	</dict>


### PR DESCRIPTION
Currently there's 3 different ways to specify the url: env var, option in klient.sh and also plist. I think the last one is not required, so this PR removes it.
