### PR TITLE
scripts: add script to upload klient/kd logs to s3 on request

### DIFF
--- a/go/src/koding/klient/app/klient_unix.go
+++ b/go/src/koding/klient/app/klient_unix.go
@@ -38,7 +38,7 @@ func (k *Klient) initRemote() {
 		k.log.Error("Failed to initialize Remote. Error: %s", err.Error())
 	}
 
-	go sendLogsOnInterval(k.log, logLocations())
+	go sendLogsOnInterval(k.log, LogLocations())
 }
 
 // sendLogsOnInterval sends klient and kd logs files to write only s3 bucket
@@ -60,7 +60,7 @@ func sendLogsOnInterval(log kite.Logger, logLocs []string) error {
 	return nil
 }
 
-func logLocations() []string {
+func LogLocations() []string {
 	if runtime.GOOS == "darwin" {
 		return []string{"/Library/Logs/klient.log", "/Library/Logs/kd.log"}
 	}

--- a/scripts/upload-logs/klient.go
+++ b/scripts/upload-logs/klient.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"koding/klient/app"
+	"koding/s3logrotate"
+	"log"
+)
+
+func main() {
+	u, err := s3logrotate.NewUploadClient("us-west-1", "koding-klient-logs")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// uploads upto 25MB
+	c := s3logrotate.New(1024*1024*25, u, app.LogLocations()...)
+
+	log.Fatal(c.ReadAndUpload())
+}


### PR DESCRIPTION
cc @rjeczalik 

Useful in debugging fellow developers kd issues. This uploads to koding-vm s3 account in `us-west-1` bucket under `<username>:<hostname>`.
