### PR TITLE
TMS-2767 ComputeController: checkMachinePermissions: ignore managed vms

### DIFF
--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -1120,6 +1120,7 @@ module.exports = class ComputeController extends KDController
 
       return  unless oldOwner
       return  if not machine.isRunning()
+      return  if machine.isManaged()
 
       @storage.fetchValue 'ignoredMachines', (ignoredMachines) =>
         ignoredMachines ?= {}


### PR DESCRIPTION
we are not able to change user data on a managed vm and for that reason we are not moving ownership of kicked user managed stack, but we are moving ownership of all machines without checking it's provider. and once we kick a user the ui side is fetching all machines and stacks, ignores managed stacks of kicked user but still processes managed vms and with that process we should ignore managed ones.

https://koding.atlassian.net/browse/TMS-2767
