### PR TITLE
TMS-2831 klienctl: map channels, migration for s3://koding-kd/klient-{darwin,linux} binary

### DIFF
--- a/go/src/github.com/koding/kite/Makefile
+++ b/go/src/github.com/koding/kite/Makefile
@@ -38,7 +38,7 @@ kontrol:
 	@`which go` run kontrol/kontrol/main.go -publickeyfile /tmp/publicKey.pem -privatekeyfile /tmp/privateKey.pem -initial -username kite -kontrolurl "http://localhost:4444/kite"
 
 	@echo "$(OK_COLOR)==> Running Kontrol $(NO_COLOR)"
-	@`which go` run kontrol/kontrol/main.go -publickeyfile /tmp/publicKey.pem -privatekeyfile /tmp/privateKey.pem -port 4444 
+	@`which go` run kontrol/kontrol/main.go -publickeyfile /tmp/publicKey.pem -privatekeyfile /tmp/privateKey.pem -port 4444
 
 install:
 	@echo "$(OK_COLOR)==> Downloading dependencies$(NO_COLOR)"
@@ -62,7 +62,7 @@ ifeq ($(KONTROL_STORAGE), "etcd")
 	@killall etcd ||:
 
 	@echo "Installing etcd"
-	test -d "_etcd" || git clone https://github.com/coreos/etcd _etcd
+	test -d "_etcd" || git clone -b release-2.3 https://github.com/coreos/etcd _etcd
 	@rm -rf _etcd/default.etcd ||: #remove previous folder
 	@cd _etcd; ./build; ./bin/etcd &
 endif
@@ -76,7 +76,7 @@ endif
 	@echo "$(OK_COLOR)==> Starting kontrol test $(NO_COLOR)"
 	@`which go` test -race $(VERBOSE) ./kontrol
 
-test: 
+test:
 	@echo "$(OK_COLOR)==> Preparing test environment $(NO_COLOR)"
 	@echo "Using $(KITE_TRANSPORT) transport"
 	@echo "Cleaning $(KITE_HOME) directory"
@@ -93,7 +93,7 @@ ifeq ($(KONTROL_STORAGE), etcd)
 	@killall etcd ||:
 
 	@echo "Installing etcd"
-	test -d "_etcd" || git clone https://github.com/coreos/etcd _etcd
+	test -d "_etcd" || git clone -b release-2.3 https://github.com/coreos/etcd _etcd
 	@rm -rf _etcd/default.etcd ||: #remove previous folder
 	@cd _etcd; ./build; ./bin/etcd &
 endif

--- a/go/src/github.com/koding/kite/config/config.go
+++ b/go/src/github.com/koding/kite/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/dgrijalva/jwt-go"
 	"github.com/koding/kite/kitekey"
 )
 
@@ -45,6 +46,21 @@ func New() *Config {
 	c := new(Config)
 	*c = *DefaultConfig
 	return c
+}
+
+// NewFromKiteKey parses the given kite key file and gives a new Config value.
+func NewFromKiteKey(file string) (*Config, error) {
+	key, err := kitekey.ParseFile(file)
+	if err != nil {
+		return nil, err
+	}
+
+	var c Config
+	if err := c.readToken(key); err != nil {
+		return nil, err
+	}
+
+	return &c, nil
 }
 
 func (c *Config) ReadEnvironmentVariables() error {
@@ -96,6 +112,10 @@ func (c *Config) ReadKiteKey() error {
 		return err
 	}
 
+	return c.readToken(key)
+}
+
+func (c *Config) readToken(key *jwt.Token) error {
 	c.KiteKey = key.Raw
 
 	if username, ok := key.Claims["sub"].(string); ok {

--- a/go/src/github.com/koding/kite/kitekey/kitekey.go
+++ b/go/src/github.com/koding/kite/kitekey/kitekey.go
@@ -2,6 +2,7 @@
 package kitekey
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
 	"os/user"
@@ -78,6 +79,16 @@ func Parse() (*jwt.Token, error) {
 	}
 
 	return jwt.Parse(kiteKey, GetKontrolKey)
+}
+
+// ParseFile reads the given kite key file and parses it as a JWT token.
+func ParseFile(file string) (*jwt.Token, error) {
+	kiteKey, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+
+	return jwt.Parse(string(bytes.TrimSpace(kiteKey)), GetKontrolKey)
 }
 
 // GetKontrolKey is used as key getter func for jwt.Parse() function.

--- a/go/src/github.com/koding/kite/kontrolclient.go
+++ b/go/src/github.com/koding/kite/kontrolclient.go
@@ -78,12 +78,14 @@ func (k *Kite) SetupKontrolClient() error {
 		k.Log.Info("Connected to Kontrol ")
 
 		// try to re-register on connect
+		k.kontrol.Lock()
 		if k.kontrol.lastRegisteredURL != nil {
 			select {
 			case k.kontrol.registerChan <- k.kontrol.lastRegisteredURL:
 			default:
 			}
 		}
+		k.kontrol.Unlock()
 
 		// signal all other methods that are listening on this channel, that we
 		// are connected to kontrol.
@@ -244,7 +246,9 @@ func (k *Kite) RegisterForever(kiteURL *url.URL) error {
 		for u := range k.kontrol.registerChan {
 			_, err := k.Register(u)
 			if err == nil {
+				k.kontrol.Lock()
 				k.kontrol.lastRegisteredURL = u
+				k.kontrol.Unlock()
 				k.signalReady()
 				continue
 			}

--- a/go/src/koding/klientctl/config/config.go
+++ b/go/src/koding/klientctl/config/config.go
@@ -34,6 +34,11 @@ const (
 	SSHDefaultKeyName = "kd-ssh-key"
 )
 
+var kd2klient = map[string]string{
+	"production":  "managed",
+	"development": "devmanaged",
+}
+
 var (
 	// Version is the current version of klientctl. This number is used
 	// by CheckUpdate to determine if current version is behind or equal to latest
@@ -61,7 +66,7 @@ var (
 	KontrolURL = "https://koding.com/kontrol/kite"
 
 	// S3KlientLatest is URL to the latest version of the klient.
-	S3KlientLatest = "https://koding-klient.s3.amazonaws.com/" + Environment + "/latest-version.txt"
+	S3KlientLatest = "https://koding-klient.s3.amazonaws.com/" + kd2klient[Environment] + "/latest-version.txt"
 
 	// S3KlientctlLatest is URL to the latest version of the klientctl.
 	S3KlientctlLatest = "https://koding-kd.s3.amazonaws.com/" + Environment + "/latest-version.txt"

--- a/wercker.yml
+++ b/wercker.yml
@@ -286,3 +286,17 @@ deploy:
     - script:
         name: deploy klient to devmanaged channel
         code: $WERCKER_ROOT/scripts/deploy-klient.sh
+
+  s3-klient-and-kd-production:
+    - script:
+        name: deploy klient to managed channel and kd to production
+        code: |
+          $WERCKER_ROOT/scripts/deploy-klient.sh
+          $WERCKER_ROOT/scripts/deploy-kd.sh
+
+  s3-klient-and-kd-development:
+    - script:
+        name: deploy klient to devmanaged channel and kd to development
+        code: |
+          $WERCKER_ROOT/scripts/deploy-klient.sh
+          $WERCKER_ROOT/scripts/deploy-kd.sh


### PR DESCRIPTION
The update for production users will look like:
- they are running version 35 now
- after deploying this to production, they kd update and get kd binary in version 36
- on another update to version 37, the kd 36 will also update klient.plist and klient.sh

/cc @sent-hil @leeola 

https://koding.atlassian.net/browse/TMS-2831
