### PR TITLE
fuseklient: use pointers wherever possible

### DIFF
--- a/go/src/koding/fuseklient/content.go
+++ b/go/src/koding/fuseklient/content.go
@@ -80,14 +80,14 @@ func (c *ContentReadWriter) Create() error {
 // If content has been already fetched, it returns from memory, instead of
 // fetching from remote. It returns the number of bytes read and and error, if
 // any.
-func (c *ContentReadWriter) ReadAt(p []byte, offset int64) (int, error) {
+func (c *ContentReadWriter) ReadAt(p *[]byte, offset int64) (int, error) {
 	if offset >= c.Size {
 		return 0, io.EOF
 	}
 
 	// everything is fetched from remote already, so return from it
 	if int64(len(c.content)) == c.Size {
-		copied := copy(p, c.content[offset:])
+		copied := copy(*p, c.content[offset:])
 		return copied, nil
 	}
 
@@ -96,7 +96,7 @@ func (c *ContentReadWriter) ReadAt(p []byte, offset int64) (int, error) {
 		return 0, err
 	}
 
-	copied := copy(p, resp.Content)
+	copied := copy(*p, resp.Content)
 	return copied, nil
 }
 

--- a/go/src/koding/fuseklient/dir.go
+++ b/go/src/koding/fuseklient/dir.go
@@ -33,7 +33,7 @@ type Dir struct {
 	// to return entries can be filtered. This is done so we set proper offset
 	// position for newly created entries. In other words once an entry is set in
 	// an offset position, it should maintain that position always.
-	Entries []fuseutil.Dirent
+	Entries []*fuseutil.Dirent
 
 	// EntriesList contains list of files and directories that belong to this
 	// directory mapped by entry name for easy lookup.
@@ -45,7 +45,7 @@ func NewDir(e *Entry, idGen *IDGen) *Dir {
 	return &Dir{
 		Entry:       e,
 		IDGen:       idGen,
-		Entries:     []fuseutil.Dirent{},
+		Entries:     []*fuseutil.Dirent{},
 		EntriesList: map[string]Node{},
 	}
 }
@@ -54,7 +54,7 @@ func NewDir(e *Entry, idGen *IDGen) *Dir {
 
 // ReadEntries returns entries starting from specified offset position. If local
 // cache is empty, it'll fetch from remote.
-func (d *Dir) ReadEntries(offset fuseops.DirOffset) ([]fuseutil.Dirent, error) {
+func (d *Dir) ReadEntries(offset fuseops.DirOffset) ([]*fuseutil.Dirent, error) {
 	d.Lock()
 	defer d.Unlock()
 
@@ -73,7 +73,7 @@ func (d *Dir) ReadEntries(offset fuseops.DirOffset) ([]fuseutil.Dirent, error) {
 	}
 
 	// filter by entries whose type is not to set fuse.DT_Unknown
-	var liveEntries []fuseutil.Dirent
+	var liveEntries []*fuseutil.Dirent
 	for _, e := range entries[offset:] {
 		if e.Type != fuseutil.DT_Unknown {
 			liveEntries = append(liveEntries, e)
@@ -356,7 +356,7 @@ func (d *Dir) Reset() error {
 	d.Lock()
 	defer d.Unlock()
 
-	d.Entries = []fuseutil.Dirent{}
+	d.Entries = []*fuseutil.Dirent{}
 	d.EntriesList = map[string]Node{}
 
 	return nil
@@ -465,13 +465,13 @@ func (d *Dir) getEntriesFromRemote() ([]*tempEntry, error) {
 	return entries, nil
 }
 
-func (d *Dir) initializeAttrs(e *tempEntry) fuseops.InodeAttributes {
+func (d *Dir) initializeAttrs(e *tempEntry) *fuseops.InodeAttributes {
 	var t = e.Time
 	if t.IsZero() {
 		t = time.Now()
 	}
 
-	return fuseops.InodeAttributes{
+	return &fuseops.InodeAttributes{
 		Size:   e.Size,
 		Uid:    d.Attrs.Uid,
 		Gid:    d.Attrs.Gid,
@@ -494,7 +494,7 @@ func (d *Dir) initializeChild(e *tempEntry) (Node, error) {
 		t = time.Now()
 	}
 
-	attrs := fuseops.InodeAttributes{
+	attrs := &fuseops.InodeAttributes{
 		Size:   e.Size,
 		Uid:    d.Attrs.Uid,
 		Gid:    d.Attrs.Gid,
@@ -508,7 +508,7 @@ func (d *Dir) initializeChild(e *tempEntry) (Node, error) {
 	n := NewEntry(d, e.Name)
 	n.Attrs = attrs
 
-	dirEntry := fuseutil.Dirent{
+	dirEntry := &fuseutil.Dirent{
 		Offset: fuseops.DirOffset(len(d.Entries)) + 1, // offset is 1 indexed
 		Inode:  n.ID,
 		Name:   e.Name,

--- a/go/src/koding/fuseklient/dir_test.go
+++ b/go/src/koding/fuseklient/dir_test.go
@@ -51,7 +51,7 @@ func TestDir(t *testing.T) {
 
 		Convey("It should return error if offset is greater than length of contents", func() {
 			d := newDir()
-			d.Entries = []fuseutil.Dirent{fuseutil.Dirent{}}
+			d.Entries = []*fuseutil.Dirent{&fuseutil.Dirent{}}
 
 			_, err := d.ReadEntries(2)
 			So(err, ShouldEqual, fuse.EIO)
@@ -59,10 +59,10 @@ func TestDir(t *testing.T) {
 
 		Convey("It should return only live entries from specified offset", func() {
 			d := newDir()
-			d.Entries = []fuseutil.Dirent{
-				fuseutil.Dirent{Type: fuseutil.DT_Directory},
-				fuseutil.Dirent{Type: fuseutil.DT_Unknown},
-				fuseutil.Dirent{Type: fuseutil.DT_Directory},
+			d.Entries = []*fuseutil.Dirent{
+				{Type: fuseutil.DT_Directory},
+				{Type: fuseutil.DT_Unknown},
+				{Type: fuseutil.DT_Directory},
 			}
 
 			entries, err := d.ReadEntries(1)
@@ -72,9 +72,9 @@ func TestDir(t *testing.T) {
 
 		Convey("It should return entries from specified offset", func() {
 			d := newDir()
-			d.Entries = []fuseutil.Dirent{
-				fuseutil.Dirent{Type: fuseutil.DT_Directory},
-				fuseutil.Dirent{Type: fuseutil.DT_Directory},
+			d.Entries = []*fuseutil.Dirent{
+				{Type: fuseutil.DT_Directory},
+				{Type: fuseutil.DT_Directory},
 			}
 
 			entries, err := d.ReadEntries(1)
@@ -345,7 +345,7 @@ func TestDir(t *testing.T) {
 			c := newDir()
 			f := NewFile(NewEntry(c, "file"))
 			c.EntriesList = map[string]Node{"file": f}
-			c.Entries = []fuseutil.Dirent{fuseutil.Dirent{}}
+			c.Entries = []*fuseutil.Dirent{&fuseutil.Dirent{}}
 
 			// create directory to hold to be moved directory
 			d := newDir()

--- a/go/src/koding/fuseklient/entry.go
+++ b/go/src/koding/fuseklient/entry.go
@@ -48,7 +48,7 @@ type Entry struct {
 	Forgotten bool
 
 	// Attrs is the list of attributes.
-	Attrs fuseops.InodeAttributes
+	Attrs *fuseops.InodeAttributes
 }
 
 // NewRootEntry is the required initializer for the root entry.
@@ -61,7 +61,7 @@ func NewRootEntry(t transport.Transport, path string) *Entry {
 		RWMutex:   sync.RWMutex{},
 		Name:      "root",
 		Forgotten: false,
-		Attrs:     fuseops.InodeAttributes{},
+		Attrs:     &fuseops.InodeAttributes{},
 	}
 }
 
@@ -114,14 +114,14 @@ func (e *Entry) Rename(name string) {
 	e.Unlock()
 }
 
-func (e *Entry) GetAttrs() fuseops.InodeAttributes {
+func (e *Entry) GetAttrs() *fuseops.InodeAttributes {
 	e.RLock()
 	defer e.RUnlock()
 
 	return e.Attrs
 }
 
-func (e *Entry) SetAttrs(attrs fuseops.InodeAttributes) {
+func (e *Entry) SetAttrs(attrs *fuseops.InodeAttributes) {
 	e.Lock()
 	e.Attrs = attrs
 	e.Unlock()
@@ -162,8 +162,8 @@ func (e *Entry) ToString() string {
 
 ///// Helpers
 
-func (e *Entry) getAttrsFromRemote() (fuseops.InodeAttributes, error) {
-	var attrs fuseops.InodeAttributes
+func (e *Entry) getAttrsFromRemote() (*fuseops.InodeAttributes, error) {
+	attrs := &fuseops.InodeAttributes{}
 
 	res, err := e.Transport.GetInfo(e.Name)
 	if err != nil {

--- a/go/src/koding/fuseklient/file.go
+++ b/go/src/koding/fuseklient/file.go
@@ -32,7 +32,7 @@ func (f *File) ReadAt(p []byte, offset int64) (int, error) {
 	f.Lock()
 	defer f.Unlock()
 
-	return f.content.ReadAt(p, offset)
+	return f.content.ReadAt(&p, offset)
 }
 
 // Create creates a new file on remote with in memory content.
@@ -131,7 +131,7 @@ func (f *File) Reset() error {
 	return nil
 }
 
-func (f *File) SetAttrs(attrs fuseops.InodeAttributes) {
+func (f *File) SetAttrs(attrs *fuseops.InodeAttributes) {
 	f.Lock()
 	defer f.Unlock()
 

--- a/go/src/koding/fuseklient/kodingnetworkfs.go
+++ b/go/src/koding/fuseklient/kodingnetworkfs.go
@@ -141,7 +141,7 @@ func NewKodingNetworkFS(t transport.Transport, c *Config) (*KodingNetworkFS, err
 	rootEntry.Gid = localGroup
 
 	// TODO: what size to set for directories
-	rootEntry.Attrs = fuseops.InodeAttributes{
+	rootEntry.Attrs = &fuseops.InodeAttributes{
 		Uid: localUser, Gid: localGroup, Mode: 0700 | os.ModeDir, Size: 10,
 	}
 
@@ -222,7 +222,7 @@ func (k *KodingNetworkFS) GetInodeAttributes(ctx context.Context, op *fuseops.Ge
 		return err
 	}
 
-	op.Attributes = entry.GetAttrs()
+	op.Attributes = *entry.GetAttrs()
 
 	return nil
 }
@@ -245,7 +245,7 @@ func (k *KodingNetworkFS) LookUpInode(ctx context.Context, op *fuseops.LookUpIno
 	k.setEntry(entry.GetID(), entry)
 
 	op.Entry.Child = entry.GetID()
-	op.Entry.Attributes = entry.GetAttrs()
+	op.Entry.Attributes = *entry.GetAttrs()
 
 	return nil
 }
@@ -277,7 +277,7 @@ func (k *KodingNetworkFS) ReadDir(ctx context.Context, op *fuseops.ReadDirOp) er
 
 	var bytesRead int
 	for _, e := range entries {
-		c := fuseutil.WriteDirent(op.Dst[bytesRead:], e)
+		c := fuseutil.WriteDirent(op.Dst[bytesRead:], *e)
 		if c == 0 {
 			break
 		}
@@ -315,7 +315,7 @@ func (k *KodingNetworkFS) MkDir(ctx context.Context, op *fuseops.MkDirOp) error 
 	k.setEntry(newDir.GetID(), newDir)
 
 	op.Entry.Child = newDir.GetID()
-	op.Entry.Attributes = newDir.GetAttrs()
+	op.Entry.Attributes = *newDir.GetAttrs()
 
 	return nil
 }
@@ -464,7 +464,7 @@ func (k *KodingNetworkFS) CreateFile(ctx context.Context, op *fuseops.CreateFile
 
 	// tell Kernel about file
 	op.Entry.Child = file.GetID()
-	op.Entry.Attributes = file.GetAttrs()
+	op.Entry.Attributes = *file.GetAttrs()
 
 	// save file to list of live nodes
 	k.setEntry(file.GetID(), file)
@@ -506,7 +506,7 @@ func (k *KodingNetworkFS) SetInodeAttributes(ctx context.Context, op *fuseops.Se
 	}
 
 	entry.SetAttrs(attrs)
-	op.Attributes = attrs
+	op.Attributes = *attrs
 
 	return nil
 }

--- a/go/src/koding/fuseklient/node.go
+++ b/go/src/koding/fuseklient/node.go
@@ -9,8 +9,8 @@ import (
 type Node interface {
 	GetID() fuseops.InodeID
 	GetType() fuseutil.DirentType
-	GetAttrs() fuseops.InodeAttributes
-	SetAttrs(fuseops.InodeAttributes)
+	GetAttrs() *fuseops.InodeAttributes
+	SetAttrs(*fuseops.InodeAttributes)
 	Forget()
 	IsForgotten() bool
 	Expire() error

--- a/go/src/koding/fuseklient/transport/disk.go
+++ b/go/src/koding/fuseklient/transport/disk.go
@@ -29,14 +29,16 @@ func NewDiskTransport(diskPath string) (*DiskTransport, error) {
 	}
 
 	return &DiskTransport{
-		DiskPath: diskPath,
+		DiskPath:  diskPath,
+		BlockSize: 1024 ^ 3,
 	}, nil
 }
 
 // DiskTransport is an implementation of Transport that reads files and dirs
 // from disk.
 type DiskTransport struct {
-	DiskPath string
+	DiskPath  string
+	BlockSize int64
 }
 
 func (d *DiskTransport) CreateDir(path string, mode os.FileMode) error {

--- a/go/src/koding/fuseklient/transport/remote.go
+++ b/go/src/koding/fuseklient/transport/remote.go
@@ -52,6 +52,8 @@ type RemoteTransport struct {
 	// IgnoreDirs are dirs that are ignored for performance purposes, ie .git
 	// .svn etc.
 	IgnoreDirs []string
+
+	BlockSize int64
 }
 
 // NewRemoteTransport initializes RemoteTransport with kite connection.
@@ -143,7 +145,7 @@ func (r *RemoteTransport) ReadFileAt(path string, offset, blockSize int64) (*Rea
 	}{
 		r.fullPath(path),
 		offset,
-		blockSize,
+		r.BlockSize,
 	}
 	res := &ReadFileRes{}
 	if err := r.trip("fs.readFile", req, &res); err != nil {


### PR DESCRIPTION
There was lot of needless objects created in fuseklient lifecycle, this pr switches to using pointers wherever possible.
