### PR TITLE
klient: remove hardcoded consts; pass it via flags

### DIFF
--- a/go/src/koding/klient/Makefile
+++ b/go/src/koding/klient/Makefile
@@ -9,7 +9,7 @@ test:
 
 build:
 	@echo "$(OK_COLOR)==> Building all packages $(NO_COLOR)"
-	@`which go` build -v -ldflags "-X koding/klient/protocol.Version=0.0.1 -X koding/klient/protocol.Environment=devbuild"
+	@`which go` build -v -ldflags "-X koding/klient/protocol.Version 0.0.1 -X koding/klient/protocol.Environment devbuild"
 
 .PHONY: all build test
 

--- a/go/src/koding/klient/app/klient.go
+++ b/go/src/koding/klient/app/klient.go
@@ -134,6 +134,11 @@ type KlientConfig struct {
 
 	NoTunnel bool
 	NoProxy  bool
+
+	LogBucketRegion   string
+	LogBucketName     string
+	LogUploadLimit    int
+	LogUploadInterval time.Duration
 }
 
 // NewKlient returns a new Klient instance

--- a/go/src/koding/klient/main.go
+++ b/go/src/koding/klient/main.go
@@ -56,6 +56,12 @@ var (
 	flagTunnelKiteURL = flag.String("tunnel-kite-url", "", "Change default tunnel server kite URL")
 	flagNoTunnel      = flag.Bool("no-tunnel", defaultNoTunnel(), "Force tunnel connection off")
 	flagNoProxy       = flag.Bool("no-proxy", false, "Force TLS proxy for tunneled connection off")
+
+	// Upload log flags
+	flagLogBucketRegion   = flag.String("log-bucket-region", "us-west-1", "Change bucket region to upload logs")
+	flagLogBucketName     = flag.String("log-bucket-name", "koding-klient-logs", "Change bucket name to upload logs")
+	flagLogUploadLimit    = flag.Int("log-upload-limit", 1024*400, "Change file size of logs")
+	flagLogUploadInterval = flag.Duration("log-upload-limit", time.Minute*3, "Change interval to upload logs")
 )
 
 func main() {
@@ -99,24 +105,28 @@ func realMain() int {
 	}
 
 	conf := &app.KlientConfig{
-		Name:           protocol.Name,
-		Environment:    protocol.Environment,
-		Region:         protocol.Region,
-		Version:        protocol.Version,
-		DBPath:         dbPath,
-		IP:             *flagIP,
-		Port:           *flagPort,
-		RegisterURL:    *flagRegisterURL,
-		KontrolURL:     *flagKontrolURL,
-		Debug:          *flagDebug,
-		UpdateInterval: *flagUpdateInterval,
-		UpdateURL:      *flagUpdateURL,
-		ScreenrcPath:   *flagScreenrc,
-		VagrantHome:    vagrantHome,
-		TunnelName:     *flagTunnelName,
-		TunnelKiteURL:  *flagTunnelKiteURL,
-		NoTunnel:       *flagNoTunnel,
-		NoProxy:        *flagNoProxy,
+		Name:              protocol.Name,
+		Environment:       protocol.Environment,
+		Region:            protocol.Region,
+		Version:           protocol.Version,
+		DBPath:            dbPath,
+		IP:                *flagIP,
+		Port:              *flagPort,
+		RegisterURL:       *flagRegisterURL,
+		KontrolURL:        *flagKontrolURL,
+		Debug:             *flagDebug,
+		UpdateInterval:    *flagUpdateInterval,
+		UpdateURL:         *flagUpdateURL,
+		ScreenrcPath:      *flagScreenrc,
+		VagrantHome:       vagrantHome,
+		TunnelName:        *flagTunnelName,
+		TunnelKiteURL:     *flagTunnelKiteURL,
+		NoTunnel:          *flagNoTunnel,
+		NoProxy:           *flagNoProxy,
+		LogBucketRegion:   *flagLogBucketRegion,
+		LogBucketName:     *flagLogBucketName,
+		LogUploadLimit:    *flagLogUploadLimit,
+		LogUploadInterval: *flagLogUploadInterval,
 	}
 
 	a := app.NewKlient(conf)

--- a/go/src/koding/klient/main.go
+++ b/go/src/koding/klient/main.go
@@ -61,7 +61,7 @@ var (
 	flagLogBucketRegion   = flag.String("log-bucket-region", "us-west-1", "Change bucket region to upload logs")
 	flagLogBucketName     = flag.String("log-bucket-name", "koding-klient-logs", "Change bucket name to upload logs")
 	flagLogUploadLimit    = flag.Int("log-upload-limit", 1024*400, "Change file size of logs")
-	flagLogUploadInterval = flag.Duration("log-upload-limit", time.Minute*3, "Change interval to upload logs")
+	flagLogUploadInterval = flag.Duration("log-upload-interval", time.Minute*3*60, "Change interval of upload logs")
 )
 
 func main() {


### PR DESCRIPTION
cc @leeola 

This PR removes ugly hardcoded consts for uploading logs to s3 and moves them to flags where they can be optionally modified.

Also making Makefile build with Go 1.4 since that's Koding official Go version. This change won't prevent 1.5 from being built, will just throw a warning.
