### PR TITLE
klient: add pprof build tag that builds with pprof; turn off tracing by default for all mounts

### DIFF
--- a/go/src/koding/fuseklient/config.go
+++ b/go/src/koding/fuseklient/config.go
@@ -8,8 +8,8 @@ type Config struct {
 	// MountName is identifier for the mounted folder.
 	MountName string `default:"fuseklient"`
 
-	// Debug determines if application debug logs are turned on.
-	Debug bool `default:true`
+	// Trace determines if trace logs are turned on.
+	Trace bool `default:false`
 
 	// NoIgnore determines whether to ignore default or user specified folders.
 	// Use this to turn off default ignoring of folders.

--- a/go/src/koding/fuseklient/kodingnetworkfs.go
+++ b/go/src/koding/fuseklient/kodingnetworkfs.go
@@ -79,7 +79,7 @@ func New(t transport.Transport, c *Config) (FS, error) {
 
 	var fs FS = ks
 
-	if c.Debug {
+	if c.Trace {
 		// TODO: move this to klient; this tries to start http server for each mount
 		go func() {
 			fmt.Println("Starting http server for tracing ", http.ListenAndServe(":8888", nil))

--- a/go/src/koding/fuseklient/kodingnetworkfs.go
+++ b/go/src/koding/fuseklient/kodingnetworkfs.go
@@ -1,9 +1,7 @@
 package fuseklient
 
 import (
-	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"path"
 	"sync"
@@ -80,11 +78,6 @@ func New(t transport.Transport, c *Config) (FS, error) {
 	var fs FS = ks
 
 	if c.Trace {
-		// TODO: move this to klient; this tries to start http server for each mount
-		go func() {
-			fmt.Println("Starting http server for tracing ", http.ListenAndServe(":8888", nil))
-		}()
-
 		fs = NewTraceFS(ks)
 	}
 

--- a/go/src/koding/kd/Makefile
+++ b/go/src/koding/kd/Makefile
@@ -3,7 +3,7 @@ OK_COLOR=\033[0;32m
 
 klient:
 	@echo "$(OK_COLOR)==> Building klient $(NO_COLOR)"
-	@`which go` build -v -ldflags "-X koding/klient/protocol.Version 0.0.1 -X koding/klient/protocol.Environment devbuild" ../klient
+	@`which go` build -v -ldflags "-X koding/klient/protocol.Version 0.0.1 -X koding/klient/protocol.Environment devbuild" -tags pprof ../klient
 	@echo "$(OK_COLOR)==> Installing klient $(NO_COLOR)"
 	@mv /opt/kite/klient/klient /opt/kite/klient/klient.old
 	@sudo mv ./klient /opt/kite/klient/klient

--- a/go/src/koding/kd/Readme.markdown
+++ b/go/src/koding/kd/Readme.markdown
@@ -64,3 +64,11 @@ If you wish to develop kd you'll need the following depedencies.
 
 Currently we're using koding.com kontrol to develop against. We'll soon provide
 a way to run Kontrol locally.
+
+## Debug
+
+  There're multiple debug/tracing options available:
+
+    * `make klient` will build klient with pprof enabled. See http://localhost:8888/debug/pprof
+    * Passing `-t` to `kd` when mount will enable trace logs. See http://localhost:8888/debug/requests
+    * Passing `-debug` to klient in `/opt/kite/klient/klient.sh` (Warning: this'll create a whole lot of output.)

--- a/go/src/koding/klient/pprof.go
+++ b/go/src/koding/klient/pprof.go
@@ -1,0 +1,5 @@
+// +build pprof
+
+package main
+
+import _ "net/http/pprof"

--- a/go/src/koding/klient/pprof.go
+++ b/go/src/koding/klient/pprof.go
@@ -2,4 +2,18 @@
 
 package main
 
-import _ "net/http/pprof"
+import (
+	"net/http"
+	_ "net/http/pprof"
+
+	"github.com/koding/logging"
+)
+
+func init() {
+	l := logging.NewLogger("init")
+
+	go func() {
+		l.Info("Starting debug server on localhost:8080")
+		l.Info("%s", http.ListenAndServe("localhost:8080", nil))
+	}()
+}

--- a/go/src/koding/klient/pprof.go
+++ b/go/src/koding/klient/pprof.go
@@ -10,10 +10,10 @@ import (
 )
 
 func init() {
-	l := logging.NewLogger("init")
-
 	go func() {
-		l.Info("Starting debug server on localhost:8080")
-		l.Info("%s", http.ListenAndServe("localhost:8080", nil))
+		l := logging.NewLogger("debug")
+		l.Info("Starting debug server on localhost:8888")
+
+		l.Info("%s", http.ListenAndServe("localhost:8888", nil))
 	}()
 }

--- a/go/src/koding/klient/remote/mount/mounter.go
+++ b/go/src/koding/klient/remote/mount/mounter.go
@@ -248,7 +248,7 @@ func (m *Mounter) fuseMountFolder(mount *Mount, retry bool) error {
 		NoIgnore:       mount.NoIgnore,
 		NoPrefetchMeta: mount.NoPrefetchMeta,
 		NoWatch:        mount.NoWatch,
-		Debug:          true, // turn on debug permanently till v1
+		Trace:          mount.Trace,
 	}
 
 	var (

--- a/go/src/koding/klient/remote/req/req.go
+++ b/go/src/koding/klient/remote/req/req.go
@@ -23,6 +23,7 @@ type MountFolder struct {
 	PrefetchAll    bool   `json:"prefetchAll"`
 	NoWatch        bool   `json:"noWatch"`
 	CachePath      string `json:"cachePath"`
+	Trace          bool   `json:"trace"`
 }
 
 // UnmountFolder is the request struct for remote.UnmountFolder method.

--- a/go/src/koding/klientctl/clifactories.go
+++ b/go/src/koding/klientctl/clifactories.go
@@ -29,12 +29,14 @@ func MountCommandFactory(c *cli.Context, log logging.Logger, cmdName string) ctl
 	opts := MountOptions{
 		Name:             c.Args().Get(0),
 		LocalPath:        c.Args().Get(1),
-		RemotePath:       c.String("remotepath"),     // note the lowercase of all chars
-		NoIgnore:         c.Bool("noignore"),         // note the lowercase of all chars
-		NoPrefetchMeta:   c.Bool("noprefetch-meta"),  // note the lowercase of all chars
-		NoWatch:          c.Bool("nowatch"),          // note the lowercase of all chars
-		PrefetchAll:      c.Bool("prefetch-all"),     // note the lowercase of all chars
-		PrefetchInterval: c.Int("prefetch-interval"), // note the lowercase of all chars
+		RemotePath:       c.String("remotepath"), // note the lowercase of all chars
+		NoIgnore:         c.Bool("noignore"),
+		NoPrefetchMeta:   c.Bool("noprefetch-meta"),
+		NoWatch:          c.Bool("nowatch"),
+		PrefetchAll:      c.Bool("prefetch-all"),
+		PrefetchInterval: c.Int("prefetch-interval"),
+		Trace:            c.Bool("trace"),
+
 		// Used for prefetch
 		SSHDefaultKeyDir:  config.SSHDefaultKeyDir,
 		SSHDefaultKeyName: config.SSHDefaultKeyName,

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -132,6 +132,10 @@ func main() {
 					Name:  "prefetch-interval",
 					Usage: "Sets how frequently folder will sync with remote, in seconds. Zero disables syncing.",
 				},
+				cli.BoolFlag{
+					Name:  "trace, t",
+					Usage: "Turn on trace logs.",
+				},
 			},
 			Action: ctlcli.FactoryAction(MountCommandFactory, log, "mount"),
 		},

--- a/go/src/koding/klientctl/mount.go
+++ b/go/src/koding/klientctl/mount.go
@@ -38,6 +38,7 @@ type MountOptions struct {
 	NoWatch          bool
 	PrefetchAll      bool
 	PrefetchInterval int
+	Trace            bool
 
 	// Used for Prefetching via RSync (SSH)
 	SSHDefaultKeyDir  string
@@ -147,6 +148,7 @@ func (c *MountCommand) Run() (int, error) {
 		PrefetchAll:    c.Options.PrefetchAll,
 		NoWatch:        c.Options.NoWatch,
 		CachePath:      getCachePath(c.Options.Name),
+		Trace:          c.Options.Trace,
 	}
 
 	// Actually mount the folder. Errors are printed by the mountFolder func to the user.


### PR DESCRIPTION
As part of my https://koding.atlassian.net/browse/TMS-2795 task I've been debugging why `git status` takes so long even when mount has a local disk cache; this PR adds some of the tools I use to regular development flow so it can be used by others as well.

I added https://github.com/koding/koding/blob/master/go/src/koding/kd for open sourcing, but it's relevant for us as well. We should consider consolidating https://github.com/koding/koding/blob/master/go/src/koding/klient/Makefile with https://github.com/koding/koding/blob/master/go/src/koding/kd/Makefile ?

cc @rjeczalik 
