### PR TITLE
klientctl: Print process errors from remote during cache

### DIFF
--- a/go/src/koding/klient/command/command.go
+++ b/go/src/koding/klient/command/command.go
@@ -8,6 +8,9 @@ import (
 	"syscall"
 
 	"github.com/koding/kite"
+
+	"koding/klient/kiteerrortypes"
+	"koding/klient/util"
 )
 
 // Output defines the response of an executed command.
@@ -26,7 +29,8 @@ func NewOutput(cmd *exec.Cmd) (*Output, error) {
 	err := cmd.Run()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); !ok {
-			return nil, err // return if it's not an exitError
+			// return if it's not an exitError
+			return nil, util.NewKiteError(kiteerrortypes.ProcessError, err)
 		} else {
 			exitStatus = exitErr.Sys().(syscall.WaitStatus).ExitStatus()
 		}

--- a/go/src/koding/klient/command/command_test.go
+++ b/go/src/koding/klient/command/command_test.go
@@ -1,0 +1,40 @@
+package command
+
+import (
+	"github.com/koding/kite"
+	. "github.com/smartystreets/goconvey/convey"
+	"koding/klient/kiteerrortypes"
+	"os/exec"
+	"testing"
+)
+
+func TestNewOutput(t *testing.T) {
+	Convey("Given a non-exitstatus error when running the process", t, func() {
+		// A fake command that should not be found, thus failing to run entirely.
+		cmd := exec.Command("newOutputFakeCommand")
+
+		Convey("It should return a kite ProcessError", func() {
+			_, err := NewOutput(cmd)
+			So(err, ShouldNotBeNil)
+
+			kiteErr, ok := err.(*kite.Error)
+			So(ok, ShouldBeTrue)
+			So(kiteErr.Type, ShouldEqual, kiteerrortypes.ProcessError)
+		})
+	})
+
+	Convey("Given an exitstatus error when running the process", t, func() {
+		cmd := exec.Command("bash", "-c", "exit 7")
+
+		Convey("It should not return an error", func() {
+			_, err := NewOutput(cmd)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("It should return the exit status", func() {
+			output, err := NewOutput(cmd)
+			So(err, ShouldBeNil)
+			So(output.ExitStatus, ShouldEqual, 7)
+		})
+	})
+}

--- a/go/src/koding/klient/kiteerrortypes/kiteerrortypes.go
+++ b/go/src/koding/klient/kiteerrortypes/kiteerrortypes.go
@@ -60,4 +60,8 @@ const (
 	// MachineAlreadyAdded is used if a machine instance was added to a Machines
 	// struct twice.
 	MachineAlreadyAdded = "MachineAlreadyAdded"
+
+	// Returned from a klient/command.Command when running the command fails in a
+	// non-exit status way.
+	ProcessError = "ProcessError"
 )

--- a/go/src/koding/klientctl/errormessages.go
+++ b/go/src/koding/klientctl/errormessages.go
@@ -168,6 +168,16 @@ Please wait a few minutes and try again.`,
 		"Error: Failed to prefetch the requested folder.\n",
 	)
 
+	// RemoteProcessFailed is used when a command was run on the remote, but the
+	// process itself failed to execute properly. *Not* an exit code, but more like
+	// a no memory.
+	//
+	// The %s arg is intended to be the full error.
+	RemoteProcessFailed = `A requested process on the remote Machine was unable to run properly,
+and exited with the following issue:
+
+%s`
+
 	// PrefetchAllAndMetaTogether is used when the user supplies both --prefetchall
 	// and --noprefetchmeta, as they are incompatible flags.
 	PrefetchAllAndMetaTogether = `Error: Cannot use both noprefetchmeta and prefetchall flags at the same time.

--- a/go/src/koding/klientctl/klientctlerrors/klientctlerrors.go
+++ b/go/src/koding/klientctl/klientctlerrors/klientctlerrors.go
@@ -113,6 +113,10 @@ func IsRemotePathNotExistErr(err error) bool {
 	return isKiteOfTypeErr(err, kiteerrortypes.RemotePathDoesNotExist)
 }
 
+func IsProcessError(err error) bool {
+	return isKiteOfTypeErr(err, kiteerrortypes.ProcessError)
+}
+
 func isKiteOfTypeErr(err error, t string) bool {
 	if err == nil {
 		return false


### PR DESCRIPTION
By printing errors, the user can be informed if the remote
machine is out of memory, or has other core reasons why it can't
run the requested exec.
