### PR TITLE
TMS-2832 klientctl: fix panic when sshing to a tunneled machine

### DIFF
--- a/go/src/koding/kites/tunnelproxy/discover/discover.go
+++ b/go/src/koding/kites/tunnelproxy/discover/discover.go
@@ -3,6 +3,7 @@ package discover
 import (
 	"encoding/json"
 	"errors"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -101,6 +102,12 @@ func (c *Client) Discover(addr, service string) (Endpoints, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusBadRequest {
+		if p, e := ioutil.ReadAll(resp.Body); e == nil && len(p) != 0 {
+			err = errors.New(string(p))
+		} else {
+			err = errors.New("invalid service: " + service)
+		}
+
 		log.Error("%s", err)
 
 		return nil, err

--- a/go/src/koding/klient/tunnel/tunnel.go
+++ b/go/src/koding/klient/tunnel/tunnel.go
@@ -212,10 +212,6 @@ func (t *Tunnel) updateOptions(reg *tunnelproxy.RegisterResult) {
 }
 
 func (t *Tunnel) initServices() {
-	if !t.isVagrant {
-		return // no ssh service for non-vagrant kites (e.g. managed ones)
-	}
-
 	s, err := t.db.Services()
 	if err == storage.ErrKeyNotFound {
 		s = tunnelproxy.Services{
@@ -250,7 +246,9 @@ func (t *Tunnel) updateServices(reg *tunnelproxy.RegisterServicesResult) {
 
 		service, ok := t.services[name]
 		if !ok {
-			service = &tunnelproxy.Service{}
+			service = &tunnelproxy.Service{
+				Name: name,
+			}
 			t.services[name] = service
 		}
 

--- a/go/src/koding/klient/tunnel/tunnel.go
+++ b/go/src/koding/klient/tunnel/tunnel.go
@@ -221,6 +221,11 @@ func (t *Tunnel) initServices() {
 			},
 		}
 
+		// if we are a host managed kite, the 127.0.0.1:22 is always accessible
+		if !t.isVagrant {
+			s["ssh"].ForwardedPort = 22
+		}
+
 		err = t.db.SetServices(s)
 	}
 

--- a/go/src/koding/klientctl/update.go
+++ b/go/src/koding/klientctl/update.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"koding/klientctl/config"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -52,7 +53,12 @@ func UpdateCommand(c *cli.Context, log logging.Logger, _ string) int {
 
 	kontrolURL := config.KontrolURL
 	if c, err := kiteconfig.NewFromKiteKey(config.KiteKeyPath); err == nil && c.KontrolURL != "" {
-		kontrolURL = c.KontrolURL
+		// BUG(rjeczalik): sandbox returns a kite.key on -register method that has
+		// KontrolURL set to default value. We workaround it here by ignoring the
+		// value.
+		if u, err := url.Parse(c.KontrolURL); err == nil && u.Host != "127.0.0.1:3000" {
+			kontrolURL = c.KontrolURL
+		}
 	}
 
 	klientSh := klientSh{


### PR DESCRIPTION
This CL:
- fixes handling 400 from /-/discover
- enables ssh service for managed kites

/cc @sent-hil 

https://koding.atlassian.net/browse/TMS-2832
