### PR TITLE
fuseklient: fix build

### DIFF
--- a/go/src/koding/fuseklient/file.go
+++ b/go/src/koding/fuseklient/file.go
@@ -151,7 +151,7 @@ func (f *File) SetAttrs(attrs *fuseops.InodeAttributes) {
 	f.setAttrs(attrs)
 }
 
-func (f *File) setAttrs(attrs fuseops.InodeAttributes) {
+func (f *File) setAttrs(attrs *fuseops.InodeAttributes) {
 	f.Attrs = attrs
 	f.content.Size = int64(attrs.Size)
 }


### PR DESCRIPTION
/cc @sent-hil @cihangir 

```
# koding/fuseklient
  ./file.go:117: cannot use attrs (type *fuseops.InodeAttributes) as type
  fuseops.InodeAttributes in argument to f.setAttrs
  ./file.go:151: cannot use attrs (type *fuseops.InodeAttributes) as type
  fuseops.InodeAttributes in argument to f.setAttrs
  ./file.go:155: cannot use attrs (type fuseops.InodeAttributes) as type
  *fuseops.InodeAttributes in assignment
```
