### PR TITLE
[Minor] Call search method without parameters

### DIFF
--- a/client/admin/lib/views/members/teammemberscommonview.coffee
+++ b/client/admin/lib/views/members/teammemberscommonview.coffee
@@ -55,7 +55,7 @@ module.exports = class TeamMembersCommonView extends KDView
     @searchContainer.addSubView @searchInput = new KDHitEnterInputView
       type        : 'text'
       placeholder : @getOptions().searchInputPlaceholder
-      callback    : @bound 'search'
+      callback    : => @search()
 
     @searchContainer.addSubView @searchClear = new KDCustomHTMLView
       tagName     : 'span'


### PR DESCRIPTION
We should not call `search` method with `@bound` because `search` method is called by `KDHitEnterInputView` with input value from here https://github.com/koding/kd/blob/master/lib/components/inputs/hitenterinputview.coffee#L27

/cc @gokmen 
