### PR TITLE
Tests - Accepted invitations should be listed TST-180

### DIFF
--- a/client/test/lib/helpers/teamshelpers.coffee
+++ b/client/test/lib/helpers/teamshelpers.coffee
@@ -116,9 +116,16 @@ module.exports =
 
   loginTeam: (browser, invalidCredentials = no) ->
 
+<<<<<<< 9fe6f69731be20f9e4e13264c3543ccbdf0a1d5d
     user       = utils.getUser()
     url        = helpers.getUrl(yes)
     inviteLink = "#{helpers.getUrl()}/Teams/Create?email=#{user.email}"
+=======
+    user               = utils.getUser()
+    url                = helpers.getUrl(yes)
+    inviteLink         = "#{helpers.getUrl()}/Teams/Create?email=#{user.email}"
+    invalidCredentials = no
+>>>>>>> Added test TST-180 - Accepted invitations should be displayed..
 
     teamsLogin        = '.TeamsModal--login'
     stackCatalogModal = '.StackCatalogModal'
@@ -1154,3 +1161,24 @@ module.exports =
       .click                      cancelButton
       .waitForElementVisible      stackNameSelector, 20000
       .assert.containsText        stackNameSelector, editedText
+
+
+  closeTeamSettingsModal: (browser) ->
+
+    adminModal  = '.AppModal.AppModal--admin.team-settings'
+    closeButton = "#{adminModal} .closeModal"
+
+    browser
+      .waitForElementVisible adminModal, 20000
+      .click                 closeButton
+
+  logoutTeam: (browser) ->
+
+    logoutLink = '.avatararea-popup.team a[href="/Logout"]'
+
+    helpers.openAvatarAreaModal(browser, yes)
+
+    browser
+     .waitForElementVisible logoutLink, 20000
+      .click                 logoutLink
+      .waitForElementVisible teamsLoginModal, 20000

--- a/client/test/lib/helpers/teamshelpers.coffee
+++ b/client/test/lib/helpers/teamshelpers.coffee
@@ -116,16 +116,10 @@ module.exports =
 
   loginTeam: (browser, invalidCredentials = no) ->
 
-<<<<<<< 9fe6f69731be20f9e4e13264c3543ccbdf0a1d5d
-    user       = utils.getUser()
-    url        = helpers.getUrl(yes)
-    inviteLink = "#{helpers.getUrl()}/Teams/Create?email=#{user.email}"
-=======
     user               = utils.getUser()
     url                = helpers.getUrl(yes)
     inviteLink         = "#{helpers.getUrl()}/Teams/Create?email=#{user.email}"
     invalidCredentials = no
->>>>>>> Added test TST-180 - Accepted invitations should be displayed..
 
     teamsLogin        = '.TeamsModal--login'
     stackCatalogModal = '.StackCatalogModal'

--- a/client/test/lib/teams/inviteteams.coffee
+++ b/client/test/lib/teams/inviteteams.coffee
@@ -52,6 +52,10 @@ module.exports =
 
   inviteUserAndJoinTeam: (browser) ->
 
+    closeModal                 = '.close-icon.closeModal'
+    acceptedInvitationsTab     = '.kdview.kdtabhandle-tabs .accepted-invitations'
+    acceptedInvitationsDetails = '.kdlistitemview-member.accepted .details'
+
     targetUser = utils.getUser yes, 1
     teamsHelpers.loginTeam(browser)
     teamsHelpers.clickTeamSettings(browser)
@@ -65,4 +69,19 @@ module.exports =
       browser.pause 2000
       teamsHelpers.checkForgotPassword(browser)
       teamsHelpers.fillJoinForm(browser, targetUser)
-      browser.end()
+
+      browser
+        .waitForElementVisible  closeModal, 20000
+        .click                  closeModal
+
+      teamsHelpers.logoutTeam(browser)
+      teamsHelpers.loginTeam(browser)
+      teamsHelpers.clickTeamSettings(browser)
+      teamsHelpers.openInvitationsTab(browser)
+
+      browser
+        .waitForElementVisible  acceptedInvitationsTab, 20000
+        .click                  acceptedInvitationsTab
+        .waitForElementVisible  acceptedInvitationsDetails, 20000
+        .assert.containsText    acceptedInvitationsDetails, targetUser.email
+        .end()

--- a/scripts/test-instance/parallel-sets.coffee
+++ b/scripts/test-instance/parallel-sets.coffee
@@ -27,6 +27,7 @@ module.exports = [
     { name: 'logout' }
     { name: 'unittests' }
     { name: 'account accountsettings' }
+    { name: 'teams inviteteams' }
   ]
 
   [
@@ -72,7 +73,6 @@ module.exports = [
   [
     { name: 'teams teams' }
     { name: 'teams stack' }
-    { name: 'teams inviteteams' }
   ]
 
   [


### PR DESCRIPTION
Added test:
- TST-180 - Accepted invitations should be listed

Note: I moved the the `inviteteams` test suite to Set 0 in parallel-sets because it was the first one that finished and the test suit takes a long time to run; but in this set it is always ok.

![capture](https://cloud.githubusercontent.com/assets/7612973/14708974/75fc9cec-07ce-11e6-99f9-6b0f214409bc.PNG)

https://koding.atlassian.net/browse/TST-180
