### PR TITLE
TMS-2816 klientctl: enabled/disable updater depending on mounted dir count

### DIFF
--- a/go/src/koding/klient/app/update_test.go
+++ b/go/src/koding/klient/app/update_test.go
@@ -1,0 +1,215 @@
+package app_test
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"koding/kites/common"
+	"koding/kites/tunnelproxy/discover/discovertest"
+	"koding/klient/app"
+	"koding/klient/remote/mount"
+)
+
+func TestUpdater(t *testing.T) {
+	const timeout = 250 * time.Millisecond
+
+	events := make(chan *mount.Event)
+	defer close(events)
+
+	s := StartUpdateServer()
+
+	u := &app.Updater{
+		Endpoint:    s.URL().String(),
+		Interval:    50 * time.Millisecond,
+		Log:         common.NewLogger("updater", true),
+		MountEvents: events,
+	}
+
+	go u.Run()
+
+	if err := s.WaitForLatestReq(timeout); err != nil {
+		t.Fatal(err)
+	}
+
+	// Send a mouting event and ensure no
+	// update attempt was made afterwards.
+	events <- &mount.Event{
+		Path: "/path1",
+		Type: mount.EventMounting,
+	}
+
+	// From this point update server will mark every latest request as illegal.
+	s.Enable(false)
+
+	if err := s.WaitForLatestReq(timeout); err == nil {
+		t.Fatal("expected to timeout waiting for latest with disabled autoupdates")
+	}
+
+	// Send event that mouting succeeded, still no update requests expected.
+	events <- &mount.Event{
+		Path: "/path1",
+		Type: mount.EventMounted,
+	}
+
+	if err := s.WaitForLatestReq(timeout); err == nil {
+		t.Fatal("expected to timeout waiting for latest with disabled autoupdates")
+	}
+
+	// Send unmount event, but for different path that was previously reported
+	// as mounted - this event should be ignored, autoupdates still disabled.
+	events <- &mount.Event{
+		Path: "/pathX",
+		Type: mount.EventUnmounted,
+	}
+
+	// Only confirmed umount enables autoupdate, since unmounting
+	// can traisition to failed - this event also does not enable autoupdates.
+	events <- &mount.Event{
+		Path: "/path1",
+		Type: mount.EventUnmounting,
+	}
+
+	if err := s.WaitForLatestReq(timeout); err == nil {
+		t.Fatal("expected to timeout waiting for latest with disabled autoupdates")
+	}
+
+	// Send unmount event for previous mount and expect autoupdates to turn on.
+	events <- &mount.Event{
+		Path: "/path1",
+		Type: mount.EventUnmounted,
+	}
+
+	s.Enable(true)
+
+	if err := s.WaitForLatestReq(timeout); err != nil {
+		t.Fatal(err)
+	}
+
+	// Send mounting event, expect autoupdates to turn off, send the mount
+	// was failed and expect the autoupdates to turn on again.
+	events <- &mount.Event{
+		Path: "/path1",
+		Type: mount.EventMounting,
+	}
+
+	s.Enable(false)
+
+	if err := s.WaitForLatestReq(timeout); err == nil {
+		t.Fatal("expected to timeout waiting for latest with disabled autoupdates")
+	}
+
+	events <- &mount.Event{
+		Path: "/path1",
+		Type: mount.EventMounting,
+		Err:  errors.New("mount failed"),
+	}
+
+	s.Enable(true)
+
+	if err := s.WaitForLatestReq(timeout); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure no update request was made while the autoupdates
+	// were expected to be disabled.
+	if err := s.Err(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type UpdateServer struct {
+	mu          sync.Mutex
+	lis         net.Listener
+	enabled     bool
+	reqEnabled  []*http.Request
+	reqDisabled []*http.Request
+}
+
+func StartUpdateServer() *UpdateServer {
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		panic(err)
+	}
+
+	wl := discovertest.NewListener(l)
+
+	u := &UpdateServer{
+		lis:     wl,
+		enabled: true,
+	}
+
+	go http.Serve(wl, u)
+
+	wl.Wait()
+
+	return u
+}
+
+func (u *UpdateServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	u.mu.Lock()
+	if u.enabled {
+		u.reqEnabled = append(u.reqEnabled, req)
+	} else {
+		u.reqDisabled = append(u.reqDisabled, req)
+	}
+	u.mu.Unlock()
+
+	w.WriteHeader(http.StatusBadRequest)
+}
+
+func (u *UpdateServer) WaitForLatestReq(timeout time.Duration) error {
+	t := time.After(timeout)
+
+	n := u.LatestReqNum()
+
+	for {
+		select {
+		case <-t:
+			return fmt.Errorf("timed out waiting for latest req after %s", timeout)
+		default:
+			if u.LatestReqNum() > n {
+				return nil
+			}
+
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+}
+
+func (u *UpdateServer) LatestReqNum() int {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	return len(u.reqEnabled)
+}
+
+func (u *UpdateServer) Err() error {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	if len(u.reqDisabled) != 0 {
+		return fmt.Errorf("%d latest requests was served when the updater was disabled", len(u.reqDisabled))
+	}
+
+	return nil
+}
+
+func (u *UpdateServer) Enable(b bool) {
+	u.mu.Lock()
+	u.enabled = b
+	u.mu.Unlock()
+}
+
+func (u *UpdateServer) URL() *url.URL {
+	return &url.URL{
+		Scheme: "http",
+		Host:   u.lis.Addr().String(),
+		Path:   "/",
+	}
+}

--- a/go/src/koding/klient/remote/mount/mount.go
+++ b/go/src/koding/klient/remote/mount/mount.go
@@ -59,6 +59,9 @@ type Mount struct {
 
 	Log logging.Logger `json:"-"`
 
+	// EventSub receives events when paths get mounted / unmounted.
+	EventSub chan<- *Event `json:"-"`
+
 	// mockable interfaces and types, used for testing and abstracting the environment
 	// away.
 
@@ -74,7 +77,30 @@ func (m *Mount) Unmount() error {
 		return nil
 	}
 
-	var err error
+	m.emit(&Event{
+		Path: m.LocalPath,
+		Type: EventUnmounting,
+	})
+
+	if err := m.unmount(); err != nil {
+		m.emit(&Event{
+			Path: m.LocalPath,
+			Type: EventUnmounting,
+			Err:  err,
+		})
+
+		return err
+	}
+
+	m.emit(&Event{
+		Path: m.LocalPath,
+		Type: EventUnmounted,
+	})
+
+	return nil
+}
+
+func (m *Mount) unmount() (err error) {
 	if m.Unmounter != nil {
 		err = m.Unmounter.Unmount()
 	} else {
@@ -88,6 +114,12 @@ func (m *Mount) Unmount() error {
 	}
 
 	return nil
+}
+
+func (m *Mount) emit(ev *Event) {
+	if m.EventSub != nil {
+		m.EventSub <- ev
+	}
 }
 
 func MountLogger(m *Mount, l logging.Logger) logging.Logger {

--- a/go/src/koding/klient/remote/mountfolder.go
+++ b/go/src/koding/klient/remote/mountfolder.go
@@ -114,6 +114,7 @@ func (r *Remote) MountFolderHandler(kreq *kite.Request) (interface{}, error) {
 		Transport:     remoteMachine,
 		PathUnmounter: fuseklient.Unmount,
 		MountAdder:    r,
+		EventSub:      r.eventSub,
 	}
 
 	if _, err := mounter.Mount(); err != nil {

--- a/go/src/koding/klient/remote/mounts.go
+++ b/go/src/koding/klient/remote/mounts.go
@@ -278,6 +278,7 @@ func (r *Remote) restoreMount(m *mount.Mount) (err error) {
 		KiteTracker:   remoteMachine.KiteTracker,
 		Transport:     remoteMachine,
 		PathUnmounter: fuseklient.Unmount,
+		EventSub:      r.eventSub,
 	}
 
 	if err := mounter.MountExisting(m); err != nil {

--- a/go/src/koding/klient/remote/remount.go
+++ b/go/src/koding/klient/remote/remount.go
@@ -74,6 +74,7 @@ func (r *Remote) RemountHandler(kreq *kite.Request) (interface{}, error) {
 		Transport:     remoteMachine,
 		PathUnmounter: fuseklient.Unmount,
 		MountAdder:    r,
+		EventSub:      r.eventSub,
 	}
 
 	if _, err = mounter.Mount(); err != nil {


### PR DESCRIPTION
If no directories are mounted with `kd mount` then autoupdater
is enabled for klient - and disabled if at least 1 dir is mounted.
When all the dirs get unmounted, the autoupdater is enabled again.

/cc @leeola @cihangir 

https://koding.atlassian.net/browse/TMS-2816
