### PR TITLE
TMS-2883 tunnelserver: make tunnel urls more human readable

### DIFF
--- a/config/credentials.dev.coffee
+++ b/config/credentials.dev.coffee
@@ -20,7 +20,9 @@ module.exports = (options) ->
     # AmazonEC2FullAccess
     worker_test_instance_launcher: dev_master
     # TunnelProxyPolicy
-    worker_tunnelproxymanager: dev_master # Name worker_tunnelproxymanager_dev
+    worker_tunnelproxymanager: # Name worker_tunnelproxymanager_dev
+      accessKeyId     : "AKIAIM3GAPJAIWTFZOJQ"
+      secretAccessKey : "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"
     #Encryption and Storage on S3
     worker_sneakerS3 : dev_master
     vm_vmwatcher:     # vm_vmwatcher_dev

--- a/config/credentials.sandbox.coffee
+++ b/config/credentials.sandbox.coffee
@@ -20,7 +20,9 @@ module.exports = (options) ->
     # AmazonEC2FullAccess
     worker_test_instance_launcher: dev_master
     # TunnelProxyPolicy
-    worker_tunnelproxymanager: dev_master # Name worker_tunnelproxymanager_dev
+    worker_tunnelproxymanager: # Name worker_tunnelproxymanager_dev
+      accessKeyId     : "AKIAIM3GAPJAIWTFZOJQ"
+      secretAccessKey : "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"
     #Encryption and Storage on S3
     worker_sneakerS3 : dev_master
     vm_vmwatcher:     # vm_vmwatcher_dev

--- a/config/main.sandbox.coffee
+++ b/config/main.sandbox.coffee
@@ -129,11 +129,11 @@ Configuration = (options = {}) ->
     limit: '1536MB'
     email: 'sysops+supervisord-sandbox@koding.com'
 
-  KONFIG.JSON            = JSON.stringify KONFIG
-  KONFIG.ENV             = (require "../deployment/envvar.coffee").create KONFIG
-  KONFIG.supervisorConf  = (require "../deployment/supervisord.coffee").create KONFIG
-  KONFIG.nginxConf       = (require "../deployment/nginx.coffee").create KONFIG, options.environment
-  KONFIG.runFile        = require('./generateRunFile').sandbox(KONFIG, options, credentials)
+  KONFIG.JSON = JSON.stringify KONFIG
+  KONFIG.ENV = (require "../deployment/envvar.coffee").create KONFIG
+  KONFIG.supervisorConf = (require "../deployment/supervisord.coffee").create KONFIG
+  KONFIG.nginxConf = (require "../deployment/nginx.coffee").create KONFIG, options.environment
+  KONFIG.runFile = require('./generateRunFile').sandbox(KONFIG, options, credentials)
   KONFIG.configCheckExempt = ["command", "output_path"]
 
   return KONFIG

--- a/config/workers.coffee
+++ b/config/workers.coffee
@@ -476,7 +476,7 @@ module.exports = (KONFIG, options, credentials) ->
     tunnelserver        :
       group             : "proxy"
       supervisord       :
-        command         : "#{GOBIN}/tunnelserver -accesskey #{credentials.awsKeys.worker_tunnelproxymanager.accessKeyId} -secretkey #{credentials.awsKeys.worker_tunnelproxymanager.secretAccessKey} -port #{KONFIG.tunnelserver.port} -basevirtualhost #{KONFIG.tunnelserver.basevirtualhost} -hostedzone #{KONFIG.tunnelserver.hostedzone} -region #{options.region} -environment #{options.environment}"
+        command         : "#{GOBIN}/tunnelserver -accesskey #{credentials.awsKeys.worker_tunnelproxymanager.accessKeyId} -secretkey #{credentials.awsKeys.worker_tunnelproxymanager.secretAccessKey} -port #{KONFIG.tunnelserver.port} -basevirtualhost #{KONFIG.tunnelserver.basevirtualhost} -hostedzone #{KONFIG.tunnelserver.hostedzone} -region #{options.region} -environment #{options.environment} -kitekey #{options.kiteHome}/kite.key -kontrolurl #{KONFIG.kontrol.url}"
       ports             :
         incoming        : "#{KONFIG.tunnelserver.port}"
       healthCheckURL    : "http://tunnelserver/healthCheck"

--- a/config/workers.coffee
+++ b/config/workers.coffee
@@ -477,7 +477,6 @@ module.exports = (KONFIG, options, credentials) ->
       group             : "proxy"
       supervisord       :
         command         : "#{GOBIN}/tunnelserver -accesskey #{credentials.awsKeys.worker_tunnelproxymanager.accessKeyId} -secretkey #{credentials.awsKeys.worker_tunnelproxymanager.secretAccessKey} -port #{KONFIG.tunnelserver.port} -basevirtualhost #{KONFIG.tunnelserver.basevirtualhost} -hostedzone #{KONFIG.tunnelserver.hostedzone} -region #{options.region} -environment #{options.environment}"
-        command         : "#{GOBIN}/tunnelserver -accesskey #{credentials.awsKeys.worker_tunnelproxymanager.accessKeyId} -secretkey #{credentials.awsKeys.worker_tunnelproxymanager.secretAccessKey} -port #{KONFIG.tunnelserver.port} -basevirtualhost #{KONFIG.tunnelserver.basevirtualhost} -hostedzone #{KONFIG.tunnelserver.hostedzone}"
       ports             :
         incoming        : "#{KONFIG.tunnelserver.port}"
       healthCheckURL    : "http://tunnelserver/healthCheck"

--- a/config/workers.coffee
+++ b/config/workers.coffee
@@ -476,6 +476,7 @@ module.exports = (KONFIG, options, credentials) ->
     tunnelserver        :
       group             : "proxy"
       supervisord       :
+        command         : "#{GOBIN}/tunnelserver -accesskey #{credentials.awsKeys.worker_tunnelproxymanager.accessKeyId} -secretkey #{credentials.awsKeys.worker_tunnelproxymanager.secretAccessKey} -port #{KONFIG.tunnelserver.port} -basevirtualhost #{KONFIG.tunnelserver.basevirtualhost} -hostedzone #{KONFIG.tunnelserver.hostedzone} -region #{options.region} -environment #{options.environment}"
         command         : "#{GOBIN}/tunnelserver -accesskey #{credentials.awsKeys.worker_tunnelproxymanager.accessKeyId} -secretkey #{credentials.awsKeys.worker_tunnelproxymanager.secretAccessKey} -port #{KONFIG.tunnelserver.port} -basevirtualhost #{KONFIG.tunnelserver.basevirtualhost} -hostedzone #{KONFIG.tunnelserver.hostedzone}"
       ports             :
         incoming        : "#{KONFIG.tunnelserver.port}"

--- a/go/src/koding/kites/cmd/tunnelserver/main.go
+++ b/go/src/koding/kites/cmd/tunnelserver/main.go
@@ -9,11 +9,6 @@ import (
 	"github.com/koding/multiconfig"
 )
 
-const (
-	Name    = "tunnelkite"
-	Version = "0.0.1"
-)
-
 func die(v interface{}) {
 	fmt.Fprintln(os.Stderr, v)
 	os.Exit(1)
@@ -25,15 +20,13 @@ func main() {
 	m := multiconfig.New()
 	m.MustLoad(&opts)
 
+	opts.KiteName = "tunnelserver"
+	opts.KiteVersion = "0.0.1"
+
 	server, err := tunnelproxy.NewServer(&opts)
 	if err != nil {
 		die(err)
 	}
 
-	k, err := tunnelproxy.NewServerKite(server, Name, Version)
-	if err != nil {
-		die(err)
-	}
-
-	k.Run()
+	server.Run()
 }

--- a/go/src/koding/kites/e2etest/e2e_test.go
+++ b/go/src/koding/kites/e2etest/e2e_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"math/rand"
 	"net"
@@ -272,46 +271,4 @@ func splitArgs() (testing, config []string) {
 		}
 	}
 	return args, []string{}
-}
-
-type debugListener struct {
-	net.Listener
-}
-
-type debugConn struct {
-	net.Conn
-}
-
-func (dl debugListener) Accept() (net.Conn, error) {
-	conn, err := dl.Listener.Accept()
-	if err != nil {
-		return nil, err
-	}
-	return debugConn{conn}, nil
-}
-
-func (dc debugConn) Write(p []byte) (int, error) {
-	fmt.Println("debugConn.Write:")
-	return io.MultiWriter(dc.Conn, os.Stderr).Write(p)
-}
-
-func (dc debugConn) Read(p []byte) (int, error) {
-	fmt.Println("debugConn.Read")
-	return io.TeeReader(dc.Conn, os.Stderr).Read(p)
-}
-
-func host(s string) string {
-	u, err := url.Parse(s)
-	if err != nil {
-		panic(err)
-	}
-	return u.Host
-}
-
-func port(s string) string {
-	_, port, err := net.SplitHostPort(s)
-	if err != nil {
-		panic(err)
-	}
-	return port
 }

--- a/go/src/koding/kites/e2etest/e2etest.sh
+++ b/go/src/koding/kites/e2etest/e2etest.sh
@@ -19,7 +19,8 @@ fi
 
 # NOTE(rjeczalik): -noclean is used to keep DNS records, sometimes
 # handy for deelopment when AWS is utterly slow.
-go test -v koding/kites/e2etest $run -- -debug -ngrokdebug -noclean
+# go test -v koding/kites/e2etest $run -- -debug -ngrokdebug -noclean
+go test -v koding/kites/e2etest $run -- -ngrokdebug -noclean
 
 # For more options see
 #

--- a/go/src/koding/kites/e2etest/kontrol_test.go
+++ b/go/src/koding/kites/e2etest/kontrol_test.go
@@ -17,6 +17,9 @@ func NewKontrol() Kontrol {
 	if Test.Debug {
 		kntrl.Kite.SetLogLevel(kite.DEBUG)
 	}
+
+	kntrl.Kite.ClientFunc = newClientFunc()
+
 	p := kontrol.NewPostgres(&psqlCfg, kntrl.Kite.Log)
 	kntrl.SetKeyPairStorage(p)
 	kntrl.SetStorage(p)

--- a/go/src/koding/kites/e2etest/net.go
+++ b/go/src/koding/kites/e2etest/net.go
@@ -1,0 +1,96 @@
+package e2etest
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/koding/kite/sockjsclient"
+)
+
+var defaultTransport = &http.Transport{
+	Proxy: http.ProxyFromEnvironment,
+	Dial: (localDialer{
+		Dialer: &net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		},
+	}).Dial,
+	TLSHandshakeTimeout: 10 * time.Second,
+}
+
+var defaultClient = &http.Client{
+	Transport: defaultTransport,
+}
+
+type debugListener struct {
+	net.Listener
+}
+
+type debugConn struct {
+	net.Conn
+}
+
+type localDialer struct {
+	*net.Dialer
+}
+
+func (dl debugListener) Accept() (net.Conn, error) {
+	conn, err := dl.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	return debugConn{conn}, nil
+}
+
+func (dc debugConn) Write(p []byte) (int, error) {
+	fmt.Println("debugConn.Write:")
+	return io.MultiWriter(dc.Conn, os.Stderr).Write(p)
+}
+
+func (dc debugConn) Read(p []byte) (int, error) {
+	fmt.Println("debugConn.Read")
+	return io.TeeReader(dc.Conn, os.Stderr).Read(p)
+}
+
+func (ld localDialer) Dial(network, addr string) (net.Conn, error) {
+	if strings.HasSuffix(addr, ".localhost") {
+		addr = "localhost"
+	}
+
+	return ld.Dialer.Dial(network, addr)
+}
+
+func newClientFunc() func(*sockjsclient.DialOptions) *http.Client {
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{
+		Transport: defaultTransport,
+		Jar:       jar,
+	}
+	return func(*sockjsclient.DialOptions) *http.Client {
+		return client
+	}
+
+}
+
+func host(s string) string {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return u.Host
+}
+
+func port(s string) string {
+	_, port, err := net.SplitHostPort(s)
+	if err != nil {
+		panic(err)
+	}
+	return port
+}

--- a/go/src/koding/kites/e2etest/presence_test.go
+++ b/go/src/koding/kites/e2etest/presence_test.go
@@ -1,0 +1,103 @@
+package e2etest
+
+import (
+	"math/rand"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+func TestE2E_Presence(t *testing.T) {
+	var (
+		err error
+		mu  sync.Mutex // protects err
+		wg  sync.WaitGroup
+	)
+
+	K := make([]*UniqueKite, 7)
+	restoreK := make([]*UniqueKite, len(K))
+
+	for i := range K {
+		hostname := "kite" + strconv.Itoa(i)
+
+		K[i] = &UniqueKite{Hostname: hostname}
+		restoreK[i] = &UniqueKite{Hostname: hostname}
+	}
+
+	// Register all the unique kites.
+	for i, k := range K {
+		wg.Add(1)
+		go func(i int, k *UniqueKite) {
+			defer wg.Done()
+
+			time.Sleep(time.Duration(3+i*(rand.Intn(3)+1)) * time.Second)
+
+			if e := k.Register(); e != nil {
+				mu.Lock()
+				err = multierror.Append(err, e)
+				mu.Unlock()
+			}
+		}(i, k)
+	}
+
+	wg.Wait()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	names := make(map[string]string, len(K))
+
+	// Ensure every kite has a unique name.
+	for i, kite := range K {
+		name := kite.RegisteredName()
+
+		if name == "" {
+			t.Errorf("%d: empty registerURL for %q", i, kite.Hostname)
+			continue
+		}
+
+		if _, ok := names[name]; ok {
+			t.Errorf("%d: duplicate name for %q: %s", i, kite.Hostname, name)
+			continue
+		}
+
+		names[name] = kite.RegisteredURL.String()
+	}
+
+	// Register again all the unique kites, ensure they have restored
+	// their registerURLs.
+
+	for _, k := range restoreK {
+		wg.Add(1)
+		go func(k *UniqueKite) {
+			defer wg.Done()
+
+			if e := k.Register(); e != nil {
+				mu.Lock()
+				err = multierror.Append(err, e)
+				mu.Unlock()
+			}
+		}(k)
+	}
+
+	wg.Wait()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := range K {
+		name := K[i].RegisteredName()
+		restoredName := restoreK[i].RegisteredName()
+
+		if name != restoredName {
+			t.Errorf("%d: name=%q != restoredName=%q", i, name, restoredName)
+		}
+	}
+
+	t.Logf("registered names: %v", names)
+}

--- a/go/src/koding/kites/e2etest/presence_test.go
+++ b/go/src/koding/kites/e2etest/presence_test.go
@@ -2,6 +2,7 @@ package e2etest
 
 import (
 	"math/rand"
+	"os"
 	"strconv"
 	"sync"
 	"testing"
@@ -11,6 +12,9 @@ import (
 )
 
 func TestE2E_Presence(t *testing.T) {
+	if os.Getenv("WERCKER") != "" {
+		t.Skip("skipping test due to missing PostgreSQL setup on Wercker - TMS-2913")
+	}
 	var (
 		err error
 		mu  sync.Mutex // protects err

--- a/go/src/koding/kites/e2etest/tunnelproxy_test.go
+++ b/go/src/koding/kites/e2etest/tunnelproxy_test.go
@@ -273,6 +273,8 @@ func testWithTunnelserver(t *testing.T, test func(*testing.T, *url.URL)) {
 		TCPRangeFrom:    10000,
 		TCPRangeTo:      50000,
 		Log:             Test.Log.New("tunnelserver"),
+		KiteName:        "tunnelserver",
+		KiteVersion:     "0.0.1",
 		Debug:           true,
 		Test:            true,
 	}
@@ -281,14 +283,9 @@ func testWithTunnelserver(t *testing.T, test func(*testing.T, *url.URL)) {
 	if err != nil {
 		t.Fatalf("error creating tunnelproxy server: %s", err)
 	}
-	serverKite, err := tunnelproxy.NewServerKite(server, "tunnelkite", "0.0.1")
-	if err != nil {
-		t.Fatalf("error creating tunnelproxy server kite: %s", err)
-	}
-	defer serverKite.Close()
+	defer server.Close()
 
-	go serverKite.Run()
-	<-serverKite.ServerReadyNotify()
+	server.Start()
 
 	test(t, serverURL)
 }

--- a/go/src/koding/kites/e2etest/tunnelproxy_test.go
+++ b/go/src/koding/kites/e2etest/tunnelproxy_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -244,6 +245,10 @@ func testTunnelserverTCP(t *testing.T, serverURL *url.URL) {
 }
 
 func testWithTunnelserver(t *testing.T, test func(*testing.T, *url.URL)) {
+	if os.Getenv("WERCKER") != "" {
+		t.Skip("skipping test due to missing PostgreSQL setup on Wercker - TMS-2913")
+	}
+
 	// Create and start Tunnel Server.
 	serverCfg, serverURL := Test.GenKiteConfig()
 	if Test.NoPublic {

--- a/go/src/koding/kites/e2etest/uniquekite_test.go
+++ b/go/src/koding/kites/e2etest/uniquekite_test.go
@@ -1,0 +1,201 @@
+package e2etest
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"koding/kites/kontrol/presence"
+
+	"github.com/koding/kite"
+	"github.com/koding/kite/protocol"
+)
+
+type UniqueKite struct {
+	Hostname      string
+	Delay         time.Duration
+	RegisteredURL *url.URL
+	Kite          *kite.Kite
+
+	presence *presence.Client
+	once     sync.Once
+}
+
+func (uk *UniqueKite) Register() error {
+	uk.once.Do(uk.init)
+
+	k, registerURL, err := uk.presence.Register()
+	if err != nil {
+		return err
+	}
+
+	uk.RegisteredURL = registerURL
+	uk.Kite = k
+
+	return nil
+}
+
+func (uk *UniqueKite) RegisteredName() string {
+	if uk.RegisteredURL == nil {
+		return ""
+	}
+
+	if strings.Count(uk.RegisteredURL.Host, ".") != 2 {
+		return ""
+	}
+
+	return uk.RegisteredURL.Host[:strings.IndexRune(uk.RegisteredURL.Host, '.')]
+}
+
+func (uk *UniqueKite) PeerReady(k *kite.Client) bool {
+	u, err := url.Parse(k.URL)
+	if err != nil {
+		panic(err)
+	}
+
+	return strings.Count(u.Host, ".") == 2
+}
+
+func (uk *UniqueKite) PeerHostname(k *kite.Client) string {
+	u, err := url.Parse(k.URL)
+	if err != nil {
+		panic(err)
+	}
+
+	host := u.Host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+
+	host = strings.TrimSuffix(host, ".localhost")
+
+	if i := strings.LastIndex(host, "."); i != -1 {
+		return host[i+1:]
+	}
+
+	return host
+}
+
+func (uk *UniqueKite) PeerReadyTimeout(n int) time.Duration {
+	return time.Duration(n) * 90 * time.Second
+}
+
+func (uk *UniqueKite) RestoreURL(u *url.URL) error {
+	time.Sleep(uk.delay()) // simulate long registration, e.g. DNS insertion
+	return nil
+}
+
+func (uk *UniqueKite) RegisterURL(peers []*kite.Client) (*url.URL, error) {
+	left := genUniqueNames(24)
+
+	m, err := toUniqueNames(peers, left)
+	if err != nil {
+		return nil, err
+	}
+
+	for k := range m {
+		delete(left, k)
+	}
+
+	time.Sleep(uk.delay()) // simulate long registration, e.g. DNS insertion
+
+	if len(left) == 0 {
+		return nil, errors.New("run out of unique names")
+	}
+
+	// Sort and pick always first available name to not
+	// randomize urls in tests.
+	names := make([]string, 0, len(left))
+	for name := range left {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	Test.Log.Info("%s observed available names: %v, choosing %q\n", uk.Hostname, m, names[0])
+
+	u := *uk.presence.InitialURL
+	u.Host = names[0] + "." + u.Host
+
+	return &u, nil
+}
+
+func (uk *UniqueKite) init() {
+	cfg, _ := Test.GenKiteConfig()
+
+	uk.presence = presence.NewClient(&presence.Options{
+		Peers: &protocol.KontrolQuery{
+			Name: "peerkite",
+		},
+		KiteConfig:  cfg,
+		KiteName:    "peerkite",
+		KiteVersion: "0.0.1",
+		InitialURL: &url.URL{
+			Scheme: "http",
+			Host:   net.JoinHostPort(uk.Hostname+".localhost", strconv.Itoa(cfg.Port)),
+			Path:   "/kite",
+		},
+		Log:              Test.Log,
+		Debug:            true,
+		KiteFunc:         kiteFunc,
+		PeerReady:        uk.PeerReady,
+		PeerHostname:     uk.PeerHostname,
+		PeerReadyTimeout: uk.PeerReadyTimeout,
+		RestoreURL:       uk.RestoreURL,
+		RegisterURL:      uk.RegisterURL,
+	})
+}
+
+func (uk *UniqueKite) delay() time.Duration {
+	if uk.Delay != 0 {
+		return uk.Delay
+	}
+
+	return 10 * time.Second
+}
+
+func kiteFunc(k *kite.Kite) {
+	// overwrite kite's http.Client to understand *.localhost addresses
+	// note: Chrome does understand "127.0.0.1 *.localhost", maybe stdlib should?
+	k.ClientFunc = newClientFunc()
+}
+
+func genUniqueNames(n int) map[string]struct{} {
+	m := make(map[string]struct{}, n)
+
+	for ; n > 0; n-- {
+		m[string('a'+n-1)] = struct{}{}
+	}
+
+	return m
+}
+
+func toUniqueNames(peers []*kite.Client, names map[string]struct{}) (map[string]struct{}, error) {
+	m := make(map[string]struct{}, len(peers))
+
+	for _, peer := range peers {
+		u, err := url.Parse(peer.URL)
+		if err != nil {
+			return nil, err
+		}
+
+		name := u.Host
+		if i := strings.IndexRune(name, '.'); i != -1 {
+			name = name[:i]
+		}
+
+		if _, ok := names[name]; !ok {
+			return nil, fmt.Errorf("invalid unique name: %s (%s)", name, peer.URL)
+		}
+
+		m[name] = struct{}{}
+	}
+
+	return m, nil
+}

--- a/go/src/koding/kites/kontrol/presence/presence.go
+++ b/go/src/koding/kites/kontrol/presence/presence.go
@@ -1,0 +1,225 @@
+// Package presence provides stateful registration to Kontrol by queueing
+// peers. Additionaly a single peer upon registration has a view of all already
+// registrated peers, which can be used to e.g. implement unique registerURLs.
+//
+// This package is used by tunnelproxy/server to implement short urls
+// per instance (a.koding.me, b.koding.me etc.).
+package presence
+
+import (
+	"net"
+	"net/url"
+	"time"
+
+	"github.com/koding/kite"
+	"github.com/koding/kite/config"
+	"github.com/koding/kite/protocol"
+	"github.com/koding/logging"
+)
+
+// Options
+type Options struct {
+	// Peers
+	Peers *protocol.KontrolQuery
+
+	// KiteConfig
+	KiteConfig *config.Config
+
+	// Log
+	Log logging.Logger
+
+	// PeerReady
+	PeerReady func(*kite.Client) bool
+
+	// PeerReadyTimeout
+	PeerReadyTimeout time.Duration
+
+	// RegFunc
+	RegisterURL func(peers []*kite.Client) (*url.URL, error)
+
+	// Debug
+	Debug bool
+}
+
+// Client
+type Client struct {
+	*Options
+}
+
+// New
+func NewClient(opts *Options) *Client {
+	return &Client{
+		Options: opts,
+	}
+}
+
+// Register
+func (c *Client) Register(name, version string) (*kite.Kite, *url.URL, error) {
+	k := c.newKite(name, version)
+	initialURL := k.RegisterURL(false)
+
+	if err := k.RegisterForever(initialURL); err != nil {
+		return nil, nil, err
+	}
+
+	ready, waitgroup, err := c.peers(k, initialURL)
+	if err == kite.ErrNoKitesAvailable {
+		return c.finalRegister(k, nil, name, version)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(waitgroup) == 0 {
+		return c.finalRegister(k, ready, name, version)
+	}
+
+	timeout := time.After(c.PeerReadyTimeout)
+	var notready map[string]*kite.Client
+
+	// We wait for kites that we initially observed as not ready.
+	// Any other kite that joins the quorum later that we did,
+	// we just ignore, since it is expected to wait for us
+	// before it can proceed.
+
+WaitForGroup:
+	for len(waitgroup) != 0 {
+		select {
+		case <-timeout:
+			break WaitForGroup
+		default:
+			time.Sleep(c.PeerReadyTimeout / 10)
+
+			ready, notready, err = c.peers(k, initialURL)
+			if err == kite.ErrNoKitesAvailable {
+				return c.finalRegister(k, nil, name, version)
+			}
+			if err != nil {
+				return nil, nil, err
+			}
+
+			for id := range waitgroup {
+				if _, ok := notready[id]; !ok {
+					delete(waitgroup, id)
+				}
+			}
+		}
+	}
+
+	if len(waitgroup) != 0 {
+		// This can happend, when a kite registered to Kontrol with initialURL,
+		// but never managed to complete the final registration (e.g. crashed).
+		ids := make([]string, 0, len(waitgroup))
+		for id := range waitgroup {
+			ids = append(ids, id)
+		}
+
+		c.Log.Warning("exceeded max allowed time waiting for the following kites to become ready: %v", ids)
+	}
+
+	return c.finalRegister(k, ready, name, version)
+}
+
+func (c *Client) peers(k *kite.Kite, self *url.URL) (ready, notready map[string]*kite.Client, err error) {
+	kites, err := k.GetKites(c.Peers)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	peers := make([]*kite.Client, 0, len(kites))
+	selfHost := trimPort(self.Host)
+
+	// filter out self by filtering out kites with public IP
+	// the same as ours
+	for _, k := range kites {
+		u, err := url.Parse(k.URL)
+		if err != nil {
+			c.Log.Warning("%s: ignoring invalid kite with URL=%q: %s", k, k.URL, err)
+			continue
+		}
+
+		if trimPort(u.Host) == selfHost {
+			continue
+		}
+
+		peers = append(peers, k)
+	}
+
+	if len(peers) == 0 {
+		return nil, nil, kite.ErrNoKitesAvailable
+	}
+
+	readyPerHost := make(map[string]*kite.Client)
+
+	for _, k := range peers {
+		if c.PeerReady(k) {
+			readyPerHost[k.Kite.Hostname] = k
+		}
+	}
+
+	notready = make(map[string]*kite.Client)
+
+	// each kite registers twice - once with public IP, then again
+	// with url built with c.RegisterURL; since Kontrol caches kites,
+	// both of them are going to be listed in GetKites response;
+	// the assumption here is if at least one kite from kites that
+	// share the same hostname is ready, then those not-ready ones
+	// are old, cached entries we we're going to ignore
+	for _, k := range peers {
+		if _, ok := readyPerHost[k.Kite.Hostname]; !ok {
+			notready[k.String()] = k
+		}
+	}
+
+	ready = make(map[string]*kite.Client, len(readyPerHost))
+
+	for _, k := range readyPerHost {
+		ready[k.String()] = k
+	}
+
+	return ready, notready, nil
+}
+
+func (c *Client) finalRegister(k *kite.Kite, ready map[string]*kite.Client, name, version string) (*kite.Kite, *url.URL, error) {
+	peers := make([]*kite.Client, 0, len(ready))
+	for _, k := range ready {
+		peers = append(peers, k)
+	}
+
+	registerURL, err := c.RegisterURL(peers)
+
+	k.Close()
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	k = c.newKite(name, version)
+
+	if err = k.RegisterForever(registerURL); err != nil {
+		return nil, nil, err
+	}
+
+	return k, registerURL, nil
+}
+
+func (c *Client) newKite(name, version string) *kite.Kite {
+	k := kite.New(name, version)
+	k.Log = c.Log
+	k.Config = c.KiteConfig
+
+	if c.Debug {
+		k.SetLogLevel(kite.DEBUG)
+	}
+
+	return k
+}
+
+func trimPort(s string) string {
+	host, _, err := net.SplitHostPort(s)
+	if err != nil {
+		return s
+	}
+
+	return host
+}

--- a/go/src/koding/kites/tunnelproxy/server.go
+++ b/go/src/koding/kites/tunnelproxy/server.go
@@ -285,6 +285,20 @@ func (res *RegisterServicesResult) Err() (err error) {
 	return err
 }
 
+func (s *Server) Run() {
+	s.kite.Run()
+}
+
+func (s *Server) Start() {
+	go s.kite.Run()
+	<-s.kite.ServerReadyNotify()
+}
+
+func (s *Server) Close() error {
+	s.kite.Close()
+	return nil
+}
+
 func (s *Server) addClient(ident, name, vhost string, services map[string]*Tunnel) {
 	s.opts.Log.Debug("%s: adding vhost=%s", ident, vhost)
 

--- a/go/src/koding/kites/tunnelproxy/tunnelproxy.go
+++ b/go/src/koding/kites/tunnelproxy/tunnelproxy.go
@@ -16,6 +16,8 @@ import (
 
 // TODO(rjeczalik): forward ports on host klient for TCP services
 
+const ttl = 60
+
 type Service struct {
 	Name          string `json:"name"`
 	LocalAddr     string `json:"localAddr"`
@@ -269,6 +271,20 @@ func extractIPs(r *http.Request) map[string]struct{} {
 	delete(ips, "")
 
 	return ips
+}
+
+func uniqueName(counter int) (name string) {
+	const base = int('z') - int('a') + 1
+
+	for ; counter > 0; counter -= base {
+		c := counter
+		if c > base {
+			c = base
+		}
+		name = string(int('a')-1+c) + name
+	}
+
+	return name
 }
 
 type callbacks struct {

--- a/go/src/koding/kites/tunnelproxy/tunnelproxy_test.go
+++ b/go/src/koding/kites/tunnelproxy/tunnelproxy_test.go
@@ -1,0 +1,20 @@
+package tunnelproxy
+
+import "testing"
+
+func TestGenName(t *testing.T) {
+	cases := map[string]map[string]struct{}{
+		"a":   nil,
+		"b":   {"a": {}, "c": {}},
+		"c":   {"a": {}, "b": {}},
+		"ac":  {"a": {}, "b": {}, "c": {}},
+		"bcc": {"a": {}, "b": {}, "c": {}, "ac": {}, "bc": {}, "cc": {}, "acc": {}},
+	}
+
+	for want, taken := range cases {
+		got := genName('a', 'c', taken)
+		if want != got {
+			t.Errorf("got %s, want %s", got, want)
+		}
+	}
+}


### PR DESCRIPTION
deps: https://github.com/koding/koding/pull/7703

after:

![after](http://i.imgur.com/eVANhxr.png)

before:

![before](http://i.imgur.com/zpB7sis.png)

It supports starting/restarting multiple tunnelserver kites at once, they got queued so at least tunnelserver kite starts and picks unique letter at once (ergo new instances can be added by autoscaling without configuration).

Next thing is to do the same for the vm name part - TMS-2914.

https://koding.atlassian.net/browse/TMS-2883
