### PR TITLE
TMS-2882 kloud/stackplan: allow for overriding credentials via apply request

### DIFF
--- a/go/src/koding/kites/kloud/kloud/stackmethods.go
+++ b/go/src/koding/kites/kloud/kloud/stackmethods.go
@@ -25,6 +25,10 @@ type ApplyRequest struct {
 	StackID   string `json:"stackId"`
 	GroupName string `json:"groupName"`
 
+	// Identifiers sets or overrides credentials set in jStackTemplate or
+	// jComputeStack, if supported by the provider.
+	Identifiers []string `json:"identifiers"`
+
 	// Destroy, when true, destroys the terraform tempalte associated with the
 	// given StackId.
 	Destroy bool

--- a/go/src/koding/kites/kloud/provider/aws/apply.go
+++ b/go/src/koding/kites/kloud/provider/aws/apply.go
@@ -44,7 +44,7 @@ func (s *Stack) Apply(ctx context.Context) (interface{}, error) {
 		return nil, err
 	}
 
-	if err := s.Builder.BuildStack(arg.StackID); err != nil {
+	if err := s.Builder.BuildStack(arg.StackID, nil); err != nil {
 		return nil, err
 	}
 

--- a/go/src/koding/kites/kloud/provider/vagrant/apply.go
+++ b/go/src/koding/kites/kloud/provider/vagrant/apply.go
@@ -41,7 +41,11 @@ func (s *Stack) Apply(ctx context.Context) (interface{}, error) {
 		return nil, err
 	}
 
-	if err := s.Builder.BuildStack(arg.StackID); err != nil {
+	overrideCreds := map[string][]string{
+		arg.Provider: arg.Identifiers,
+	}
+
+	if err := s.Builder.BuildStack(arg.StackID, overrideCreds); err != nil {
 		return nil, err
 	}
 

--- a/go/src/koding/kites/kloud/stackplan/builder.go
+++ b/go/src/koding/kites/kloud/stackplan/builder.go
@@ -115,7 +115,7 @@ func NewBuilder(opts *BuilderOptions) *Builder {
 // BuildStack fetches stack details from MongoDB.
 //
 // When nil error is returned, the  b.Stack field is non-nil.
-func (b *Builder) BuildStack(stackID string) error {
+func (b *Builder) BuildStack(stackID string, overrideCreds map[string][]string) error {
 	computeStack, err := modelhelper.GetComputeStack(stackID)
 	if err != nil {
 		return err
@@ -144,6 +144,11 @@ func (b *Builder) BuildStack(stackID string) error {
 		if _, ok := credentials[k]; !ok {
 			credentials[k] = v
 		}
+	}
+
+	// Set or override credentials when passed in apply request.
+	for k, v := range overrideCreds {
+		credentials[k] = v
 	}
 
 	b.Log.Debug("Stack built: len(machines)=%d, len(credentials)=%d", len(machineIDs), len(credentials))


### PR DESCRIPTION
This PR makes it possible to send credentials with apply request for vagrant. The purpose is to allow user to use their own provisioner (kite ID).

@gokmen Do we need anything more from kloud?

https://koding.atlassian.net/browse/TMS-2882
