### PR TITLE
wercker: fix running go generate koding/config

### DIFF
--- a/go/src/koding/config/config.go
+++ b/go/src/koding/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import "encoding/json"
 
-//go:generate ../../../bin/go-bindata -modtime 1446555960 -pkg config -o config.json.go config.json
+//go:generate go-bindata -mode 420 -modtime 1446555960 -pkg config -o config.json.go config.json
 
 // Builtin represents an embedded configuration.
 var Builtin *Config


### PR DESCRIPTION
Not quite sure what's the difference between:

https://app.wercker.com/#build/572719ba24fc9c711d0294d8

vs

https://app.wercker.com/#build/57285d6f24fc9c711d03e9f4

That for sandbox build it does not lookup go-bindata binary correctly. Instead of debugging this I'm adding go-bindata's dir to $PATH:

![pic](http://i.imgur.com/7yoxwhA.png)

https://app.wercker.com/#applications/53cd92eedabd120e390b36bd/settings/envvars

And calling it directly with this PR.
