### PR TITLE
TMS-2844 klientctl: Added folder autocompletion for fish

### DIFF
--- a/go/src/koding/klient/app/klient_unix.go
+++ b/go/src/koding/klient/app/klient_unix.go
@@ -19,6 +19,7 @@ func (k *Klient) addRemoteHandlers() {
 	k.kite.HandleFunc("remote.status", k.remote.StatusHandler)
 	k.kite.HandleFunc("remote.remount", k.remote.RemountHandler)
 	k.kite.HandleFunc("remote.mountInfo", k.remote.MountInfoHandler)
+	k.kite.HandleFunc("remote.readDirectory", k.remote.ReadDirectoryHandler)
 }
 
 // Initializing the remote re-establishes any previously-running remote

--- a/go/src/koding/klient/fs/fs.go
+++ b/go/src/koding/klient/fs/fs.go
@@ -25,19 +25,20 @@ var (
 	mu             sync.Mutex // protects watchCallbacks
 )
 
+type ReadDirectoryOptions struct {
+	Path     string
+	OnChange dnode.Function
+
+	// Recursive specifies if results contain info about nested file/folder.
+	Recursive bool
+
+	// IgnoreFolders specifies which folders to not return results for
+	// when reading recursively.
+	IgnoreFolders []string
+}
+
 func ReadDirectory(r *kite.Request) (interface{}, error) {
-	var params struct {
-		Path     string
-		OnChange dnode.Function
-
-		// Recursive specifies if results contain info about nested file/folder.
-		Recursive bool
-
-		// IgnoreFolders specifies which folders to not return results for
-		// when reading recursively.
-		IgnoreFolders []string
-	}
-
+	var params ReadDirectoryOptions
 	if r.Args == nil {
 		return nil, errors.New("arguments are not passed")
 	}

--- a/go/src/koding/klient/remote/cache.go
+++ b/go/src/koding/klient/remote/cache.go
@@ -12,7 +12,6 @@ import (
 	"koding/klient/remote/mount"
 	"koding/klient/remote/req"
 	"koding/klient/remote/rsync"
-	"path"
 )
 
 // CacheFolderHandler implements a prefetching / caching mechanism, currently
@@ -78,11 +77,11 @@ func (r *Remote) CacheFolderHandler(kreq *kite.Request) (interface{}, error) {
 	}
 
 	if params.RemotePath == "" {
-		// TODO: Deprecate in favor of a more robust way to identify the home dir.
-		// This assumes that the username klient is running under has a home
-		// at /home/username. Not true for root, if the user isn't the same user
-		// as klient is running under, and not true if the homedir isn't /home.
-		params.RemotePath = path.Join("/home", remoteMachine.Username)
+		home, err := remoteMachine.Home()
+		if err != nil {
+			return nil, err
+		}
+		params.RemotePath = home
 	}
 
 	remoteSize, err := getSizeOfRemoteFolder(remoteMachine, params.RemotePath)

--- a/go/src/koding/klient/remote/machine/machine.go
+++ b/go/src/koding/klient/remote/machine/machine.go
@@ -1,7 +1,9 @@
 package machine
 
 import (
+	"errors"
 	"fmt"
+	"path"
 	"time"
 
 	"github.com/koding/logging"
@@ -457,6 +459,20 @@ func (m *Machine) DoesRemoteDirExist(p string) (bool, error) {
 	}
 
 	return res.ExitStatus == 0, nil
+}
+
+// Home attempts to return the home directory of the remote machine.
+func (m *Machine) Home() (string, error) {
+	u := m.Username
+	if u == "" {
+		return "", errors.New("Unable to find home directory")
+	}
+
+	// TODO: Deprecate in favor of a more robust way to identify the home dir.
+	// This assumes that the username klient is running under has a home
+	// at /home/username. Not true for root, if the user isn't the same user
+	// as klient is running under, and not true if the homedir isn't /home.
+	return path.Join("/home", u), nil
 }
 
 func (ms MachineStatus) String() string {

--- a/go/src/koding/klient/remote/mountfolder.go
+++ b/go/src/koding/klient/remote/mountfolder.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"regexp"
 	"strconv"
 
@@ -83,11 +82,11 @@ func (r *Remote) MountFolderHandler(kreq *kite.Request) (interface{}, error) {
 	}
 
 	if params.RemotePath == "" {
-		// TODO: Deprecate in favor of a more robust way to identify the home dir.
-		// This assumes that the username klient is running under has a home
-		// at /home/username. Not true for root, if the user isn't the same user
-		// as klient is running under, and not true if the homedir isn't /home.
-		params.RemotePath = path.Join("/home", remoteMachine.Username)
+		home, err := remoteMachine.Home()
+		if err != nil {
+			return nil, err
+		}
+		params.RemotePath = home
 	}
 
 	if remoteMachine.IsMountingLocked() {

--- a/go/src/koding/klient/remote/readdirectory.go
+++ b/go/src/koding/klient/remote/readdirectory.go
@@ -1,0 +1,56 @@
+package remote
+
+import (
+	"errors"
+	"fmt"
+	"koding/klient/remote/req"
+
+	"github.com/koding/kite"
+	"github.com/koding/logging"
+)
+
+//  implements a prefetching / caching mechanism, currently
+// implemented
+func (r *Remote) ReadDirectoryHandler(kreq *kite.Request) (interface{}, error) {
+	log := logging.NewLogger("remote").New("remote.readDirectory")
+
+	var params req.ReadDirectoryOptions
+	if kreq.Args == nil {
+		return nil, errors.New("arguments are not passed")
+	}
+
+	if err := kreq.Args.One().Unmarshal(&params); err != nil {
+		err = fmt.Errorf(
+			"remote.readDirectory: Error '%s' while unmarshalling request '%s'\n",
+			err, kreq.Args.One(),
+		)
+		r.log.Error(err.Error())
+		return nil, err
+	}
+
+	switch {
+	case params.Machine == "":
+		return nil, errors.New("Missing required argument `machine`.")
+	}
+
+	log = log.New(
+		"machineName", params.Machine,
+		"remotePath", params.Path,
+	)
+
+	remoteMachine, err := r.GetDialedMachine(params.Machine)
+	if err != nil {
+		log.Error("Error getting dialed, valid machine. err:%s", err)
+		return nil, err
+	}
+
+	if params.Path == "" {
+		home, err := remoteMachine.Home()
+		if err != nil {
+			return nil, err
+		}
+		params.Path = home
+	}
+
+	return remoteMachine.Tell("fs.readDirectory", params)
+}

--- a/go/src/koding/klient/remote/req/req.go
+++ b/go/src/koding/klient/remote/req/req.go
@@ -1,6 +1,7 @@
 package req
 
 import (
+	"koding/klient/fs"
 	"koding/klient/remote/rsync"
 	"time"
 )
@@ -108,6 +109,14 @@ type MountInfoResponse struct {
 // Remount is the struct for klient's remote.remount method.
 type Remount struct {
 	MountName string `json:"mountName"`
+}
+
+type ReadDirectoryOptions struct {
+	// The embedded ReadDirectoryOptions
+	fs.ReadDirectoryOptions
+
+	// The machine name to run the ReadDirectory on.
+	Machine string
 }
 
 func (i StatusItem) String() string {

--- a/go/src/koding/klientctl/autocomplete/files.go
+++ b/go/src/koding/klientctl/autocomplete/files.go
@@ -19,7 +19,21 @@ function __kd_subcommand
   return 0
 end
 
-complete -f -c kd -a '(kd (__kd_subcommand) --generate-bash-completion)'
+function __kd_subcommand_args
+  set cmd (commandline -op)
+  set cmdCount (count $cmd)
+  if test $cmdCount -lt 3
+    return 0
+  end
+  # Ensure fish takes the args as separate, not a single string as is the case
+  # if we used $cmd[3..cmdCount]
+  for i in (seq 3 $cmdCount)
+    echo $cmd[$i]
+  end
+  return 0
+end
+
+complete -f -c kd -a '(kd (__kd_subcommand) --generate-bash-completion (__kd_subcommand_args))'
 `
 
 	// The bash completion file, usually placed in /etc/bash_completion.d/kd
@@ -31,6 +45,8 @@ _cli_bash_autocomplete() {
   local cur opts base
   COMPREPLY=()
   cur="${COMP_WORDS[COMP_CWORD]}"
+  # Experimental full completion - not working yet
+  #opts=$( ${COMP_WORDS[@]:0:2} --generate-bash-completion ${COMP_WORDS[@]:2:$COMP_CWORD} )
   opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
   COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
   return 0

--- a/go/src/koding/klientctl/ctlcli/ctlcli.go
+++ b/go/src/koding/klientctl/ctlcli/ctlcli.go
@@ -28,6 +28,9 @@ type Command interface {
 // AutocompleteCommand is an interface for a Command that wants to provide
 // Autocomplete functionality.
 type AutocompleteCommand interface {
+	// Autocomplete prints to Stdout what is to be autocompleted, one item per line.
+	// Handling of the autocompletion is done by the shell (bash/fish/etc), this
+	// method simply prints to Stdout.
 	Autocomplete(args ...string) error
 }
 

--- a/go/src/koding/klientctl/mount_test.go
+++ b/go/src/koding/klientctl/mount_test.go
@@ -11,13 +11,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/koding/kite/dnode"
 	"koding/klient/kiteerrortypes"
 	"koding/klient/remote/restypes"
 	"koding/klient/util"
 	"koding/klientctl/klientctlerrors"
 	"koding/klientctl/list"
 	"koding/klientctl/util/testutil"
+
+	"github.com/koding/kite/dnode"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/go/src/koding/klientctl/util/testutil/fakeklient.go
+++ b/go/src/koding/klientctl/util/testutil/fakeklient.go
@@ -1,11 +1,13 @@
 package testutil
 
 import (
-	"github.com/koding/kite"
-	"github.com/koding/kite/dnode"
 	"koding/klient/command"
+	"koding/klient/fs"
 	"koding/klient/remote/req"
 	"koding/klientctl/list"
+
+	"github.com/koding/kite"
+	"github.com/koding/kite/dnode"
 )
 
 type FakeKlient struct {
@@ -92,4 +94,8 @@ func (k *FakeKlient) RemoteMountFolder(req.MountFolder) (string, error) {
 
 func (k *FakeKlient) Tell(string, ...interface{}) (*dnode.Partial, error) {
 	return k.ReturnTellPartial, k.ReturnTellErr
+}
+
+func (k *FakeKlient) RemoteReadDirectory(string, string) ([]fs.FileEntry, error) {
+	return nil, nil
 }


### PR DESCRIPTION
Bash is still having trouble, needs more debugging. The core logic is
there for any shell, bash is just doing some odd things, so the bash
script may need tweaking or autocomplete implementation may need to be
split up for each specific shell _(ie, if it's an issue of fish and bash
behaving differently)_.

https://koding.atlassian.net/browse/TMS-2844
