### PR TITLE
TMS-2905 IDE: dim inactive terminal

### DIFF
--- a/client/app/lib/terminal/webtermview.coffee
+++ b/client/app/lib/terminal/webtermview.coffee
@@ -243,7 +243,9 @@ module.exports = class WebTermView extends KDCustomScrollView
 
     for theme in settings.themes
       @container.unsetClass theme.value
+      @container.unsetClass 'dim-if-inactive'
       @messagePane.unsetClass theme.value
+      @messagePane.unsetClass 'dim-if-inactive'
 
     font        = @appStorage.getValue 'font'
     theme       = @appStorage.getValue 'theme'
@@ -256,14 +258,20 @@ module.exports = class WebTermView extends KDCustomScrollView
     @container.setStyle
       fontSize: @appStorage.getValue('fontSize') + 'px'
 
-    this.setStyle
-      color: (global.getComputedStyle @container.getElement()).backgroundColor
+    @updateColor()
 
     @terminal.updateSize true
     @terminal.scrollToBottom()
     @terminal.controlCodeReader.visualBell = @appStorage.getValue 'visualBell'
     @terminal.setScrollbackLimit @appStorage.getValue 'scrollback'
     @terminal.cursor.setBlinking @appStorage.getValue 'blinkingCursor'
+
+
+  updateColor: ->
+
+    @setStyle
+      color: (global.getComputedStyle @container.getElement()).backgroundColor
+
 
   setKeyView: ->
     kd.getSingleton('windowController').addLayer this
@@ -274,6 +282,7 @@ module.exports = class WebTermView extends KDCustomScrollView
   setFocus: (state = yes) ->
     @focused = state
     @terminal.setFocused state
+    @updateColor()
 
   click: ->
     @setKeyView()

--- a/client/app/lib/terminal/webtermview.coffee
+++ b/client/app/lib/terminal/webtermview.coffee
@@ -212,6 +212,7 @@ module.exports = class WebTermView extends KDCustomScrollView
         'visualBell'     : no
         'scrollback'     : 1000
         'blinkingCursor' : no
+        'dimIfInactive'  : no
 
       @updateSettings()
 
@@ -246,7 +247,8 @@ module.exports = class WebTermView extends KDCustomScrollView
 
     font        = @appStorage.getValue 'font'
     theme       = @appStorage.getValue 'theme'
-    themeBucket = [font, theme].join ' '
+    dimFlag     = if @appStorage.getValue('dimIfInactive') then 'dim-if-inactive' else ''
+    themeBucket = [font, theme, dimFlag].join ' '
 
     @container.setClass themeBucket
     @messagePane.setClass themeBucket

--- a/client/ide/lib/index.coffee
+++ b/client/ide/lib/index.coffee
@@ -247,7 +247,7 @@ class IDEAppController extends AppController
     return  if tabView is @activeTabView
     return  if tabView.isDestroyed
 
-    @setActivePaneFocus off
+    @setActivePaneFocus off, yes
     @activeTabView = tabView
     @setActivePaneFocus on
 

--- a/client/ide/lib/styl/ide.styl
+++ b/client/ide/lib/styl/ide.styl
@@ -1306,3 +1306,16 @@ body.ide .kddialogview.save-as-dialog
     shadow                  none
     vendor                  transition, width .3s ease .05s\,\
                                         margin .3s ease
+
+.terminal.unfocused
+  .console.dim-if-inactive
+
+    bg                      color, #444 !important
+    color                   #ddd
+
+    .outlined
+      shadow                inset 0 0 0 1px #ddd !important
+
+    *
+      color                 #ddd !important
+      bg                    color, #444 !important

--- a/client/ide/lib/workspace/panes/ideterminalpane.coffee
+++ b/client/ide/lib/workspace/panes/ideterminalpane.coffee
@@ -99,13 +99,14 @@ module.exports = class IDETerminalPane extends IDEPane
   setFocus: (state) ->
 
     super state
-    @webtermView.setFocus state
-    kd.singletons.mainView.setKeyView null  if state
 
     classToSet   = if state then 'focused' else 'unfocused'
     classToUnset = if state then 'unfocused' else 'focused'
     @setClass classToSet
     @unsetClass classToUnset
+
+    @webtermView.setFocus state
+    kd.singletons.mainView.setKeyView null  if state
 
 
   serialize: ->

--- a/client/ide/lib/workspace/panes/ideterminalpane.coffee
+++ b/client/ide/lib/workspace/panes/ideterminalpane.coffee
@@ -8,7 +8,7 @@ module.exports = class IDETerminalPane extends IDEPane
 
   constructor: (options = {}, data) ->
 
-    options.cssClass  = 'terminal-pane terminal'
+    options.cssClass  = 'terminal-pane terminal unfocused'
     options.paneType  = 'terminal'
     options.readOnly ?= no
 
@@ -101,6 +101,11 @@ module.exports = class IDETerminalPane extends IDEPane
     super state
     @webtermView.setFocus state
     kd.singletons.mainView.setKeyView null  if state
+
+    classToSet   = if state then 'focused' else 'unfocused'
+    classToUnset = if state then 'unfocused' else 'focused'
+    @setClass classToSet
+    @unsetClass classToUnset
 
 
   serialize: ->

--- a/client/ide/lib/workspace/panes/settings/ideterminalsettingsview.coffee
+++ b/client/ide/lib/workspace/panes/settings/ideterminalsettingsview.coffee
@@ -36,10 +36,14 @@ module.exports = class IDETerminalSettingsView extends IDESettingsView
       size          : 'tiny settings-on-off'
       callback      : (state) => @emit 'SettingsChanged', 'blinkingCursor', state
 
+    @dimIfInactive  = new KodingSwitch
+      size          : 'tiny settings-on-off'
+      callback      : (state) => @emit 'SettingsChanged', 'dimIfInactive', state
+
   getStorageInformation: -> { name: 'Terminal', version: '1.0.1' }
 
   getSettingKeys: ->
-    return [ 'visualBell', 'font', 'theme', 'fontSize', 'scrollback', 'blinkingCursor' ]
+    return [ 'visualBell', 'font', 'theme', 'fontSize', 'scrollback', 'blinkingCursor', 'dimIfInactive' ]
 
   defaults:
     font           : 'ubuntu-mono'
@@ -48,6 +52,7 @@ module.exports = class IDETerminalSettingsView extends IDESettingsView
     visualBell     : no
     scrollback     : 1000
     blinkingCursor : yes
+    dimIfInactive  : no
 
   pistachio: ->
     '''
@@ -59,5 +64,6 @@ module.exports = class IDETerminalSettingsView extends IDESettingsView
         <li class="with-select">Scrollback  {{> @scrollback}}</li>
         <li>Use visual bell                 {{> @visualBell}}</li>
         <li>Blinking cursor                 {{> @blinkingCursor}}</li>
+        <li>Dim if inactive                 {{> @dimIfInactive}}</li>
       </ul>
     '''


### PR DESCRIPTION
@gokmen, can you review these changes?
http://recordit.co/xNtjVG6UQ2

/cc @sinan 

Currently the same "inactive" styles are used for all possible terminal themes. Does it make sense to use a separate "inactive" version for each theme?

https://koding.atlassian.net/browse/TMS-2905
