### PR TITLE
GEN-2534 config: fix or update hardcoded postgre passwords

### DIFF
--- a/config/credentials.default.coffee
+++ b/config/credentials.default.coffee
@@ -58,14 +58,14 @@ module.exports = (options) ->
   postgres =
     host: "#{options.serviceHost}"
     port: "5432"
-    username: "socialapp201506"
-    password: "socialapp201506"
+    username: "socialapp_2016_05"
+    password: "socialapp_2016_05"
     dbname: "social"
   kontrolPostgres =
     host: "#{options.serviceHost}"
     port: 5432
-    username: "kontrolapp201506"
-    password: "kontrolapp201506"
+    username: "kontrolapp_2016_05"
+    password: "kontrolapp_2016_05"
     dbname: "social"
     connecttimeout: 20
   pubnub =

--- a/config/generateRunFile.coffee
+++ b/config/generateRunFile.coffee
@@ -396,7 +396,7 @@ generateDev = (KONFIG, options, credentials) ->
           exit 1
       fi
 
-      EXISTS=$(PGPASSWORD=kontrolapp201506 psql -tA -h #{options.boot2dockerbox} social -U kontrolapp201506 -c "Select 1 from pg_tables where tablename = 'key' AND schemaname = 'kite';")
+      EXISTS=$(PGPASSWORD=#{credentials.postgres.password} psql -tA -h #{options.boot2dockerbox} social -U #{credentials.postgres.username} -c "Select 1 from pg_tables where tablename = 'key' AND schemaname = 'kite';")
       if [[ $EXISTS != '1' ]]; then
         echo ""
         echo "You don't have the new Kontrol Postgres. Please call ./run buildservices."
@@ -461,8 +461,8 @@ generateDev = (KONFIG, options, credentials) ->
       # Include this to dockerfile before we continute with building
       mkdir -p kontrol
       cp #{options.projectRoot}/go/src/github.com/koding/kite/kontrol/*.sql kontrol/
-      sed -i -e 's/somerandompassword/kontrolapp201506/' kontrol/001-schema.sql
-      sed -i -e 's/kontrolapplication/kontrolapp201506/' kontrol/001-schema.sql
+      sed -i -e 's/somerandompassword/#{credentials.postgres.password}/' kontrol/001-schema.sql
+      sed -i -e 's/kontrolapplication/#{credentials.postgres.username}/' kontrol/001-schema.sql
 
       docker build -t koding/postgres .
 

--- a/go/src/koding/kites/e2etest/e2e_test.go
+++ b/go/src/koding/kites/e2etest/e2e_test.go
@@ -200,8 +200,8 @@ func (cfg *Config) setDefaults() {
 		cfg.Postgres = kontrol.PostgresConfig{
 			Host:           cfg.DockerHost,
 			Port:           5432,
-			Username:       "kontrolapp201506",
-			Password:       "kontrolapp201506",
+			Username:       "kontrolapp_2016_05",
+			Password:       "kontrolapp_2016_05",
 			DBName:         "social",
 			ConnectTimeout: 20,
 		}

--- a/go/src/socialapi/db/sql/definition/000-cleanup.sql
+++ b/go/src/socialapi/db/sql/definition/000-cleanup.sql
@@ -11,6 +11,7 @@ DROP ROLE IF EXISTS social;
 -- DROP OWNED BY socialapplication CASCADE;
 DROP USER IF EXISTS socialapplication;
 DROP USER IF EXISTS socialapp201506;
+DROP USER IF EXISTS socialapp_2016_05;
 
 -- Drop tablespaces
 -- we dont need tablespaces anymore...

--- a/go/src/socialapi/db/sql/definition/001-database.sql
+++ b/go/src/socialapi/db/sql/definition/001-database.sql
@@ -5,14 +5,14 @@ CREATE ROLE social;
 CREATE USER socialapplication PASSWORD 'socialapplication';
 
 -- new socialapp user
-CREATE USER socialapp201506 PASSWORD 'socialapp201506'; -- password is just for reference
+CREATE USER socialapp_2016_05 PASSWORD 'socialapp_2016_05'; -- password is just for reference
 
 -- social superuser
 CREATE USER social_superuser PASSWORD 'social_superuser';
 
 -- grant access to social role for all users
 GRANT social TO socialapplication;
-GRANT social TO socialapp201506;
+GRANT social TO socialapp_2016_05;
 
 ALTER USER social_superuser WITH SUPERUSER;
 

--- a/go/src/socialapi/db/sql/migrations/0014_update_roles_to_social_and_create_user.up.sql
+++ b/go/src/socialapi/db/sql/migrations/0014_update_roles_to_social_and_create_user.up.sql
@@ -22,14 +22,14 @@ BEGIN
    IF NOT EXISTS (
       SELECT *
       FROM   pg_catalog.pg_user
-      WHERE  usename = 'socialapp201506') THEN
+      WHERE  usename = 'socialapp_2016_05') THEN
 
-      CREATE USER socialapp201506 PASSWORD 'socialapp201506';
+      CREATE USER socialapp_2016_05 PASSWORD 'socialapp_2016_05';
    END IF;
 END
 $body$
 ;
-GRANT social TO socialapp201506;
+GRANT social TO socialapp_2016_05;
 
 DO
 $body$
@@ -37,9 +37,9 @@ BEGIN
    IF NOT EXISTS (
       SELECT *
       FROM   pg_catalog.pg_user
-      WHERE  usename = 'kontrolapp201506') THEN
+      WHERE  usename = 'kontrolapp_2016_05') THEN
 
-      CREATE USER kontrolapp201506 PASSWORD 'kontrolapp201506';
+      CREATE USER kontrolapp_2016_05 PASSWORD 'kontrolapp_2016_05';
    END IF;
 END
 $body$
@@ -59,6 +59,6 @@ END
 $body$
 ;
 
-GRANT kontrol TO kontrolapp201506;
+GRANT kontrol TO kontrolapp_2016_05;
 
 ALTER USER paymentro with password 'N8bG8ZVjp2y87Zxfi3';


### PR DESCRIPTION
In several places we're hardcoding postgre password, like Go test codes
or migration files.

This PR fixes hardcoded creds to use configured ones or updates the
hardcoded values.

The e2etest will get fixed by TMS-2891 to use creds from configuration
instead of hardcoding them.

https://koding.atlassian.net/browse/GEN-2534
