### PR TITLE
TMS-3019 sidebar: fix long stack name style

### DIFF
--- a/client/app/lib/components/sidebarsection/styl/sidebarsection.styl
+++ b/client/app/lib/components/sidebarsection/styl/sidebarsection.styl
@@ -18,14 +18,16 @@
   line-height               16px
   word-spacing              0.2em
   text-transform            uppercase
-  ellipsis()
   antialiased()
 
   a
   a:active
   a:visited
     color                   $gray-8
+    display                 inline-block
+    width                   205px
     noTextDeco()
+    ellipsis()
     pointer()
 
 .SidebarSection-body

--- a/client/app/lib/components/sidebarstacksection/styl/sidebarstacksection.styl
+++ b/client/app/lib/components/sidebarstacksection/styl/sidebarstacksection.styl
@@ -37,13 +37,18 @@
     text-transform          capitalize
     noTextDeco()
 
-    &:hover a:after
-      content               ''
-      r-sprite              'app' '20_chevron_gray'
-      margin-left           1px
-      opacity               .7
-      vertical-align        top
-      dIBlock()
+    &:hover a
+      width                 190px
+      &:after
+        box-shadow          0 0 15px #323232
+        content             ''
+        r-sprite            'app' '20_chevron_gray'
+        margin-left         1px
+        opacity             .7
+        position            absolute
+        right               0
+        top                 -3px
+        dIBlock()
 
     &:hover .SidebarSection-secondaryLink
       visible()
@@ -62,7 +67,7 @@
       rel()
       borderBox()
       dIBlock()
-      top                   -2px
+      top                   -6px
       border                2px solid rgba(255, 255, 255, .2)
       height                6px
       rounded               100%


### PR DESCRIPTION
![sidebar-text-overflow](https://cloud.githubusercontent.com/assets/1783869/15271560/fe42485c-1a04-11e6-876c-fcf21eb01d2f.gif)

https://koding.atlassian.net/browse/TMS-3019
