### PR TITLE
kloud: add support for KONFIG_ prefix

### DIFF
--- a/go/src/koding/kites/kloud/main.go
+++ b/go/src/koding/kites/kloud/main.go
@@ -141,7 +141,15 @@ func main() {
 	conf := new(Config)
 
 	// Load the config, it's reads environment variables or from flags
-	multiconfig.New().MustLoad(conf)
+	mc := multiconfig.New()
+	mc.Loader = multiconfig.MultiLoader(
+		&multiconfig.TagLoader{},
+		&multiconfig.EnvironmentLoader{},
+		&multiconfig.EnvironmentLoader{Prefix: "KONFIG_KLOUD"},
+		&multiconfig.FlagLoader{},
+	)
+
+	mc.MustLoad(conf)
 
 	if conf.Version {
 		fmt.Println(kloud.VERSION)

--- a/go/src/koding/kites/kontrol/kontrol.go
+++ b/go/src/koding/kites/kontrol/kontrol.go
@@ -18,6 +18,7 @@ func main() {
 	loader := multiconfig.MultiLoader(
 		&multiconfig.TagLoader{},
 		&multiconfig.EnvironmentLoader{Prefix: "kontrol"},
+		&multiconfig.EnvironmentLoader{Prefix: "KONFIG_KONTROL"},
 		&multiconfig.FlagLoader{EnvPrefix: "kontrol"},
 	)
 


### PR DESCRIPTION
The envs for kloud would then become:
- `KONFIG_IP`
- `KONFIG_PORT`
- etc.

It supports old envs as well to not break dev scripts.
