### PR TITLE
klient, kd: set proper GOMAXPROCS

### DIFF
--- a/go/src/koding/klient/main.go
+++ b/go/src/koding/klient/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"koding/klient/app"
@@ -73,6 +74,11 @@ func main() {
 
 func realMain() int {
 	flag.Parse()
+
+	// For forward-compatibility with go1.5+, where GOMAXPROCS is
+	// always set to a number of available cores.
+	runtime.GOMAXPROCS(runtime.NumCPU())
+
 	if *flagVersion {
 		fmt.Println(protocol.Version)
 		return 0

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"runtime"
 
 	"koding/klientctl/config"
 	"koding/klientctl/ctlcli"
@@ -38,6 +39,10 @@ var sudoRequiredFor = []string{
 var log logging.Logger
 
 func main() {
+	// For forward-compatibility with go1.5+, where GOMAXPROCS is
+	// always set to a number of available cores.
+	runtime.GOMAXPROCS(runtime.NumCPU())
+
 	// The writer used for the logging output. Either a file, or /dev/null
 	var logWriter io.Writer
 


### PR DESCRIPTION
For backward-compatibility with go1.5+, where GOMAXPROCS is
always set to a number of available cores.

/cc @leeola 
