### PR TITLE
kite: revert aud fix

### DIFF
--- a/go/src/github.com/koding/kite/request.go
+++ b/go/src/github.com/koding/kite/request.go
@@ -224,7 +224,7 @@ func (k *Kite) AuthenticateFromToken(r *Request) error {
 	// check if we have an audience and it matches our own signature
 	audience, ok := token.Claims["aud"].(string)
 	if ok && audience != "/" {
-		if err := checkAudience(k.Kite().String(), audience); err != nil {
+		if checkAudience(k.Kite().String(), audience); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This PR reverts aud check, as kd ssh relies on it.

After kd / klient is fixed to have proper kite paths, it will be
reverted back.
