### PR TITLE
klientctl: use timeout for ssh to prevent hangs

### DIFF
--- a/go/src/koding/klientctl/ssh/ssh.go
+++ b/go/src/koding/klientctl/ssh/ssh.go
@@ -148,6 +148,8 @@ func (s *SSHCommand) Run(machine string) error {
 		"-i", s.PrivateKeyPath(),
 		"-o", "ServerAliveInterval=300",
 		"-o", "ServerAliveCountMax=3",
+		"-o", "ConnectTimeout=7",
+		"-o", "ConnectionAttempts=1",
 		userhost,
 	}
 


### PR DESCRIPTION
Fixes indefinitely hanging `kd ssh` when remote endpoint is down.
