### PR TITLE
TMS-3139 kite: ignore extra o frames

### DIFF
--- a/go/src/github.com/koding/kite/sockjsclient/xhr.go
+++ b/go/src/github.com/koding/kite/sockjsclient/xhr.go
@@ -124,15 +124,12 @@ func (x *XHRSession) Recv() (string, error) {
 
 			switch frame {
 			case 'o':
-				// Abort session on second 'o' frame:
-				//
-				//   https://github.com/sockjs/sockjs-protocol/wiki/Connecting-to-SockJS-without-the-browser
-				//
+				// ignore extra o-frames
 				x.mu.Lock()
-				x.opened = false
+				x.opened = true
 				x.mu.Unlock()
 
-				return "", errors.New("session aborted")
+				continue
 			case 'a':
 				// received an array of messages
 				var messages []string


### PR DESCRIPTION
This is a guess - did not manage yet to repro browser <-> kloud
connection problems to make it possible to inspect req/resp.

This reverts a change in kite that may be causing disconnections,
when sockjs client does send multiple o frames.

Going to push to upstream if it fixes the problem.

https://koding.atlassian.net/browse/TMS-3139
