### PR TITLE
Utilize supervisor to start workers in run script

### DIFF
--- a/config/main.dev.coffee
+++ b/config/main.dev.coffee
@@ -83,6 +83,10 @@ Configuration = (options = {}) ->
   KONFIG.workers = require('./workers')(KONFIG, options, credentials)
   KONFIG.client.runtimeOptions = require('./generateRuntimeConfig')(KONFIG, credentials, options)
 
+  options.requirementCommands = [
+    "$KONFIG_PROJECTROOT/scripts/generate-kite-keys.sh"
+  ]
+
   KONFIG.supervisord =
     logdir   : "$KONFIG_PROJECTROOT/.logs"
     rundir   : "$KONFIG_PROJECTROOT/.supervisor"


### PR DESCRIPTION
Signed-off-by: Sonmez Kartal sonmez@koding.com
