### PR TITLE
api/amazon: implement workaround for accessing availability zones

### DIFF
--- a/go/src/koding/kites/kloud/provider/aws/bootstrap.go
+++ b/go/src/koding/kites/kloud/provider/aws/bootstrap.go
@@ -70,6 +70,8 @@ func (s *Stack) bootstrap(arg *kloud.BootstrapRequest) (interface{}, error) {
 
 		if c, err := amazon.NewClient(opts); err == nil && len(c.Zones) != 0 {
 			availabilityZone = c.Zones[0]
+		} else {
+			s.Log.Warning("unable to guess availability zones for %q: %v", cred.Identifier, err)
 		}
 
 		s.Log.Debug("Fetching the AWS user information to get the account ID: %s", awsAccountID)


### PR DESCRIPTION
Parse the zones from CreateSubnet error message. More details here:

  http://stackoverflow.com/questions/22744467/vpc-capable-availability-zones-in-amazon/22812138#22812138
