### PR TITLE
TMS-3245 Onboarding improvements

### DIFF
--- a/client/app/lib/onboarding/onboardingcontroller.coffee
+++ b/client/app/lib/onboarding/onboardingcontroller.coffee
@@ -89,6 +89,8 @@ module.exports = class OnboardingController extends KDController
 
     return @pendingQueue.push [].slice.call(arguments)  unless @isReady
 
+    @refresh()
+
     onboarding = @onboardings[name]
     return  unless onboarding
     return  unless onboarding.partial.items?.length
@@ -230,16 +232,16 @@ module.exports = class OnboardingController extends KDController
 
 
   ###*
-   * Handles FrontAppIsChanged event of appManager and refreshes all
-   * onboarding items so they can be hidden if their target elements
-   * are not visible on new app
+   * Handles FrontAppIsChanged event of appManager and hides all
+   * onboarding items at that moment. If a new app has onboardings,
+   * they will be run using run() later when the page is ready
    *
    * @param {object} appInstance     - new application
    * @param {object} prevAppInstance - previous application
   ###
   handleFrontAppChanged: (appInstance, prevAppInstance) ->
 
-    @viewController.refreshItems()
+    @viewController.hideItems()
 
 
   ###*

--- a/client/app/lib/onboarding/onboardingcontroller.coffee
+++ b/client/app/lib/onboarding/onboardingcontroller.coffee
@@ -13,17 +13,6 @@ OnboardingConstants = require './onboardingconstants'
 ###
 module.exports = class OnboardingController extends KDController
 
-  ###*
-   * A list of onboardings that can be shown on the page at the same time
-  ###
-  CooperativeOnboardings = [
-    [
-      'IDELoaded'
-      #'CollaborationStarted'
-      'IDESettingsOpened'
-    ]
-  ]
-
   constructor: (options = {}, data) ->
 
     super options, data
@@ -99,8 +88,6 @@ module.exports = class OnboardingController extends KDController
   run: (name, isModal) ->
 
     return @pendingQueue.push [].slice.call(arguments)  unless @isReady
-
-    @refreshCooperativeOnboardings name
 
     onboarding = @onboardings[name]
     return  unless onboarding
@@ -226,29 +213,13 @@ module.exports = class OnboardingController extends KDController
    * Refreshes onboarding items according to the state of elements
    * they are attached to. If elements are hidden, items get hidden too,
    * and vice versa.
-   * If onboarding has cooperative onboardings, they can be refreshed too
    *
-   * @param {string} name        - name of onboarding which items should be refreshed
-   * @param {bool} isCooperative - a flag shows if it's necessary to refresh cooperative onboardings
+   * @param {string} name - name of onboarding which items should be refreshed
   ###
-  refresh: (name, isCooperative = yes) ->
+  refresh: (name) ->
 
     @viewController.refreshItems name
-    @refreshCooperativeOnboardings name  if isCooperative
 
-
-  ###*
-   * Refreshes cooperative onboardings for specific onboarding
-   *
-   * @param {string} name - name of onboarding which should be checked
-   * for cooperative onboardings
-  ###
-  refreshCooperativeOnboardings: (name) ->
-
-    for onboardings in CooperativeOnboardings
-      if onboardings.indexOf(name) > -1
-        for cooperativeOnboarding in onboardings when cooperativeOnboarding isnt name
-          @refresh cooperativeOnboarding, no
 
   ###*
    * Removes onboarding items from the page
@@ -259,16 +230,16 @@ module.exports = class OnboardingController extends KDController
 
 
   ###*
-   * Handles FrontAppIsChanged event of appManager and hides all
-   * onboarding items at that moment. If a new app has onboardings,
-   * they will be run using run() later when the page is ready
+   * Handles FrontAppIsChanged event of appManager and refreshes all
+   * onboarding items so they can be hidden if their target elements
+   * are not visible on new app
    *
    * @param {object} appInstance     - new application
    * @param {object} prevAppInstance - previous application
   ###
   handleFrontAppChanged: (appInstance, prevAppInstance) ->
 
-    @viewController.hideItems()
+    @viewController.refreshItems()
 
 
   ###*

--- a/client/app/lib/onboarding/onboardingevent.coffee
+++ b/client/app/lib/onboarding/onboardingevent.coffee
@@ -1,12 +1,5 @@
 module.exports = [
   'IDELoaded'
-  #'CollaborationStarted'
-  #'ChangelogChannelViewed'
-  #'OtherChannelViewed'
-  #'NewPrivateMessageOpened'
-  #'PrivateMessagesViewed'
-  #'VMSettingsOpened'
-  #'WorkspaceSettingsOpened'
   'IDESettingsOpened'
   'StacksViewed'
   'VMsViewed'

--- a/client/app/lib/onboarding/onboardingevent.coffee
+++ b/client/app/lib/onboarding/onboardingevent.coffee
@@ -8,4 +8,5 @@ module.exports = [
   'TeamBillingViewed'
   'KodingUtilitiesViewed'
   'MyAccountViewed'
+  'StackEditorOpened'
 ]

--- a/client/app/lib/onboarding/onboardingitemview.coffee
+++ b/client/app/lib/onboarding/onboardingitemview.coffee
@@ -10,47 +10,55 @@ module.exports = class OnboardingItemView extends KDView
 
   ###*
    * Tries to find a target element in DOM.
-   * If it's found, renders onboarding throbber with tooltip for it.
+   * If it's found and target is visible, renders onboarding throbber with tooltip for it.
    * Also, tracks the time user spent to view the onboarding tooltip
-   *
-   * @return {bool|Error} - yes if target element is found, otherwise - Error object
+   * If path is incorrect and error happens, it saves isError flag and skips exectution.
   ###
   render: ->
+
+    return  if @isError
 
     { path, name } = @getData()
     { onboardingName, isModal } = @getOptions()
 
     try
       @targetElement = @getElementByPath path
-
-      if @targetElement.is ':visible'
-        { placementX, placementY, offsetX, offsetY, content, tooltipPlacement, color, targetIsScrollable } = @getData()
-        @throbber = new ThrobberView {
-          cssClass    : kd.utils.curry color, if isModal then 'modal-throbber' else ''
-          delegate    : @targetElement
-          tooltipText : "<div class='has-markdown'>#{applyMarkdown(content, { sanitize : no }) ? ''}</div>"
-          placementX
-          placementY
-          offsetX
-          offsetY
-          tooltipPlacement
-          targetIsScrollable
-        }
-        @throbber.on 'TooltipShown', =>
-          @startTrackDate = new Date()
-        @throbber.on 'TooltipClosed', =>
-          @throbber.destroy()
-          if @startTrackDate
-            OnboardingMetrics.trackView onboardingName, name, new Date() - @startTrackDate
-          @startTrackDate = null
-          @emit 'OnboardingItemCompleted'
-        @show()
-      else
-        return new Error "Target doesn't exist in DOM or invisible. name = #{name}, onboardingName = #{onboardingName}"
     catch e
-      return new Error "Couldn't create onboarding item. name = #{name}, onboardingName = #{onboardingName}"
+      kd.warn "Couldn't create onboarding item. name = #{name}, onboardingName = #{onboardingName}", e
+      @isError = yes
+      return
 
-    return yes
+    if @isTargetVisible()
+      { placementX, placementY, offsetX, offsetY, content, tooltipPlacement, color, targetIsScrollable } = @getData()
+      @throbber = new ThrobberView {
+        cssClass    : kd.utils.curry color, if isModal then 'modal-throbber' else ''
+        delegate    : @targetElement
+        tooltipText : "<div class='has-markdown'>#{applyMarkdown(content, { sanitize : no }) ? ''}</div>"
+        placementX
+        placementY
+        offsetX
+        offsetY
+        tooltipPlacement
+        targetIsScrollable
+      }
+      @throbber.on 'TooltipShown', =>
+        @startTrackDate = new Date()
+      @throbber.on 'TooltipClosed', =>
+        @removeThrobber()
+        if @startTrackDate
+          OnboardingMetrics.trackView onboardingName, name, new Date() - @startTrackDate
+        @startTrackDate = null
+        @emit 'OnboardingItemCompleted'
+
+
+  isReady: -> @throbber?
+
+
+  isTargetVisible: ->
+
+    return @targetElement and
+    @targetElement.is(':visible') and
+    @targetElement.css('visibility') isnt 'hidden'
 
 
   ###*
@@ -75,30 +83,28 @@ module.exports = class OnboardingItemView extends KDView
   refresh: ->
 
     if @targetElement?.closest('body').length
-      visible = @targetElement.is(':visible') and @targetElement.css('visibility') isnt 'hidden'
-      if visible
-        @show()
-        @throbber.setPosition()
-      else @hide()
-      return yes
+      if @isTargetVisible()
+        if @throbber
+          @throbber.setPosition()
+        else
+          @render()
+      else
+        @removeThrobber()
     else
-      @throbber?.destroy()
-      return @render()
+      @removeThrobber()
+      @render()
 
 
-  show: -> @throbber?.show()
+  removeThrobber: ->
 
+    return  unless @throbber
 
-  hide: -> @throbber?.hide()
-
-
-  handleTargetDestroyed: ->
-
-    @targetElement = null
-    @throbber?.destroy()
+    @throbber.destroy()
+    @throbber = null
 
 
   destroy: ->
 
-    @handleTargetDestroyed()
+    @targetElement = null
+    @removeThrobber()
     super

--- a/client/app/lib/onboarding/onboardingtask.coffee
+++ b/client/app/lib/onboarding/onboardingtask.coffee
@@ -39,4 +39,4 @@ module.exports = class OnboardingTask extends KDObject
         notReadyItems.push item
 
     if notReadyItems.length > 0 and new Date() - @startTime < @maxTime
-        kd.utils.wait @timeInterval, @lazyBound 'processItems', notReadyItems, itemMethod
+      kd.utils.wait @timeInterval, @lazyBound 'processItems', notReadyItems, itemMethod

--- a/client/app/lib/onboarding/onboardingtask.coffee
+++ b/client/app/lib/onboarding/onboardingtask.coffee
@@ -22,28 +22,21 @@ module.exports = class OnboardingTask extends KDObject
 
   ###*
    * Executes itemMethod for each item in items.
-   * For all items which return error it repeats processing
+   * For all items which are still not ready it repeats processing
    * with delay of @timeInterval.
-   * If the task works more that @maxTime, it stops and logs
-   * all item errors in console
+   * If the task works more that @maxTime, it stops executing
    *
    * @param {Array} items       - a list of items
    * @param {string} itemMethod - name of method which should be executed for each item
   ###
   processItems: (items, itemMethod) ->
 
-    failedItems = []
-    errors      = []
+    notReadyItems = []
 
     for item in items
-      result = item[itemMethod]?()
-      if result instanceof Error
-        failedItems.push item
-        errors.push result
+      item[itemMethod]?()
+      if not item.isReady() and not item.isError
+        notReadyItems.push item
 
-    if errors.length > 0
-      if new Date() - @startTime >= @maxTime
-        for error in errors
-          kd.warn "Onbarding: #{error.message}"
-      else
-        kd.utils.wait @timeInterval, @lazyBound 'processItems', failedItems, itemMethod
+    if notReadyItems.length > 0 and new Date() - @startTime < @maxTime
+        kd.utils.wait @timeInterval, @lazyBound 'processItems', notReadyItems, itemMethod

--- a/client/app/lib/onboarding/onboardingviewcontroller.coffee
+++ b/client/app/lib/onboarding/onboardingviewcontroller.coffee
@@ -20,19 +20,12 @@ module.exports = class OnboardingViewController extends KDViewController
    * Item views are grouped by onboarding name.
    * If item views already exist for onboarding,
    * it just refreshes them.
-   * Before running items it refreshes existent items
-   * of other onboardings. In some cases onboarding running
-   * signals that something happens on the page, therefore we need
-   * to make sure that all existent items are still actual
    *
    * @param {string} name     - onboarding name
    * @param {Array} items     - a list of onboarding items
    * @param {isModal} isModal - a flag shows if onboarding is running on the modal
   ###
   runItems: (name, items, isModal = no) ->
-
-    otherNames = Object.keys(@itemViews).filter (_name) -> _name isnt name
-    @refreshItems _name for _name in otherNames
 
     return  unless items.length
     return new OnboardingTask views, 'refresh'  if views = @itemViews[name]
@@ -91,3 +84,12 @@ module.exports = class OnboardingViewController extends KDViewController
       delete @itemViews[name]
     else
       @itemViews = {}
+
+
+  ###*
+   * Hides all onboarding items
+  ###
+  hideItems: ->
+
+    for own name, views of @itemViews
+      view.removeThrobber()  for view in views

--- a/client/dashboard/lib/views/onboarding/onboardingeventname.coffee
+++ b/client/dashboard/lib/views/onboarding/onboardingeventname.coffee
@@ -8,3 +8,4 @@ module.exports =
   TeamBillingViewed       : 'Team Billing viewed'
   KodingUtilitiesViewed   : 'Koding Utilities viewed'
   MyAccountViewed         : 'My Account information viewed'
+  StackEditorOpened       : 'Stack editor opened'

--- a/client/dashboard/lib/views/onboarding/onboardingeventname.coffee
+++ b/client/dashboard/lib/views/onboarding/onboardingeventname.coffee
@@ -1,12 +1,5 @@
 module.exports =
   IDELoaded               : 'IDE/Terminal loaded for the first time'
-  #CollaborationStarted    : 'Collaboration button clicked for the first time'
-  #ChangelogChannelViewed  : 'Viewed #changelog'
-  #OtherChannelViewed      : 'Viewed other #channel for the first time'
-  #NewPrivateMessageOpened : 'New Private Message form opened'
-  #PrivateMessagesViewed   : 'Private Messages viewed for the first time'
-  #VMSettingsOpened        : 'VM Settings opened'
-  #WorkspaceSettingsOpened : 'Workspace Settings opened'
   IDESettingsOpened       : 'IDE/Terminal settings clicked'
   StacksViewed            : 'Stack list viewed'
   VMsViewed               : 'VM list viewed'

--- a/client/home/lib/index.coffee
+++ b/client/home/lib/index.coffee
@@ -59,13 +59,17 @@ module.exports = class HomeAppController extends AppController
 
     if identifier
       targetPaneView.handleIdentifier? identifier, action
-    else
+    else if action
       targetPaneView.handleAction? action
-
-    unless identifier and action
+    else
+      { onboarding }  = kd.singletons
       onboardingEvent = @getOnboardingEventByPane targetPane
-      kd.singletons.onboarding.run onboardingEvent, yes  if onboardingEvent
-      return
+      if onboardingEvent
+        onboarding.run onboardingEvent, yes
+      else
+        onboarding.refresh()
+
+    return  unless identifier and action
 
     targetPaneView.emit 'SubTabRequested', action, identifier
     { parentTabTitle } = targetPane.getOptions()

--- a/client/home/lib/index.coffee
+++ b/client/home/lib/index.coffee
@@ -62,12 +62,7 @@ module.exports = class HomeAppController extends AppController
     else if action
       targetPaneView.handleAction? action
     else
-      { onboarding }  = kd.singletons
-      onboardingEvent = @getOnboardingEventByPane targetPane
-      if onboardingEvent
-        onboarding.run onboardingEvent, yes
-      else
-        onboarding.refresh()
+      @doOnboarding targetPane
 
     return  unless identifier and action
 
@@ -95,6 +90,16 @@ module.exports = class HomeAppController extends AppController
 
 
   fetchNavItems: (cb) -> cb TABS
+
+
+  doOnboarding: (pane) ->
+
+    { onboarding }  = kd.singletons
+    onboardingEvent = @getOnboardingEventByPane pane
+    if onboardingEvent
+      onboarding.run onboardingEvent, yes
+    else
+      onboarding.refresh()
 
 
   getOnboardingEventByPane: (pane) ->

--- a/client/home/lib/stacks/index.coffee
+++ b/client/home/lib/stacks/index.coffee
@@ -81,6 +81,8 @@ module.exports = class HomeStacks extends kd.CustomScrollView
 
   handleIdentifier: (identifier, action) ->
 
+    { onboarding } = kd.singletons
+
     for pane in @tabView.panes when kd.utils.slugify(pane.name) is action
       pane_ = @tabView.showPane pane
       if action is 'virtual-machines'
@@ -92,6 +94,7 @@ module.exports = class HomeStacks extends kd.CustomScrollView
 
         VirtualMachinesSelectedMachineFlux.actions.setSelectedMachine identifier
         EnvironmentFlux.actions.loadMachineSharedUsers machine.get '_id'
+        onboarding.run 'VMsViewed', yes
       break
 
   createStacksViews: ->

--- a/client/ide/lib/views/tabview/idefilestabview.coffee
+++ b/client/ide/lib/views/tabview/idefilestabview.coffee
@@ -57,6 +57,9 @@ module.exports = class IDEFilesTabView extends IDEWorkspaceTabView
 
     @tabView.addPane filesPane
 
+    { onboarding } = kd.singletons
+    filesPane.on 'KDTabPaneActive', -> onboarding.refresh()
+
     @on 'MachineMountRequested', (machineData, rootPath) =>
       @finderPane.emit 'MachineMountRequested', machineData, rootPath
 
@@ -75,7 +78,6 @@ module.exports = class IDEFilesTabView extends IDEWorkspaceTabView
 
     { onboarding } = kd.singletons
     settingsPane.on 'KDTabPaneActive', -> onboarding.run 'IDESettingsOpened'
-    settingsPane.on 'KDTabPaneInactive', -> onboarding.refresh 'IDESettingsOpened'
 
 
   # createToggleMenu: ->

--- a/client/stack-editor/lib/index.coffee
+++ b/client/stack-editor/lib/index.coffee
@@ -109,6 +109,9 @@ module.exports = class StackEditorAppController extends AppController
     editor.setAttribute 'testpath', 'StackEditor-isVisible'
     editor.show()
 
+    { onboarding } = kd.singletons
+    onboarding.run 'StackEditorOpened'
+
 
   reloadEditor: (template) ->
 
@@ -161,5 +164,3 @@ module.exports = class StackEditorAppController extends AppController
     #       '''
 
     return view
-
-


### PR DESCRIPTION
@sinan, can you please review these onboarding changes?
- I added onboarding event for Stack Editor page. It makes possible to put throbbers on this page
- I completely removed solo onboarding events. However, I didn't change solo code since I assume it will be removed in the future
- I changed logic of onboarding items refresh. I removed cooperative onboardings since it confuses more than helps. Now I just simply re-render all onboardings when there is an assumption that something has changed on the page and it can affect onboarding throbbers
- Also, I removed old optimization logic from `OnboardingItemView` making it easier to understand and added a few bug fixes of target element search

https://koding.atlassian.net/browse/TMS-3245
