### PR TITLE
klientctl: Added kd log

### DIFF
--- a/go/src/koding/klient/logfetcher/logfetcher.go
+++ b/go/src/koding/klient/logfetcher/logfetcher.go
@@ -78,7 +78,7 @@ func Tail(r *kite.Request) (interface{}, error) {
 			return nil, err
 		}
 
-		lines, err := getOffsetLines(f, defaultOffsetChunkSize, params.LineOffset)
+		lines, err := GetOffsetLines(f, defaultOffsetChunkSize, params.LineOffset)
 		f.Close()
 
 		if err != nil {
@@ -175,7 +175,7 @@ func Tail(r *kite.Request) (interface{}, error) {
 	return true, nil
 }
 
-func getOffsetLines(f *os.File, chunkSize int64, requestedLines int) ([]string, error) {
+func GetOffsetLines(f *os.File, chunkSize int64, requestedLines int) ([]string, error) {
 	var (
 		newLineChar = byte('\n')
 		foundLines  []string
@@ -190,7 +190,7 @@ func getOffsetLines(f *os.File, chunkSize int64, requestedLines int) ([]string, 
 	// then the start is the same as the end. Empty file, nothing we can do.
 	start, err := f.Seek(0, 2)
 	if err != nil {
-		return nil, fmt.Errorf("getOffsetLines: Failed to seek. err:%s", err)
+		return nil, fmt.Errorf("GetOffsetLines: Failed to seek. err:%s", err)
 	}
 	if start == 0 {
 		return nil, nil

--- a/go/src/koding/klient/logfetcher/logfetcher_test.go
+++ b/go/src/koding/klient/logfetcher/logfetcher_test.go
@@ -313,7 +313,7 @@ func TestGetOffsetLines(t *testing.T) {
 	defer file1.Close()
 
 	offset := 3
-	result, err := getOffsetLines(file1, 4, offset)
+	result, err := GetOffsetLines(file1, 4, offset)
 	if err != nil {
 		t.Error(err)
 	}
@@ -328,7 +328,7 @@ func TestGetOffsetLines(t *testing.T) {
 
 	// Set the offset to the entire file.
 	offset = len(sourceLines) + 1
-	result, err = getOffsetLines(file1, 4, offset)
+	result, err = GetOffsetLines(file1, 4, offset)
 	if err != nil {
 		t.Error(err)
 	}
@@ -349,7 +349,7 @@ func TestGetOffsetLines(t *testing.T) {
 
 	fmt.Println("Requesting empty lines")
 	offset = 3
-	result, err = getOffsetLines(file2, 4, offset)
+	result, err = GetOffsetLines(file2, 4, offset)
 	if err != nil {
 		t.Error(err)
 	}
@@ -376,7 +376,7 @@ func TestGetOffsetLines(t *testing.T) {
 	defer file1.Close()
 
 	offset = 3
-	result, err = getOffsetLines(file1, defaultOffsetChunkSize, offset)
+	result, err = GetOffsetLines(file1, defaultOffsetChunkSize, offset)
 	if err != nil {
 		t.Error(err)
 	}

--- a/go/src/koding/klientctl/clifactories.go
+++ b/go/src/koding/klientctl/clifactories.go
@@ -13,6 +13,7 @@ import (
 	"koding/klientctl/cp"
 	"koding/klientctl/ctlcli"
 	"koding/klientctl/klient"
+	"koding/klientctl/logcmd"
 	"koding/klientctl/metrics"
 	"koding/klientctl/remount"
 	"koding/klientctl/repair"
@@ -224,6 +225,37 @@ func CpCommandFactory(c *cli.Context, log logging.Logger, cmdName string) ctlcli
 		return ctlcli.NewErrorCommand(
 			os.Stdout, log, err,
 			"Unable to create cp command",
+		)
+	}
+
+	return cmd
+}
+
+func LogCommandFactory(c *cli.Context, log logging.Logger, cmdName string) ctlcli.Command {
+	log = log.New(fmt.Sprintf("command:%s", cmdName))
+
+	// Fill our repair options from the CLI. Any empty options are okay, as
+	// the command struct is responsible for verifying valid opts.
+	opts := logcmd.Options{
+		Debug:             c.Bool("debug"),
+		KdLog:             !c.Bool("no-kd-log"),
+		KlientLog:         !c.Bool("no-klient-log"),
+		KdLogLocation:     c.String("kd-log-file"),
+		KlientLogLocation: c.String("klient-log-file"),
+		Lines:             c.Int("lines"),
+	}
+
+	init := logcmd.Init{
+		Stdout: os.Stdout,
+		Log:    log,
+		Helper: ctlcli.CommandHelper(c, cmdName),
+	}
+
+	cmd, err := logcmd.NewCommand(init, opts)
+	if err != nil {
+		return ctlcli.NewErrorCommand(
+			os.Stdout, log, err,
+			"Unable to create log command",
 		)
 	}
 

--- a/go/src/koding/klientctl/config/config.go
+++ b/go/src/koding/klientctl/config/config.go
@@ -32,6 +32,10 @@ const (
 
 	// SSHDefaultKeyName is the default name of the ssh key pair.
 	SSHDefaultKeyName = "kd-ssh-key"
+
+	// used in combination with os-specific log paths under _linux and _darwin.
+	kdLogName     = "kd.log"
+	klientLogName = "klient.log"
 )
 
 var environments = map[string]string{

--- a/go/src/koding/klientctl/config/config_darwin.go
+++ b/go/src/koding/klientctl/config/config_darwin.go
@@ -1,0 +1,13 @@
+package config
+
+import "path/filepath"
+
+const logFilePath = "/Library/Logs"
+
+func GetKlientLogPath() string {
+	return filepath.Join(logFilePath, klientLogName)
+}
+
+func GetKdLogPath() string {
+	return filepath.Join(logFilePath, kdLogName)
+}

--- a/go/src/koding/klientctl/config/config_linux.go
+++ b/go/src/koding/klientctl/config/config_linux.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const (
+	logFilePath        = "/var/log"
+	upstartlogFilePath = "/var/log/upstart"
+)
+
+// returnExistingPath checks the given paths and returns the first
+// that exists. If none exist, empty is returned.
+func returnExistingPath(paths []string) string {
+	for _, p := range paths {
+		if _, err := os.Stat(logFilePath); !os.IsNotExist(err) {
+			return p
+		}
+	}
+
+	return ""
+}
+
+func GetKlientLogPath() string {
+	return returnExistingPath([]string{
+		filepath.Join(logFilePath, klientLogName),
+		filepath.Join(upstartlogFilePath, klientLogName),
+	})
+}
+
+func GetKdLogPath() string {
+	return returnExistingPath([]string{
+		filepath.Join(logFilePath, kdLogName),
+		filepath.Join(upstartlogFilePath, kdLogName),
+	})
+}

--- a/go/src/koding/klientctl/logcmd/command.go
+++ b/go/src/koding/klientctl/logcmd/command.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"koding/klient/logfetcher"
+	"koding/klientctl/config"
 	"koding/klientctl/ctlcli"
 	"koding/klientctl/util"
 	"os"
@@ -94,13 +95,11 @@ func (c *Command) Run() (int, error) {
 // handleOptions deals with options, erroring if options are missing, etc.
 func (c *Command) handleOptions() error {
 	if c.Options.KdLogLocation == "" {
-		// TODO: !! Get from Service, for multi OS support
-		c.Options.KdLogLocation = "/Library/Logs/kd.log"
+		c.Options.KdLogLocation = config.GetKdLogPath()
 	}
 
 	if c.Options.KlientLogLocation == "" {
-		// TODO: !! Get from Service, for multi OS support
-		c.Options.KlientLogLocation = "/Library/Logs/klient.log"
+		c.Options.KlientLogLocation = config.GetKlientLogPath()
 	}
 
 	if c.Options.Lines == 0 {
@@ -128,20 +127,25 @@ func (c *Command) tailFile(path string, n int) error {
 	return nil
 }
 
-func (c *Command) tailLogs() error {
+func (c *Command) tailLogs() (err error) {
 	if c.Options.KdLog {
-		err := c.tailFile(c.Options.KdLogLocation, c.Options.Lines)
+		logLoc := c.Options.KdLogLocation
+		err = c.tailFile(logLoc, c.Options.Lines)
+
+		// Just logging here, because we want to print both logs if possible.
 		if err != nil {
-			return err
+			c.Log.Error("Tailing %q returned err: %s", logLoc, err)
 		}
 	}
 
 	if c.Options.KlientLog {
-		err := c.tailFile(c.Options.KlientLogLocation, c.Options.Lines)
+		logLoc := c.Options.KlientLogLocation
+		err = c.tailFile(logLoc, c.Options.Lines)
+		// Just logging here, because we want to print both logs if possible.
 		if err != nil {
-			return err
+			c.Log.Error("Tailing %q returned err: %s", logLoc, err)
 		}
 	}
 
-	return nil
+	return err
 }

--- a/go/src/koding/klientctl/logcmd/command.go
+++ b/go/src/koding/klientctl/logcmd/command.go
@@ -1,0 +1,147 @@
+package logcmd
+
+import (
+	"errors"
+	"io"
+	"koding/klient/logfetcher"
+	"koding/klientctl/ctlcli"
+	"koding/klientctl/util"
+	"os"
+
+	"github.com/koding/logging"
+)
+
+// Options for the command, generally mapped 1:1 to
+// CLI options for the given command.
+type Options struct {
+	Debug             bool
+	Lines             int
+	KdLog             bool
+	KlientLog         bool
+	KdLogLocation     string
+	KlientLogLocation string
+}
+
+// Init contains various instances required for a Command instance to be initialized.
+type Init struct {
+	Stdout io.Writer
+	Log    logging.Logger
+
+	// The ctlcli Helper. See the type docs for a better understanding of this.
+	Helper ctlcli.Helper
+}
+
+func (i Init) CheckValid() error {
+	if i.Stdout == nil {
+		return errors.New("MissingArgument: Stdout")
+	}
+
+	if i.Log == nil {
+		return errors.New("MissingArgument: Log")
+	}
+
+	if i.Helper == nil {
+		return errors.New("MissingArgument: Helper")
+	}
+
+	return nil
+}
+
+// Command implements the klientctl.Command interface for `kd sync`
+type Command struct {
+	// Embedded Init gives us our Klient/etc instances.
+	Init
+	Options Options
+	Stdout  *util.Fprint
+}
+
+func NewCommand(i Init, o Options) (*Command, error) {
+	if err := i.CheckValid(); err != nil {
+		return nil, err
+	}
+
+	if o.Debug {
+		i.Log.SetLevel(logging.DEBUG)
+	}
+
+	c := &Command{
+		Init:    i,
+		Options: o,
+		// Override the init stdout writer with an Fprint writer
+		Stdout: util.NewFprint(i.Stdout),
+	}
+
+	return c, nil
+}
+
+// Help prints help to the caller.
+func (c *Command) Help() {
+	c.Helper(c.Stdout)
+}
+
+func (c *Command) Run() (int, error) {
+	if err := c.handleOptions(); err != nil {
+		return 1, err
+	}
+
+	if err := c.tailLogs(); err != nil {
+		return 2, err
+	}
+
+	return 0, nil
+}
+
+// handleOptions deals with options, erroring if options are missing, etc.
+func (c *Command) handleOptions() error {
+	if c.Options.KdLogLocation == "" {
+		// TODO: !! Get from Service, for multi OS support
+		c.Options.KdLogLocation = "/Library/Logs/kd.log"
+	}
+
+	if c.Options.KlientLogLocation == "" {
+		// TODO: !! Get from Service, for multi OS support
+		c.Options.KlientLogLocation = "/Library/Logs/klient.log"
+	}
+
+	if c.Options.Lines == 0 {
+		c.Options.Lines = 20
+	}
+
+	return nil
+}
+
+func (c *Command) tailFile(path string, n int) error {
+	f, err := os.OpenFile(path, os.O_RDONLY, 0600)
+	if err != nil {
+		return err
+	}
+
+	lines, err := logfetcher.GetOffsetLines(f, 1024, n)
+	if err != nil {
+		return err
+	}
+
+	for _, l := range lines {
+		c.Stdout.Printlnf(l)
+	}
+
+	return nil
+}
+
+func (c *Command) tailLogs() error {
+	if c.Options.KdLog {
+		err := c.tailFile(c.Options.KdLogLocation, c.Options.Lines)
+		if err != nil {
+			return err
+		}
+	}
+
+	if c.Options.KlientLog {
+		err := c.tailFile(c.Options.KlientLogLocation, c.Options.Lines)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -341,6 +341,18 @@ func main() {
 				CpCommandFactory, log, "cp",
 			),
 		},
+		cli.Command{
+			Name: "log",
+			Flags: []cli.Flag{
+				cli.BoolFlag{Name: "debug"},
+				cli.BoolFlag{Name: "no-kd-log"},
+				cli.BoolFlag{Name: "no-klient-log"},
+				cli.StringFlag{Name: "kd-log-file"},
+				cli.StringFlag{Name: "klient-log-file"},
+				cli.IntFlag{Name: "lines, n"},
+			},
+			Action: ctlcli.FactoryAction(LogCommandFactory, log, "log"),
+		},
 	}
 
 	app.Run(os.Args)


### PR DESCRIPTION
To ease debugging user issues, `kd log` was added as a temporary solution. In the near future, we will likely expand upon the UX, making it upoad to some endpoint, but for now it just prints.

With this PR, on OSX the UX can be:

```
kd log -n 50 | pbcopy
```

To load both kd and klient logs into memory.

assigned: @rjeczalik 
