### PR TITLE
Several fixes for onboarding

### DIFF
--- a/client/account/lib/accountcredentiallist.coffee
+++ b/client/account/lib/accountcredentiallist.coffee
@@ -102,7 +102,9 @@ module.exports = class AccountCredentialList extends KodingListView
           style      : "solid medium #{unless bootstrapped then 'hidden' else 'cancel'}"
           attributes :
             testpath : 'destroyAll'
-          loader     : yes
+          loader     :
+            shape    : 'spiral'
+            color    : '#a4a4a4'
           callback   : ->
             callback { action : 'DestroyAll', modal }
         Remove       :

--- a/client/account/lib/views/accountcredentiallistcontroller.coffee
+++ b/client/account/lib/views/accountcredentiallistcontroller.coffee
@@ -96,18 +96,17 @@ module.exports = class AccountCredentialListController extends KodingListControl
 
       listView.askForConfirm { credential, bootstrapped }, ({ action, modal }) =>
 
-        modal['button_Remove'].disable()
-
         switch action
 
           when 'Remove'
-            @removeCredential item, (err) -> modal.destroy()
+            @removeCredential item, -> modal.destroy()
 
           when 'DestroyAll'
             @destroyResources credential, (err) =>
               if err
-                modal.buttons.DestroyAll.hideLoader()
-                modal.buttons.Remove.enable()
+                modal['button_DestroyAll'].hideLoader()
+                modal['button_Remove'].hideLoader()
+                modal.destroy()
               else
                 @removeCredential item, -> modal.destroy()
 

--- a/client/app/lib/nostackfoundview.coffee
+++ b/client/app/lib/nostackfoundview.coffee
@@ -29,7 +29,7 @@ module.exports = class NoStackFoundView extends ReactView
 
     { groupsController, computeController, mainView } = kd.singletons
 
-    return <div/>  unless globals.config?.roles
+    return <div/>  unless globals.userRoles
     return <div/>  if mainView.introVideoViewIsShown
 
     if groupsController.canEditGroup()


### PR DESCRIPTION
- We were using `globals.config.roles` before, so i changed the check in `NoStackFoundView` to work with `userRoles`
- Loader on destroy button was white again, fixed.
- When an operation is completed in the credential remove modal, modal destroys itself.

Fixes #8265 
