### PR TITLE
CredentialStore: keep credentials only on sneaker if it's supported

### DIFF
--- a/workers/social/lib/social/models/computeproviders/credentialstore.coffee
+++ b/workers/social/lib/social/models/computeproviders/credentialstore.coffee
@@ -45,11 +45,7 @@ module.exports = class CredentialStore
     data = { meta, originId, identifier }
 
     if @SNEAKER_SUPPORTED
-      storeOnSneaker client, data, (err) ->
-        # This part can be removed once kloud is ready
-        # to use sneaker by default ~ GG cc/ RJ
-        return callback err  if err
-        storeOnMongo data, callback
+      storeOnSneaker client, data, callback
     else
       storeOnMongo data, callback
 
@@ -121,14 +117,8 @@ module.exports = class CredentialStore
     { identifier, meta } = data
 
     if @SNEAKER_SUPPORTED
-
-      storeOnSneaker client, data, (err) ->
-        return callback err  if err
-
-        updateOnMongo identifier, meta, callback
-
+      storeOnSneaker client, data, callback
     else
-
       updateOnMongo identifier, meta, callback
 
   # UPDATE ENDS ---------------------------------------------------------------


### PR DESCRIPTION
This PR disables credential store on mongo, after a while we can remove existing credentials from mongo as well. All new credentials will be stored on Sneaker and all updates will happen on Sneaker only if it's supported. On remove operations it will be removed from both whether exists or not.
