### PR TITLE
stackplan: fix BuildMachines

### DIFF
--- a/go/src/koding/kites/kloud/stackplan/builder.go
+++ b/go/src/koding/kites/kloud/stackplan/builder.go
@@ -302,9 +302,6 @@ func (b *Builder) BuildMachines(ctx context.Context) error {
 			// A shared user is (owner + permanent).
 			if (user.Sudo || !user.Permanent) && user.Owner {
 				validUsers[user.Id.Hex()] = user
-			} else {
-				// return early, we don't accept invalid inputs for apply method
-				return fmt.Errorf("machine '%s' is not valid. Aborting apply", machine.ObjectId.Hex())
 			}
 		}
 	}


### PR DESCRIPTION
Fixes erroneous validation logic, which reported error if a
jMachine.Users had a user without owner right.

The purpose of such check is to ensure that apply action is only
performed by an owner, never by a user with insufficient permissions.

However that check exists in a different part of the Builder logic,
and the check removed here is simply wrong - it causes that any
jMachine that was shared with different user is going to be reported
as invalid.
