### PR TITLE
Several Fixes

### DIFF
--- a/client/app/lib/commonviews/avatarviews/avatarview.coffee
+++ b/client/app/lib/commonviews/avatarviews/avatarview.coffee
@@ -158,12 +158,11 @@ module.exports = class AvatarView extends LinkView
 
     kd.getSingleton('groupsController').ready =>
 
-      { _id } = @getData()
-
-      nickname = profile?.nickname
+      return  unless account = @getData()
 
       unless isKoding()
-        @getData()?.fetchMyPermissionsAndRoles (err, res) =>
+        return  if account.fake
+        account.fetchMyPermissionsAndRoles (err, res) =>
           { roles } = res
           hasOwner = 'owner' in roles
           hasAdmin = 'admin' in roles
@@ -180,7 +179,7 @@ module.exports = class AvatarView extends LinkView
       href = if payload?.channelIntegrationId
         "/Admin/Integrations/Configure/#{payload.channelIntegrationId}"
       else
-        if isKoding() and nickname
+        if isKoding() and nickname = account.profile
         then "/#{nickname}"
         else '/#'
 

--- a/client/app/lib/flux/environment/getters.coffee
+++ b/client/app/lib/flux/environment/getters.coffee
@@ -136,14 +136,16 @@ stacks = [
         stack
           .set 'accessLevel', templates.getIn [stack.get('baseStackId'), 'accessLevel']
           .update 'machines', (machines) ->
-            machines.map (id) ->
-              machine = machinesWorkspaces.get(id)
-              type    = if machine.getIn ['meta', 'oldOwner'] then 'reassigned' else 'own'
+            machines
+              .filter (id) -> !!machinesWorkspaces.get(id)
+              .map (id) ->
+                machine = machinesWorkspaces.get(id)
+                type    = if machine.getIn ['meta', 'oldOwner'] then 'reassigned' else 'own'
 
-              machine
-                .set 'type', type
-                .set 'owner', getMachineOwner machine
-                .set 'isApproved', yes
+                machine
+                  .set 'type', type
+                  .set 'owner', getMachineOwner machine
+                  .set 'isApproved', yes
 ]
 
 teamStacks = [

--- a/client/app/lib/react/reactview.coffee
+++ b/client/app/lib/react/reactview.coffee
@@ -3,6 +3,14 @@ ReactDOM = require 'react-dom'
 
 module.exports = class ReactView extends kd.CustomHTMLView
 
+  constructor: (options = {}, data) ->
+
+    super options, data
+
+    @on 'KDObjectWillBeDestroyed', =>
+      ReactDOM.unmountComponentAtNode @getElement()
+
+
   renderReact: ->
 
     console.error "#{@constructor.name}: needs to implement 'renderReact' method"
@@ -16,3 +24,4 @@ module.exports = class ReactView extends kd.CustomHTMLView
       @renderReact()
       @getElement()
     )
+

--- a/client/home/lib/flux/actions.coffee
+++ b/client/home/lib/flux/actions.coffee
@@ -52,6 +52,17 @@ checkFinishedSteps = ->
   if reactor.evaluate(EnvironmentGetters.stacks).size
     markAsDone 'stackCreation'
 
+
+  unobserve = reactor.observe EnvironmentGetters.stacks, (_stacks) ->
+    isStackBuilt = no
+    _stacks.forEach (stack) ->
+      return  if isStackBuilt
+      status = stack.get 'status'
+      if status isnt 'NotInitialized'
+        kd.utils.defer -> markAsDone 'buildStack'
+        isStackBuilt = yes
+        unobserve()
+
   remote.api.JCredential.some {}, { limit: 1 }, (err, res) ->
     return  if err
     markAsDone 'enterCredentials'  if res?.length

--- a/client/home/lib/flux/actions.coffee
+++ b/client/home/lib/flux/actions.coffee
@@ -52,16 +52,8 @@ checkFinishedSteps = ->
   if reactor.evaluate(EnvironmentGetters.stacks).size
     markAsDone 'stackCreation'
 
-
   unobserve = reactor.observe EnvironmentGetters.stacks, (_stacks) ->
-    isStackBuilt = no
-    _stacks.forEach (stack) ->
-      return  if isStackBuilt
-      status = stack.get 'status'
-      if status isnt 'NotInitialized'
-        kd.utils.defer -> markAsDone 'buildStack'
-        isStackBuilt = yes
-        unobserve()
+    checkStacksForBuild _stacks, unobserve
 
   remote.api.JCredential.some {}, { limit: 1 }, (err, res) ->
     return  if err
@@ -92,7 +84,16 @@ checkFinishedSteps = ->
       kd.utils.killRepeat kiteTimer
       markAsDone 'installKd'
 
+checkStacksForBuild = (stacks, unobserve) ->
 
+  isStackBuilt = no
+  stacks.forEach (stack) ->
+    return  if isStackBuilt
+    status = stack.get 'status'
+    if status isnt 'NotInitialized'
+      kd.utils.defer -> markAsDone 'buildStack'
+      isStackBuilt = yes
+      unobserve()
 
 
 module.exports = {

--- a/client/ide/lib/index.coffee
+++ b/client/ide/lib/index.coffee
@@ -215,6 +215,11 @@ class IDEAppController extends AppController
 
     @on 'WorkspaceChannelChanged', @bound 'onWorkspaceChannelChanged'
 
+    return  unless @workspaceData
+
+    unless 'function' is typeof @workspaceData.on
+      @workspaceData = remote.revive @workspaceData
+
     @workspaceData.on 'update', (fields) =>
 
       fields.forEach (field) =>

--- a/client/ide/lib/routes.coffee
+++ b/client/ide/lib/routes.coffee
@@ -64,6 +64,8 @@ loadIDE = (data) ->
 
   if machine.data?.generatedFrom?
     actions.setSelectedTemplateId machine.data.generatedFrom.templateId
+  else
+    actions.setSelectedTemplateId null
 
   appManager = kd.getSingleton 'appManager'
   ideApps    = appManager.appControllers.IDE

--- a/client/ide/lib/routes.coffee
+++ b/client/ide/lib/routes.coffee
@@ -62,7 +62,7 @@ loadIDE = (data) ->
   selectWorkspaceOnSidebar data
   actions.setSelectedMachineId machine._id
 
-  if machine.data.generatedFrom?
+  if machine.data?.generatedFrom?
     actions.setSelectedTemplateId machine.data.generatedFrom.templateId
 
   appManager = kd.getSingleton 'appManager'


### PR DESCRIPTION
- Somehow when a ReactView destroyed the react component inside was thinking that it's still mounted and was trying to listen to the events when they are dead. Manually unmounting the component when reactview was being destroyed fixed the issue.
- In avatars we are using optimistic rendering (render with fake data), I needed to add a check to make sure it's not a fake view before trying to fetch the permissions.
- Somehow workspaces in getters causing some problems, I made sure if there is such a problem, it's filtered out from the stack (this was happening when you try to switch to a collaboration machine from another place for the first time) and it was causing lots of stack breaking errors, i made sure those are not even passed down to the views/components.
- When you navigate to an IDE We are selecting its stack, but since a collaboration machine doesn't have a stack, it doesn't have related properties (mainly in `data` prop of machine object), I made sure that if data doesn't exist it doesn't try to select a stack/template instead it selects a `null` one to make nothing is selected.
- If you refresh into a collaboration machine, we were trying to bind events to  `this.workspaceData` before it's revived, I made sure that if there is no `on` event on the object, it's revived before it's being used.

Fixes #8300 
Fixes #8306 
Fixes #8291
