### PR TITLE
klientctl: Added automatic mount settings based on remote mount

### DIFF
--- a/go/src/koding/klient/app/klient_unix.go
+++ b/go/src/koding/klient/app/klient_unix.go
@@ -21,6 +21,7 @@ func (k *Klient) addRemoteHandlers() {
 	k.kite.HandleFunc("remote.mountInfo", k.remote.MountInfoHandler)
 	k.kite.HandleFunc("remote.readDirectory", k.remote.ReadDirectoryHandler)
 	k.kite.HandleFunc("remote.currentUsername", k.remote.CurrentUsername)
+	k.kite.HandleFunc("remote.getPathSize", k.remote.GetPathSize)
 }
 
 // Initializing the remote re-establishes any previously-running remote

--- a/go/src/koding/klient/remote/mountfolder.go
+++ b/go/src/koding/klient/remote/mountfolder.go
@@ -130,18 +130,6 @@ func (r *Remote) MountFolderHandler(kreq *kite.Request) (interface{}, error) {
 		return nil, err
 	}
 
-	// Check the remote size, so we can print a warning to the user if needed.
-	if !params.NoPrefetchMeta || !params.PrefetchAll {
-		res, err := checkSizeOfRemoteFolder(remoteMachine, params.RemotePath)
-
-		// If there's no error, clear the machine status.
-		if err == nil {
-			remoteMachine.SetStatus(machine.MachineStatusUnknown, "")
-		}
-
-		return res, err
-	}
-
 	remoteMachine.SetStatus(machine.MachineStatusUnknown, "")
 
 	return nil, nil

--- a/go/src/koding/klient/remote/readdirectory.go
+++ b/go/src/koding/klient/remote/readdirectory.go
@@ -11,8 +11,8 @@ import (
 	"github.com/koding/logging"
 )
 
-//  implements a prefetching / caching mechanism, currently
-// implemented
+// ReadDirectoryHandler calls a remote machine's fs.readDirectory method with
+// the given args.
 func (r *Remote) ReadDirectoryHandler(kreq *kite.Request) (interface{}, error) {
 	log := logging.NewLogger("remote").New("remote.readDirectory")
 

--- a/go/src/koding/klient/remote/req/req.go
+++ b/go/src/koding/klient/remote/req/req.go
@@ -134,6 +134,16 @@ type ReadDirectoryOptions struct {
 	Machine string
 }
 
+type GetPathSizeOptions struct {
+	Debug bool
+
+	// The machine name to run the ReadDirectory on.
+	Machine string
+
+	// The path to get size of.
+	RemotePath string
+}
+
 // CurrentUsernameOptions
 type CurrentUsernameOptions struct {
 	Debug bool

--- a/go/src/koding/klient/remote/size.go
+++ b/go/src/koding/klient/remote/size.go
@@ -1,0 +1,93 @@
+package remote
+
+import (
+	"errors"
+	"fmt"
+	"koding/klient/remote/mount"
+	"koding/klient/remote/req"
+	"path"
+	"path/filepath"
+
+	"github.com/koding/kite"
+	"github.com/koding/logging"
+)
+
+// GetPathSize gets the size of a remote path.
+//
+// NOTE: This implementation is the same as what mountFolder is using. A more
+// robust one should be implemented on the remote klient. Eg, fs.getSize, etc.
+func (r *Remote) GetPathSize(kreq *kite.Request) (interface{}, error) {
+	log := logging.NewLogger("remote").New("remote.getPathSize")
+
+	var opts req.GetPathSizeOptions
+	if kreq.Args == nil {
+		return nil, errors.New("arguments are not passed")
+	}
+
+	if err := kreq.Args.One().Unmarshal(&opts); err != nil {
+		err = fmt.Errorf(
+			"remote.getPathSize: %s, while unmarshalling request: %q\n",
+			err, kreq.Args.One(),
+		)
+		log.Error(err.Error())
+		return nil, err
+	}
+
+	if opts.Machine == "" {
+		return nil, errors.New("missing required argument: machine")
+	}
+
+	if opts.Debug {
+		log.SetLevel(logging.DEBUG)
+	}
+
+	log = log.New(
+		"machineName", opts.Machine,
+		"remotePath", opts.RemotePath,
+	)
+
+	remoteMachine, err := r.GetDialedMachine(opts.Machine)
+	if err != nil {
+		log.Error("Error getting dialed, valid machine. err:%s", err)
+		return nil, err
+	}
+
+	if opts.RemotePath == "" {
+		log.Debug("RemotePath option is empty, finding default.")
+
+		home, err := remoteMachine.HomeWithDefault()
+		if err != nil {
+			log.Error("Failed to get remote home. err:%s", err)
+			return nil, err
+		}
+		opts.RemotePath = home
+	}
+
+	if !filepath.IsAbs(opts.RemotePath) {
+		log.Debug("RemotePath is not absolute. Joining it to home.")
+
+		home, err := remoteMachine.HomeWithDefault()
+		if err != nil {
+			log.Error("Failed to get remote home. err:%s", err)
+			return nil, err
+		}
+		opts.RemotePath = path.Join(home, opts.RemotePath)
+	}
+
+	exists, err := remoteMachine.DoesRemotePathExist(opts.RemotePath)
+	if err != nil {
+		log.Error("Unable to determine if remote path exists. err:%s", err)
+		return nil, err
+	}
+
+	if !exists {
+		log.Error("Remote path does not exist. path:%s", opts.RemotePath)
+		return nil, mount.ErrRemotePathDoesNotExist
+	}
+
+	size, err := getSizeOfRemoteFolder(remoteMachine, opts.RemotePath)
+	if err != nil {
+		log.Error("Failed to get remote size. path:%s, err:%s", opts.RemotePath, err)
+	}
+	return size, err
+}

--- a/go/src/koding/klientctl/klient/klient.go
+++ b/go/src/koding/klientctl/klient/klient.go
@@ -287,7 +287,7 @@ func (k *Klient) RemoteReadDirectory(mountName, remotePath string) ([]fs.FileEnt
 	return files, nil
 }
 
-// CurrentUsername calls klient's `remote.currentUsername` method
+// RemoteCurrentUsername calls klient's `remote.currentUsername` method
 func (k *Klient) RemoteCurrentUsername(opts req.CurrentUsernameOptions) (string, error) {
 	var username string
 
@@ -297,4 +297,16 @@ func (k *Klient) RemoteCurrentUsername(opts req.CurrentUsernameOptions) (string,
 	}
 
 	return username, kRes.Unmarshal(&username)
+}
+
+// RemoteGetPathSize calls the klient's `remote.getPathSize` method
+func (k *Klient) RemoteGetPathSize(opts req.GetPathSizeOptions) (uint64, error) {
+	var size uint64
+
+	kRes, err := k.Tell("remote.getPathSize", opts)
+	if err != nil {
+		return size, err
+	}
+
+	return size, kRes.Unmarshal(&size)
 }

--- a/go/src/koding/klientctl/util/testutil/fakeklient.go
+++ b/go/src/koding/klientctl/util/testutil/fakeklient.go
@@ -103,3 +103,7 @@ func (k *FakeKlient) RemoteReadDirectory(string, string) ([]fs.FileEntry, error)
 func (k *FakeKlient) RemoteCurrentUsername(req.CurrentUsernameOptions) (string, error) {
 	return "", nil
 }
+
+func (k *FakeKlient) RemoteGetPathSize(opts req.GetPathSizeOptions) (uint64, error) {
+	return 0, nil
+}


### PR DESCRIPTION
Changed the behavior of a raw `kd mount` to determine the recommended type for the remote folder. Eg, large folders use oneway, tiny folders use plain fuse, etc.

Note that there is no interactive UI at this time for picking a mount type.
