### PR TITLE
klientctl: Changed list --json behavior

### DIFF
--- a/go/src/koding/klientctl/list/types.go
+++ b/go/src/koding/klientctl/list/types.go
@@ -13,6 +13,10 @@ import (
 
 type KiteInfo struct {
 	restypes.ListMachineInfo
+
+	// A human readable status rather than the integer type as we're using for
+	// the machine.MachineStatus'.
+	MachineStatusName string `json:"machineStatusName"`
 }
 
 // KiteInfos is a slice of KiteInfo with helper methods.

--- a/go/src/koding/klientctl/list/types_test.go
+++ b/go/src/koding/klientctl/list/types_test.go
@@ -4,13 +4,14 @@ import (
 	"sort"
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
 	"koding/klient/remote/machine"
 	"koding/klient/remote/restypes"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func newKiteInfo(vmName string, status machine.MachineStatus) KiteInfo {
-	info := KiteInfo{restypes.ListMachineInfo{
+	info := KiteInfo{ListMachineInfo: restypes.ListMachineInfo{
 		VMName:        vmName,
 		MachineStatus: status,
 	}}

--- a/go/src/koding/klientctl/mount_test.go
+++ b/go/src/koding/klientctl/mount_test.go
@@ -277,7 +277,7 @@ func TestMountFindMachineName(t *testing.T) {
 		var stdout bytes.Buffer
 		c := &MountCommand{
 			Klient: &testutil.FakeKlient{
-				ReturnInfos: []list.KiteInfo{list.KiteInfo{restypes.ListMachineInfo{
+				ReturnInfos: []list.KiteInfo{{ListMachineInfo: restypes.ListMachineInfo{
 					VMName: "foo",
 				}},
 				},

--- a/go/src/koding/klientctl/repair/command_test.go
+++ b/go/src/koding/klientctl/repair/command_test.go
@@ -57,10 +57,10 @@ func TestRepairCommandRun(t *testing.T) {
 			Repairers:      []Repairer{repairerA, repairerB},
 			KlientService:  &testutil.FakeService{},
 			Klient: &testutil.FakeKlient{
-				ReturnInfos: []list.KiteInfo{list.KiteInfo{restypes.ListMachineInfo{
+				ReturnInfos: []list.KiteInfo{{ListMachineInfo: restypes.ListMachineInfo{
 					VMName: "foo",
 					// Content doesn't matter, just length
-					Mounts: []restypes.ListMountInfo{restypes.ListMountInfo{}}}},
+					Mounts: []restypes.ListMountInfo{{}}}},
 				}},
 		}
 
@@ -92,10 +92,10 @@ func TestRepairCommandRun(t *testing.T) {
 			Repairers:      []Repairer{repairerA, repairerB, repairerC},
 			KlientService:  &testutil.FakeService{},
 			Klient: &testutil.FakeKlient{
-				ReturnInfos: []list.KiteInfo{list.KiteInfo{restypes.ListMachineInfo{
+				ReturnInfos: []list.KiteInfo{{ListMachineInfo: restypes.ListMachineInfo{
 					VMName: "foo",
 					// Content doesn't matter, just length
-					Mounts: []restypes.ListMountInfo{restypes.ListMountInfo{}}}},
+					Mounts: []restypes.ListMountInfo{{}}}},
 				}},
 		}
 

--- a/go/src/koding/klientctl/restart.go
+++ b/go/src/koding/klientctl/restart.go
@@ -60,7 +60,7 @@ func RestartCommand(c *cli.Context, log logging.Logger, _ string) int {
 		return 1
 	}
 
-	fmt.Println("Waiting until started...")
+	fmt.Println("Starting...")
 
 	err = WaitUntilStarted(config.KlientAddress, CommandAttempts, CommandWaitTime)
 	if err != nil {

--- a/go/src/koding/klientctl/shortcut/machinename_test.go
+++ b/go/src/koding/klientctl/shortcut/machinename_test.go
@@ -13,9 +13,9 @@ func TestMachineShortcutGetNameFromShortcut(t *testing.T) {
 	Convey("", t, func() {
 		k := &testutil.FakeKlient{
 			ReturnInfos: list.KiteInfos{
-				list.KiteInfo{restypes.ListMachineInfo{VMName: "foo"}},
-				list.KiteInfo{restypes.ListMachineInfo{VMName: "bar"}},
-				list.KiteInfo{restypes.ListMachineInfo{VMName: "caz"}},
+				list.KiteInfo{ListMachineInfo: restypes.ListMachineInfo{VMName: "foo"}},
+				list.KiteInfo{ListMachineInfo: restypes.ListMachineInfo{VMName: "bar"}},
+				list.KiteInfo{ListMachineInfo: restypes.ListMachineInfo{VMName: "caz"}},
 			},
 		}
 		ms := NewMachineShortcut(k)

--- a/go/src/koding/klientctl/start.go
+++ b/go/src/koding/klientctl/start.go
@@ -29,7 +29,7 @@ func StartCommand(c *cli.Context, log logging.Logger, _ string) int {
 		return 1
 	}
 
-	fmt.Println("Waiting until started...")
+	fmt.Println("Starting...")
 
 	err = WaitUntilStarted(config.KlientAddress, CommandAttempts, CommandWaitTime)
 	if err != nil {

--- a/go/src/koding/klientctl/unmount_test.go
+++ b/go/src/koding/klientctl/unmount_test.go
@@ -163,7 +163,7 @@ func TestUnmountFindMountAndPath(t *testing.T) {
 
 		Convey("Given a machine name that does not exist", func() {
 			c.Options.MountName = "bar"
-			fakeKlient.ReturnInfos = []list.KiteInfo{list.KiteInfo{restypes.ListMachineInfo{
+			fakeKlient.ReturnInfos = []list.KiteInfo{{ListMachineInfo: restypes.ListMachineInfo{
 				VMName: "foo",
 			}},
 			}
@@ -177,10 +177,10 @@ func TestUnmountFindMountAndPath(t *testing.T) {
 
 		Convey("Given a machine that has mounts", func() {
 			c.Options.MountName = "foo"
-			fakeKlient.ReturnInfos = []list.KiteInfo{list.KiteInfo{restypes.ListMachineInfo{
+			fakeKlient.ReturnInfos = []list.KiteInfo{{ListMachineInfo: restypes.ListMachineInfo{
 				VMName: "foo",
 				// Content doesn't matter, just length
-				Mounts: []restypes.ListMountInfo{restypes.ListMountInfo{}},
+				Mounts: []restypes.ListMountInfo{{}},
 			}},
 			}
 
@@ -191,7 +191,7 @@ func TestUnmountFindMountAndPath(t *testing.T) {
 
 		Convey("Given a machine that has no mounts", func() {
 			c.Options.MountName = "foo"
-			fakeKlient.ReturnInfos = []list.KiteInfo{list.KiteInfo{restypes.ListMachineInfo{
+			fakeKlient.ReturnInfos = []list.KiteInfo{{ListMachineInfo: restypes.ListMachineInfo{
 				VMName: "foo",
 				// Content doesn't matter, just length
 				Mounts: []restypes.ListMountInfo{},


### PR DESCRIPTION
It was requested that `kd ls --all` and `kd ls --all --json` have the
same behavior. This change implements that, along with a status
name for easy external usage.
