### PR TITLE
Fix sidebar editor cache problems

### DIFF
--- a/client/app/lib/components/sidebar/index.coffee
+++ b/client/app/lib/components/sidebar/index.coffee
@@ -93,8 +93,8 @@ module.exports = class Sidebar extends React.Component
     switch title
       when 'Edit' then router.handleRoute "/Stack-Editor/#{id}"
       when 'Initialize'
-        EnvironmentFlux.actions.generateStack(id).then ->
-          kd.singletons.appManager.tell 'Stackeditor', 'reloadEditor', { _id: id }
+        EnvironmentFlux.actions.generateStack(id).then ({ template }) ->
+          kd.singletons.appManager.tell 'Stackeditor', 'reloadEditor', template
 
 
 

--- a/client/app/lib/components/sidebarstacksection/index.coffee
+++ b/client/app/lib/components/sidebarstacksection/index.coffee
@@ -72,12 +72,12 @@ module.exports = class SidebarStackSection extends React.Component
     MENU.destroy()
 
     templateId = stack.get 'baseStackId'
-
     switch title
       when 'Edit' then router.handleRoute "/Stack-Editor/#{templateId}"
       when 'Reinitialize', 'Update'
         reinitStackFromWidget(stack).then ->
-          appManager.tell 'Stackeditor', 'reloadEditor', { _id: templateId }
+          # invalidate editor cache
+          appManager.tell 'Stackeditor', 'removeEditor', templateId
       when 'Destroy VMs' then deleteStack { stack }
       when 'VMs' then router.handleRoute "/Home/Stacks/virtual-machines"
 

--- a/client/app/lib/flux/environment/actions.coffee
+++ b/client/app/lib/flux/environment/actions.coffee
@@ -609,13 +609,13 @@ generateStack = (stackTemplateId) ->
       return reject(err)  if err
 
       generateStackFromTemplate stackTemplate
-        .then ({ stack }) ->
+        .then ({ stack, template }) ->
           { results : { machines } } = stack
           [ machine ] = machines
           computeController.reset yes, ->
             computeController.reloadIDE machine.obj.slug
-            resolve({ stack })
-          new kd.NotificationView { title: 'Stack generated successfully' }
+            new kd.NotificationView { title: 'Stack generated successfully' }
+            resolve({ stack, template })
         .catch (err) ->
           showError err
           reject(err)

--- a/client/app/lib/flux/environment/getters.coffee
+++ b/client/app/lib/flux/environment/getters.coffee
@@ -182,6 +182,12 @@ privateStackTemplates = [
         .set 'isDefault', template.get('_id') in (getGroup().stackTemplates or [])
 ]
 
+allStackTemplates = [
+  teamStackTemplates
+  privateStackTemplates
+  (teamTemplates, privateTemplates) -> teamTemplates.merge privateTemplates
+]
+
 inUseTeamStackTemplates = [
   teamStackTemplates
   (templates) -> templates.filter (t) -> t.get('inUse')
@@ -239,6 +245,7 @@ module.exports = {
   selectedTemplateId : SelectedTemplateIdStore
   teamStackTemplates
   privateStackTemplates
+  allStackTemplates
   inUseTeamStackTemplates
   inUsePrivateStackTemplates
   draftStackTemplates


### PR DESCRIPTION
It was causing an error in the console because of the fact that I was passing down a fake stack template to simulate reload behavior.
