### PR TITLE
stack editor: "delete stack template" removed from members' editor

### DIFF
--- a/client/stack-editor/lib/editor/index.coffee
+++ b/client/stack-editor/lib/editor/index.coffee
@@ -58,7 +58,7 @@ module.exports = class StackEditorView extends kd.View
       if not @isMine and stackTemplate
         @tabView.setClass 'StackEditorTabs isntMine'
         @warningView.show()
-        @secondaryActions.hide()
+        @deleteStack.hide()
         @saveButton.setClass 'isntMine'
         @inputTitle.setClass 'template-title isntMine'
 
@@ -92,7 +92,7 @@ module.exports = class StackEditorView extends kd.View
       cssClass             : 'StackEditor-SecondaryActions'
 
 
-    @secondaryActions.addSubView new CustomLinkView
+    @secondaryActions.addSubView @deleteStack = new CustomLinkView
       cssClass : 'HomeAppView--button danger'
       title    : 'DELETE STACK TEMPLATE'
       click    : @bound 'deleteStack'


### PR DESCRIPTION
Fixes #8495

![image](https://cloud.githubusercontent.com/assets/8138047/16998881/3ab00dca-4e70-11e6-88a6-3b10a94b4bdf.png)
