### PR TITLE
sidebar: fix lineheight of stack items

### DIFF
--- a/client/app/lib/components/sidebarsection/styl/sidebarsection.styl
+++ b/client/app/lib/components/sidebarsection/styl/sidebarsection.styl
@@ -27,6 +27,8 @@
     color                   $gray-8
     display                 inline-block
     width                   186px
+    line-height             18px
+    vertical-align          middle
     noTextDeco()
     ellipsis()
     pointer()

--- a/client/app/lib/components/sidebarsection/styl/sidebarsection.styl
+++ b/client/app/lib/components/sidebarsection/styl/sidebarsection.styl
@@ -28,7 +28,7 @@
     display                 inline-block
     width                   186px
     line-height             18px
-    vertical-align          middle
+    vertical-align          top
     noTextDeco()
     ellipsis()
     pointer()

--- a/client/app/lib/components/sidebarstacksection/styl/sidebarstacksection.styl
+++ b/client/app/lib/components/sidebarstacksection/styl/sidebarstacksection.styl
@@ -67,7 +67,6 @@
       rel()
       borderBox()
       dIBlock()
-      top                   -6px
       border                2px solid rgba(255, 255, 255, .2)
       height                6px
       rounded               100%

--- a/client/app/lib/components/sidebarstacksection/styl/sidebarstacksection.styl
+++ b/client/app/lib/components/sidebarstacksection/styl/sidebarstacksection.styl
@@ -70,6 +70,7 @@
       border                2px solid rgba(255, 255, 255, .2)
       height                6px
       rounded               100%
+      top                   -1px
       width                 6px
       margin-right          5px
 


### PR DESCRIPTION
Fixes #8497 

-Firefox-
![image](https://cloud.githubusercontent.com/assets/8138047/17001186/d6ac9ed2-4e7a-11e6-82c0-7dee1a3ca0b0.png)

-Chrome-
![image](https://cloud.githubusercontent.com/assets/8138047/17001206/e9b32a8c-4e7a-11e6-9c99-92cd165ea44b.png)

-Safari-
![image](https://cloud.githubusercontent.com/assets/8138047/17001220/f9a68eca-4e7a-11e6-9392-7a4d3fce662c.png)
