### PR TITLE
Add support for dynamic group plan

### DIFF
--- a/servers/lib/server/handlers/createteam.coffee
+++ b/servers/lib/server/handlers/createteam.coffee
@@ -168,6 +168,8 @@ createGroupKallback = (client, req, res, body) ->
       domains
       # username or email of the user, can be already registered or a new one for creation
       username
+      # title of team's plan
+      plan
     } = body
 
     token = result.newToken or result.replacementToken
@@ -195,14 +197,17 @@ createGroupKallback = (client, req, res, body) ->
       username         : result.account.profile.nickname
     }
 
-    JGroup.create client,
+    createOptions =
       slug            : slug
       title           : companyName
-    # config          : { plan: 'trial' } # default team plan
       visibility      : 'hidden'
       allowedDomains  : convertToArray domains # clear & convert domains into array
       defaultChannels : []
-    , owner, afterGroupCreate
+
+    if plan
+      createOptions.config = { plan }
+
+    JGroup.create client, createOptions, owner, afterGroupCreate
 
 
 

--- a/servers/lib/server/handlers/createteam.test.coffee
+++ b/servers/lib/server/handlers/createteam.test.coffee
@@ -610,7 +610,6 @@ runTests = -> describe 'server.handlers.createteam', ->
 
       (next) ->
         JGroup.one { slug: options.body.slug }, (err, group) ->
-          console.log({err, group})
           expect(err).to.not.exist
           expect(group).to.exist
           expect(group.config.plan).to.be.equal 'foo'

--- a/servers/lib/server/handlers/createteam.test.coffee
+++ b/servers/lib/server/handlers/createteam.test.coffee
@@ -596,6 +596,34 @@ runTests = -> describe 'server.handlers.createteam', ->
         done()
 
 
+  it 'should save given plan title to the config', (done) ->
+
+    options = { body: { plan: 'foo', slug: "slug#{generateRandomString 11}" } }
+
+    queue = [
+      (next) ->
+        generateCreateTeamRequestParams options, (createTeamRequestParams) ->
+          request.post createTeamRequestParams, (err, res, body) ->
+            expect(err).to.not.exist
+            expect(res.statusCode).to.be.equal 200
+            next()
+
+      (next) ->
+        setTimeout ->
+          JGroup.one { slug: options.body.slug }, (err, group) ->
+            console.log({err, group})
+            expect(err).to.not.exist
+            expect(group).to.exist
+            expect(group.config.plan).to.be.equal 'foo'
+            next()
+        , 1000
+    ]
+
+    async.series queue, (err) ->
+      expect(err).to.not.exist
+      done()
+
+
 beforeTests()
 
 runTests()

--- a/servers/lib/server/handlers/createteam.test.coffee
+++ b/servers/lib/server/handlers/createteam.test.coffee
@@ -609,14 +609,12 @@ runTests = -> describe 'server.handlers.createteam', ->
             next()
 
       (next) ->
-        setTimeout ->
-          JGroup.one { slug: options.body.slug }, (err, group) ->
-            console.log({err, group})
-            expect(err).to.not.exist
-            expect(group).to.exist
-            expect(group.config.plan).to.be.equal 'foo'
-            next()
-        , 1000
+        JGroup.one { slug: options.body.slug }, (err, group) ->
+          console.log({err, group})
+          expect(err).to.not.exist
+          expect(group).to.exist
+          expect(group.config.plan).to.be.equal 'foo'
+          next()
     ]
 
     async.series queue, (err) ->

--- a/workers/social/lib/social/models/computeproviders/computeprovider.coffee
+++ b/workers/social/lib/social/models/computeproviders/computeprovider.coffee
@@ -328,7 +328,7 @@ module.exports = class ComputeProvider extends Base
     catch
       callback new KodingError 'Template is not valid'
 
-    teamutils.generateConstraints planConfig, (err, rules) ->
+    teamutils.fetchConstraints planConfig, (err, rules) ->
 
       { passed, results } = konstraints template, rules, {}
       return new KodingError results.last[1]  unless passed
@@ -427,7 +427,7 @@ module.exports = class ComputeProvider extends Base
 
     planConfig = helpers.getPlanConfig group
 
-    teamutils.getPlanData planConfig, (err, plan) =>
+    teamutils.fetchPlanData planConfig, (err, plan) =>
 
       return callback err  if err
 
@@ -456,7 +456,7 @@ module.exports = class ComputeProvider extends Base
     planConfig   = helpers.getPlanConfig group
     maxAllowed   = MAX_INT
 
-    teamutils.getPlanData planConfig, (err, plan) =>
+    teamutils.fetchPlanData planConfig, (err, plan) =>
 
       return callback err  if err
 

--- a/workers/social/lib/social/models/computeproviders/computeprovider.coffee
+++ b/workers/social/lib/social/models/computeproviders/computeprovider.coffee
@@ -321,19 +321,19 @@ module.exports = class ComputeProvider extends Base
 
   # Just takes the plan config and the stack template content generates rules
   # based on th plan then verifies the content based on the rules generated
-  @validateTemplateContent = (content, planConfig) ->
-
-    rules = teamutils.generateConstraints planConfig
+  @validateTemplateContent = (content, planConfig, callback) ->
 
     try
       template = JSON.parse content
     catch
-      return new KodingError 'Template is not valid'
+      callback new KodingError 'Template is not valid'
 
-    { passed, results } = konstraints template, rules, {}
-    return new KodingError results.last[1]  unless passed
+    teamutils.generateConstraints planConfig, (err, rules) ->
 
-    return null
+      { passed, results } = konstraints template, rules, {}
+      return new KodingError results.last[1]  unless passed
+
+      return null
 
 
   # Template checker, this will fetch the stack template from given id,
@@ -351,7 +351,7 @@ module.exports = class ComputeProvider extends Base
       return callback err  if err
       return callback new KodingError 'Stack template not found'  unless data
 
-      callback @validateTemplateContent data.template.content, planConfig
+      @validateTemplateContent data.template.content, planConfig, callback
 
 
   # Takes an array of stack template ids and returns the final result ^^
@@ -425,23 +425,24 @@ module.exports = class ComputeProvider extends Base
 
     return callback null  if group.slug is 'koding'
 
-    planConfig   = helpers.getPlanConfig group
+    planConfig = helpers.getPlanConfig group
 
-    maxAllowed   = MAX_INT
-    if planConfig.plan
-      plan       = teamutils.getPlanData planConfig
+    teamutils.getPlanData planConfig, (err, plan) =>
+
+      return callback err  if err
+
       maxAllowed = plan.member ? MAX_INT
 
-    JCounter = require '../counter'
-    JCounter[change]
-      namespace : group.getAt 'slug'
-      type      : @COUNTER_TYPE.stacks
-      max       : maxAllowed
-      min       : 0
-    , (err) ->
-      # no worries about `decrement` errors
-      # since 0 is already defined as min ~ GG
-      callback if change is 'increment' then err else null
+      JCounter = require '../counter'
+      JCounter[change]
+        namespace : group.getAt 'slug'
+        type      : @COUNTER_TYPE.stacks
+        max       : maxAllowed
+        min       : 0
+      , (err) ->
+        # no worries about `decrement` errors
+        # since 0 is already defined as min ~ GG
+        callback if change is 'increment' then err else null
 
 
   @updateGroupInstanceUsage = (options, callback) ->
@@ -452,23 +453,26 @@ module.exports = class ComputeProvider extends Base
     # A stack template without machines in it? ~ GG
     return callback null  if group.slug is 'koding' or amount is 0
 
-    maxAllowed   = MAX_INT
     planConfig   = helpers.getPlanConfig group
-    if planConfig.plan
-      plan       = teamutils.getPlanData planConfig
-      maxAllowed = plan.maxInstance ? MAX_INT
+    maxAllowed   = MAX_INT
 
-    JCounter = require '../counter'
-    JCounter[change]
-      namespace : group.getAt 'slug'
-      amount    : amount
-      type      : @COUNTER_TYPE.instances
-      max       : maxAllowed
-      min       : 0
-    , (err) ->
-      # no worries about `decrement` errors
-      # since 0 is already defined as min ~ GG
-      callback if change is 'increment' then err else null
+    teamutils.getPlanData planConfig, (err, plan) =>
+
+      return callback err  if err
+
+      maxAllowed = plan.maxInstance  if plan
+
+      JCounter = require '../counter'
+      JCounter[change]
+        namespace : group.getAt 'slug'
+        amount    : amount
+        type      : @COUNTER_TYPE.instances
+        max       : maxAllowed
+        min       : 0
+      , (err) ->
+        # no worries about `decrement` errors
+        # since 0 is already defined as min ~ GG
+        callback if change is 'increment' then err else null
 
 
   @updateGroupResourceUsage = (options, callback) ->

--- a/workers/social/lib/social/models/computeproviders/computeprovider.coffee
+++ b/workers/social/lib/social/models/computeproviders/computeprovider.coffee
@@ -326,14 +326,14 @@ module.exports = class ComputeProvider extends Base
     try
       template = JSON.parse content
     catch
-      callback new KodingError 'Template is not valid'
+      return callback new KodingError 'Template is not valid'
 
     teamutils.fetchConstraints planConfig, (err, rules) ->
 
       { passed, results } = konstraints template, rules, {}
-      return new KodingError results.last[1]  unless passed
+      return callback new KodingError results.last[1]  unless passed
 
-      return null
+      return callback null
 
 
   # Template checker, this will fetch the stack template from given id,

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -160,28 +160,28 @@ module.exports = class JStackTemplate extends Module
       unless data?.title
         return callback new KodingError 'Title required.'
 
-      if validationError = validateTemplate data.template, group
-        return callback validationError
+      validateTemplate data.template, group, (err) ->
+        return callback validationError  if err
 
-      if data.config?
-        data.config.groupStack = no
+        if data.config?
+          data.config.groupStack = no
 
-      stackTemplate = new JStackTemplate
-        originId    : delegate.getId()
-        group       : client.context.group
-        title       : data.title
-        config      : data.config      ? {}
-        description : data.description ? ''
-        machines    : data.machines    ? []
-        accessLevel : data.accessLevel ? 'private'
-        template    : generateTemplateObject \
-          data.template, data.rawContent, data.templateDetails
-        credentials : data.credentials
+        stackTemplate = new JStackTemplate
+          originId    : delegate.getId()
+          group       : client.context.group
+          title       : data.title
+          config      : data.config      ? {}
+          description : data.description ? ''
+          machines    : data.machines    ? []
+          accessLevel : data.accessLevel ? 'private'
+          template    : generateTemplateObject \
+            data.template, data.rawContent, data.templateDetails
+          credentials : data.credentials
 
-      stackTemplate.save (err) ->
-        if err
-        then callback new KodingError 'Failed to save stack template', err
-        else callback null, stackTemplate
+        stackTemplate.save (err) ->
+          if err
+          then callback new KodingError 'Failed to save stack template', err
+          else callback null, stackTemplate
 
 
   @some$: permit 'list stack templates',

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -135,13 +135,13 @@ module.exports = class JStackTemplate extends Module
     }
 
 
-  validateTemplate = (template, group) ->
+  validateTemplate = (template, group, callback) ->
 
     planConfig = helpers.getPlanConfig group
-    return  unless planConfig.plan # No plan, no pain.
+    return callback null  unless planConfig.plan # No plan, no pain.
 
     ComputeProvider = require './computeprovider'
-    return ComputeProvider.validateTemplateContent template, planConfig
+    ComputeProvider.validateTemplateContent template, planConfig, callback
 
 
   @create = permit 'create stack template',

--- a/workers/social/lib/social/models/computeproviders/teamutils.coffee
+++ b/workers/social/lib/social/models/computeproviders/teamutils.coffee
@@ -3,6 +3,7 @@ TEAMPLANS   = require './teamplans'
 
 konstraints = require 'konstraints'
 _           = require 'underscore'
+JGroupPlan  = require '../group/groupplan'
 
 
 shareCredentials = (options, callback) ->
@@ -40,7 +41,11 @@ getPlanData = (planConfig, callback) ->
     result = _.extend {}, TEAMPLANS[plan], (overrides || {})
     return callback null, result
 
-  callback null, TEAMPLANS['default']
+  JGroupPlan.one { name: plan }, (err, planData) ->
+    return callback err  if err
+    return callback null, TEAMPLANS['default']  unless planData
+    return callback null, planData
+
 
 # Takes plan config as reference and generates valid konstraint
 # rules based on the TEAMPLANS data ~ GG

--- a/workers/social/lib/social/models/computeproviders/teamutils.coffee
+++ b/workers/social/lib/social/models/computeproviders/teamutils.coffee
@@ -49,9 +49,7 @@ fetchPlanData = (planConfig, callback) ->
 
 # Takes plan config as reference and generates valid konstraint
 # rules based on the TEAMPLANS data ~ GG
-generateConstraints = (planConfig, callback) -> getPlanData planConfig, (err, plan) ->
-
-  return callback err  if err
+generateConstraints = (plan) ->
 
   # First rule be an object.
   rules = [ { $typeof : 'object' } ]
@@ -128,7 +126,7 @@ generateConstraints = (planConfig, callback) -> getPlanData planConfig, (err, pl
                  { 'volume_size?': { $gte: 3 } }  # min volume size 3GB
             ] }
 
-  callback null, rules
+  return rules
 
 
 module.exports = {

--- a/workers/social/lib/social/models/computeproviders/teamutils.coffee
+++ b/workers/social/lib/social/models/computeproviders/teamutils.coffee
@@ -32,16 +32,15 @@ shareCredentials = (options, callback) ->
 # Returns plan data
 # If plan is not found, it fallbacks to default
 # If there are plan overrides, they override plan properties
-getPlanData = (planConfig) ->
+getPlanData = (planConfig, callback) ->
 
   { plan, overrides } = planConfig
 
-  if plan not in Object.keys TEAMPLANS
-    _.clone TEAMPLANS['default']
-  else
-    overrides ?= {}
-    _.extend {}, TEAMPLANS[plan], overrides
+  if plan in Object.keys TEAMPLANS
+    result = _.extend {}, TEAMPLANS[plan], (overrides || {})
+    return callback null, result
 
+  callback null, TEAMPLANS['default']
 
 # Takes plan config as reference and generates valid konstraint
 # rules based on the TEAMPLANS data ~ GG

--- a/workers/social/lib/social/models/computeproviders/teamutils.coffee
+++ b/workers/social/lib/social/models/computeproviders/teamutils.coffee
@@ -43,8 +43,14 @@ fetchPlanData = (planConfig, callback) ->
 
   JGroupPlan.one { name: plan }, (err, planData) ->
     return callback err  if err
-    return callback null, TEAMPLANS['default']  unless planData
+    return callback null, _.clone TEAMPLANS['default']  unless planData
     return callback null, planData
+
+
+fetchConstraints = (planConfig, callback) ->
+  fetchPlanData planConfig, (err, plan) ->
+    return callback err  if err
+    callback null, generateConstraints plan
 
 
 # Takes plan config as reference and generates valid konstraint
@@ -130,5 +136,5 @@ generateConstraints = (plan) ->
 
 
 module.exports = {
-  generateConstraints, getPlanData, shareCredentials, TEAMPLANS
+  fetchConstraints, generateConstraints, fetchPlanData, shareCredentials, TEAMPLANS
 }

--- a/workers/social/lib/social/models/computeproviders/teamutils.coffee
+++ b/workers/social/lib/social/models/computeproviders/teamutils.coffee
@@ -44,9 +44,9 @@ getPlanData = (planConfig, callback) ->
 
 # Takes plan config as reference and generates valid konstraint
 # rules based on the TEAMPLANS data ~ GG
-generateConstraints = (planConfig) ->
+generateConstraints = (planConfig, callback) -> getPlanData planConfig, (err, plan) ->
 
-  plan  = getPlanData planConfig
+  return callback err  if err
 
   # First rule be an object.
   rules = [ { $typeof : 'object' } ]
@@ -123,7 +123,7 @@ generateConstraints = (planConfig) ->
                  { 'volume_size?': { $gte: 3 } }  # min volume size 3GB
             ] }
 
-  return rules
+  callback null, rules
 
 
 module.exports = {

--- a/workers/social/lib/social/models/computeproviders/teamutils.coffee
+++ b/workers/social/lib/social/models/computeproviders/teamutils.coffee
@@ -33,7 +33,7 @@ shareCredentials = (options, callback) ->
 # Returns plan data
 # If plan is not found, it fallbacks to default
 # If there are plan overrides, they override plan properties
-getPlanData = (planConfig, callback) ->
+fetchPlanData = (planConfig, callback) ->
 
   { plan, overrides } = planConfig
 

--- a/workers/social/lib/social/models/computeproviders/teamutils.coffee
+++ b/workers/social/lib/social/models/computeproviders/teamutils.coffee
@@ -38,7 +38,7 @@ getPlanData = (planConfig, callback) ->
   { plan, overrides } = planConfig
 
   if plan in Object.keys TEAMPLANS
-    result = _.extend {}, TEAMPLANS[plan], (overrides || {})
+    result = _.extend {}, TEAMPLANS[plan], (overrides ? {})
     return callback null, result
 
   JGroupPlan.one { name: plan }, (err, planData) ->

--- a/workers/social/lib/social/models/computeproviders/teamutils.test.coffee
+++ b/workers/social/lib/social/models/computeproviders/teamutils.test.coffee
@@ -111,11 +111,11 @@ runTests = -> describe 'workers.social.models.computeproviders.teamutils', (done
           done()
 
 
-      it 'should return default value when given plan is not even on the db', ->
+      it 'should return default value when given plan is not even on the db', (done) ->
         createGroupOptions =
           body:
             plan: "nonexistent-plan-#{generateRandomString 10}"
-            slug: "team-with-nonexistent-plan-config-#{generateRandomString 10}"
+            slug: "planless-team-#{generateRandomString 10}"
 
         _group = null
 
@@ -138,16 +138,13 @@ runTests = -> describe 'workers.social.models.computeproviders.teamutils', (done
           (next) ->
             teamutils.fetchPlanData _group.config, (err, planData) ->
               expect(err).to.not.exist
-
               expect(planData).to.be.eql teamplans.default
-
               next()
         ]
 
         async.series queue, (err) ->
           expect(err).to.not.exist
           done()
-
 
 
 beforeTests()

--- a/workers/social/lib/social/models/computeproviders/teamutils.test.coffee
+++ b/workers/social/lib/social/models/computeproviders/teamutils.test.coffee
@@ -1,0 +1,157 @@
+async = require 'async'
+
+{ expect, generateRandomString } = require '../../../../testhelper'
+{ generateCreateTeamRequestParams } = require '../../../../../../servers/testhelper/handler/teamhelper'
+{ checkBongoConnectivity, request } = require '../../../../../../servers/testhelper'
+
+teamutils = require './teamutils'
+teamplans = require './teamplans'
+
+JGroup = require '../group'
+JGroupPlan = require '../group/groupplan'
+
+beforeTests = -> before (done) -> checkBongoConnectivity done
+
+
+runTests = -> describe 'workers.social.models.computeproviders.teamutils', (done) ->
+
+  describe 'teamutils', ->
+
+    describe '#getPlanData()', ->
+
+      it 'should return hardcoded team plan if it exists', (done) ->
+
+        trialPlan = teamplans['trial']
+
+        options = { body: { plan: 'trial', slug: "trial-plan-#{generateRandomString 10}" } }
+
+        queue = [
+          (next) ->
+            generateCreateTeamRequestParams options, (createTeamRequestParams) ->
+              request.post createTeamRequestParams, (err, res) ->
+                expect(err).to.not.exist
+                expect(res.statusCode).to.be.equal 200
+                next()
+
+          (next) ->
+            JGroup.one { slug: options.body.slug }, (err, group) ->
+              expect(err).to.not.exist
+              expect(group).to.exist
+              expect(group.config.plan).to.be.equal 'trial'
+              next()
+
+          (next) ->
+            teamutils.getPlanData { plan: 'trial' }, (err, planData) ->
+              expect(err).to.not.exist
+              expect(planData).to.exist
+              expect(planData).to.be.eql trialPlan
+              next()
+        ]
+
+        async.series queue, (err) ->
+          console.log {err}
+          expect(err).to.not.exist
+          done()
+
+
+      it 'should return a team plan from db if it exists', (done) ->
+
+        createGroupOptions =
+          body:
+            plan: "awesome-plan-#{generateRandomString 10}"
+            slug: "awesome-team-#{generateRandomString 10}"
+
+        onDemandPlanOptions =
+          name               : createGroupOptions.body.plan
+          member             : 5000
+          validFor           : 0
+          instancePerMember  : 90
+          allowedInstances   : []
+          maxInstance        : 9000
+          storagePerInstance : 1000
+          restrictions       : {}
+
+        _group = null
+
+        queue = [
+          (next) ->
+            # we are saving a group plan first
+            (new JGroupPlan onDemandPlanOptions).save next
+
+          (next) ->
+            generateCreateTeamRequestParams createGroupOptions, (createTeamRequestParams) ->
+              request.post createTeamRequestParams, (err, res, body) ->
+                expect(err).to.not.exist
+                expect(res.statusCode).to.be.equal 200
+                next()
+
+          (next) ->
+            JGroup.one { slug: createGroupOptions.body.slug }, (err, group) ->
+              expect(err).to.not.exist
+              expect(group).to.exist
+              expect(group.config.plan).to.be.equal createGroupOptions.body.plan
+              _group = group
+              next()
+
+          (next) ->
+            teamutils.getPlanData _group.config, (err, planData) ->
+              expect(err).to.not.exist
+              expect(planData).to.exist
+              expect(planData.member).to.be.equal 5000
+              expect(planData.validFor).to.be.equal 0
+              expect(planData.instancePerMember).to.be.equal 90
+              expect(planData.maxInstance).to.be.equal 9000
+              expect(planData.storagePerInstance).to.be.equal 1000
+              expect(planData.allowedInstances.length).to.be.eql 0
+              expect(planData.restrictions).to.be.eql {}
+              next()
+        ]
+
+        async.series queue, (err) ->
+          expect(err).to.not.exist
+          done()
+
+
+      it 'should return default value when given plan is not even on the db', ->
+        createGroupOptions =
+          body:
+            plan: "nonexistent-plan-#{generateRandomString 10}"
+            slug: "team-with-nonexistent-plan-config-#{generateRandomString 10}"
+
+        _group = null
+
+        queue = [
+          (next) ->
+            generateCreateTeamRequestParams createGroupOptions, (createTeamRequestParams) ->
+              request.post createTeamRequestParams, (err, res, body) ->
+                expect(err).to.not.exist
+                expect(res.statusCode).to.be.equal 200
+                next()
+
+          (next) ->
+            JGroup.one { slug: createGroupOptions.body.slug }, (err, group) ->
+              expect(err).to.not.exist
+              expect(group).to.exist
+              expect(group.config.plan).to.be.equal createGroupOptions.body.plan
+              _group = group
+              next()
+
+          (next) ->
+            teamutils.getPlanData _group.config, (err, planData) ->
+              expect(err).to.not.exist
+
+              expect(planData).to.be.eql teamplans.default
+
+              next()
+        ]
+
+        async.series queue, (err) ->
+          expect(err).to.not.exist
+          done()
+
+
+
+beforeTests()
+
+runTests()
+

--- a/workers/social/lib/social/models/computeproviders/teamutils.test.coffee
+++ b/workers/social/lib/social/models/computeproviders/teamutils.test.coffee
@@ -49,7 +49,6 @@ runTests = -> describe 'workers.social.models.computeproviders.teamutils', (done
         ]
 
         async.series queue, (err) ->
-          console.log {err}
           expect(err).to.not.exist
           done()
 

--- a/workers/social/lib/social/models/computeproviders/teamutils.test.coffee
+++ b/workers/social/lib/social/models/computeproviders/teamutils.test.coffee
@@ -17,7 +17,7 @@ runTests = -> describe 'workers.social.models.computeproviders.teamutils', (done
 
   describe 'teamutils', ->
 
-    describe '#getPlanData()', ->
+    describe '#fetchPlanData()', ->
 
       it 'should return hardcoded team plan if it exists', (done) ->
 
@@ -41,7 +41,7 @@ runTests = -> describe 'workers.social.models.computeproviders.teamutils', (done
               next()
 
           (next) ->
-            teamutils.getPlanData { plan: 'trial' }, (err, planData) ->
+            teamutils.fetchPlanData { plan: 'trial' }, (err, planData) ->
               expect(err).to.not.exist
               expect(planData).to.exist
               expect(planData).to.be.eql trialPlan
@@ -93,7 +93,7 @@ runTests = -> describe 'workers.social.models.computeproviders.teamutils', (done
               next()
 
           (next) ->
-            teamutils.getPlanData _group.config, (err, planData) ->
+            teamutils.fetchPlanData _group.config, (err, planData) ->
               expect(err).to.not.exist
               expect(planData).to.exist
               expect(planData.member).to.be.equal 5000
@@ -136,7 +136,7 @@ runTests = -> describe 'workers.social.models.computeproviders.teamutils', (done
               next()
 
           (next) ->
-            teamutils.getPlanData _group.config, (err, planData) ->
+            teamutils.fetchPlanData _group.config, (err, planData) ->
               expect(err).to.not.exist
 
               expect(planData).to.be.eql teamplans.default

--- a/workers/social/lib/social/models/group/groupplan.coffee
+++ b/workers/social/lib/social/models/group/groupplan.coffee
@@ -1,0 +1,26 @@
+{ Module } = require 'jraphical'
+
+module.exports = class JGroupPlan extends Module
+
+  @set
+    indexes:
+      name: 'unique'
+
+    sharedEvents:
+      static: []
+      instance: []
+
+    schema               :
+      name               : String
+      member             : Number
+      validFor           : Number
+      instancePerMember  : Number
+      allowedInstances   : [String]
+      maxInstance        : Number
+      storagePerInstance : Number
+      restrictions       :
+        supports         : [String]
+        provider         : [String]
+        resource         : [String]
+        custom           : Object
+

--- a/workers/social/lib/social/models/group/groupplan.test.coffee
+++ b/workers/social/lib/social/models/group/groupplan.test.coffee
@@ -1,0 +1,14 @@
+JGroupPlan = require './groupplan'
+{ expect } = require '../../../../testhelper'
+
+
+runTests = -> describe 'workers.social.models.group.groupplan', ->
+
+  describe 'JGroupPlan', ->
+
+    it 'should exist', ->
+      expect(JGroupPlan).to.be.a 'function'
+      expect(JGroupPlan.set).to.be.a 'function'
+
+
+runTests()


### PR DESCRIPTION
This is the implementation required for current system to work with dynamic group plans.

I am not sure if this is 100% correct, i might have to revisit what we are doing [here](https://github.com/koding/koding/blob/master/workers/social/lib/social/models/computeproviders/helpers.coffee#L61). Here is the simple flow:
- Save given `config.plan` to group no matter what.
- While reading a group's plan:
  - First try to find it in `teamplans.coffee`, if it exists then return it.
  - Second, try to see if there is a `JGroupPlan` instance, if it exists then return it.
  - Third, return default plan in `teamplans.coffee`

Let me know if i need to do something more.

/cc @szkl @cihangir 

Related with #8471 
