### PR TITLE
'There's a stack generated from this template by another team member.' is sometimes appearing for the private stack templates

### DIFF
--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -496,7 +496,10 @@ module.exports = class JStackTemplate extends Module
     success: (client, callback) ->
 
       JComputeStack = require '../stack'
-      JComputeStack.some { baseStackId: @_id }, { limit: 1 }, (err, stacks) ->
+      JComputeStack.some {
+        baseStackId: @_id
+        'status.state': { $ne: 'Destroying' }
+      }, { limit: 1 }, (err, stacks) ->
         result = stacks?.length > 0
         callback err, result
 


### PR DESCRIPTION
![](http://g.recordit.co/DFVUqWzcdY.gif)
fixes #8296 
