### PR TITLE
dont show save diaglog modal if file type is yaml

### DIFF
--- a/client/ace/lib/aceview.coffee
+++ b/client/ace/lib/aceview.coffee
@@ -120,6 +120,9 @@ module.exports = class AceView extends JView
 
     @ace.on 'ace.requests.save', (contents) =>
       file = @getData()
+
+      return  if file.path.endsWith '.yaml'
+
       if /localfile:/.test file.path
         @openSaveDialog()
       else


### PR DESCRIPTION
fixes #8529 

Not sure to solve this problem in this way. @sinan
