### PR TITLE
client: support: remove old chatlio implementation

### DIFF
--- a/client/app/lib/util/fetchChatlioKey.coffee
+++ b/client/app/lib/util/fetchChatlioKey.coffee
@@ -1,6 +1,5 @@
 kd = require 'kd'
 globals = require 'globals'
-KODING_CHATLIO_KEY = 'ae02da65-1664-4e7b-49c8-31abedbb80ed'
 
 module.exports = fetchChatlioKey = (callback = noop) ->
 
@@ -10,12 +9,6 @@ module.exports = fetchChatlioKey = (callback = noop) ->
 
     team = groupsController.getCurrentGroup()
     chatlioId = team.customize?.chatlioId
-    # if user is an admin or owner
-    # their support requests should
-    # come to koding support not to
-    # their own slack that they set up
-    if isAdmin = groupsController.canEditGroup()
-      chatlioId = KODING_CHATLIO_KEY
 
     return callback no  unless chatlioId
 


### PR DESCRIPTION
legacy cleaning. key is deleted on chatlio as well. /cc @cihangir 
