### PR TITLE
klient: lazy heartbeats

### DIFF
--- a/go/src/koding/klient/vagrant/handlers.go
+++ b/go/src/koding/klient/vagrant/handlers.go
@@ -577,7 +577,6 @@ func retry(op func() error) {
 	retry := backoff.NewExponentialBackOff()
 	retry.MaxElapsedTime = 2 * time.Minute
 	retry.MaxInterval = 10 * time.Second
-	retry.Reset()
 
 	backoff.Retry(op, retry)
 }


### PR DESCRIPTION
This PR makes vagrant.\* commands start sending heartbeats after
the vagrant command execution is successful (in progress).

Also fixes a bug, when heartbeats were stopped right after early return
of the async watchCommand func.

/cc @cihangir 
