### PR TITLE
Minor improvements to scripts/copy_vault.sh script

### DIFF
--- a/scripts/copy_vault.sh
+++ b/scripts/copy_vault.sh
@@ -11,7 +11,6 @@ if [ ! -d "./vault" ]; then
   log "vault folder does not exist at ./vault"
   log "trying to clone it"
   git clone git@github.com:koding/vault.git ./vault
-  exit 0;
 fi
 
 
@@ -22,7 +21,6 @@ log "getting status"
 if [ ! -d './.git' ]; then
   log "vault folder is not a git folder, skip updating"
   log "there can be misconfigurations in your system, just sayin.."
-  exit 0;
 fi
 
 # save any existing changes
@@ -35,7 +33,6 @@ v=$(git diff-tree -r --name-only --no-commit-id HEAD..origin/master 2>&1)
 if [ -z "$v" ]; then
     echo "vault is up-to-date with origin/master!"
     git stash pop
-    exit 0;
 fi
 
 git pull --rebase origin master

--- a/scripts/copy_vault.sh
+++ b/scripts/copy_vault.sh
@@ -12,7 +12,7 @@ if [ ! -d "./vault" ]; then
   log "trying to clone it"
   git clone git@github.com:koding/vault.git ./vault
   exit 0;
-fi;
+fi
 
 
 cd ./vault

--- a/scripts/copy_vault.sh
+++ b/scripts/copy_vault.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+set -o errexit
+
 #  make relative paths work.
 cd $(dirname $0)/..
 


### PR DESCRIPTION
copy_vault.sh script was exiting with success code 0 because exit code of `git` was overwritten.

``` bash
exit 0
```

`errexit` makes script exit right if a command in the pipeline exits with a failure code.
