### PR TITLE
'Keep Rocking' button on success modal for onboarding items does nothing.

### DIFF
--- a/client/home/lib/styl/homeonboardingcongratmodal.styl
+++ b/client/home/lib/styl/homeonboardingcongratmodal.styl
@@ -4,6 +4,7 @@ Home OnBoarding Congrat Modal styles
 */
 }
 .kdmodal.Congratulation-modal
+  left 546px !important
   border-radius             6px
   border                    0px
   font-family               proxima-nova, sans-serif

--- a/client/home/lib/welcome/welcomemodal.coffee
+++ b/client/home/lib/welcome/welcomemodal.coffee
@@ -1,7 +1,7 @@
 kd = require 'kd'
 HomeWelcome = require './'
 LocalStorage = require 'app/localstorage'
-
+globals = require 'globals'
 
 module.exports = class WelcomeModal extends kd.ModalView
 
@@ -20,8 +20,8 @@ module.exports = class WelcomeModal extends kd.ModalView
 
     router.once 'RouteInfoHandled', => @destroy no
 
-    mainController.once 'AllWelcomeStepsDone', @bound 'showCongratulationModal'
     mainController.once 'AllWelcomeStepsDone', @bound 'destroy'
+    mainController.once 'AllWelcomeStepsDone', @bound 'showCongratulationModal'
     mainController.once 'AllWelcomeStepsNotDoneYet', @bound 'initialShow'
 
     storage.setValue 'landedOnWelcome', ''
@@ -29,23 +29,33 @@ module.exports = class WelcomeModal extends kd.ModalView
 
   showCongratulationModal: ->
 
-    modal = new kd.ModalView
-      title : 'Success!'
-      width : 530
-      cssClass : 'Congratulation-modal'
-      content : "<p class='description'>Congratulations. You have completed all items on your onboarding list.</p>"
+    { appStorageController } = kd.singletons
+
+    appStorage = appStorageController.storage "WelcomeSteps-#{globals.currentGroup.slug}"
+    appStorage.fetchValue 'OnboardingSuccessModalShown', (result) ->
+
+      return  if result
+
+      appStorage.setValue 'OnboardingSuccessModalShown', yes
+
+      modal = new kd.ModalView
+        title : 'Success!'
+        width : 530
+        cssClass : 'Congratulation-modal'
+        content : "<p class='description'>Congratulations. You have completed all items on your onboarding list.</p>"
 
 
-    kd.View::addSubView.call modal, new kd.CustomHTMLView
-      cssClass : 'alien'
+      kd.View::addSubView.call modal, new kd.CustomHTMLView
+        cssClass : 'alien'
 
 
-    modal.addSubView new kd.CustomHTMLView
-      cssClass : 'image-wrapper'
+      modal.addSubView new kd.CustomHTMLView
+        cssClass : 'image-wrapper'
 
-    modal.addSubView new kd.ButtonView
-      title : 'KEEP ROCKING!'
-      cssClass: 'GenericButton'
+      modal.addSubView new kd.ButtonView
+        title : 'KEEP ROCKING!'
+        cssClass: 'GenericButton'
+        callback : -> modal.destroy()
 
 
   initialShow: ->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

fixes #8683 
## Description

<!--- Describe your changes in detail -->

`Keep Rocking` button closes the modal
We will show success modal only once

I couldn't fix `Centeralize the modal according to IDE` because of not able to build stack in development. It is `WIP` because of that reason
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

After finishing all items in onboarding list the modal will appear. 
The button will close modal
Refresh or logged out and in will not cause to show that modal again.
## Screenshots (if appropriate):

![](https://monosnap.com/file/D7FCAkPBjVPn331RYLfXe3BpKRCmyN.png)
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
