### PR TITLE
dashboard: dont let team name to be an empty string

### DIFF
--- a/client/home/lib/myteam/components/hometeamsettings/view.coffee
+++ b/client/home/lib/myteam/components/hometeamsettings/view.coffee
@@ -93,7 +93,7 @@ TeamDomain = ({ slug }) ->
 TeamName = ({ canEdit, title, teamName, callback }) ->
 
   encode = if title then title else ''
-  value = teamName or Encoder.htmlDecode encode
+  value = teamName ? Encoder.htmlDecode encode
 
   className = if canEdit then 'half' else 'half TeamName'
 


### PR DESCRIPTION
## Description

Currently, team name couldn't be an empty string and the current name was reloaded, with this PR you can edit your team name properly.
## Motivation and Context

Fixes #8706  
## How Has This Been Tested?

Manually
## Screenshots (if appropriate):

![image](http://g.recordit.co/xlr0XS2ddK.gif)
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
