### PR TITLE
client: update 'Expand' and 'Collapse' button

### DIFF
--- a/client/app/lib/components/contentModal/styl/contentModal.styl
+++ b/client/app/lib/components/contentModal/styl/contentModal.styl
@@ -324,12 +324,17 @@ main.main-container
       font-weight           300
 
     button.expand-button
+
       abs 0 40px 375px 0
       z-index 10
+      background-color      #fff !important
+      border                2px solid #CBCBCB
+      span
+        color               #858585 !important
+        line-height         25px
 
     button.minimize-button
       display none
-
 
 .ContentModal.expanded-stack-template-preview
   left 10px !important
@@ -356,3 +361,9 @@ main.main-container
   button.minimize-button
     abs 97px 60px 0 0
     z-index 10
+    background-color      #fff !important
+    border                2px solid #CBCBCB
+    span
+      color               #858585 !important
+      line-height         25px
+

--- a/client/app/lib/components/contentModal/styl/contentModal.styl
+++ b/client/app/lib/components/contentModal/styl/contentModal.styl
@@ -324,7 +324,6 @@ main.main-container
       font-weight           300
 
     button.expand-button
-
       abs 0 40px 375px 0
       z-index 10
       background-color      #fff !important
@@ -335,6 +334,7 @@ main.main-container
 
     button.minimize-button
       display none
+
 
 .ContentModal.expanded-stack-template-preview
   left 10px !important
@@ -366,4 +366,3 @@ main.main-container
     span
       color               #858585 !important
       line-height         25px
-

--- a/client/app/lib/components/contentModal/styl/contentModal.styl
+++ b/client/app/lib/components/contentModal/styl/contentModal.styl
@@ -12,6 +12,20 @@ contentModal.styl
   border                    none
   z-index                   10003
 
+  button.solid-bg
+    background-color        #fff
+    border                  2px solid #CBCBCB
+    span.button-title
+    &:active span.button-title
+      color                 #858585
+      line-height           25px
+    &:hover
+      background-color      #fff
+
+
+
+
+
   &.kdmodal
     .kdmodal-inner
     .kdmodal-content
@@ -326,11 +340,6 @@ main.main-container
     button.expand-button
       abs 0 40px 375px 0
       z-index 10
-      background-color      #fff !important
-      border                2px solid #CBCBCB
-      span
-        color               #858585 !important
-        line-height         25px
 
     button.minimize-button
       display none
@@ -361,8 +370,3 @@ main.main-container
   button.minimize-button
     abs 97px 60px 0 0
     z-index 10
-    background-color      #fff !important
-    border                2px solid #CBCBCB
-    span
-      color               #858585 !important
-      line-height         25px

--- a/client/app/lib/components/contentModal/styl/contentModal.styl
+++ b/client/app/lib/components/contentModal/styl/contentModal.styl
@@ -22,10 +22,6 @@ contentModal.styl
     &:hover
       background-color      #fff
 
-
-
-
-
   &.kdmodal
     .kdmodal-inner
     .kdmodal-content

--- a/client/stacks/lib/views/stacks/stacktemplatepreviewmodal.coffee
+++ b/client/stacks/lib/views/stacks/stacktemplatepreviewmodal.coffee
@@ -25,7 +25,7 @@ module.exports = class StackTemplatePreviewModal extends ContentModal
       tagName : 'main'
 
     @main.addSubView expandButton = new kd.ButtonView
-      cssClass : 'solid compact light-gray expand-button'
+      cssClass : 'solid compact expand-button'
       title : 'Expand'
       callback : =>
         @unsetClass 'stack-template-preview'
@@ -35,7 +35,7 @@ module.exports = class StackTemplatePreviewModal extends ContentModal
 
 
     @main.addSubView @minimizeButton = new kd.ButtonView
-      cssClass : 'solid compact light-gray minimize-button hidden'
+      cssClass : 'solid compact minimize-button hidden'
       title : 'Collapse'
       callback : =>
         @setClass 'stack-template-preview'

--- a/client/stacks/lib/views/stacks/stacktemplatepreviewmodal.coffee
+++ b/client/stacks/lib/views/stacks/stacktemplatepreviewmodal.coffee
@@ -25,7 +25,7 @@ module.exports = class StackTemplatePreviewModal extends ContentModal
       tagName : 'main'
 
     @main.addSubView expandButton = new kd.ButtonView
-      cssClass : 'solid compact expand-button'
+      cssClass : 'solid compact solid-bg expand-button'
       title : 'Expand'
       callback : =>
         @unsetClass 'stack-template-preview'
@@ -35,7 +35,7 @@ module.exports = class StackTemplatePreviewModal extends ContentModal
 
 
     @main.addSubView @minimizeButton = new kd.ButtonView
-      cssClass : 'solid compact minimize-button hidden'
+      cssClass : 'solid compact solid-bg minimize-button hidden'
       title : 'Collapse'
       callback : =>
         @setClass 'stack-template-preview'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Currently, 'Expand' and 'Collapse' buttons were overlapping with template text. With this PR, they don't overlap anymore.
## Motivation and Context

Fixes #8684 
## How Has This Been Tested?

Manually
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
