### PR TITLE
klientctl: subprocess update

### DIFF
--- a/go/src/koding/klientctl/checkupdate.go
+++ b/go/src/koding/klientctl/checkupdate.go
@@ -75,10 +75,6 @@ func NewCheckUpdate() *CheckUpdate {
 
 // IsUpdateAvailable checks if a newer version of `kd` is available.
 func (c *CheckUpdate) IsUpdateAvailable() (bool, error) {
-	if !c.ForceCheck && c.RandomSeededNumber != 1 {
-		return false, nil
-	}
-
 	resp, err := http.Get(c.Location)
 	if err != nil {
 		return false, err

--- a/go/src/koding/klientctl/checkupdate_test.go
+++ b/go/src/koding/klientctl/checkupdate_test.go
@@ -70,18 +70,6 @@ func TestIsUpdateAvailable(t *testing.T) {
 		So(noUpdate, ShouldBeFalse)
 	})
 
-	Convey("It shouldn't update if randomly seeded number is not 1", t, func() {
-		u := CheckUpdate{
-			LocalVersion:       1,
-			Location:           "http://location:9999",
-			RandomSeededNumber: 2,
-		}
-
-		noUpdate, err := u.IsUpdateAvailable()
-		So(err, ShouldBeNil)
-		So(noUpdate, ShouldBeFalse)
-	})
-
 	Convey("It should return err if unable to check for update", t, func() {
 		u := CheckUpdate{Location: "http://location:9999", RandomSeededNumber: 1}
 

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -261,6 +261,12 @@ func main() {
 					Name:  "force",
 					Usage: "Updates kd & klient to latest available version.",
 				},
+				cli.BoolFlag{
+					Name: "continue",
+					// TODO(leeola): Update to the latest cli package, and use the Hidden flag
+					// for this bool flag.
+					Usage: "An internal flag, not intended for use.",
+				},
 			},
 		},
 		cli.Command{

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -265,7 +265,7 @@ func main() {
 					Name: "continue",
 					// TODO(leeola): Update to the latest cli package, and use the Hidden flag
 					// for this bool flag.
-					Usage: "An internal flag, not intended for use.",
+					Usage: "Internal use only.",
 				},
 			},
 		},

--- a/go/src/koding/klientctl/update.go
+++ b/go/src/koding/klientctl/update.go
@@ -328,11 +328,7 @@ func flagsFromContext(c *cli.Context) []string {
 // as would be returned by Context.String("flagName").
 func isStringZeroValue(s string) bool {
 	switch s {
-	case "":
-		return true
-	case "0":
-		return true
-	case "false":
+	case "", "0", "false":
 		return true
 	default:
 		return false

--- a/go/src/koding/klientctl/update.go
+++ b/go/src/koding/klientctl/update.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"os/user"
 	"path/filepath"
 	"runtime"
@@ -28,11 +29,12 @@ func UpdateCommand(c *cli.Context, log logging.Logger, _ string) int {
 	}
 
 	var (
-		forceUpdate   = c.Bool("force")
-		klientVersion = c.Int("klient-version")
-		klientChannel = c.String("klient-channel")
-		kdVersion     = c.Int("kd-version")
-		kdChannel     = c.String("kd-channel")
+		forceUpdate    = c.Bool("force")
+		klientVersion  = c.Int("klient-version")
+		klientChannel  = c.String("klient-channel")
+		kdVersion      = c.Int("kd-version")
+		kdChannel      = c.String("kd-channel")
+		continueUpdate = c.Bool("continue")
 	)
 
 	if kdChannel == "" {
@@ -66,6 +68,63 @@ func UpdateCommand(c *cli.Context, log logging.Logger, _ string) int {
 		} else {
 			fmt.Println("An update is available.")
 		}
+	}
+
+	if kdVersion == 0 {
+		var err error
+
+		kdVersion, err = latestVersion(config.S3KlientctlLatest)
+		if err != nil {
+			log.Error("Error fetching klientctl update version. err: %s", err)
+			fmt.Println(FailedCheckingUpdateAvailable)
+			return 1
+		}
+	}
+
+	if klientVersion == 0 {
+		var err error
+
+		klientVersion, err = latestVersion(config.S3KlientLatest)
+		if err != nil {
+			log.Error("Error fetching klient update version. err: %s", err)
+			fmt.Println(FailedCheckingUpdateAvailable)
+			return 1
+		}
+	}
+
+	klientPath := filepath.Join(KlientDirectory, "klient")
+	klientctlPath := filepath.Join(KlientctlDirectory, "kd")
+	klientUrl := config.S3Klient(klientVersion, klientChannel)
+	klientctlUrl := config.S3Klientctl(kdVersion, kdChannel)
+
+	// If --continue is not passed, download kd and then call the new kd binary with
+	// `kd update --continue`, so that the new code handles updates to klient.sh,
+	// service, and any migration code needed.
+	if !continueUpdate {
+		// Only show this message once.
+		fmt.Println("Updating...")
+
+		if err := downloadRemoteToLocal(klientctlUrl, klientctlPath); err != nil {
+			log.Error("Error downloading klientctl. err:%s", err)
+			fmt.Println(FailedDownloadUpdate)
+			return 1
+		}
+
+		flags := flagsFromContext(c)
+		// Very important to pass --continue for the subprocess.
+		// --force also helps ensure it updates, since the subprocess is technically
+		// the latest KD version.
+		flags = append([]string{"update", "--continue=true", "--force=true"}, flags...)
+		log.Info("%s", flags)
+		cmd := exec.Command(klientctlPath, flags...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			log.Error("error during --continue update. err: %s", err)
+			return 1
+		}
+
+		return 0
 	}
 
 	kontrolURL := config.KontrolURL
@@ -111,45 +170,10 @@ func UpdateCommand(c *cli.Context, log logging.Logger, _ string) int {
 		return 1
 	}
 
-	if kdVersion == 0 {
-		var err error
-
-		kdVersion, err = latestVersion(config.S3KlientctlLatest)
-		if err != nil {
-			log.Error("Error checking if update is available. err: %s", err)
-			fmt.Println(FailedCheckingUpdateAvailable)
-			return 1
-		}
-	}
-
-	if klientVersion == 0 {
-		var err error
-
-		klientVersion, err = latestVersion(config.S3KlientLatest)
-		if err != nil {
-			log.Error("Error checking if update is available. err: %s", err)
-			fmt.Println(FailedCheckingUpdateAvailable)
-			return 1
-		}
-	}
-
-	// download klient and kd to approprite place
-	dlPaths := map[string]string{
-		// /opt/kite/klient/klient
-		filepath.Join(KlientDirectory, "klient"): config.S3Klient(klientVersion, klientChannel),
-
-		// /usr/local/bin/kd
-		filepath.Join(KlientctlDirectory, "kd"): config.S3Klientctl(kdVersion, kdChannel),
-	}
-
-	fmt.Println("Updating...")
-
-	for localPath, remotePath := range dlPaths {
-		if err := downloadRemoteToLocal(remotePath, localPath); err != nil {
-			log.Error("Error updating. err:%s", err)
-			fmt.Println(FailedDownloadUpdate)
-			return 1
-		}
+	if err := downloadRemoteToLocal(klientUrl, klientPath); err != nil {
+		log.Error("Error downloading klient. err:%s", err)
+		fmt.Println(FailedDownloadUpdate)
+		return 1
 	}
 
 	klientScript := filepath.Join(KlientDirectory, "klient.sh")
@@ -284,4 +308,33 @@ func checkUpdate() (bool, error) {
 	checkUpdate.ForceCheck = true
 
 	return checkUpdate.IsUpdateAvailable()
+}
+
+// parse a codegansta/cli context and return a slice of flag=value.
+func flagsFromContext(c *cli.Context) []string {
+	flags := []string{}
+
+	for _, flag := range c.FlagNames() {
+		// Only add the flag and value if the value is not a zero value.
+		if value := c.String(flag); !isStringZeroValue(value) {
+			flags = append(flags, fmt.Sprintf(`--%s="%s"`, flag, value))
+		}
+	}
+
+	return flags
+}
+
+// isStringZeroValue checks if the given string is a zero value in string form,
+// as would be returned by Context.String("flagName").
+func isStringZeroValue(s string) bool {
+	switch s {
+	case "":
+		return true
+	case "0":
+		return true
+	case "false":
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
This allows kd update to execute the new code, during the update
process. Ensuring migrations and etc can be done on immediately on
update.

Related: #8517
