### PR TITLE
Resource state modal: timeouts during software installation

### DIFF
--- a/client/app/lib/providers/resourcestatemodal/constants.coffee
+++ b/client/app/lib/providers/resourcestatemodal/constants.coffee
@@ -13,3 +13,4 @@ module.exports =
   MAX_BUILD_PROGRESS_VALUE              : 60
   DEFAULT_BUILD_DURATION                : 300
   TIMEOUT_DURATION                      : 120
+  MACHINE_PING_TIMEOUT                  : 5

--- a/client/app/lib/providers/resourcestatemodal/controllers/buildstackcontroller.coffee
+++ b/client/app/lib/providers/resourcestatemodal/controllers/buildstackcontroller.coffee
@@ -78,18 +78,17 @@ module.exports = class BuildStackController extends kd.Controller
 
   completeBuildProcess: ->
 
-    { MAX_BUILD_PROGRESS_VALUE, DEFAULT_BUILD_DURATION } = constants
-    { stack } = @getData()
+    { MAX_BUILD_PROGRESS_VALUE, DEFAULT_BUILD_DURATION, TIMEOUT_DURATION } = constants
+    { stack, stackTemplate } = @getData()
 
     @buildStackPage.setData { stack, file : @getLogFile() }
     @updateProgress  MAX_BUILD_PROGRESS_VALUE, 'Installing software...'
 
-    { stackTemplate } = @getData()
     duration = stackTemplate.config?.buildDuration ? DEFAULT_BUILD_DURATION
 
     @postBuildTimer = new ProgressUpdateTimer { duration }
     @postBuildTimer.on 'ProgressUpdated', @bound 'updatePostBuildProgress'
-    @timeoutChecker = new TimeoutChecker { duration : constants.TIMEOUT_DURATION }
+    @timeoutChecker = new TimeoutChecker { duration : TIMEOUT_DURATION }
     @timeoutChecker.on 'Timeout', @bound 'handleTimeout'
 
 
@@ -109,6 +108,7 @@ module.exports = class BuildStackController extends kd.Controller
     kite = machine.getBaseKite()
 
     @postBuildTimer.stop()
+    @timeoutChecker.stop()
 
     return @showError 'Machine doesn\'t respond'  unless kite.ping?
 

--- a/client/app/lib/providers/resourcestatemodal/controllers/buildstackcontroller.coffee
+++ b/client/app/lib/providers/resourcestatemodal/controllers/buildstackcontroller.coffee
@@ -129,8 +129,6 @@ module.exports = class BuildStackController extends kd.Controller
     container.showPage @errorPage
     @errorPage.setErrors [ err ]
 
-    @timeoutChecker.stop()
-
 
   showLogs: ->
 

--- a/client/app/lib/providers/resourcestatemodal/controllers/machineflowcontroller.coffee
+++ b/client/app/lib/providers/resourcestatemodal/controllers/machineflowcontroller.coffee
@@ -33,7 +33,7 @@ module.exports = class MachineFlowController extends kd.Controller
       .then (response) =>
         @onDataLoaded()
         @updateStatus
-          status     : response.Status
+          status     : response.State
           percentage : response.percentage
           eventId    : machineId
       .catch (err) =>

--- a/client/app/lib/providers/resourcestatemodal/controllers/progressupdatetimer.coffee
+++ b/client/app/lib/providers/resourcestatemodal/controllers/progressupdatetimer.coffee
@@ -29,3 +29,4 @@ module.exports = class ProgressUpdateTimer extends kd.Object
   stop: ->
 
     kd.utils.killWait @timer
+    @timer = null

--- a/client/app/lib/providers/resourcestatemodal/controllers/timeoutchecker.coffee
+++ b/client/app/lib/providers/resourcestatemodal/controllers/timeoutchecker.coffee
@@ -21,4 +21,8 @@ module.exports = class TimeoutChecker extends kd.Object
     { duration } = @getOptions()
     @timer = kd.utils.wait duration * 1000, @lazyBound 'emit', 'Timeout'
 
-  stop: -> kd.utils.killWait @timer
+
+  stop: ->
+
+    kd.utils.killWait @timer
+    @timer = null

--- a/client/app/lib/providers/resourcestatemodal/views/stackflow/buildstacktimeoutpageview.coffee
+++ b/client/app/lib/providers/resourcestatemodal/views/stackflow/buildstacktimeoutpageview.coffee
@@ -1,0 +1,47 @@
+kd = require 'kd'
+BaseErrorPageView = require '../baseerrorpageview'
+BuildStackHeaderView = require './buildstackheaderview'
+WizardSteps = require './wizardsteps'
+WizardProgressPane = require './wizardprogresspane'
+
+module.exports = class BuildStackTimeoutPageView extends BaseErrorPageView
+
+  constructor: (options = {}, data) ->
+
+    super options, data
+
+    { stack } = @getData()
+    @header   = new BuildStackHeaderView {}, stack
+
+    @progressPane = new WizardProgressPane
+      currentStep : WizardSteps.BuildStack
+
+    @startButton = new kd.ButtonView
+      title    : 'Start using My VM'
+      cssClass : 'GenericButton'
+      callback : @lazyBound 'emit', 'ClosingRequested'
+
+    @setErrors [
+      '''
+      Software installation is taking longer than expected. However, your machine is now ready to use.
+      Start using it and check the logs to look into the installation state.
+      '''
+    ]
+
+
+  pistachio: ->
+
+    '''
+      <div class="build-stack-flow error-page build-stack-timeout-page">
+        {{> @header}}
+        {{> @progressPane}}
+        <section class="main">
+          <h2>It timed out</h2>
+          <p>There was a timeout while installing your software.</p>
+          {{> @errorContainer}}
+        </section>
+        <footer>
+          {{> @startButton}}
+        </footer>
+      </div>
+    '''

--- a/client/app/lib/providers/resourcestatemodal/views/stackflow/buildstacktimeoutpageview.coffee
+++ b/client/app/lib/providers/resourcestatemodal/views/stackflow/buildstacktimeoutpageview.coffee
@@ -1,20 +1,11 @@
 kd = require 'kd'
 BaseErrorPageView = require '../baseerrorpageview'
-BuildStackHeaderView = require './buildstackheaderview'
-WizardSteps = require './wizardsteps'
-WizardProgressPane = require './wizardprogresspane'
 
 module.exports = class BuildStackTimeoutPageView extends BaseErrorPageView
 
   constructor: (options = {}, data) ->
 
     super options, data
-
-    { stack } = @getData()
-    @header   = new BuildStackHeaderView {}, stack
-
-    @progressPane = new WizardProgressPane
-      currentStep : WizardSteps.BuildStack
 
     @startButton = new kd.ButtonView
       title    : 'Start using My VM'
@@ -32,9 +23,7 @@ module.exports = class BuildStackTimeoutPageView extends BaseErrorPageView
   pistachio: ->
 
     '''
-      <div class="build-stack-flow error-page build-stack-timeout-page">
-        {{> @header}}
-        {{> @progressPane}}
+      <div class="error-page build-stack-timeout-page">
         <section class="main">
           <h2>It timed out</h2>
           <p>There was a timeout while installing your software.</p>

--- a/client/app/lib/providers/resourcestatemodal/views/stackflow/wizardprogresspane.coffee
+++ b/client/app/lib/providers/resourcestatemodal/views/stackflow/wizardprogresspane.coffee
@@ -12,7 +12,11 @@ module.exports = class WizardProgressPane extends kd.View
     @addSteps()
 
 
-  addAlien: -> @addSubView new kd.CustomHTMLView { cssClass : 'alien' }
+  addAlien: ->
+
+    @addSubView new kd.CustomHTMLView
+      tagName  : 'figure'
+      cssClass : 'alien'
 
 
   addSteps: ->

--- a/client/app/lib/providers/resourcestatemodal/views/stackflow/wizardsteps.coffee
+++ b/client/app/lib/providers/resourcestatemodal/views/stackflow/wizardsteps.coffee
@@ -18,5 +18,6 @@ module.exports = {
       require './buildstacksuccesspageview'
       require './buildstackerrorpageview'
       require './buildstacklogspageview'
+      require './buildstacktimeoutpageview'
     ]
 }

--- a/client/app/lib/providers/test/resourcestatemodal/credentialscontroller.test.coffee
+++ b/client/app/lib/providers/test/resourcestatemodal/credentialscontroller.test.coffee
@@ -7,11 +7,14 @@ CredentialsErrorPageView = require 'app/providers/resourcestatemodal/views/stack
 
 describe 'CredentialsController', ->
 
-  container    = null
-  stack        = { title : 'Test stack', status : { state : 'NotInitialized' } }
-  credentials  = { provider : 'aws', items : [] }
-  requirements = { provider : 'userInput', items : [] }
-  kdCmd        = ''
+  container     = null
+  stack         =
+    title       : 'Test stack'
+    status      : { state : 'NotInitialized' }
+    credentials : { custom : [ '123' ] }
+  credentials   = { provider : 'aws', items : [] }
+  requirements  = { provider : 'userInput', items : [] }
+  kdCmd         = ''
 
   beforeEach ->
 
@@ -128,17 +131,16 @@ describe 'CredentialsController', ->
       expect(activePane).toExist()
       expect(activePane.mainView instanceof CredentialsErrorPageView).toBeTruthy()
 
-    it 'should emit StartBuild event with passed identifiers', ->
+    it 'should emit StartBuild event with passed identifiers', (done) ->
 
-      identifiers = ['123', '456']
+      identifiers = [ { aws : [ '456' ] } ]
 
       controller = new CredentialsController { container }, stack
       controller.setup credentials, requirements, kdCmd
 
-      listener = { callback: kd.noop }
-      spy = expect.spyOn listener, 'callback'
+      controller.on 'StartBuild', (_identifiers) ->
+        expect(_identifiers['aws']).toEqual [ '456' ]
+        expect(_identifiers['custom']).toEqual [ '123' ]
+        done()
 
-      controller.on 'StartBuild', (_identifiers) -> listener.callback _identifiers
       controller.handleSubmitResult null, identifiers
-
-      expect(spy).toHaveBeenCalledWith identifiers

--- a/client/app/lib/providers/test/resourcestatemodal/instructionscontroller.test.coffee
+++ b/client/app/lib/providers/test/resourcestatemodal/instructionscontroller.test.coffee
@@ -8,6 +8,7 @@ StackTemplatePageView = require 'app/providers/resourcestatemodal/views/stackflo
 describe 'InstructionsController', ->
 
   stackTemplate = { description : 'Test template', template : { rawContent : 'test' } }
+  stack = { title : 'Test template stack' }
   container = null
 
   beforeEach ->
@@ -19,7 +20,7 @@ describe 'InstructionsController', ->
 
     it 'should show stack template page if readme page requests it', ->
 
-      controller = new InstructionsController { container }, stackTemplate
+      controller = new InstructionsController { container }, { stackTemplate, stack }
       controller.readmePage.emit 'StackTemplateRequested'
 
       activePane = container.getActivePane()
@@ -28,7 +29,7 @@ describe 'InstructionsController', ->
 
     it 'should show readme page if stack template page requests it', ->
 
-      controller = new InstructionsController { container }, stackTemplate
+      controller = new InstructionsController { container }, { stackTemplate, stack }
       controller.readmePage.emit 'StackTemplateRequested'
       controller.stackTemplatePage.emit 'ReadmeRequested'
 
@@ -38,7 +39,7 @@ describe 'InstructionsController', ->
 
     it 'requests next page from parent controller if readme or stack template pages ask for that', ->
 
-      controller = new InstructionsController { container }, stackTemplate
+      controller = new InstructionsController { container }, { stackTemplate, stack }
 
       listener = { callback: kd.noop }
       spy = expect.spyOn listener, 'callback'
@@ -56,7 +57,7 @@ describe 'InstructionsController', ->
 
     it 'should show readme page by default', ->
 
-      controller = new InstructionsController { container }, stackTemplate
+      controller = new InstructionsController { container }, { stackTemplate, stack }
       controller.show()
 
       activePane = container.getActivePane()

--- a/client/app/lib/providers/test/resourcestatemodal/machineflowcontroller.test.coffee
+++ b/client/app/lib/providers/test/resourcestatemodal/machineflowcontroller.test.coffee
@@ -122,9 +122,9 @@ describe 'MachineFlowController', ->
       expect(activePane).toExist()
       expect(activePane.mainView instanceof StartMachineProgressPageView).toBeTruthy()
 
-      { progressBar } = controller.startMachineProgressPage
+      { progressBar, statusText } = controller.startMachineProgressPage
       expect(progressBar.bar.getWidth()).toEqual percentage
-      expect(progressBar.darkLabel.getElement().innerHTML).toEqual "#{message}&nbsp;"
+      expect(statusText.getElement().innerHTML).toEqual message
 
     it 'should show progress page when machine is stopping', ->
 
@@ -140,9 +140,9 @@ describe 'MachineFlowController', ->
       expect(activePane).toExist()
       expect(activePane.mainView instanceof StopMachineProgressPageView).toBeTruthy()
 
-      { progressBar } = controller.stopMachineProgressPage
+      { progressBar, statusText } = controller.stopMachineProgressPage
       expect(progressBar.bar.getWidth()).toEqual percentage
-      expect(progressBar.darkLabel.getElement().innerHTML).toEqual "#{message}&nbsp;"
+      expect(statusText.getElement().innerHTML).toEqual message
 
     it 'should emit ResourceBecameRunning event if machine unexpectedly became running', ->
 

--- a/client/app/lib/styl/resourcestatemodal.styl
+++ b/client/app/lib/styl/resourcestatemodal.styl
@@ -670,6 +670,17 @@ $regularColor               = #989898
       height                356px
 
 
+  .build-stack-timeout-page
+
+    .error-container .error-content
+
+      .error-title
+        hidden()
+
+      p
+        padding-top         0
+
+
   .start-machine-page
 
     section.main


### PR DESCRIPTION
## Description

In case software installation process takes more time than expected (5 min by default or duration specified in `koding`  `buildDuration` section of stack template) we should not show regular build stack error screen with `Try Building Again` button since click on this button can break correct work of stack build. Instead, we can `ping` machine to check if it works fine and let user start using machine looking into the installation state in logs. To achieve it I introduce a new `Timeout` screen with `Start using your VM` button which should be shown when such timeout happens
Also, I added a couple of minor fixes:
- tag name of alien icon is changed to `figure`
- when current machine state is requested in `MachineFlowController`, wrong property `Status` was used to get machine status from response, it was fixed to use correct property `State`
## Motivation and Context

This change is intended to avoid breaking stack installation process when it takes a lot of time 
https://github.com/koding/koding/issues/8647
## How Has This Been Tested?

Manually
## Screenshots (if appropriate):

http://take.ms/Un3zM
http://recordit.co/q156BtjFVZ (see the beginning and end of the video)
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
