### PR TITLE
'Rename VM' feature is missing on vm settings modal

### DIFF
--- a/client/app/lib/flux/environment/actions.coffee
+++ b/client/app/lib/flux/environment/actions.coffee
@@ -769,6 +769,10 @@ unshareMachineWihAllUsers = (machineId) ->
 
     async.series queue, (err) -> if err then reject() else resolve()
 
+setLabel = (machineUId, label) ->
+
+  fetchMachineByUId machineUId, (machine) ->
+    machine.setLabel label
 
 
 module.exports = {
@@ -815,4 +819,5 @@ module.exports = {
   unshareMachineWithUser
   unshareMachineWihAllUsers
   disconnectMachine
+  setLabel
 }

--- a/client/app/lib/flux/environment/actions.coffee
+++ b/client/app/lib/flux/environment/actions.coffee
@@ -771,8 +771,11 @@ unshareMachineWihAllUsers = (machineId) ->
 
 setLabel = (machineUId, label) ->
 
-  fetchMachineByUId machineUId, (machine) ->
-    machine.setLabel label
+  new Promise (resolve, reject) ->
+    fetchMachineByUId machineUId, (machine) ->
+      machine.setLabel label, (err, newLabel) ->
+        return reject err  if err
+        resolve newLabel
 
 
 module.exports = {

--- a/client/home/lib/styl/homevirtualmachines.styl
+++ b/client/home/lib/styl/homevirtualmachines.styl
@@ -50,11 +50,20 @@ $borderColor                = #CACACA
         margin-right        0
 
     .MachinesListItem-machineLabel
-      flex                  1 0 auto
-      margin-left           22px
-      width                 144px
-      ellipsis()
-      pointer()
+      .kdinput.text
+        flex                0 1 auto
+        margin              -16px 0 0 18px
+        width               150px
+        padding-left        10px
+        ellipsis()
+        pointer()
+        border              1px solid transparent
+        border-radius       3px
+        box-shadow          none
+        cursor              text
+        &:hover
+        &:focus
+          border            1px solid #e3e3e3
 
     .SidebarListItem-progressbar
       abs                   76px 0 0 0px
@@ -134,10 +143,11 @@ $borderColor                = #CACACA
 
 
 .MachinesListItem-machineLabel
-  color                     $titleColor
-  font-size                 16px
-  font-weight               600
-  letter-spacing            .2px
+  .kdinput.text
+    color                     $titleColor
+    font-size                 16px
+    font-weight               600
+    letter-spacing            .2px
 
   &:before
     content                 ''

--- a/client/home/lib/styl/homevirtualmachines.styl
+++ b/client/home/lib/styl/homevirtualmachines.styl
@@ -50,8 +50,11 @@ $borderColor                = #CACACA
         margin-right        0
 
     .MachinesListItem-machineLabel
+      margin-right          18px
       .kdinput.text
         flex                0 1 auto
+        padding-top         7px
+        padding-bottom      7px
         margin              -16px 0 0 18px
         width               150px
         padding-left        10px
@@ -61,8 +64,10 @@ $borderColor                = #CACACA
         border-radius       3px
         box-shadow          none
         cursor              text
-        &:hover
+        pointer-events      none
+
         &:focus
+          pointer-events    auto
           border            1px solid #e3e3e3
 
     .SidebarListItem-progressbar
@@ -189,7 +194,15 @@ $borderColor                = #CACACA
         bg                  color $red
 
 
+.MachineListItem--Edit-name
+  margin-left               29px
+  font-size                 13px
+  color                     #67A2EE
+  width                     64px
+
 .MachineDetails
+
+  margin-top                -10px
 
   .GenericToggler
     font-size               14px

--- a/client/home/lib/virtualmachines/components/machineslist/listitem.coffee
+++ b/client/home/lib/virtualmachines/components/machineslist/listitem.coffee
@@ -5,7 +5,7 @@ Machine = require 'app/providers/machine'
 immutable = require 'immutable'
 VirtualMachinesSelectedMachineFlux = require 'home/virtualmachines/flux/selectedmachine'
 KDReactorMixin = require 'app/flux/base/reactormixin'
-
+EnvironmentFlux = require 'app/flux/environment'
 module.exports = class MachinesListItem extends React.Component
 
   @propTypes =
@@ -43,6 +43,14 @@ module.exports = class MachinesListItem extends React.Component
     return {
       selectedMachine: VirtualMachinesSelectedMachineFlux.getters.selectedMachine
     }
+
+  constructor: (props) ->
+
+    super props
+
+    @state =
+      machineLabel: @props.machine.get 'label'
+
 
 
   renderMachineDetails: ->
@@ -114,6 +122,31 @@ module.exports = class MachinesListItem extends React.Component
       <cite style={width: "#{percentage}%"} />
     </div>
 
+  setMachineLabel: ->
+
+    machineUId = @props.machine.get 'uid'
+    EnvironmentFlux.actions.setLabel machineUId, @state.machineLabel
+
+  inputOnChange: (event) ->
+
+    { value: machineLabel } = event.target
+    @setState { machineLabel: machineLabel }
+
+
+  renderStackTitle: ->
+
+    <div className="MachinesListItem-stackLabel">
+      <a href="#" className="HomeAppView--button primary">{@props.stack.get 'title'}</a>
+    </div>
+
+  inputOnBlur: (event) ->
+
+    @setMachineLabel()
+
+  inputOnKeyDown: (event) ->
+
+    if event.keyCode is 13
+      @refs.inputbox.blur()
 
   render: ->
 
@@ -134,9 +167,7 @@ module.exports = class MachinesListItem extends React.Component
           {@renderProgressbar()}
         </div>
         {@renderIpAddress()}
-        <div className="MachinesListItem-stackLabel">
-          <a href="#" className="HomeAppView--button primary">{@props.stack.get 'title'}</a>
-        </div>
+        {@renderStackTitle()}
         {@renderDetailToggle()}
       </header>
       {@renderMachineDetails()}

--- a/client/home/lib/virtualmachines/components/machineslist/listitem.coffee
+++ b/client/home/lib/virtualmachines/components/machineslist/listitem.coffee
@@ -122,11 +122,15 @@ module.exports = class MachinesListItem extends React.Component
     else ''
 
     <div className="MachinesListItem#{expanded}">
-      <header>
-        <div
-          className="MachinesListItem-machineLabel #{@props.machine.getIn ['status', 'state']}"
-          onClick={@bound 'toggle'}>
-          {@props.machine.get 'label'}
+      <header className='MachinesListItem-header'>
+        <div className="MachinesListItem-machineLabel #{@props.machine.getIn ['status', 'state']}">
+          <input
+            ref='inputbox'
+            value={@state.machineLabel}
+            className="kdinput text template-title autogrow"
+            onChange={@bound 'inputOnChange'}
+            onBlur={@bound 'inputOnBlur'}
+            onKeyDown={@bound 'inputOnKeyDown'} />
           {@renderProgressbar()}
         </div>
         {@renderIpAddress()}

--- a/client/home/lib/virtualmachines/components/machineslist/listitem.coffee
+++ b/client/home/lib/virtualmachines/components/machineslist/listitem.coffee
@@ -38,11 +38,13 @@ module.exports = class MachinesListItem extends React.Component
     onUnsharedWithUser     : kd.noop
     onDisconnectVM         : kd.noop
 
+
   getDataBindings: ->
 
     return {
       selectedMachine: VirtualMachinesSelectedMachineFlux.getters.selectedMachine
     }
+
 
   constructor: (props) ->
 
@@ -52,12 +54,10 @@ module.exports = class MachinesListItem extends React.Component
       machineLabel: @props.machine.get 'label'
 
 
-
   renderMachineDetails: ->
 
     return null  unless @props.shouldRenderDetails
     return null  unless @props.machine.get('label') is @state.selectedMachine
-
 
     <main className="MachinesListItem-machineDetails">
       <MachineDetails
@@ -75,6 +75,17 @@ module.exports = class MachinesListItem extends React.Component
         onDisconnectVM={@props.onDisconnectVM}
       />
     </main>
+
+
+  renderEditname: ->
+
+    return null  unless @props.shouldRenderDetails
+    return null  unless @props.machine.get('label') is @state.selectedMachine
+
+    <div className='MachineListItem--Edit-name' onClick={@bound 'onClickEditname'}>Edit Name </div>
+
+
+  onClickEditname: -> @refs.inputbox.focus()
 
 
   toggle: (event) ->
@@ -122,10 +133,17 @@ module.exports = class MachinesListItem extends React.Component
       <cite style={width: "#{percentage}%"} />
     </div>
 
+
   setMachineLabel: ->
 
     machineUId = @props.machine.get 'uid'
     EnvironmentFlux.actions.setLabel machineUId, @state.machineLabel
+      .then (label) =>
+        kd.singletons.router.handleRoute "/Home/Stacks/virtual-machines/#{@state.machineLabel}"
+      .catch (err) =>
+        @setState { machineLabel: @props.machine.get 'label' }
+        new kd.NotificationView { title: 'Something went wrong', duration: 2000 }
+
 
   inputOnChange: (event) ->
 
@@ -170,6 +188,7 @@ module.exports = class MachinesListItem extends React.Component
         {@renderStackTitle()}
         {@renderDetailToggle()}
       </header>
+      {@renderEditname()}
       {@renderMachineDetails()}
     </div>
 

--- a/client/home/lib/virtualmachines/components/machineslist/listitem.coffee
+++ b/client/home/lib/virtualmachines/components/machineslist/listitem.coffee
@@ -136,6 +136,10 @@ module.exports = class MachinesListItem extends React.Component
 
   setMachineLabel: ->
 
+    unless @state.machineLabel
+      @setState { machineLabel: @props.machine.get 'label'}
+      return
+
     machineUId = @props.machine.get 'uid'
     EnvironmentFlux.actions.setLabel machineUId, @state.machineLabel
       .then (label) =>

--- a/client/home/lib/virtualmachines/components/machineslist/listitem.coffee
+++ b/client/home/lib/virtualmachines/components/machineslist/listitem.coffee
@@ -182,7 +182,7 @@ module.exports = class MachinesListItem extends React.Component
           <input
             ref='inputbox'
             value={@state.machineLabel}
-            className="kdinput text template-title autogrow"
+            className="kdinput text"
             onChange={@bound 'inputOnChange'}
             onBlur={@bound 'inputOnBlur'}
             onKeyDown={@bound 'inputOnKeyDown'} />

--- a/client/stack-editor/lib/editor/index.coffee
+++ b/client/stack-editor/lib/editor/index.coffee
@@ -31,6 +31,7 @@ ContentModal = require 'app/components/contentModal'
 createShareModal = require './createShareModal'
 { actions : HomeActions } = require 'home/flux'
 isMine = require 'app/util/isMine'
+CustomLinkView = require 'app/customlinkview'
 
 module.exports = class StackEditorView extends kd.View
 
@@ -272,9 +273,13 @@ module.exports = class StackEditorView extends kd.View
         { changeTemplateTitle } = EnvironmentFlux.actions
         changeTemplateTitle stackTemplate?._id, e.target.value
 
+    @header.addSubView @editName = new CustomLinkView
+      cssClass: 'edit-name'
+      title: 'Edit Name'
+      click : =>
+        @inputTitle.setFocus()
 
     @header.addSubView @inputTitle = new kd.InputView options
-
 
     kd.singletons.reactor.observe valueGetter, (value) =>
 
@@ -287,6 +292,13 @@ module.exports = class StackEditorView extends kd.View
     @inputTitle.on 'viewAppended', =>
       @inputTitle.prepareClone()
       @inputTitle.resize()
+
+    @inputTitle.on 'blur', =>
+      @editName.show()
+
+    @inputTitle.on 'focus', =>
+      @inputTitle.resize()
+      @editName.hide()
 
 
   createOutputView: ->

--- a/client/stack-editor/lib/styl/stackeditorheader.styl
+++ b/client/stack-editor/lib/styl/stackeditorheader.styl
@@ -15,12 +15,13 @@ $borderColor                = #E3E3E3
   flex-flow                 row nowrap
   justify-content           space-around
   margin-bottom             33px
-  &:before
-    content                 ''
-    bg                      color #73C461
-    size                    10px 10px
-    abs                     61px 0 0 42px
-    rounded                 5px
+
+  .edit-name
+    color #67A2EE
+    text-decoration none
+    font-size 13px
+    font-weight 300
+    abs 81px 0 0 42px
 
   .buttons
     flex                    1 0 auto
@@ -34,13 +35,12 @@ $borderColor                = #E3E3E3
       display               none
 
 
-
   .kdinput.text
     flex                    0 1 auto
     font-size               20px
     display                 block
-    size                    auto 50px
-    padding                 10px 25px
+    size                    auto 42px
+    padding                 5px 0
     border                  1px solid transparent
     rounded                 3px
     color                   #424242
@@ -49,12 +49,18 @@ $borderColor                = #E3E3E3
     font-weight             400
     outline                 none
     shadow                  none
+    pointer-events          none
     &.isntMine
       opacity               .5
       pointer-events        none
 
-    &:focus
     &:hover
+      border                1px solid transparent
+
+    &:focus
+      pointer-events        auto
+      padding-left          10px
+      padding-right         10px
       outline               inherit
       bg                    color #FFFFFF
       border                1px solid $borderColor


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

User will be able to update machine name from virtual machine tab.
## Description

<!--- Describe your changes in detail -->

When user focus on any machine name on virtual machine, we will give user ability to update machine label and after user blur input box or hit enter we will update the machine name.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->
#8643
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

Go to virtual machine tab, edit any machine name then blur input box or hit enter. You will see updated machine name from both sidebar and the virtual machine tab.
## Screenshots (if appropriate):

http://recordit.co/rIBYZ2eZsL
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
