### PR TITLE
Onboarding Congrat Modal Styling is not loaded in some cases

### DIFF
--- a/client/app/lib/styl/onboardingcongratmodal.styl
+++ b/client/app/lib/styl/onboardingcongratmodal.styl
@@ -1,6 +1,6 @@
 @css {
 /*
-Home OnBoarding Congrat Modal styles
+OnBoarding Congrat Modal styles
 */
 }
 .kdmodal.Congratulation-modal


### PR DESCRIPTION
Onboarding Congrat Modal has style anymore.
## Description

because of home app's styles doesn't loaded yet sometimes onboarding congrat modal styling is showed without styling. I just moved that styling file to app module.
## Motivation and Context
#8683
## How Has This Been Tested?

WIP
## Screenshots (if appropriate):
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
