### PR TITLE
Team permissions for Stack creation and see/list members

### DIFF
--- a/client/app/lib/components/sidebarstacksection/sidebarnostacks.coffee
+++ b/client/app/lib/components/sidebarstacksection/sidebarnostacks.coffee
@@ -1,8 +1,26 @@
 React = require 'kd-react'
 Link  = require 'app/components/common/link'
+canCreateStacks = require 'app/util/canCreateStacks'
+isAdmin = require 'app/util/isAdmin'
 
 
 module.exports = class SidebarNoStacks extends React.Component
+
+  renderMessage: ->
+    if canCreateStacks()
+      <p>
+        Your stacks has not been
+        fully configured yet, please
+        finalize onboarding steps.
+      </p>
+    else
+      <p>
+        Your stacks has not been
+        fully configured yet, please
+        wait until your admin sets
+        them up for you.
+      </p>
+
 
 
   render: ->
@@ -13,11 +31,7 @@ module.exports = class SidebarNoStacks extends React.Component
       </Link>
       <section className='SidebarSection SidebarStackSection SidebarStackWidgets'>
         <div className='SidebarSection-body'>
-          <p>
-            Your stacks has not been
-            fully configured yet, please
-            finalize onboarding steps.
-          </p>
+          {@renderMessage()}
         </div>
       </section>
     </div>

--- a/client/app/lib/nostackfoundview.coffee
+++ b/client/app/lib/nostackfoundview.coffee
@@ -64,7 +64,7 @@ module.exports = class NoStackFoundView extends ReactView
       <div className="NoStackFoundView-wrapper">
         <h2>Your Team Stack is Pending</h2>
         <p>
-          Your team admins haven't created your stack yet. If you want to experiment
+          Your team admins haven&apos;t created your stack yet. If you want to experiment
           the stacks you can go ahead and create a personal stack.
           We will guide you through setting up a stack on Koding. You can read more
           information about stacks <a href="https://www.koding.com/docs/creating-an-aws-stack">here</a>.

--- a/client/app/lib/nostackfoundview.coffee
+++ b/client/app/lib/nostackfoundview.coffee
@@ -2,6 +2,8 @@ kd = require 'kd'
 React = require 'kd-react'
 globals = require 'globals'
 ReactView = require 'app/react/reactview'
+canCreateStacks = require 'app/util/canCreateStacks'
+isAdmin = require 'app/util/isAdmin'
 
 module.exports = class NoStackFoundView extends ReactView
 
@@ -27,12 +29,12 @@ module.exports = class NoStackFoundView extends ReactView
 
   renderReact: ->
 
-    { groupsController, computeController, mainView } = kd.singletons
+    { computeController, mainView } = kd.singletons
 
     return <div/>  unless globals.userRoles
     return <div/>  if mainView.introVideoViewIsShown
 
-    if groupsController.canEditGroup()
+    if isAdmin()
 
       <div className="NoStackFoundView-wrapper">
         <h2>Create a stack for your team</h2>
@@ -44,6 +46,17 @@ module.exports = class NoStackFoundView extends ReactView
         <div className='ButtonContainer'>
           <button className='GenericButton' onClick={@bound 'onClick'}>CREATE A TEAM STACK</button>
         </div>
+      </div>
+
+    else if not canCreateStacks()
+
+      <div className="NoStackFoundView-wrapper">
+        <h2>Your Team Stack is Pending</h2>
+        <p>
+          Your team admins haven&apos;t created your stack yet.
+          Unfortunately there is not much you can do at this moment.
+          Please contact your team admin.
+        </p>
       </div>
 
     else

--- a/client/app/lib/util/canCreateStacks.coffee
+++ b/client/app/lib/util/canCreateStacks.coffee
@@ -1,0 +1,5 @@
+kd = require 'kd'
+isAdmin = require 'app/util/isAdmin'
+
+module.exports = canCreateStacks = ->
+  isAdmin() or !!kd.singletons.groupsController.getCurrentGroup().customize?.membersCanCreateStacks

--- a/client/app/lib/util/canCreateStacks.coffee
+++ b/client/app/lib/util/canCreateStacks.coffee
@@ -1,5 +1,5 @@
 kd = require 'kd'
-isAdmin = require 'app/util/isAdmin'
+getGroup = require 'app/util/getGroup'
 
 module.exports = canCreateStacks = ->
-  isAdmin() or !!kd.singletons.groupsController.getCurrentGroup().customize?.membersCanCreateStacks
+  isAdmin() or !!getGroup().customize?.membersCanCreateStacks

--- a/client/app/lib/util/canSeeMembers.coffee
+++ b/client/app/lib/util/canSeeMembers.coffee
@@ -1,4 +1,4 @@
-kd = require 'kd'
+getGroup = require 'app/util/getGroup'
 
 module.exports = canSeeMembers = ->
-  !kd.singletons.groupsController.getCurrentGroup().customize?.hideTeamMembers
+  !getGroup().customize?.hideTeamMembers

--- a/client/app/lib/util/canSeeMembers.coffee
+++ b/client/app/lib/util/canSeeMembers.coffee
@@ -1,0 +1,4 @@
+kd = require 'kd'
+
+module.exports = canSeeMembers = ->
+  !kd.singletons.groupsController.getCurrentGroup().customize?.hideTeamMembers

--- a/client/app/lib/util/isAdmin.coffee
+++ b/client/app/lib/util/isAdmin.coffee
@@ -1,0 +1,3 @@
+kd = require 'kd'
+
+module.exports = isAdmin = -> kd.singletons.groupsController.canEditGroup()

--- a/client/app/lib/util/teamHasStack.coffee
+++ b/client/app/lib/util/teamHasStack.coffee
@@ -1,0 +1,3 @@
+kd = require 'kd'
+
+module.exports = teamHasStack = -> !!kd.singletons.groupsController.getCurrentGroup().stackTemplates?.length

--- a/client/app/lib/util/teamHasStack.coffee
+++ b/client/app/lib/util/teamHasStack.coffee
@@ -1,3 +1,3 @@
-kd = require 'kd'
+getGroup = require 'app/util/getGroup'
 
-module.exports = teamHasStack = -> !!kd.singletons.groupsController.getCurrentGroup().stackTemplates?.length
+module.exports = teamHasStack = -> !!getGroup().stackTemplates?.length

--- a/client/home/lib/flux/getters.coffee
+++ b/client/home/lib/flux/getters.coffee
@@ -1,6 +1,7 @@
 kd = require 'kd'
 welcomeStepsAll = [ 'WelcomeStepsStore' ]
 EnvironmentFlux = require 'app/flux/environment'
+canCreateStacks = require 'app/util/canCreateStacks'
 isAdmin = require 'app/util/isAdmin'
 teamHasStack = require 'app/util/teamHasStack'
 
@@ -29,6 +30,10 @@ welcomeSteps = [
         steps = steps.delete 'stackCreation'
     else
       steps = steps.delete 'buildStack'  unless isAdmin()
+
+    unless canCreateStacks()
+      steps = steps.delete 'stackCreation'
+      steps = steps.delete 'installKd'
 
     return steps.sortBy (a) -> a.get('order')
 ]

--- a/client/home/lib/flux/getters.coffee
+++ b/client/home/lib/flux/getters.coffee
@@ -1,13 +1,8 @@
 kd = require 'kd'
 welcomeStepsAll = [ 'WelcomeStepsStore' ]
 EnvironmentFlux = require 'app/flux/environment'
-
-teamHasStack = ->
-  kd.singletons.groupsController.getCurrentGroup().stackTemplates?.length
-
-isAdmin = ->
-  kd.singletons.groupsController.canEditGroup()
-
+isAdmin = require 'app/util/isAdmin'
+teamHasStack = require 'app/util/teamHasStack'
 
 welcomeStepsByRole = [
   EnvironmentFlux.getters.stacks

--- a/client/home/lib/myteam/components/hometeampermissions/container.coffee
+++ b/client/home/lib/myteam/components/hometeampermissions/container.coffee
@@ -1,0 +1,46 @@
+kd              = require 'kd'
+React           = require 'kd-react'
+TeamFlux        = require 'app/flux/teams'
+KDReactorMixin  = require 'app/flux/base/reactormixin'
+View            = require './view'
+showError       = require 'app/util/showError'
+
+notify = (title, duration = 5000) -> new kd.NotificationView { title, duration }
+
+module.exports = class HomeTeamPermissionsContainer extends React.Component
+
+  getDataBindings: ->
+    return {
+      team: TeamFlux.getters.team
+    }
+
+  componentDidMount: ->
+
+  updateTeam: (permission, state) ->
+
+    customize = @state.team.get 'customize'
+    customize = if customize then customize.toJS() else {}
+
+    if state
+      customize[permission] = on
+    else
+      delete customize[permission]
+
+    dataToUpdate = { customize }
+
+    TeamFlux.actions.updateTeam(dataToUpdate).then ({ message }) =>
+      @setState { permission: state }
+    .catch ({ message }) -> @setState { permission: not state }
+
+
+  render: ->
+
+    <View
+      ref='view'
+      team={@state.team}
+      canCreateStacks={@state.team.getIn ['customize', 'membersCanCreateStacks']}
+      seeTeamMembers={not @state.team.getIn ['customize', 'hideTeamMembers']}
+      onToggle={@bound 'updateTeam'}/>
+
+
+HomeTeamPermissionsContainer.include [KDReactorMixin]

--- a/client/home/lib/myteam/components/hometeampermissions/index.coffee
+++ b/client/home/lib/myteam/components/hometeampermissions/index.coffee
@@ -1,0 +1,2 @@
+module.exports           = require './view'
+module.exports.Container = require './container'

--- a/client/home/lib/myteam/components/hometeampermissions/view.coffee
+++ b/client/home/lib/myteam/components/hometeampermissions/view.coffee
@@ -1,0 +1,33 @@
+kd     = require 'kd'
+React  = require 'kd-react'
+Toggle = require 'app/components/common/toggle'
+
+module.exports = class HomeTeamPermissionsView extends React.Component
+
+  render: ->
+
+    <div>
+      <div className='Permissions-Line'>
+        <ToggleButton
+          checked={@props.canCreateStacks}
+          callback={@props.onToggle.bind this, 'membersCanCreateStacks'} />
+        <p className='primary'>
+          <strong>Stack Creation</strong>
+          Enable team members to create stacks
+        </p>
+      </div>
+      <div className='Permissions-Line'>
+        <ToggleButton
+          checked={@props.seeTeamMembers}
+          callback={(state) => @props.onToggle 'hideTeamMembers', not state} />
+        <p className='primary'>
+          <strong>See/Invite team members</strong>
+          Enable team members to see/invite other members
+        </p>
+      </div>
+    </div>
+
+
+ToggleButton = ({ checked, callback }) ->
+
+  <Toggle checked={checked} className='OnOffButton' callback={callback} />

--- a/client/home/lib/myteam/hometeampermissions.coffee
+++ b/client/home/lib/myteam/hometeampermissions.coffee
@@ -1,0 +1,10 @@
+kd = require 'kd'
+React = require 'kd-react'
+ReactView = require 'app/react/reactview'
+
+TeamPermissions = require './components/hometeampermissions'
+
+module.exports = class HomeTeamPermissions extends ReactView
+
+  renderReact: ->
+    <TeamPermissions.Container />

--- a/client/home/lib/myteam/index.coffee
+++ b/client/home/lib/myteam/index.coffee
@@ -3,18 +3,21 @@ HomeTeamConnectSlack = require './hometeamconnectslack'
 HomeTeamSendInvites  = require './hometeamsendinvites'
 HomeTeamTeammates    = require './hometeamteammates'
 HomeTeamSettings     = require './hometeamsettings'
+HomeTeamPermissions  = require './hometeampermissions'
 TeamFlux             = require 'app/flux/teams'
 AppFlux              = require 'app/flux'
 whoami               = require 'app/util/whoami'
 remote               = require('app/remote').getInstance()
 camilizeString = require 'app/util/camelizeString'
 toImmutable = require 'app/util/toImmutable'
+isAdmin = require 'app/util/isAdmin'
 
 SECTIONS =
   'Invite Using Slack' : HomeTeamConnectSlack
   'Send Invites'       : HomeTeamSendInvites
   Teammates            : HomeTeamTeammates
   'Team Settings'      : HomeTeamSettings
+  Permissions          : HomeTeamPermissions
 
 header = (title) ->
   new kd.CustomHTMLView
@@ -120,6 +123,9 @@ module.exports = class HomeMyTeam extends kd.CustomScrollView
 
     @wrapper.addSubView header  'Send Invites'
     @wrapper.addSubView @sendInvites = section 'Send Invites'
+    if isAdmin()
+      @wrapper.addSubView header  'Permissions'
+      @wrapper.addSubView @permissions = section 'Permissions'
 
 
     @wrapper.addSubView header  'Invite Using Slack'

--- a/client/home/lib/myteam/index.coffee
+++ b/client/home/lib/myteam/index.coffee
@@ -10,6 +10,7 @@ whoami               = require 'app/util/whoami'
 remote               = require('app/remote').getInstance()
 camilizeString = require 'app/util/camelizeString'
 toImmutable = require 'app/util/toImmutable'
+canSeeMembers = require 'app/util/canSeeMembers'
 isAdmin = require 'app/util/isAdmin'
 
 SECTIONS =
@@ -121,18 +122,20 @@ module.exports = class HomeMyTeam extends kd.CustomScrollView
     @wrapper.addSubView header  'Team Settings'
     @wrapper.addSubView @teamSettings = section 'Team Settings'
 
-    @wrapper.addSubView header  'Send Invites'
-    @wrapper.addSubView @sendInvites = section 'Send Invites'
     if isAdmin()
       @wrapper.addSubView header  'Permissions'
       @wrapper.addSubView @permissions = section 'Permissions'
 
+    if isAdmin() or canSeeMembers()
 
-    @wrapper.addSubView header  'Invite Using Slack'
-    @wrapper.addSubView @connectSlack = section 'Invite Using Slack'
-    @connectSlack.on 'InvitationsAreSent', -> TeamFlux.actions.loadPendingInvitations()
+      @wrapper.addSubView header  'Send Invites'
+      @wrapper.addSubView @sendInvites = section 'Send Invites'
 
-    @wrapper.addSubView header  'Teammates'
-    @wrapper.addSubView @teammates = section 'Teammates'
+      @wrapper.addSubView header  'Invite Using Slack'
+      @wrapper.addSubView @connectSlack = section 'Invite Using Slack'
+      @connectSlack.on 'InvitationsAreSent', -> TeamFlux.actions.loadPendingInvitations()
+
+      @wrapper.addSubView header  'Teammates'
+      @wrapper.addSubView @teammates = section 'Teammates'
 
     @scrollToSectionArea()

--- a/client/home/lib/stacks/index.coffee
+++ b/client/home/lib/stacks/index.coffee
@@ -19,6 +19,9 @@ EnvironmentFlux = require 'app/flux/environment'
 AddManagedMachineModal = require 'app/providers/managed/addmanagedmachinemodal'
 VirtualMachinesSelectedMachineFlux = require 'home/virtualmachines/flux/selectedmachine'
 
+canCreateStacks = require 'app/util/canCreateStacks'
+isAdmin = require 'app/util/isAdmin'
+
 module.exports = class HomeStacks extends kd.CustomScrollView
 
   constructor: (options = {}, data) ->
@@ -105,11 +108,12 @@ module.exports = class HomeStacks extends kd.CustomScrollView
     actions.loadTeamStackTemplates()
     actions.loadPrivateStackTemplates()
 
-    @stacks.addSubView view = new HomeStacksCreate
+    if canCreateStacks()
+      @stacks.addSubView view = new HomeStacksCreate
 
-    view.on 'CreateButtonClick', =>
-      @destroy()
-      kd.singletons.router.handleRoute '/Stack-Editor/New'
+      view.on 'CreateButtonClick', =>
+        @destroy()
+        kd.singletons.router.handleRoute '/Stack-Editor/New'
 
     @stacks.addSubView headerize 'Team Stacks'
     @stacks.addSubView sectionize 'Team Stacks', HomeStacksTeamStacks, { delegate : this }

--- a/client/home/lib/styl/homekodingutilities.styl
+++ b/client/home/lib/styl/homekodingutilities.styl
@@ -42,6 +42,7 @@ welcome.styl
 
 .HomeAppView--section.koding-button
 .HomeAppView--section.customer-feedback
+.HomeAppView--section.permissions
 .HomeAppView--section.intercom-integration
   z-index                   1
   rel()

--- a/client/home/lib/styl/homekodingutilities.styl
+++ b/client/home/lib/styl/homekodingutilities.styl
@@ -46,9 +46,9 @@ welcome.styl
   z-index                   1
   rel()
 
-  .TryOnKoding-onOffButton
+  .OnOffButton
     abs                     47px 36px
-  input.TryOnKoding-onOffButton
+  input.OnOffButton
     hidden()
 
   .primary

--- a/client/home/lib/styl/homemyteam.styl
+++ b/client/home/lib/styl/homemyteam.styl
@@ -62,6 +62,15 @@ homemyteam.styl
       .HomeAppView--button.fr
         margin-right  16px
 
+.HomeAppView--section.permissions
+  .Permissions-Line
+    margin-bottom           20px
+    rel()
+    &:last-child
+      margin-bottom         0
+
+    .OnOffButton
+      abs                   14px 0px
 
 
 .HomeAppView--uploadLogo

--- a/client/home/lib/utilities/components/tryonkoding/view.coffee
+++ b/client/home/lib/utilities/components/tryonkoding/view.coffee
@@ -52,7 +52,7 @@ ToggleButton = ({ checked, callback, canEdit }) ->
 
   return <span></span>  unless canEdit
 
-  <Toggle checked={checked} className='TryOnKoding-onOffButton' callback={callback} />
+  <Toggle checked={checked} className='TryOnKoding-onOffButton OnOffButton' callback={callback} />
 
 
 Primary = ({ className }) ->

--- a/client/stack-editor/lib/editor/index.coffee
+++ b/client/stack-editor/lib/editor/index.coffee
@@ -32,6 +32,7 @@ createShareModal = require './createShareModal'
 { actions : HomeActions } = require 'home/flux'
 isMine = require 'app/util/isMine'
 CustomLinkView = require 'app/customlinkview'
+isAdmin = require 'app/util/isAdmin'
 
 module.exports = class StackEditorView extends kd.View
 
@@ -56,7 +57,7 @@ module.exports = class StackEditorView extends kd.View
 
       { groupsController } = kd.singletons
 
-      @isMine = groupsController.canEditGroup() or isMine(stackTemplate)
+      @isMine = isAdmin() or isMine(stackTemplate)
 
       if not @isMine and stackTemplate
         @tabView.setClass 'StackEditorTabs isntMine'
@@ -431,8 +432,6 @@ module.exports = class StackEditorView extends kd.View
 
   afterProcessTemplate: (method) ->
 
-    canEditGroup = kd.singletons.groupsController.canEditGroup()
-
     switch method
       when 'initialize'
         @generateStackButton.show()
@@ -461,7 +460,6 @@ module.exports = class StackEditorView extends kd.View
   processTemplate: (stackTemplate) ->
 
     { groupsController, computeController } = kd.singletons
-    canEditGroup = groupsController.canEditGroup()
 
     @handleCheckTemplate { stackTemplate }, (err, machines) =>
 
@@ -487,7 +485,7 @@ module.exports = class StackEditorView extends kd.View
       # stacktemplates set for a team this will be broken ~ GG
 
       if hasStack
-        if canEditGroup
+        if isAdmin()
           # admin is editing a team stack
           if stackTemplate.isDefault
             @_handleSetDefaultTemplate =>

--- a/client/stack-editor/lib/routehandler.coffee
+++ b/client/stack-editor/lib/routehandler.coffee
@@ -6,7 +6,7 @@ isAdmin = require 'app/util/isAdmin'
 module.exports = -> lazyrouter.bind 'stackeditor', (type, info, state, path, ctx) ->
 
   unless canCreateStacks()
-    new kd.NotificationView title: 'You are not allowed to create stacks!'
+    new kd.NotificationView { title: 'You are not allowed to create stacks!' }
     return kd.singletons.router.back()
 
   kd.singletons.appManager.open 'Stackeditor', (app) ->

--- a/client/stack-editor/lib/routehandler.coffee
+++ b/client/stack-editor/lib/routehandler.coffee
@@ -1,8 +1,13 @@
 kd = require 'kd'
 lazyrouter = require 'app/lazyrouter'
-
+canCreateStacks = require 'app/util/canCreateStacks'
+isAdmin = require 'app/util/isAdmin'
 
 module.exports = -> lazyrouter.bind 'stackeditor', (type, info, state, path, ctx) ->
+
+  unless canCreateStacks()
+    new kd.NotificationView title: 'You are not allowed to create stacks!'
+    return kd.singletons.router.back()
 
   kd.singletons.appManager.open 'Stackeditor', (app) ->
 


### PR DESCRIPTION
## Description

This change puts two settings in Dashboard>My Team:
- Enable team members to create stacks
- Enable team members to see/invite other members
## Motivation and Context
- Public teams may not want to show all members to everyone for privacy concerns.
- Teams(esp. for software trials) may not want their members to create stacks to avoid high cloud provider costs.
## How Has This Been Tested?

Tested all scenarios, for every state.
## Screenshots (if appropriate):

![gif](http://g.recordit.co/QtiEFo9dGA.gif)
full: http://recordit.co/QtiEFo9dGA
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
