### PR TITLE
After saving the Stack Template, Editing Stack from Sidebar menu widget show Previous Stack Template

### DIFF
--- a/client/app/lib/components/sidebar/index.coffee
+++ b/client/app/lib/components/sidebar/index.coffee
@@ -94,7 +94,7 @@ module.exports = class Sidebar extends React.Component
       when 'Edit' then router.handleRoute "/Stack-Editor/#{id}"
       when 'Initialize'
         EnvironmentFlux.actions.generateStack(id).then ({ template }) ->
-          kd.singletons.appManager.tell 'Stackeditor', 'reloadEditor', template
+          kd.singletons.appManager.tell 'Stackeditor', 'reloadEditor', template._id
 
 
 

--- a/client/app/lib/components/sidebarstacksection/index.coffee
+++ b/client/app/lib/components/sidebarstacksection/index.coffee
@@ -78,7 +78,7 @@ module.exports = class SidebarStackSection extends React.Component
       when 'Reinitialize', 'Update'
         reinitStackFromWidget(stack).then ->
           # invalidate editor cache
-          appManager.tell 'Stackeditor', 'reloadEditor', stack.get('baseTemplate').toJS()
+          appManager.tell 'Stackeditor', 'reloadEditor', templateId
       when 'Destroy VMs' then deleteStack { stack }
       when 'VMs' then router.handleRoute "/Home/Stacks/virtual-machines"
 

--- a/client/app/lib/components/sidebarstacksection/stackupdatedwidget.coffee
+++ b/client/app/lib/components/sidebarstacksection/stackupdatedwidget.coffee
@@ -23,8 +23,9 @@ module.exports = class StackUpdatedWidget extends React.Component
 
   handleOnClick : ->
     { appManager, router } = kd.singletons
-    appManager.tell 'Stackeditor', 'reloadEditor', @props.stack.get('baseTemplate').toJS()
-    actions.reinitStackFromWidget @props.stack
+    { templateId } =  @props.stack.get('baseTemplate').toJS()
+    actions.reinitStackFromWidget(@props.stack).then ->
+      appManager.tell 'Stackeditor', 'reloadEditor', templateId
 
 
   handleOnClose: ->

--- a/client/app/lib/flux/environment/actions.coffee
+++ b/client/app/lib/flux/environment/actions.coffee
@@ -599,6 +599,20 @@ updateStackTemplate = (stackTemplate, options) ->
       reactor.dispatch actions.UPDATE_STACK_TEMPLATE_SUCCESS, successPayload
       resolve successPayload
 
+fetchAndUpdateStackTemplate = (templateId) ->
+
+  { computeController, reactor } = kd.singletons
+  reactor.dispatch actions.UPDATE_STACK_TEMPLATE_BEGIN
+
+  new Promise (resolve, reject) ->
+    computeController.fetchStackTemplate templateId, (err, stackTemplate) ->
+      if err
+        reactor.dispatch actions.UPDATE_STACK_TEMPLATE_FAIL, { err }
+        reject err
+        return
+
+      reactor.dispatch actions.UPDATE_STACK_TEMPLATE_SUCCESS, { stackTemplate }
+      resolve stackTemplate
 
 generateStack = (stackTemplateId) ->
 
@@ -823,4 +837,5 @@ module.exports = {
   unshareMachineWihAllUsers
   disconnectMachine
   setLabel
+  fetchAndUpdateStackTemplate
 }

--- a/client/stack-editor/lib/index.coffee
+++ b/client/stack-editor/lib/index.coffee
@@ -140,7 +140,7 @@ module.exports = class StackEditorAppController extends AppController
 
     { computeController } = kd.singletons
 
-    computeController.fetchStackTemplate templateId, (err, template) =>
+    EnvironmentFlux.actions.fetchAndUpdateStackTemplate templateId, (template) =>
       @removeEditor template._id
       @showView template
 

--- a/client/stack-editor/lib/index.coffee
+++ b/client/stack-editor/lib/index.coffee
@@ -136,10 +136,13 @@ module.exports = class StackEditorAppController extends AppController
     editor?.destroy()
 
 
-  reloadEditor: (template) ->
+  reloadEditor: (templateId) ->
 
-    @removeEditor template._id
-    @showView template
+    { computeController } = kd.singletons
+
+    computeController.fetchStackTemplate templateId, (err, template) =>
+      @removeEditor template._id
+      @showView template
 
 
   createEditor: (stackTemplate) ->

--- a/client/stack-editor/lib/index.coffee
+++ b/client/stack-editor/lib/index.coffee
@@ -106,7 +106,7 @@ module.exports = class StackEditorAppController extends AppController
 
     unless @editors[id]
       @editors[id] = editor = @createEditor stackTemplate
-      editor.on 'Reload', @lazyBound 'reloadEditor', stackTemplate
+      editor.on 'Reload', @lazyBound 'reloadEditor', stackTemplate._id
       @mainView.addSubView editor
 
     return  unless editor = @editors[id]


### PR DESCRIPTION
After you save the stack template if you click to edit from sidebar it was showing previous state.

<!--- Describe your changes in detail -->

Edit reloadEditor function to accept stack template id and fetch current stack template.
## Motivation and Context
#8793
## How Has This Been Tested?

Edit stack template -> save -> edit once again from sidebar or any where you will see up to date stack template.
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
