### PR TITLE
klient: removed unix size check

### DIFF
--- a/go/src/koding/klient/app/klient.go
+++ b/go/src/koding/klient/app/klient.go
@@ -346,6 +346,7 @@ func (k *Klient) RegisterMethods() {
 	k.kite.HandleFunc("fs.move", fs.Move)
 	k.kite.HandleFunc("fs.copy", fs.Copy)
 	k.kite.HandleFunc("fs.getDiskInfo", fs.GetDiskInfo)
+	k.kite.HandleFunc("fs.getPathSize", fs.GetPathSize)
 
 	// Vagrant
 	k.kite.HandleFunc("vagrant.create", k.vagrant.Create)

--- a/go/src/koding/klient/remote/cache.go
+++ b/go/src/koding/klient/remote/cache.go
@@ -96,14 +96,14 @@ func (r *Remote) CacheFolderHandler(kreq *kite.Request) (interface{}, error) {
 		}
 	}
 
-	var remoteSize int
+	var remoteSize int64
 	if params.LocalToRemote {
 		remoteSize, err = getSizeOfLocalPath(params.LocalPath)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		remoteSize, err = getSizeOfRemoteFolder(remoteMachine, params.RemotePath)
+		remoteSize, err = remoteMachine.GetFolderSize(params.RemotePath)
 		if err != nil {
 			return nil, err
 		} else {

--- a/go/src/koding/klient/remote/rsync/rsync.go
+++ b/go/src/koding/klient/remote/rsync/rsync.go
@@ -38,7 +38,7 @@ type SyncOpts struct {
 	SSHPrivateKeyPath string `json:"sshPrivateKeyPath"`
 	RemoteDir         string `json:"remoteDir"`
 	LocalDir          string `json:"localDir"`
-	DirSize           int    `json:"dirSize"`
+	DirSize           int64  `json:"dirSize"`
 	LocalToRemote     bool   `json:"localToRemote"`
 	IgnoreFile        string `json:"ignoreFile"`
 	IncludePath       bool   `json:"includePath"`

--- a/go/src/koding/klient/remote/size.go
+++ b/go/src/koding/klient/remote/size.go
@@ -13,9 +13,6 @@ import (
 )
 
 // GetPathSize gets the size of a remote path.
-//
-// NOTE: This implementation is the same as what mountFolder is using. A more
-// robust one should be implemented on the remote klient. Eg, fs.getSize, etc.
 func (r *Remote) GetPathSize(kreq *kite.Request) (interface{}, error) {
 	log := logging.NewLogger("remote").New("remote.getPathSize")
 
@@ -85,9 +82,10 @@ func (r *Remote) GetPathSize(kreq *kite.Request) (interface{}, error) {
 		return nil, mount.ErrRemotePathDoesNotExist
 	}
 
-	size, err := getSizeOfRemoteFolder(remoteMachine, opts.RemotePath)
+	size, err := remoteMachine.GetFolderSize(opts.RemotePath)
 	if err != nil {
 		log.Error("Failed to get remote size. path:%s, err:%s", opts.RemotePath, err)
 	}
+
 	return size, err
 }


### PR DESCRIPTION
Path size checking in KD was using unix tools, blocking windows support.
