### PR TITLE
client: removing shadow from highlighted menu item

### DIFF
--- a/client/app/lib/components/sidebar/styl/sidebarmenu.styl
+++ b/client/app/lib/components/sidebar/styl/sidebarmenu.styl
@@ -16,6 +16,7 @@
     font-weight             300
     font-size               14px
     padding                 14px 25px
+    text-shadow             none
     borderBox()
 
     &:first-of-type
@@ -28,7 +29,6 @@
     &:hover
       bg                    color, #F3F3F3
       color                 #4BAF60
-      text-shadow           none
 
   .kdlistitemview-contextitem.custom-view
     bg                      color, #FBFBFB


### PR DESCRIPTION
## Description

Currently, menu items on stack menu have had shadow before exiting.
## Motivation and Context

Fixes #8810 
## How Has This Been Tested?

Manually
## Screenshots (if appropriate):

![image](http://g.recordit.co/hfrgatNA48.gif)
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
