### PR TITLE
provider/aws: set region field for all machines in plan response

### DIFF
--- a/go/src/koding/kites/kloud/provider/aws/plan.go
+++ b/go/src/koding/kites/kloud/provider/aws/plan.go
@@ -130,6 +130,14 @@ func (s *Stack) Plan(ctx context.Context) (interface{}, error) {
 
 	s.Log.Debug("Machines planned to be created: %+v", machines)
 
+	if region != "" {
+		// Update Region for all the machine. See inline
+		// doc for the field.
+		for _, m := range machines {
+			m.Region = region
+		}
+	}
+
 	return &kloud.PlanResponse{
 		Machines: machines.Slice(),
 	}, nil

--- a/go/src/koding/kites/kloud/provider/vagrant/plan.go
+++ b/go/src/koding/kites/kloud/provider/vagrant/plan.go
@@ -56,7 +56,8 @@ func (s *Stack) Plan(ctx context.Context) (interface{}, error) {
 
 	s.Log.Debug("Injecting Vagrant data")
 
-	if _, _, err := s.InjectVagrantData(); err != nil {
+	hostQuery, _, err := s.InjectVagrantData()
+	if err != nil {
 		return nil, err
 	}
 
@@ -66,6 +67,12 @@ func (s *Stack) Plan(ctx context.Context) (interface{}, error) {
 	machines, err := s.machinesFromTemplate(s.Builder.Template)
 	if err != nil {
 		return nil, errors.New("failure reading machines: " + err.Error())
+	}
+
+	if hostQuery != "" {
+		for _, m := range machines {
+			m.HostQueryString = hostQuery
+		}
 	}
 
 	s.Log.Debug("Machines planned to be created: %+v", machines)

--- a/go/src/koding/kites/kloud/stackplan/stackplan.go
+++ b/go/src/koding/kites/kloud/stackplan/stackplan.go
@@ -45,6 +45,11 @@ type Machine struct {
 	RegisterURL string             `json:"registerURL,omitempty"`
 	State       machinestate.State `json:"state,omitempty"`
 	StateReason string             `json:"stateReason,omitempty"`
+
+	// Fields that client expects to be set. The value is
+	// copied from credentials.
+	Region          string `json:"region"`
+	HostQueryString string `json:"hostQueryString"`
 }
 
 // Machines represents group of machines mapped by a label.


### PR DESCRIPTION
Fixes #8835.
