### PR TITLE
client/vm: dont show edit name link while editing

### DIFF
--- a/client/home/lib/styl/homevirtualmachines.styl
+++ b/client/home/lib/styl/homevirtualmachines.styl
@@ -195,6 +195,7 @@ $borderColor                = #CACACA
 
 
 .MachineListItem--Edit-name
+  abs()
   margin-left               29px
   font-size                 13px
   color                     #67A2EE

--- a/client/home/lib/virtualmachines/components/machineslist/listitem.coffee
+++ b/client/home/lib/virtualmachines/components/machineslist/listitem.coffee
@@ -52,6 +52,7 @@ module.exports = class MachinesListItem extends React.Component
 
     @state =
       machineLabel: @props.machine.get 'label'
+      showEditName: yes
 
 
   renderMachineDetails: ->
@@ -79,13 +80,20 @@ module.exports = class MachinesListItem extends React.Component
 
   renderEditname: ->
 
+    return null  unless @state.showEditName
     return null  unless @props.shouldRenderDetails
     return null  unless @props.machine.get('label') is @state.selectedMachine
 
     <div className='MachineListItem--Edit-name' onClick={@bound 'onClickEditname'}>Edit Name </div>
 
 
-  onClickEditname: -> @refs.inputbox.focus()
+  onClickEditname: ->
+
+    @setState { showEditName: no }
+    @refs.inputbox.focus()
+    setTimeout =>
+      @refs.inputbox.selectionStart = @refs.inputbox.selectionEnd = 100000
+    , 0
 
 
   toggle: (event) ->
@@ -163,6 +171,7 @@ module.exports = class MachinesListItem extends React.Component
 
   inputOnBlur: (event) ->
 
+    @setState { showEditName: yes }
     @setMachineLabel()
 
   inputOnKeyDown: (event) ->

--- a/client/home/lib/virtualmachines/components/machineslist/listitem.coffee
+++ b/client/home/lib/virtualmachines/components/machineslist/listitem.coffee
@@ -91,9 +91,9 @@ module.exports = class MachinesListItem extends React.Component
 
     @setState { showEditName: no }
     @refs.inputbox.focus()
-    setTimeout =>
+
+    kd.utils.defer =>
       @refs.inputbox.selectionStart = @refs.inputbox.selectionEnd = 100000
-    , 0
 
 
   toggle: (event) ->


### PR DESCRIPTION
This fixes the showing edit name link in virtual machines tab while editing
## Description

Dont show the edit name link while editing
put the cursor at the end of input box
## Motivation and Context
#8809
## How Has This Been Tested?

edit vm name in virtual machine tab
edit name link will be disappeared and cursor will go to at the end of input box
## Screenshots (if appropriate):

http://recordit.co/4JO4MwhK8j
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
