### PR TITLE
ResourceStateModal: style changes for left bottom button

### DIFF
--- a/client/app/lib/styl/resourcestatemodal.styl
+++ b/client/app/lib/styl/resourcestatemodal.styl
@@ -59,24 +59,24 @@ $regularColor               = #989898
         display             block
 
     .GenericButton.secondary
-      width               165px
-      height              42px
-      padding             0
-      text-transform      none !important
-      color               #57a2d2
-      bg                  color, #fff
-      border              1px solid #e4e4e4
+      min-width             146px
+      height                42px
+      padding               0 15px
+      text-transform        uppercase
+      color                 #5e5e5e
+      bg                    color, #fff
+      border                1px solid #e4e4e4
 
       .button-title
-        font-size         14px
+        font-size           14px
 
     footer
-      bg                  color, #f4f4f4
+      bg                    color, #f4f4f4
 
       .GenericButton.secondary
         abs()
-        top               14px
-        left              30px
+        top                 14px
+        left                30px
 
 
   .start-machine-flow,


### PR DESCRIPTION
## Description

These are the minor style changes @ftasdelen asked to add to resource state modal for left button on the footer panel:
- uppercase
- gray color
## Screenshots (if appropriate):

![screen shot 2016-08-16 at 20 56 04](https://cloud.githubusercontent.com/assets/492219/17710169/ca9bf4a0-63f4-11e6-8136-0ec4a7938ff3.png)
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
