### PR TITLE
Client logs for stack failures

### DIFF
--- a/client/app/lib/providers/computeeventlistener.coffee
+++ b/client/app/lib/providers/computeeventlistener.coffee
@@ -3,6 +3,7 @@ globals  = require 'globals'
 Machine  = require './machine'
 Tracker  = require 'app/util/tracker'
 getGroup = require 'app/util/getGroup'
+sendDataDogEvent = require 'app/util/sendDataDogEvent'
 
 
 module.exports = class ComputeEventListener extends kd.Object
@@ -169,6 +170,7 @@ module.exports = class ComputeEventListener extends kd.Object
           computeController.triggerReviveFor eventId, type is 'apply'
         else if event.error and event.percentage is 100 and type is 'apply'
           if isMyStack
+            sendDataDogEvent 'StackBuildFailed', { prefix: 'stack-build' }
             Tracker.track Tracker.STACKS_BUILD_FAILED, {
               customEvent :
                 stackId   : eventId

--- a/client/app/lib/terminal/webtermmessagepane.coffee
+++ b/client/app/lib/terminal/webtermmessagepane.coffee
@@ -76,8 +76,6 @@ module.exports = class WebTermMessagePane extends KDCustomScrollView
         'Failed to connect to terminal,
         click here to try again.', 'RequestReconnect'
 
-      sendDataDogEvent 'TerminalConnectionFailed'
-
     else if err.message is 'session limit has reached'
 
       @setMessage \

--- a/client/app/lib/util/enableLogs.coffee
+++ b/client/app/lib/util/enableLogs.coffee
@@ -2,7 +2,7 @@ dateFormat = require 'dateformat'
 globals = require 'globals'
 disableLogs = require './disableLogs'
 
-module.exports = (state = yes) ->
+module.exports = enableLogs = (state = yes) ->
 
   return disableLogs()  unless state
   return if globals.logsEnabled

--- a/client/app/lib/util/parseLogs.coffee
+++ b/client/app/lib/util/parseLogs.coffee
@@ -1,6 +1,6 @@
 globals = require 'globals'
 
-module.exports = ->
+module.exports = parseLogs = ->
   globals.__logs   ?= []
   l = '\n'; l += "#{line}\n"  for line in globals.__logs
   l += '\nEOF Logs.\n'

--- a/client/app/lib/util/s3upload.coffee
+++ b/client/app/lib/util/s3upload.coffee
@@ -4,7 +4,7 @@ kd = require 'kd'
 remote = require('../remote').getInstance()
 uuid = require 'node-uuid'
 
-module.exports = (options, callback = kd.noop) ->
+module.exports = s3upload = (options, callback = kd.noop) ->
 
   { name, content, mimeType, timeout } = options
 

--- a/client/app/lib/util/sendDataDogEvent.coffee
+++ b/client/app/lib/util/sendDataDogEvent.coffee
@@ -30,6 +30,8 @@ module.exports = sendDataDogEvent = (eventName, options = {}) ->
 
       sendEvent logs
 
+    , options.prefix
+
   else
 
     # Send only events on production

--- a/client/app/lib/util/sendDataDogEvent.coffee
+++ b/client/app/lib/util/sendDataDogEvent.coffee
@@ -3,7 +3,7 @@ parseLogs = require './parseLogs'
 uploadLogs = require './uploadLogs'
 globals = require 'globals'
 
-module.exports = (eventName, options = {}) ->
+module.exports = sendDataDogEvent = (eventName, options = {}) ->
 
   options.eventName = eventName
   options.sendLogs ?= yes

--- a/client/app/lib/util/uploadLogs.coffee
+++ b/client/app/lib/util/uploadLogs.coffee
@@ -1,7 +1,7 @@
 s3upload  = require './s3upload'
 parseLogs = require './parseLogs'
 
-module.exports = (callback, content) ->
+module.exports = uploadLogs = (callback, prefix, content) ->
 
   content ?= parseLogs()
 

--- a/client/app/lib/util/uploadLogs.coffee
+++ b/client/app/lib/util/uploadLogs.coffee
@@ -4,8 +4,9 @@ parseLogs = require './parseLogs'
 module.exports = uploadLogs = (callback, prefix, content) ->
 
   content ?= parseLogs()
+  prefix = "#{prefix}_"  if prefix
 
   s3upload {
-    name: "logs_#{new Date().toISOString()}.txt"
+    name: "logs_#{prefix ? ''}#{new Date().toISOString()}.txt"
     content
   }, callback

--- a/workers/social/lib/social/models/datadog.coffee
+++ b/workers/social/lib/social/models/datadog.coffee
@@ -37,6 +37,12 @@ module.exports = class DataDog extends Base
       notify : '@slack-alerts'
       tags   : ['user:%nickname%', 'team:%team%', 'version:%version%', 'context:terminal']
 
+    StackBuildFailed:
+      title  : 'stack.failed'
+      text   : 'Stack build failed for user %nickname% on %team% team'
+      notify : '@slack-alerts'
+      tags   : ['user:%nickname%', 'team:%team%', 'version:%version%', 'context:stacks']
+
     ForbiddenChannel:
       title  : 'channel.forbidden'
       text   : 'Access is prohibited for channel with token: %channelToken%'

--- a/workers/social/lib/social/models/datadog.coffee
+++ b/workers/social/lib/social/models/datadog.coffee
@@ -29,19 +29,19 @@ module.exports = class DataDog extends Base
       title  : 'vms.failed'
       text   : 'VM start failed for user: %nickname%'
       notify : '@slack-alerts'
-      tags   : ['user:%nickname%', 'version:%version%', 'context:vms']
+      tags   : ['user:%nickname%', 'team:%team%', 'version:%version%', 'context:vms']
 
     TerminalConnectionFailed:
       title  : 'terminal.failed'
       text   : 'Terminal connection failed for user: %nickname%'
       notify : '@slack-alerts'
-      tags   : ['user:%nickname%', 'version:%version%', 'context:terminal']
+      tags   : ['user:%nickname%', 'team:%team%', 'version:%version%', 'context:terminal']
 
     ForbiddenChannel:
       title  : 'channel.forbidden'
       text   : 'Access is prohibited for channel with token: %channelToken%'
       notify : '@slack-alerts'
-      tags   : ['user:%nickname%', 'version:%version%', 'context:pubnub-channel', 'channel-token:%channelToken%']
+      tags   : ['user:%nickname%', 'team:%team%', 'version:%version%', 'context:pubnub-channel', 'channel-token:%channelToken%']
 
     MachineTurnedOn:
       title         : 'machine.turnedon'
@@ -83,7 +83,7 @@ module.exports = class DataDog extends Base
 
   @sendEvent = secure (client, data, callback = -> ) ->
 
-    { connection:{ delegate } } = client
+    { connection: { delegate }, context: { group } } = client
 
     unless delegate
       return callback new KodingError 'Account not found'
@@ -100,6 +100,7 @@ module.exports = class DataDog extends Base
 
     { nickname } = delegate.profile
     tags['nickname'] = nickname
+    tags['team'] = group
 
     title = ev.title
     text  = parseText ev.text, tags

--- a/workers/social/lib/social/models/s3.coffee
+++ b/workers/social/lib/social/models/s3.coffee
@@ -39,6 +39,10 @@ module.exports = class S3 extends Base
     unless delegate.type is 'registered'
       return callback new KodingError 'Not allowed'
 
+    if not AWS_KEY or not AWS_SECRET
+      return callback new KodingError \
+        'S3 logs upload disabled because of missing configuration'
+
     { nickname } = delegate.profile
 
     expiration = new Date(Date.now() + EXPIREIN * 1000).toISOString()


### PR DESCRIPTION
For the existing client logs system, this MR provides `StackBuildFailed` events.
## Description

Currently we are firing events on terminal connections, vm failures etc. with this one we will get the client logs once a stack build failed.
## Motivation and Context

It's hard to see what's wrong on stack build failures. This let us to see what's happening under the hood. 
## How Has This Been Tested?

Some examples can be found on Datadog dashboards and Slack channels for proper notifications with the events that I triggered from my development environment.
## Screenshots (if appropriate):

An example output of uploaded client log;

```
[15:08:07][i] [kontrol] INFO    Trying to connect to http://dev.koding.com:8090/kontrol/kite
[15:08:07][i] [kontrol] NOTICE  Connected to Kite: http://dev.koding.com:8090/kontrol/kite
[15:08:08][i] [kloud] INFO      Trying to connect to http://dev.koding.com:8090/kloud/kite
[15:08:08][i] [kloud] NOTICE    Connected to Kite: http://dev.koding.com:8090/kloud/kite
[15:08:21][w] [kloud:info] failed, sending current state back: {
        "currentState": "NotInitialized",
        "err": {
            "message": "unable to create AWS client for user: AuthFailure: AWS was not able to validate the provided access credentials\n\tstatus code: 401, request id: aef663fc-f60c-4417-99d8-33b9b6a7ac5e",
            "name": "KiteError",
            "type": "genericError",
            "code": ""
        }
}
[15:08:21][l] info response: {
        "State": "NotInitialized"
}
[15:08:24][l] [KLOUD:checkTemplate] {
        "message": "apply failed with code: 1, output: o:Refreshing Terraform state prior to plan...\n\ne:Error refreshing state: 1 error(s) occurred:\n\n* 1 error(s) occurred:\n\n* InvalidClientTokenId: The security token included in the request is invalid.\n\tstatus code: 403, request id: 4c64f461-6473-11e6-bd31-73efac3e79fa\n",
        "name": "KiteError",
        "type": "genericError",
        "code": ""
} undefined

EOF Logs.
```
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

`terminal.failed` events are disabled with this MR, they are useless and creating lots of noise right now, it will be fixed on the UI later on.
## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
