### PR TITLE
Handle realtime stack template events

### DIFF
--- a/client/app/lib/flux/environment/actions.coffee
+++ b/client/app/lib/flux/environment/actions.coffee
@@ -660,24 +660,24 @@ disconnectMachine = (machine) ->
   computeController.destroy machine
 
 
-removeStackTemplate = (template) ->
+removeStackTemplate = (stackTemplate) ->
 
   { reactor, groupsController } = kd.singletons
 
   currentGroup = groupsController.getCurrentGroup()
 
   return new Promise (resolve, reject) ->
-    reactor.dispatch actions.REMOVE_STACK_TEMPLATE_BEGIN, { template }
-    template.delete (err) ->
+    reactor.dispatch actions.REMOVE_STACK_TEMPLATE_BEGIN, { stackTemplate }
+    stackTemplate.delete (err) ->
       if err
-        reactor.dispatch actions.REMOVE_STACK_TEMPLATE_FAIL, { template, err }
+        reactor.dispatch actions.REMOVE_STACK_TEMPLATE_FAIL, { stackTemplate, err }
         reject err
         return
 
-      if template.accessLevel is 'group'
-        currentGroup.sendNotification 'GroupStackTemplateRemoved', template._id
+      if stackTemplate.accessLevel is 'group'
+        currentGroup.sendNotification 'GroupStackTemplateRemoved', stackTemplate._id
 
-      reactor.dispatch actions.REMOVE_STACK_TEMPLATE_SUCCESS, { template }
+      reactor.dispatch actions.REMOVE_STACK_TEMPLATE_SUCCESS, { id: stackTemplate._id }
       resolve()
 
       Tracker.track Tracker.STACKS_DELETE_TEMPLATE

--- a/client/app/lib/flux/environment/stores/privatestacktemplatesstore.coffee
+++ b/client/app/lib/flux/environment/stores/privatestacktemplatesstore.coffee
@@ -46,7 +46,7 @@ module.exports = class PrivateStackTemplatesStore extends KodingFluxStore
         .setIn [id, 'isDirty'], yes
 
 
-  remove: (stackTemplates, { template }) -> stackTemplates.remove template._id
+  remove: (stackTemplates, { id }) -> stackTemplates.remove id
 
 
   updateSingle: (stackTemplates, { stackTemplate }) ->

--- a/client/app/lib/flux/environment/stores/teamstacktemplatesstore.coffee
+++ b/client/app/lib/flux/environment/stores/teamstacktemplatesstore.coffee
@@ -41,7 +41,7 @@ module.exports = class TeamStackTemplatesStore extends KodingFluxStore
         .setIn [id, 'isDirty'], yes
 
 
-  remove: (stackTemplates, { template }) -> stackTemplates.remove template._id
+  remove: (stackTemplates, { id }) -> stackTemplates.remove id
 
   updateSingle: (stackTemplates, { stackTemplate }) ->
 

--- a/client/stack-editor/lib/editor/index.coffee
+++ b/client/stack-editor/lib/editor/index.coffee
@@ -850,9 +850,8 @@ module.exports = class StackEditorView extends kd.View
 
     groupsController.setDefaultTemplate stackTemplate, (err) =>
 
-      template = stackTemplate
       reactor.dispatch 'UPDATE_TEAM_STACK_TEMPLATE_SUCCESS', { stackTemplate }
-      reactor.dispatch 'REMOVE_PRIVATE_STACK_TEMPLATE_SUCCESS', { template }
+      reactor.dispatch 'REMOVE_PRIVATE_STACK_TEMPLATE_SUCCESS', { id: stackTemplate._id }
 
       @setAsDefaultButton.hideLoader()
 


### PR DESCRIPTION
## Description

Our `Environment` flux module is not aware of the changes made to `JStackTemplate` instances. 
## Motivation and Context

See #8863 for detailed information. Basically this was causing members not getting updates to the templates without refetching the stack template instance again. 
## How Has This Been Tested?

Manually.
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
