### PR TITLE
koding: add deploy scripts for klient/kd

### DIFF
--- a/go/src/koding/klient/DEPLOYMENT.md
+++ b/go/src/koding/klient/DEPLOYMENT.md
@@ -1,0 +1,91 @@
+klient deployment notes
+=======================
+
+* Configure
+
+Configure an AWS profile for uploading files to S3:
+
+```bash
+~ $ aws --profile koding-klient configure
+aws --profile XD configure
+AWS Access Key ID [None]: ***
+AWS Secret Access Key [None]: ***
+Default region name [None]: us-east-1
+Default output format [None]: json
+```
+
+* Build
+
+```bash
+klient $ ./build.sh
+usage: build.sh CHANNEL [VERSION]
+```
+
+```bash
+klient $ ./build.sh development
+# builing klient: version 215, channel development, os Darwin
+~/src/github.com/koding/koding ~/src/github.com/koding/koding/go/src/koding/klient
+koding/klient
+# builing klient: version 215, channel development, os Linux
+/opt/koding /opt/koding
+koding/klient
+building klient
+preparing build folders
+preparing install folders
+starting build process
+.  .  .  .  .  .  .
+
+success 'klient_0.1.215_development_amd64.deb' is ready. Some helpful commands for you:
+
+  show deb content   : dpkg -c klient_0.1.215_development_amd64.deb
+  show basic info    : dpkg -f klient_0.1.215_development_amd64.deb
+  install to machine : dpkg -i klient_0.1.215_development_amd64.deb
+
+Package: klient
+Version: 0.1.215
+Architecture: amd64
+Maintainer: Koding Developers <hello@koding.com>
+Installed-Size: 10361
+Section: devel
+Priority: extra
+Homepage: https://koding.com
+Description: klient Kite
+/opt/koding
+~/src/github.com/koding/koding/go/src/koding/klient
+# built klient successfully: version 215, channel development, os Darwin
+```
+
+* Deploy
+
+```bash
+klient $ ./deploy.sh
+usage: deploy.sh CHANNEL VERSION [AWS PROFILE] [S3 BUCKET]
+```
+
+```bash
+klient $ ./deploy.sh development 215
+# uploading files to s3://koding-klient/development/215/
+upload: ../../../../klient-0.1.215.gz to s3://koding-klient/development/215/klient-0.1.215.gz
+upload: ../../../../klient-0.1.215.darwin_amd64.gz to s3://koding-klient/development/215/klient-0.1.215.darwin_amd64.gz
+upload: ../../../../klient_0.1.215_development_amd64.deb to s3://koding-klient/development/215/klient_0.1.215_development_amd64.deb
+# uploading files to s3://koding-klient/development/latest/
+delete: s3://koding-klient/development/latest/klient-0.1.214.darwin_amd64.gz
+delete: s3://koding-klient/development/latest/klient-0.1.214.gz
+delete: s3://koding-klient/development/latest/klient.deb
+delete: s3://koding-klient/development/latest/klient.darwin_amd64.gz
+delete: s3://koding-klient/development/latest/klient.gz
+delete: s3://koding-klient/development/latest/klient_0.1.214_development_amd64.deb
+copy: s3://koding-klient/development/215/klient-0.1.215.gz to s3://koding-klient/development/latest/klient-0.1.215.gz
+copy: s3://koding-klient/development/215/klient-0.1.215.darwin_amd64.gz to s3://koding-klient/development/latest/klient-0.1.215.darwin_amd64.gz
+copy: s3://koding-klient/development/215/klient_0.1.215_development_amd64.deb to s3://koding-klient/development/latest/klient_0.1.215_development_amd64.deb
+copy: s3://koding-klient/development/latest/klient-0.1.215.gz to s3://koding-klient/development/latest/klient.gz
+copy: s3://koding-klient/development/latest/klient-0.1.215.darwin_amd64.gz to s3://koding-klient/development/latest/klient.darwin_amd64.gz
+copy: s3://koding-klient/development/latest/klient_0.1.215_development_amd64.deb to s3://koding-klient/development/latest/klient.deb
+delete: s3://koding-klient/install.sh
+upload: ./install.sh to s3://koding-klient/install.sh
+# updating latest-version.txt to 215
+delete: s3://koding-klient/development/latest-version.txt
+upload: ./latest-version.txt to s3://koding-klient/development/latest-version.txt
+```
+
+:tada:

--- a/go/src/koding/klient/Dockerfile
+++ b/go/src/koding/klient/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:14.04
+MAINTAINER Rafal Jeczalik <rafal@koding.com>
+
+ENV GOPATH /opt/koding/go
+
+WORKDIR /opt/koding
+
+RUN apt-get update && apt-get install -y build-essential ubuntu-dev-tools dh-make && apt-get clean && \
+    curl -sSL https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz | tar -C /usr/local/ -zxf - && \
+    ln -s /usr/local/go/bin/go /usr/local/bin/go

--- a/go/src/koding/klient/build.sh
+++ b/go/src/koding/klient/build.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_PATH=$(git rev-parse --show-toplevel)
+CHANNEL=${1:-}
+VERSION=${2:-}
+
+export GOBIN="${REPO_PATH}"
+
+die() {
+	echo $* 1>&2
+	exit 1
+}
+
+if [[ -z "$CHANNEL" ]]; then
+	die "usage: build.sh CHANNEL [VERSION]"
+fi
+
+if [[ -z "$VERSION" ]]; then
+	VERSION=$(curl -sSL https://koding-klient.s3.amazonaws.com/${CHANNEL}/latest-version.txt)
+	let VERSION++
+fi
+
+PREFIX="klient-0.1.${VERSION}"
+
+klient_build() {
+	go install -v -ldflags "-X koding/klient/protocol.Version=0.1.${VERSION} -X koding/klient/protocol.Environment=${CHANNEL}" koding/klient
+}
+
+echo "# builing klient: version ${VERSION}, channel ${CHANNEL}, os $(uname)"
+
+if [[ "$(uname)" == "Linux" ]]; then
+	if [[ -z "$VERSION" ]]; then
+		die "usage: build.sh CHANNEL [VERSION]"
+	fi
+
+	PREFIX_DEB="klient_0.1.${VERSION}_${CHANNEL}_amd64.deb"
+
+	pushd $REPO_PATH
+
+	klient_build
+
+	# validate klient version
+	[[ $(./klient -version) == "0.1.${VERSION}" ]]
+
+	# prepare klient.gz
+	gzip -9 -N -f klient
+	mv klient.gz "${PREFIX}.gz"
+
+	go run "${REPO_PATH}/go/src/koding/klient/build/build.go" -e "$CHANNEL" -b "$VERSION"
+	dpkg -f "$PREFIX_DEB"
+
+	popd
+
+	exit 0
+fi
+
+pushd $REPO_PATH
+
+klient_build
+
+gzip -9 -N -f klient
+mv klient.gz "${PREFIX}.darwin_amd64.gz"
+
+docker run -t -v $PWD:/opt/koding koding/base:klient go/src/koding/klient/build.sh "$CHANNEL" "$VERSION"
+
+popd
+
+echo "# built klient successfully: version ${VERSION}, channel ${CHANNEL}, os $(uname)"

--- a/go/src/koding/klient/deploy.sh
+++ b/go/src/koding/klient/deploy.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_PATH=$(git rev-parse --show-toplevel)
+CHANNEL=${1:-}
+VERSION=${2:-}
+PROFILE=${3:-koding-klient}
+BUCKET=${4:-koding-klient}
+
+die() {
+	echo $* 1>&2
+	exit 1
+}
+
+if [[ -z "$CHANNEL" ]] || [[ -z "$VERSION" ]]; then
+	die "usage: deploy.sh CHANNEL VERSION [AWS PROFILE] [S3 BUCKET]"
+fi
+
+s3cp() {
+	aws --profile "$PROFILE" s3 cp --acl public-read $*
+}
+
+s3rm() {
+	aws --profile "$PROFILE" s3 rm $*
+}
+
+DISTRIB=(
+	"${REPO_PATH}/klient-0.1.${VERSION}.gz"
+	"${REPO_PATH}/klient-0.1.${VERSION}.darwin_amd64.gz"
+	"${REPO_PATH}/klient_0.1.${VERSION}_${CHANNEL}_amd64.deb"
+)
+
+
+for file in "${DISTRIB[@]}"; do
+	[[ -f "$file" ]]
+done
+
+echo "# uploading files to s3://${BUCKET}/${CHANNEL}/${VERSION}/"
+
+for file in "${DISTRIB[@]}"; do
+	s3cp "$file" "s3://${BUCKET}/${CHANNEL}/${VERSION}/"
+done
+
+echo "# uploading files to s3://${BUCKET}/${CHANNEL}/latest/"
+
+s3rm --recursive "s3://${BUCKET}/${CHANNEL}/latest/"
+
+s3cp "s3://${BUCKET}/${CHANNEL}/${VERSION}/klient-0.1.${VERSION}.gz" "s3://${BUCKET}/${CHANNEL}/latest/"
+s3cp "s3://${BUCKET}/${CHANNEL}/${VERSION}/klient-0.1.${VERSION}.darwin_amd64.gz" "s3://${BUCKET}/${CHANNEL}/latest/"
+s3cp "s3://${BUCKET}/${CHANNEL}/${VERSION}/klient_0.1.${VERSION}_${CHANNEL}_amd64.deb" "s3://${BUCKET}/${CHANNEL}/latest/"
+
+s3cp "s3://${BUCKET}/${CHANNEL}/latest/klient-0.1.${VERSION}.gz" "s3://${BUCKET}/${CHANNEL}/latest/klient.gz"
+s3cp "s3://${BUCKET}/${CHANNEL}/latest/klient-0.1.${VERSION}.darwin_amd64.gz" "s3://${BUCKET}/${CHANNEL}/latest/klient.darwin_amd64.gz"
+s3cp "s3://${BUCKET}/${CHANNEL}/latest/klient_0.1.${VERSION}_${CHANNEL}_amd64.deb" "s3://${BUCKET}/${CHANNEL}/latest/klient.deb"
+
+s3rm "s3://${BUCKET}/install.sh"
+s3cp "${REPO_PATH}/go/src/koding/klient/install.sh" "s3://${BUCKET}/install.sh"
+
+echo "# updating latest-version.txt to $VERSION"
+
+echo $VERSION > latest-version.txt
+
+s3rm "s3://${BUCKET}/${CHANNEL}/latest-version.txt"
+s3cp latest-version.txt "s3://${BUCKET}/${CHANNEL}/latest-version.txt"
+
+rm -f latest-version.txt

--- a/go/src/koding/klientctl/DEPLOYMENT.md
+++ b/go/src/koding/klientctl/DEPLOYMENT.md
@@ -1,0 +1,63 @@
+klient deployment notes
+=======================
+
+* Configure
+
+Configure an AWS profile for uploading files to S3:
+
+```bash
+~ $ aws --profile koding-klient configure
+AWS Access Key ID [None]: ***
+AWS Secret Access Key [None]: ***
+Default region name [None]: us-east-1
+Default output format [None]: json
+```
+
+Export segment.io key:
+
+```bash
+~ $ export KD_SEGMENTIO_KEY=***
+```
+
+* Build
+
+```bash
+klientctl $ ./build.sh
+usage: build.sh CHANNEL [VERSION]
+```
+
+```bash
+klientctl $ ./build.sh development
+# builing kd: version 103, channel development, os Darwin
+~/src/github.com/koding/koding ~/src/github.com/koding/koding/go/src/koding/klientctl
+koding/klientctl
+# builing kd: version 103, channel development, os Linux
+/opt/koding /opt/koding
+koding/klientctl
+/opt/koding
+~/src/github.com/koding/koding/go/src/koding/klientctl
+# built kd successfully: version 103, channel development, os Darwin
+```
+
+* Deploy
+
+```bash
+klientctl $ ./deploy.sh
+usage: deploy.sh CHANNEL VERSION [AWS PROFILE] [S3 BUCKET]
+```
+
+```bash
+klientctl $ ./deploy.sh development 103
+~/src/github.com/koding/koding ~/src/github.com/koding/koding/go/src/koding/klientctl
+# uploading files to s3://koding-kd/development/103/
+upload: ./kd-0.1.103.linux_amd64.gz to s3://koding-kd/development/103/kd-0.1.103.linux_amd64.gz
+upload: ./kd-0.1.103.darwin_amd64.gz to s3://koding-kd/development/103/kd-0.1.103.darwin_amd64.gz
+delete: s3://koding-kd/development/install-kd.sh
+upload: ./install-kd.sh to s3://koding-kd/development/install-kd.sh
+# updating latest-version.txt to 103
+delete: s3://koding-kd/development/latest-version.txt
+upload: ./latest-version.txt to s3://koding-kd/development/latest-version.txt
+~/src/github.com/koding/koding/go/src/koding/klientctl
+```
+
+:tada:

--- a/go/src/koding/klientctl/build.sh
+++ b/go/src/koding/klientctl/build.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_PATH=$(git rev-parse --show-toplevel)
+CHANNEL=${1:-}
+VERSION=${2:-}
+KD_SEGMENTIO_KEY=${KD_SEGMENTIO_KEY}
+
+export GOBIN="${REPO_PATH}"
+
+die() {
+	echo $* 1>&2
+	exit 1
+}
+
+if [[ -z "$CHANNEL" ]]; then
+	die "usage: build.sh CHANNEL [VERSION]"
+fi
+
+KONTROL_URL="https://koding.com/kontrol/kite"
+if [[ "$CHANNEL" == "development" ]]; then
+	KONTROL_URL="https://sandbox.koding.com/kontrol/kite"
+fi
+
+if [[ -z "$VERSION" ]]; then
+	VERSION=$(curl -sSL https://koding-kd.s3.amazonaws.com/${CHANNEL}/latest-version.txt)
+	let VERSION++
+fi
+
+kd_build() {
+	go build -v -ldflags "-X koding/klientctl/config.Version=$VERSION -X koding/klientctl/config.SegmentKey=$KD_SEGMENTIO_KEY -X koding/klientctl/config.Environment=$CHANNEL -X koding/klientctl/config.KontrolURL=$KONTROL_URL" koding/klientctl
+	mv "${REPO_PATH}/klientctl" "${REPO_PATH}/kd"
+}
+
+PREFIX="kd-0.1.${VERSION}"
+
+echo "# builing kd: version ${VERSION}, channel ${CHANNEL}, os $(uname)"
+
+if [[ "$(uname)" == "Linux" ]]; then
+	if [[ -z "$VERSION" ]]; then
+		die "usage: build.sh CHANNEL [VERSION]"
+	fi
+
+	pushd $REPO_PATH
+
+	kd_build
+
+	# validate kd version
+	[[ "$(./kd -version)" == "kd version 0.1.${VERSION}" ]]
+
+	gzip -9 -N -f kd
+	mv kd.gz "${PREFIX}.linux_amd64.gz"
+
+	popd
+
+	exit 0
+fi
+
+pushd $REPO_PATH
+
+kd_build
+
+gzip -9 -N -f kd
+mv kd.gz "${PREFIX}.darwin_amd64.gz"
+
+docker run -t -v $PWD:/opt/koding -e KD_SEGMENTIO_KEY="$KD_SEGMENTIO_KEY" koding/base:klient go/src/koding/klientctl/build.sh "$CHANNEL" "$VERSION"
+
+popd
+
+echo "# built kd successfully: version ${VERSION}, channel ${CHANNEL}, os $(uname)"

--- a/go/src/koding/klientctl/deploy.sh
+++ b/go/src/koding/klientctl/deploy.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_PATH=$(git rev-parse --show-toplevel)
+CHANNEL=${1:-}
+VERSION=${2:-}
+PROFILE=${3:-koding-klient}
+BUCKET=${4:-koding-kd}
+
+die() {
+	echo $* 1>&2
+	exit 1
+}
+
+if [[ -z "$CHANNEL" ]] || [[ -z "$VERSION" ]]; then
+	die "usage: deploy.sh CHANNEL VERSION [AWS PROFILE] [S3 BUCKET]"
+fi
+
+s3cp() {
+	aws --profile "$PROFILE" s3 cp --acl public-read $*
+}
+
+s3rm() {
+	aws --profile "$PROFILE" s3 rm $*
+}
+
+pushd "${REPO_PATH}"
+
+[[ -f "kd-0.1.${VERSION}.linux_amd64.gz" ]]
+[[ -f "kd-0.1.${VERSION}.darwin_amd64.gz" ]]
+
+echo "# uploading files to s3://${BUCKET}/${CHANNEL}/"
+
+s3cp "kd-0.1.${VERSION}.linux_amd64.gz" "s3://${BUCKET}/${CHANNEL}/"
+s3cp "kd-0.1.${VERSION}.darwin_amd64.gz" "s3://${BUCKET}/${CHANNEL}/"
+
+cp -f go/src/koding/klientctl/install-kd.sh install-kd.sh
+sed -i "" -e "s|\%RELEASE_CHANNEL\%|${CHANNEL}|g" install-kd.sh
+s3rm "s3://${BUCKET}/${CHANNEL}/install-kd.sh"
+s3cp install-kd.sh "s3://${BUCKET}/${CHANNEL}/install-kd.sh"
+rm -f install-kd.sh
+
+echo "# updating latest-version.txt to $VERSION"
+
+echo $VERSION > latest-version.txt
+
+s3rm "s3://${BUCKET}/${CHANNEL}/latest-version.txt"
+s3cp latest-version.txt "s3://${BUCKET}/${CHANNEL}/latest-version.txt"
+
+rm -f latest-version.txt
+
+popd


### PR DESCRIPTION
This PR adds deploy scripts for klient and klientctl.
## Description

Currently wercker builds klient and klientctl with go1.4 for both Linux and Darwin using crosscompilation trick (https://github.com/koding/wercker-box/commit/9fd03b13968493ffa68dc7837be92e45ed2ba204). For go1.7 the trick does not work anymore - however it's tricky to detect that, since `user.Current()` has non-cgo implementation for all the platfroms. But presence of `_noncgo_` symbols and lack of `cgoLookup*` ones in crosscompiled binaries hints they were compiled without netCgo support.

This PR adds deploy script for manual deployment of klient + kd. The binaries under Linux are built with ubuntu:14.04, as .deb building requires upstart support, which does not exists for debootstrap scripts starting 15.04 and forward.
## Motivation and Context

To aid deploying klient + kd built with go1.7.
## How Has This Been Tested?

Manually.
## Screenshots (if appropriate):
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
