### PR TITLE
Klientctl start healthcheck

### DIFF
--- a/go/src/koding/klientctl/build.sh
+++ b/go/src/koding/klientctl/build.sh
@@ -23,13 +23,18 @@ if [[ "$CHANNEL" == "development" ]]; then
 	KONTROL_URL="https://sandbox.koding.com/kontrol/kite"
 fi
 
+TUNNEL_URL="http://t.koding.com/kite"
+if [[ "$CHANNEL" == "development" ]]; then
+	TUNNEL_URL="http://dev-t.koding.com/kite"
+fi
+
 if [[ -z "$VERSION" ]]; then
 	VERSION=$(curl -sSL https://koding-kd.s3.amazonaws.com/${CHANNEL}/latest-version.txt)
 	let VERSION++
 fi
 
 kd_build() {
-	go build -v -ldflags "-X koding/klientctl/config.Version=$VERSION -X koding/klientctl/config.SegmentKey=$KD_SEGMENTIO_KEY -X koding/klientctl/config.Environment=$CHANNEL -X koding/klientctl/config.KontrolURL=$KONTROL_URL" koding/klientctl
+	go build -v -ldflags "-X koding/klientctl/config.Version=$VERSION -X koding/klientctl/config.SegmentKey=$KD_SEGMENTIO_KEY -X koding/klientctl/config.Environment=$CHANNEL -X koding/klientctl/config.TunnelKiteAddress $TUNNEL_URL -X koding/klientctl/config.KontrolURL=$KONTROL_URL" koding/klientctl
 	mv "${REPO_PATH}/klientctl" "${REPO_PATH}/kd"
 }
 

--- a/go/src/koding/klientctl/config/config.go
+++ b/go/src/koding/klientctl/config/config.go
@@ -82,6 +82,11 @@ var (
 	// KontrolURL is overwritten during deploy via linker flag.
 	KontrolURL = "https://koding.com/kontrol/kite"
 
+	// TunnelKiteAddress is the address that koding's tunnel service is run on.
+	//
+	// This is overwritten during deploy via linker flag.
+	TunnelKiteAddress = "http://t.koding.com/kite"
+
 	// S3KlientLatest is URL to the latest version of the klient.
 	S3KlientLatest = "https://koding-klient.s3.amazonaws.com/" + kd2klient(Environment) + "/latest-version.txt"
 
@@ -97,6 +102,7 @@ func init() {
 		fmt.Println("KiteVersion", KiteVersion)
 		fmt.Println("KiteKeyPath", KiteKeyPath)
 		fmt.Println("KontrolURL", KontrolURL)
+		fmt.Println("TunnelKiteAddress", TunnelKiteAddress)
 		fmt.Println("S3KlientLatest", S3KlientLatest)
 		fmt.Println("S3KlientctlLatest", S3KlientctlLatest)
 	}

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -93,6 +93,12 @@ func main() {
 		os.Exit(10)
 	}
 
+	// TODO(leeola): deprecate this default, instead passing it as a dependency
+	// to the users of it.
+	//
+	// init the defaultHealthChecker with the log.
+	defaultHealthChecker = NewDefaultHealthChecker(log)
+
 	app := cli.NewApp()
 	app.Name = config.Name
 	app.Version = getReadableVersion(config.Version)

--- a/go/src/koding/klientctl/mount_test.go
+++ b/go/src/koding/klientctl/mount_test.go
@@ -13,6 +13,7 @@ import (
 
 	"koding/klient/kiteerrortypes"
 	"koding/klient/remote/restypes"
+	klienttestutil "koding/klient/testutil"
 	"koding/klient/util"
 	"koding/klientctl/klientctlerrors"
 	"koding/klientctl/list"
@@ -22,6 +23,10 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 )
+
+func init() {
+	defaultHealthChecker = NewDefaultHealthChecker(klienttestutil.DiscardLogger)
+}
 
 // BlockingIO is a struct primarily for mocking the behavior of Stdin. Stdin blocks
 // the Reader while waiting for input, so mocking Stdin with a typical Buffer can

--- a/go/src/koding/klientctl/restart.go
+++ b/go/src/koding/klientctl/restart.go
@@ -16,6 +16,8 @@ func RestartCommand(c *cli.Context, log logging.Logger, _ string) int {
 		return 1
 	}
 
+	log = log.New("cmd:restart")
+
 	s, err := newService(nil)
 	if err != nil {
 		log.Error("Error creating Service. err:%s", err)

--- a/go/src/koding/klientctl/restart.go
+++ b/go/src/koding/klientctl/restart.go
@@ -54,21 +54,9 @@ func RestartCommand(c *cli.Context, log logging.Logger, _ string) int {
 		fmt.Println("Stopped successfully.")
 	}
 
-	if err := s.Start(); err != nil {
-		log.Error("Error starting Service. err:%s", err)
-		fmt.Println(FailedStartKlient)
-		return 1
-	}
-
-	fmt.Println("Starting...")
-
-	err = WaitUntilStarted(config.KlientAddress, CommandAttempts, CommandWaitTime)
-	if err != nil {
-		log.Error(
-			"Timed out while waiting for Klient to start. attempts:%d, err:%s",
-			15, err,
-		)
-		fmt.Println(FailedStartKlient)
+	// No UX message needed, startKlient will do that itself.
+	if err := startKlient(log, s); err != nil {
+		log.Error("failed to start klient: %s", err)
 		return 1
 	}
 

--- a/go/src/koding/klientctl/start.go
+++ b/go/src/koding/klientctl/start.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/codegangsta/cli"
 	"github.com/koding/logging"
+	"github.com/koding/service"
 )
 
 // StartCommand starts local klient. Requires sudo.
@@ -23,21 +24,9 @@ func StartCommand(c *cli.Context, log logging.Logger, _ string) int {
 		return 1
 	}
 
-	if err := s.Start(); err != nil {
-		log.Error("Error starting Service. err:%s", err)
-		fmt.Println(FailedStartKlient)
-		return 1
-	}
-
-	fmt.Println("Starting...")
-
-	err = WaitUntilStarted(config.KlientAddress, CommandAttempts, CommandWaitTime)
-	if err != nil {
-		log.Error(
-			"Timed out while waiting for Klient to start. attempts:%d, err:%s",
-			15, err,
-		)
-		fmt.Println(FailedStartKlient)
+	// No UX message needed, startKlient will do that itself.
+	if err := startKlient(log, s); err != nil {
+		log.Error("failed to start klient: %s", err)
 		return 1
 	}
 
@@ -61,4 +50,43 @@ func WaitUntilStarted(address string, attempts int, pauseIntv time.Duration) err
 		}
 	}
 	return err
+}
+
+func startKlient(log logging.Logger, s service.Service) error {
+	// For debug purposes, run a health check before we even attempt to start. This
+	// will help give us a sense of what this machine's health check was before
+	// klient tried to start.
+	if res, ok := defaultHealthChecker.CheckAllWithResponse(); !ok {
+		log.Warning("before attempting to start klient health check returned not-okay. reason: %s", res)
+	}
+
+	if err := s.Start(); err != nil {
+		log.Error("Error starting Service. err:%s", err)
+		fmt.Println(FailedStartKlient)
+		return err
+	}
+
+	fmt.Println("Starting...")
+
+	err := WaitUntilStarted(config.KlientAddress, CommandAttempts, CommandWaitTime)
+	if err != nil {
+		log.Error(
+			"Timed out while waiting for Klient to start. attempts:%d, err:%s",
+			CommandAttempts, err,
+		)
+
+		if s, ok := defaultHealthChecker.CheckAllWithResponse(); !ok {
+			fmt.Printf(`Failed to start %s in time.
+
+A health check found the following issue:
+%s
+`, config.KlientName, s)
+		} else {
+			fmt.Println(FailedStartKlient)
+		}
+
+		return err
+	}
+
+	return nil
 }

--- a/go/src/koding/klientctl/start.go
+++ b/go/src/koding/klientctl/start.go
@@ -56,7 +56,7 @@ func startKlient(log logging.Logger, s service.Service) error {
 	// For debug purposes, run a health check before we even attempt to start. This
 	// will help give us a sense of what this machine's health check was before
 	// klient tried to start.
-	if res, ok := defaultHealthChecker.CheckAllWithResponse(); !ok {
+	if res, ok := defaultHealthChecker.CheckAllExceptRunning(); !ok {
 		log.Warning("before attempting to start klient health check returned not-okay. reason: %s", res)
 	}
 
@@ -75,7 +75,7 @@ func startKlient(log logging.Logger, s service.Service) error {
 			CommandAttempts, err,
 		)
 
-		if s, ok := defaultHealthChecker.CheckAllWithResponse(); !ok {
+		if s, ok := defaultHealthChecker.CheckAllExceptRunning(); !ok {
 			fmt.Printf(`Failed to start %s in time.
 
 A health check found the following issue:

--- a/go/src/koding/klientctl/start.go
+++ b/go/src/koding/klientctl/start.go
@@ -17,6 +17,8 @@ func StartCommand(c *cli.Context, log logging.Logger, _ string) int {
 		return 1
 	}
 
+	log = log.New("cmd:start")
+
 	s, err := newService(nil)
 	if err != nil {
 		log.Error("Error creating Service. err:%s", err)

--- a/go/src/koding/klientctl/start.go
+++ b/go/src/koding/klientctl/start.go
@@ -47,7 +47,7 @@ func WaitUntilStarted(address string, attempts int, pauseIntv time.Duration) err
 	for i := 0; i < attempts; i++ {
 		time.Sleep(pauseIntv)
 
-		if err = defaultHealthChecker.CheckLocal(); err == nil {
+		if err = defaultHealthChecker.LocalRequirements(); err == nil {
 			break
 		}
 	}

--- a/go/src/koding/klientctl/status.go
+++ b/go/src/koding/klientctl/status.go
@@ -247,6 +247,23 @@ func (c *HealthChecker) CheckRemote() error {
 // TODO: Enable debug logs
 // log.Print(err.Error())
 func (c *HealthChecker) CheckAllWithResponse() (res string, ok bool) {
+	// Check remote endpoints first, to debug what might be blocking Klient
+	// from starting.
+	if err := defaultHealthChecker.CheckRemote(); err != nil {
+		switch err.(type) {
+		case ErrHealthNoInternet:
+			res = fmt.Sprintf(`Error: You do not appear to have a properly working internet connection.`)
+
+		case ErrHealthNoKontrolHTTPResponse:
+			res = fmt.Sprintf(`Error: koding.com does not appear to be responding.`)
+
+		default:
+			res = fmt.Sprintf("Unknown remote healthcheck error: %s", err.Error())
+		}
+
+		return res, false
+	}
+
 	if err := defaultHealthChecker.CheckLocal(); err != nil {
 		switch err.(type) {
 		case ErrHealthNoHTTPReponse:
@@ -279,21 +296,6 @@ Please run the following command:
 
 		default:
 			res = fmt.Sprintf("Unknown local healthcheck error: %s", err.Error())
-		}
-
-		return res, false
-	}
-
-	if err := defaultHealthChecker.CheckRemote(); err != nil {
-		switch err.(type) {
-		case ErrHealthNoInternet:
-			res = fmt.Sprintf(`Error: You do not appear to have a properly working internet connection.`)
-
-		case ErrHealthNoKontrolHTTPResponse:
-			res = fmt.Sprintf(`Error: koding.com does not appear to be responding.`)
-
-		default:
-			res = fmt.Sprintf("Unknown remote healthcheck error: %s", err.Error())
 		}
 
 		return res, false

--- a/go/src/koding/klientctl/status.go
+++ b/go/src/koding/klientctl/status.go
@@ -280,8 +280,7 @@ func (c *HealthChecker) CheckAllExceptRunning() (res string, ok bool) {
 	if err := c.LocalRequirements(); err != nil {
 		switch err.(type) {
 		// Ignore dialing or bad klient http responses for CheckAllExceptRunning.
-		case ErrHealthNoHTTPReponse:
-		case ErrHealthDialFailed:
+		case ErrHealthNoHTTPReponse, ErrHealthDialFailed:
 		default:
 			c.Log.Warning("CheckAllExceptRunning found local error: %s", err)
 			return c.errorToMessage(err), false

--- a/go/src/koding/klientctl/status_test.go
+++ b/go/src/koding/klientctl/status_test.go
@@ -24,8 +24,8 @@ func TestHealthCheckRemote(t *testing.T) {
 			HTTPClient: &http.Client{
 				Timeout: 4 * time.Second,
 			},
-			RemoteKiteAddress: ts.URL,
-			RemoteHTTPAddress: ts.URL,
+			KontrolAddress:       ts.URL,
+			InternetCheckAddress: ts.URL,
 		}
 
 		So(c.CheckRemote(), ShouldBeNil)
@@ -37,8 +37,8 @@ func TestHealthCheckRemote(t *testing.T) {
 			HTTPClient: &http.Client{
 				Timeout: 4 * time.Second,
 			},
-			RemoteKiteAddress: "http://foo",
-			RemoteHTTPAddress: "http://bar",
+			KontrolAddress:       "http://foo",
+			InternetCheckAddress: "http://bar",
 		}
 
 		err := c.CheckRemote()
@@ -61,8 +61,8 @@ func TestHealthCheckRemote(t *testing.T) {
 			HTTPClient: &http.Client{
 				Timeout: 4 * time.Second,
 			},
-			RemoteKiteAddress: tsKon.URL,
-			RemoteHTTPAddress: tsNet.URL,
+			KontrolAddress:       tsKon.URL,
+			InternetCheckAddress: tsNet.URL,
 		}
 
 		err := c.CheckRemote()
@@ -84,8 +84,8 @@ func TestHealthCheckRemote(t *testing.T) {
 			HTTPClient: &http.Client{
 				Timeout: 4 * time.Second,
 			},
-			RemoteKiteAddress: tsNet.URL,
-			RemoteHTTPAddress: tsKon.URL,
+			KontrolAddress:       tsNet.URL,
+			InternetCheckAddress: tsKon.URL,
 		}
 
 		err := c.CheckRemote()
@@ -107,8 +107,8 @@ func TestHealthCheckRemote(t *testing.T) {
 			HTTPClient: &http.Client{
 				Timeout: 1 * time.Second,
 			},
-			RemoteKiteAddress: ts.URL,
-			RemoteHTTPAddress: ts.URL,
+			KontrolAddress:       ts.URL,
+			InternetCheckAddress: ts.URL,
 		}
 
 		err := c.CheckRemote()

--- a/go/src/koding/klientctl/status_test.go
+++ b/go/src/koding/klientctl/status_test.go
@@ -29,7 +29,7 @@ func TestHealthCheckRemote(t *testing.T) {
 			TunnelKiteAddress:    ts.URL,
 		}
 
-		So(c.CheckRemote(), ShouldBeNil)
+		So(c.RemoteRequirements(), ShouldBeNil)
 	})
 
 	Convey("Should return no internet if the inetAddress fails", t, func() {
@@ -42,7 +42,7 @@ func TestHealthCheckRemote(t *testing.T) {
 			InternetCheckAddress: "http://bar",
 		}
 
-		err := c.CheckRemote()
+		err := c.RemoteRequirements()
 		So(err, ShouldNotBeNil)
 		So(err, ShouldHaveSameTypeAs, ErrHealthNoInternet{})
 	})
@@ -66,7 +66,7 @@ func TestHealthCheckRemote(t *testing.T) {
 			InternetCheckAddress: tsNet.URL,
 		}
 
-		err := c.CheckRemote()
+		err := c.RemoteRequirements()
 		So(err, ShouldNotBeNil)
 		So(err, ShouldHaveSameTypeAs, ErrKodingService{})
 	})
@@ -89,7 +89,7 @@ func TestHealthCheckRemote(t *testing.T) {
 			InternetCheckAddress: tsKon.URL,
 		}
 
-		err := c.CheckRemote()
+		err := c.RemoteRequirements()
 		So(err, ShouldNotBeNil)
 		So(err, ShouldHaveSameTypeAs, ErrKodingService{})
 	})
@@ -112,7 +112,7 @@ func TestHealthCheckRemote(t *testing.T) {
 			InternetCheckAddress: ts.URL,
 		}
 
-		err := c.CheckRemote()
+		err := c.RemoteRequirements()
 		So(err, ShouldNotBeNil)
 	})
 }

--- a/go/src/koding/klientctl/status_test.go
+++ b/go/src/koding/klientctl/status_test.go
@@ -26,6 +26,7 @@ func TestHealthCheckRemote(t *testing.T) {
 			},
 			KontrolAddress:       ts.URL,
 			InternetCheckAddress: ts.URL,
+			TunnelKiteAddress:    ts.URL,
 		}
 
 		So(c.CheckRemote(), ShouldBeNil)
@@ -67,7 +68,7 @@ func TestHealthCheckRemote(t *testing.T) {
 
 		err := c.CheckRemote()
 		So(err, ShouldNotBeNil)
-		So(err, ShouldHaveSameTypeAs, ErrHealthNoKontrolHTTPResponse{})
+		So(err, ShouldHaveSameTypeAs, ErrKodingService{})
 	})
 
 	Convey("Should return unexpected response if the kontrol response is.. unexpected", t, func() {
@@ -90,7 +91,7 @@ func TestHealthCheckRemote(t *testing.T) {
 
 		err := c.CheckRemote()
 		So(err, ShouldNotBeNil)
-		So(err, ShouldHaveSameTypeAs, ErrHealthUnexpectedResponse{})
+		So(err, ShouldHaveSameTypeAs, ErrKodingService{})
 	})
 
 	Convey("Should timeout after X seconds", t, func() {

--- a/scripts/deploy-kd.sh
+++ b/scripts/deploy-kd.sh
@@ -28,10 +28,15 @@ if [[ "$CHANNEL" == "development" ]]; then
 	KONTROL_URL="https://sandbox.koding.com/kontrol/kite"
 fi
 
+TUNNEL_URL="http://t.koding.com/kite"
+if [[ "$CHANNEL" == "development" ]]; then
+	TUNNEL_URL="http://dev-t.koding.com/kite"
+fi
+
 # NOTE(rjeczalik): kd expects the version to be a single digit, while klient
 # expect semver - making a note until this is made consistent.
 kd_build() {
-	GOOS="${1:-}" GOARCH=amd64 go build -v -ldflags "-X koding/klientctl/config.Version $NEWBUILDNO -X koding/klientctl/config.SegmentKey \"$KD_SEGMENTIO_KEY\" -X koding/klientctl/config.Environment $CHANNEL -X koding/klientctl/config.KontrolURL $KONTROL_URL" -o kd koding/klientctl
+	GOOS="${1:-}" GOARCH=amd64 go build -v -ldflags "-X koding/klientctl/config.Version $NEWBUILDNO -X koding/klientctl/config.SegmentKey \"$KD_SEGMENTIO_KEY\" -X koding/klientctl/config.Environment $CHANNEL -X koding/klientctl/config.TunnelKiteAddress $TUNNEL_URL -X koding/klientctl/config.KontrolURL $KONTROL_URL" -o kd koding/klientctl
 }
 
 # build klient binary for linux


### PR DESCRIPTION
Klient can "fail to start" even if the users internet is down, or
other external issues. By health checking, we attempt to give them
accurate information of possible causes for klient not starting.

Also, for debugging, we health check before even starting klient - just
to have a record of if the user tried to start klient before their
internet was fully up _(mainly for debugging purposes)_.
