### PR TITLE
myteam: add height of permission section to scroll properly

### DIFF
--- a/client/home/lib/myteam/index.coffee
+++ b/client/home/lib/myteam/index.coffee
@@ -66,6 +66,7 @@ module.exports = class HomeMyTeam extends kd.CustomScrollView
       viewTop = @wrapper.getY()
       subViewTop = subView.getY()
       sectionHeader = 88  # height of header of dashboard
+      sectionHeader = sectionHeader + 235 # height of permisson section
 
       scrollMuch = subViewTop - viewTop - sectionHeader
 


### PR DESCRIPTION
Scroll wasn't working properly after we add permission section to my team page.
## Description

Add height of permission section to scrollToSectionArea function.
## Motivation and Context
#8856
## How Has This Been Tested?

Manually
## Screenshots (if appropriate):

http://recordit.co/Nku5URloZW  -> 1280 x 800
http://recordit.co/hlulw8VJOC -> 1280 x 1024
http://recordit.co/7vzE8Gs6L3 -> 1024 x 700
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
