### PR TITLE
klientctl: added --fuse option

### DIFF
--- a/go/src/koding/klientctl/clifactories.go
+++ b/go/src/koding/klientctl/clifactories.go
@@ -45,6 +45,7 @@ func MountCommandFactory(c *cli.Context, log logging.Logger, cmdName string) ctl
 		OneWaySync:       c.Bool("oneway-sync"),
 		OneWayInterval:   c.Int("oneway-interval"),
 		Debug:            c.Bool("debug"),
+		Fuse:             c.Bool("fuse"),
 
 		// Used for prefetch
 		SSHDefaultKeyDir:  config.SSHDefaultKeyDir,

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -151,27 +151,32 @@ func main() {
 				},
 				cli.IntFlag{
 					Name:  "oneway-interval",
-					Usage: "Sets how frequently local folder will sync with remote, in seconds. Default is 2 seconds.",
+					Usage: "Sets how frequently local folder will sync with remote, in seconds. ",
+					Value: 2,
+				},
+				cli.BoolFlag{
+					Name:  "fuse, f",
+					Usage: "Mount the remote folder via Fuse.",
 				},
 				cli.BoolFlag{
 					Name:  "noprefetch-meta, p",
-					Usage: "Retrieve only top level folder/files. Rest is fetched on request (fastest to mount).",
+					Usage: "For fuse: Retrieve only top level folder/files. Rest is fetched on request (fastest to mount).",
 				},
 				cli.BoolFlag{
 					Name:  "prefetch-all, a",
-					Usage: "Prefetch all contents of the remote directory up front.",
+					Usage: "For fuse: Prefetch all contents of the remote directory up front.",
 				},
 				cli.IntFlag{
 					Name:  "prefetch-interval",
-					Usage: "Sets how frequently remote folder will sync with local, in seconds.",
+					Usage: "For fuse: Sets how frequently remote folder will sync with local, in seconds.",
 				},
 				cli.BoolFlag{
 					Name:  "nowatch, w",
-					Usage: "Disable watching for changes on remote machine.",
+					Usage: "For fuse: Disable watching for changes on remote machine.",
 				},
 				cli.BoolFlag{
 					Name:  "noignore, i",
-					Usage: "Retrieve all files and folders, including ignored folders like .git & .svn.",
+					Usage: "For fuse: Retrieve all files and folders, including ignored folders like .git & .svn.",
 				},
 				cli.BoolFlag{
 					Name:  "trace, t",

--- a/go/src/koding/klientctl/mount.go
+++ b/go/src/koding/klientctl/mount.go
@@ -57,6 +57,7 @@ type MountOptions struct {
 	Trace            bool
 	OneWaySync       bool
 	OneWayInterval   int
+	Fuse             bool
 
 	// Used for Prefetching via RSync (SSH)
 	SSHDefaultKeyDir  string
@@ -354,6 +355,9 @@ func (c *MountCommand) handleOptions() (int, error) {
 	if c.Options.OneWaySync {
 		var invalidOption bool
 		switch {
+		case c.Options.Fuse:
+			c.printfln(errormessages.InvalidCLIOption, "--fuse", "--oneway-sync")
+			invalidOption = true
 		case c.Options.PrefetchAll:
 			c.printfln(errormessages.InvalidCLIOption, "--prefetch-all", "--oneway-sync")
 			invalidOption = true


### PR DESCRIPTION
To simplify the UX of turning off "smart mount", a --fuse option has
been added. This will force the usage of Fuse regardless of the remote
folders size or containing data. Further modification of the fuse
settings can of course still use --prefetch-all and etc.
