### PR TITLE
Added a docker-composer version note to readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,6 +21,7 @@ rest you can follow these steps:
 ```bash
 git clone https://github.com/koding/docker-compose.git koding-docker-compose
 cd koding-docker-compose
+# Requires docker-compose version >= 1.6
 docker-compose up -d
 ```
 


### PR DESCRIPTION
Added a note to the readme to let nooblets know that they'll need docker-composer >= version 1.6.

If this prevents head-smashing for even one person, we will have done well.
