### PR TITLE
provider/vagrant: fix appending to user-defined ports

### DIFF
--- a/go/src/koding/kites/kloud/provider/vagrant/stackplan.go
+++ b/go/src/koding/kites/kloud/provider/vagrant/stackplan.go
@@ -163,9 +163,17 @@ func (s *Stack) InjectVagrantData() (string, stackplan.KiteMap, error) {
 			box["box"] = "${var.vagrant_box}"
 		}
 
-		ports, ok := box["forwarded_ports"].([]interface{})
-		if !ok {
-			ports = make([]interface{}, 0)
+		var ports []interface{}
+
+		switch p := box["forwarded_ports"].(type) {
+		case []interface{}:
+			ports = p
+		case []map[string]interface{}:
+			ports = make([]interface{}, len(p))
+
+			for i := range p {
+				ports[i] = p[i]
+			}
 		}
 
 		// klient kite port


### PR DESCRIPTION
The array type is `[]interface{}` in encoding/json, in yaml-go it can also be `[]map[string]interface{}`.

The missing test for this case as well as other cases I'm going to send in separate PR.
