### PR TITLE
StackEditor: editor updates after button actions

### DIFF
--- a/client/stack-editor/lib/editor/index.coffee
+++ b/client/stack-editor/lib/editor/index.coffee
@@ -865,7 +865,7 @@ module.exports = class StackEditorView extends kd.View
 
       return  if @outputView.handleError err
 
-      @setAsDefaultButton.hide()
+      @setAsDefaultButton.disable()
 
       Tracker.track Tracker.STACKS_MAKE_DEFAULT
 

--- a/client/stack-editor/lib/editor/index.coffee
+++ b/client/stack-editor/lib/editor/index.coffee
@@ -515,9 +515,9 @@ module.exports = class StackEditorView extends kd.View
       else
         # admin is creating a new stack
         if isAdmin()
+          @afterProcessTemplate 'maketeamdefault'
+          @afterProcessTemplate 'initialize'
           if hasGroupTemplates
-            @afterProcessTemplate 'maketeamdefault'
-            @afterProcessTemplate 'initialize'
             computeController.checkGroupStacks()
           else
             @handleSetDefaultTemplate =>

--- a/client/stack-editor/lib/index.coffee
+++ b/client/stack-editor/lib/index.coffee
@@ -23,6 +23,13 @@ module.exports = class StackEditorAppController extends AppController
 
     @selectedEditor = null
 
+    { router } = kd.singletons
+    router.on 'RouteInfoHandled', (routeInfo) =>
+      return  unless @selectedEditor
+
+      { data, reloadRequired } = @selectedEditor
+      @removeEditor data.stackTemplate._id  if reloadRequired
+
 
   openEditor: (stackTemplateId) ->
 
@@ -140,9 +147,8 @@ module.exports = class StackEditorAppController extends AppController
 
     { computeController } = kd.singletons
 
-    EnvironmentFlux.actions.fetchAndUpdateStackTemplate templateId, (template) =>
-      @removeEditor template._id
-      @showView template
+    EnvironmentFlux.actions.fetchAndUpdateStackTemplate(templateId).then (template) =>
+      @editors[template._id]?.reloadRequired = yes
 
 
   createEditor: (stackTemplate) ->

--- a/client/stack-editor/lib/index.coffee
+++ b/client/stack-editor/lib/index.coffee
@@ -143,13 +143,17 @@ module.exports = class StackEditorAppController extends AppController
     editor?.destroy()
 
 
-  reloadEditor: (templateId) ->
+  reloadEditor: (templateId, skipDataUpdate) ->
 
-    { computeController } = kd.singletons
+    return @markAsReloadRequired templateId  if skipDataUpdate
 
-    EnvironmentFlux.actions.fetchAndUpdateStackTemplate(templateId).then (template) =>
-      templateId = template._id
-      @shouldReloadMap[templateId] = yes  if @editors[templateId]?
+    EnvironmentFlux.actions.fetchAndUpdateStackTemplate(templateId)
+      .then @lazyBound 'markAsReloadRequired', templateId
+
+
+  markAsReloadRequired: (templateId) ->
+
+    @shouldReloadMap[templateId] = yes  if @editors[templateId]?
 
 
   createEditor: (stackTemplate) ->

--- a/client/stack-editor/lib/styl/stackeditor.styl
+++ b/client/stack-editor/lib/styl/stackeditor.styl
@@ -223,6 +223,7 @@ $borderColor                = #E3E3E3
   button
     &[disabled]
       opacity               .5
+      color                 #fff
 
   .kdformview
     margin-top              20px


### PR DESCRIPTION
## Description

This PR contains a few fixes in stack editor:
- it leaves `Make Team Default` button visible (and disabled) on the editor after user made stack template default for the team
- it returned back reloading editor on `Reload` event (previously it was broken)
## Motivation and Context

https://github.com/koding/koding/issues/8791
https://github.com/koding/koding/issues/8969
## Screenshots (if appropriate):

http://recordit.co/sX3fC8Es1M
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
