### PR TITLE
Config: Use google api key from credentials

### DIFF
--- a/config/credentials.default.coffee
+++ b/config/credentials.default.coffee
@@ -128,6 +128,7 @@ module.exports = (options) ->
     client_id: ''
     client_secret: ''
     redirect_uri: "http://dev.koding.com:8090/-/oauth/google/callback"
+    apiKey: ''
   twitter =
     key: ''
     secret: ''
@@ -245,4 +246,5 @@ module.exports = (options) ->
     dummyAdmins
     druid
     clearbit
+    intercomAppId
   }

--- a/config/generateRuntimeConfig.coffee
+++ b/config/generateRuntimeConfig.coffee
@@ -34,7 +34,7 @@ module.exports = (KONFIG, credentials, options) ->
     troubleshoot         : { idleTime: 1000 * 60 * 60, externalUrl: 'https://s3.amazonaws.com/koding-ping/healthcheck.json' }
     stripe               : { token: credentials.stripe.publicToken }
     broker               : { uri: '/subscribe' }
-    google               : { apiKey: '' }
+    google               : { apiKey: credentials.google.apiKey }
     gitlab               : { team: credentials.gitlab.team }
     paypal               : { formUrl: credentials.paypal.formUrl }
     embedly              : { apiKey: credentials.embedly.apiKey }


### PR DESCRIPTION
Export google api key to client correctly to make collaboration work again with url shortener.
