### PR TITLE
client: style fix for close icon position

### DIFF
--- a/client/app/lib/styl/homewelcome.styl
+++ b/client/app/lib/styl/homewelcome.styl
@@ -30,6 +30,7 @@ $linkColor                  = #56A2D3
     .close-icon.closeModal
       r-sprite              app modal_close
       margin                16px 16px 0 0
+      background-position   0
 
 
 .WelcomeStacksView


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Currently, the close icon at home welcome steps were not positioned correctly. This PR fixes that problem.
## Motivation and Context

Fixes #8963 
## How Has This Been Tested?

Manually.
## Screenshots (if appropriate):

Currently: 
![image](https://cloud.githubusercontent.com/assets/8138047/18306082/1a423626-749f-11e6-8512-51bf51e32a3d.png)

After PR:
![image](https://cloud.githubusercontent.com/assets/8138047/18306099/285adde4-749f-11e6-881b-be17a8845ff7.png)
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
