### PR TITLE
'Edit' option is not available on stack menu for member's personal stacks. And After changing 'Always ON' or 'VM Sharing' state, 'Edit VM Name' is not working properly.

### DIFF
--- a/client/app/lib/components/sidebarstacksection/index.coffee
+++ b/client/app/lib/components/sidebarstacksection/index.coffee
@@ -113,7 +113,8 @@ module.exports = class SidebarStackSection extends React.Component
     if managedVM
       menuItems['VMs'] = { callback }
     else
-      menuItems['Edit'] = { callback }  if isAdmin()
+      if isAdmin() or @props.stack.get('accessLevel') is 'private'
+        menuItems['Edit'] = { callback }
       ['Reinitialize', 'VMs', 'Destroy VMs'].forEach (name) ->
         menuItems[name] = { callback }
 

--- a/client/app/lib/flux/environment/actions.coffee
+++ b/client/app/lib/flux/environment/actions.coffee
@@ -797,9 +797,12 @@ unshareMachineWihAllUsers = (machineId) ->
 
 setLabel = (machineUId, label) ->
 
+  {computeController} = kd.singletons
+
   new Promise (resolve, reject) ->
     fetchMachineByUId machineUId, (machine) ->
       machine.setLabel label, (err, newLabel) ->
+        computeController.triggerReviveFor machine._id
         return reject err  if err
         resolve newLabel
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Members will see edit option in their stack menu items
Even After changing machine stack user will be able to edit machine label
## Motivation and Context

fixes #8973 
fixes #8972 
## How Has This Been Tested?

Manually
## Screenshots (if appropriate):

![](https://monosnap.com/file/dqTl5bj5NoO8k3LvI2NQcExOULQ3rj.png)
http://recordit.co/N3pDBHyvdh
