### PR TITLE
Verify user email if it wasn't verified while fetching otaToken

### DIFF
--- a/workers/social/lib/social/models/account.coffee
+++ b/workers/social/lib/social/models/account.coffee
@@ -1365,26 +1365,18 @@ module.exports = class JAccount extends jraphical.Module
 
     return errorCallback()  unless sessionToken
 
-    @isEmailVerified (err, isVerified) ->
+    JSession         = require './session'
+    { v4: createId } = require 'node-uuid'
 
-      return callback err  if err
+    JSession.one { clientId: sessionToken }, (err, session) ->
 
-      if not isVerified
-        message = 'Sorry, you need to confirm your email address first.'
-        return callback new KodingError message
+      if err or not session
+        return errorCallback()
 
-      JSession         = require './session'
-      { v4: createId } = require 'node-uuid'
-
-      JSession.one { clientId: sessionToken }, (err, session) ->
-
-        if err or not session
-          return errorCallback()
-
-        [otaToken] = createId().split '-'
-        session.update { $set: { otaToken } }, (err) ->
-          if err then errorCallback()
-          else callback null, otaToken
+      [otaToken] = createId().split '-'
+      session.update { $set: { otaToken } }, (err) ->
+        if err then errorCallback()
+        else callback null, otaToken
 
 
   ###*


### PR DESCRIPTION
For users from solo account with no verified email, verify their emails while fetching otaToken.
## Motivation and Context

fixes #8910 
## How Has This Been Tested?

It doesn't break anything for other users.
Needs an account with not verified email and will see otaToken in Cli section in utilities
