### PR TITLE
client: size fix for leave shared session

### DIFF
--- a/client/app/lib/components/sidebarmachineslistitem/styl/sidebarwidget.styl
+++ b/client/app/lib/components/sidebarmachineslistitem/styl/sidebarwidget.styl
@@ -26,7 +26,6 @@
       height  42px
 
     .GenericButton
-      max-width 100px
       .button-title
         line-height 14px
         font-size 14px
@@ -34,6 +33,7 @@
       width   200px
       display flex
       button.reject
+        max-width 100px
         float   left
         background            #FFFFFF
         border                1px solid #BEBEBE
@@ -43,6 +43,7 @@
           color               #5E5E5E
 
       button.accept
+        max-width 100px
         float                 right
         .button-title
           font-weight         300


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Currently, leave shared VM button wasn't looking as it should be. This PR fixes that.
## Motivation and Context

Fixes #8974 
## How Has This Been Tested?

Manually
## Screenshots (if appropriate):

Chrome: 
![image](https://cloud.githubusercontent.com/assets/8138047/18334085/8471696a-7529-11e6-9c54-23f061f83194.png)

Firefox:
![image](https://cloud.githubusercontent.com/assets/8138047/18334089/8be6ebb6-7529-11e6-80fb-333f76bbf008.png)
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
