### PR TITLE
Terminal: don't calculate and resize terminals while parents are hidden

### DIFF
--- a/client/app/lib/terminal/terminal.coffee
+++ b/client/app/lib/terminal/terminal.coffee
@@ -211,10 +211,9 @@ module.exports = class Terminal extends KDObject
 
     @updateAppSize()
 
-    return  unless @parent
-
     [swidth, sheight] = [@parent.getWidth(), @parent.getHeight()]
 
+    return  if 0 in [swidth, sheight]
     return  if not force and swidth is @currentWidth and sheight is @currentHeight
 
     @scrollToBottom()

--- a/client/ide/lib/workspace/idelayoutmanager.coffee
+++ b/client/ide/lib/workspace/idelayoutmanager.coffee
@@ -273,7 +273,7 @@ module.exports = class IDELayoutManager extends KDObject
    * @param {Object} snapshot
    * @return {Object} Key value map with pane identifiers.
   ###
-  @getPaneHashMap: (snapshot) ->
+  @getPaneHashMap = (snapshot) ->
 
     panes   = {}
     asArray = IDELayoutManager.convertSnapshotToFlatArray snapshot
@@ -297,7 +297,7 @@ module.exports = class IDELayoutManager extends KDObject
    * @param {Array} panes  Referenced parameter
    * @param {Array} views
   ###
-  @findPanesFromArray: (panes, views) ->
+  @findPanesFromArray = (panes, views) ->
 
     return  unless views?.length
 


### PR DESCRIPTION
## Description

Terminal panes are getting set to `1,1` size because of wrong calculation for hidden panes, we don't need that so this change fixes that behaviour.

fixes #8976 
## Screenshots (if appropriate):

![](http://g.recordit.co/DrMN5tezJG.gif)
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
