### PR TITLE
add make team default button for Sidebar stack menu items

### DIFF
--- a/client/app/lib/components/sidebarstacksection/index.coffee
+++ b/client/app/lib/components/sidebarstacksection/index.coffee
@@ -8,6 +8,7 @@ StackUpdatedWidget        = require './stackupdatedwidget'
 getBoundingClientReact    = require 'app/util/getBoundingClientReact'
 SidebarMachinesListItem   = require 'app/components/sidebarmachineslistitem'
 isAdmin = require 'app/util/isAdmin'
+remote = require 'app/remote'
 { findDOMNode } = require 'react-dom'
 
 require './styl/sidebarstacksection.styl'
@@ -68,7 +69,7 @@ module.exports = class SidebarStackSection extends React.Component
 
   onMenuItemClick: (item, event) ->
 
-    { appManager, router } = kd.singletons
+    { appManager, router, linkController, computeController } = kd.singletons
     { stack } = @props
     { reinitStackFromWidget, deleteStack } = EnvironmentFlux.actions
 
@@ -76,6 +77,7 @@ module.exports = class SidebarStackSection extends React.Component
     MENU.destroy()
 
     templateId = stack.get 'baseStackId'
+
 
     switch title
       when 'Edit' then router.handleRoute "/Stack-Editor/#{templateId}"
@@ -87,7 +89,10 @@ module.exports = class SidebarStackSection extends React.Component
       when 'VMs' then router.handleRoute "/Home/Stacks/virtual-machines"
       when 'Open on GitLab'
         remoteUrl = stack.getIn ['config', 'remoteDetails', 'originalUrl']
-        kd.singletons.linkController.openOrFocus remoteUrl
+        linkController.openOrFocus remoteUrl
+      when 'Make Team Default'
+        remote.api.JStackTemplate.one { _id: templateId }, (err, template) ->
+          computeController.makeTeamDefault template, no  unless err
 
 
   onTitleClick: (event) ->
@@ -117,6 +122,8 @@ module.exports = class SidebarStackSection extends React.Component
         menuItems['Edit'] = { callback }
       ['Reinitialize', 'VMs', 'Destroy VMs'].forEach (name) ->
         menuItems[name] = { callback }
+      if isAdmin() and not @isSharedTeamStackTemplate()
+        menuItems['Make Team Default'] = { callback }
 
     { top } = findDOMNode(this).getBoundingClientRect()
 
@@ -125,6 +132,14 @@ module.exports = class SidebarStackSection extends React.Component
     MENU = new kd.ContextMenu menuOptions, menuItems
 
     MENU.once 'KDObjectWillBeDestroyed', -> kd.utils.wait 50, -> MENU = null
+
+
+  isSharedTeamStackTemplate: ->
+
+    { groupsController } = kd.singletons
+    { stackTemplates } = groupsController.getCurrentGroup()
+
+    return @props.stack.get('baseStackId') in stackTemplates
 
 
   renderStackUpdatedWidget: ->

--- a/client/app/lib/components/sidebarstacksection/index.coffee
+++ b/client/app/lib/components/sidebarstacksection/index.coffee
@@ -9,6 +9,7 @@ getBoundingClientReact    = require 'app/util/getBoundingClientReact'
 SidebarMachinesListItem   = require 'app/components/sidebarmachineslistitem'
 isAdmin = require 'app/util/isAdmin'
 remote = require 'app/remote'
+isStackTemplateSharedWithTeam = require 'app/util/isstacktemplatesharedwithteam'
 { findDOMNode } = require 'react-dom'
 
 require './styl/sidebarstacksection.styl'
@@ -122,7 +123,7 @@ module.exports = class SidebarStackSection extends React.Component
         menuItems['Edit'] = { callback }
       ['Reinitialize', 'VMs', 'Destroy VMs'].forEach (name) ->
         menuItems[name] = { callback }
-      if isAdmin() and not @isSharedTeamStackTemplate()
+      if isAdmin() and not isStackTemplateSharedWithTeam @props.stack.get 'baseStackId'
         menuItems['Make Team Default'] = { callback }
 
     { top } = findDOMNode(this).getBoundingClientRect()
@@ -132,14 +133,6 @@ module.exports = class SidebarStackSection extends React.Component
     MENU = new kd.ContextMenu menuOptions, menuItems
 
     MENU.once 'KDObjectWillBeDestroyed', -> kd.utils.wait 50, -> MENU = null
-
-
-  isSharedTeamStackTemplate: ->
-
-    { groupsController } = kd.singletons
-    { stackTemplates } = groupsController.getCurrentGroup()
-
-    return @props.stack.get('baseStackId') in stackTemplates
 
 
   renderStackUpdatedWidget: ->

--- a/client/app/lib/styl/generic.styl
+++ b/client/app/lib/styl/generic.styl
@@ -35,6 +35,10 @@ $secondaryActiveColor       = #656565
     &:hover
       bg                    color, $secondaryActiveColor
 
+  &:focus
+    border          1px solid rgba(125,190,241,1)
+    shadow          0 0 3px rgba(125,190,241,.7), 0 0 0px 1px #7dbef1 !important
+
   span.button-title
     font-family             SoleilFamily
     font-size               13.5px
@@ -48,6 +52,11 @@ $secondaryActiveColor       = #656565
       font-size             14px
       font-weight           500
       letter-spacing        .3px
+
+.GenericButton[disabled]
+.GenericButton[disabled]:hover
+.GenericButton[disabled]:active
+  bg                        color, $accentColor !important
 
 
 .GenericButtonGroup

--- a/client/app/lib/util/isstacktemplatesharedwithteam.coffee
+++ b/client/app/lib/util/isstacktemplatesharedwithteam.coffee
@@ -1,0 +1,8 @@
+kd = require 'kd'
+
+module.exports = isStackTemplateSharedWithTeam = (baseStackId) ->
+
+  { groupsController } = kd.singletons
+  { stackTemplates } = groupsController.getCurrentGroup()
+
+  return baseStackId in stackTemplates

--- a/client/stack-editor/lib/editor/index.coffee
+++ b/client/stack-editor/lib/editor/index.coffee
@@ -175,6 +175,9 @@ module.exports = class StackEditorView extends kd.View
     @createOutputView()
     @createMainButtons()
 
+    # if stackTemplate is initialized make save button disabled
+    @saveButton.setClass 'disableButton'  if stackTemplate?.machines.length
+
     @providersView.on 'ItemSelected', (credentialItem) =>
 
       credential = credentialItem.getData()
@@ -237,6 +240,7 @@ module.exports = class StackEditorView extends kd.View
 
       editorView.on 'EditorReady', =>
         ace.on 'FileContentChanged', =>
+          @saveButton.unsetClass 'disableButton'
           @changedContents[key] = ace.isContentChanged()
 
 

--- a/client/stack-editor/lib/editor/index.coffee
+++ b/client/stack-editor/lib/editor/index.coffee
@@ -176,10 +176,10 @@ module.exports = class StackEditorView extends kd.View
     @createMainButtons()
 
     # if stackTemplate is initialized make save button disabled
-    @saveButton.setClass 'disableButton'  if stackTemplate?.machines.length
+    @saveButton.disable()  if stackTemplate?.machines.length
 
     @providersView.on 'ItemSelected', (credentialItem) =>
-
+      @saveButton.enable() # credential change, enable button
       credential = credentialItem.getData()
 
       @credentialStatusView.setCredential credential
@@ -188,7 +188,7 @@ module.exports = class StackEditorView extends kd.View
       credentialItem.inuseView.show()
 
     @providersView.on 'ItemDeleted', (credential) =>
-
+      @saveButton.enable() # credential change, enable button
       { identifier } = credential.getData()
       if identifier in @credentialStatusView.credentials
         @credentialStatusView.setCredential() # To unset active credential since it's deleted
@@ -240,7 +240,7 @@ module.exports = class StackEditorView extends kd.View
 
       editorView.on 'EditorReady', =>
         ace.on 'FileContentChanged', =>
-          @saveButton.unsetClass 'disableButton'
+          @saveButton.enable()
           @changedContents[key] = ace.isContentChanged()
 
 

--- a/client/stack-editor/lib/styl/stackeditorheader.styl
+++ b/client/stack-editor/lib/styl/stackeditorheader.styl
@@ -33,7 +33,9 @@ $borderColor                = #E3E3E3
       padding               12px 20px
     &.isntMine
       display               none
-
+    &.disableButton
+      opacity 0.5
+      pointer-events none
 
   .kdinput.text
     flex                    0 1 auto

--- a/client/stack-editor/lib/styl/stackeditorheader.styl
+++ b/client/stack-editor/lib/styl/stackeditorheader.styl
@@ -29,13 +29,11 @@ $borderColor                = #E3E3E3
   .GenericButton
     margin                  3px 0 0 10px
     padding                 12px 40px
+    height                  43px
     &:not(.save-test)
       padding               12px 20px
     &.isntMine
       display               none
-    &.disableButton
-      opacity 0.5
-      pointer-events none
 
   .kdinput.text
     flex                    0 1 auto


### PR DESCRIPTION
This pr give admins chance to make their stacks default for team from sidebar menu item. 
And also this pr improves user experience
## Description
- For initialized stack templates, when user edit his/her own stack template, will see `Save` button disabled, after editing stack template user will be able to save new stack template and rest is same.
- Admins will be able to make their stack default for team from sidebar menu items. 
## Motivation and Context
#8952
## How Has This Been Tested?

manually
## Screenshots (if appropriate):

http://recordit.co/pERYRhKR7R
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
