### PR TITLE
StackUpdatedWidget: make visible when stack unread count increases

### DIFF
--- a/client/app/lib/components/sidebarstacksection/index.coffee
+++ b/client/app/lib/components/sidebarstacksection/index.coffee
@@ -33,10 +33,16 @@ module.exports = class SidebarStackSection extends React.Component
 
 
   getDataBindings: ->
+
     selectedTemplateId: EnvironmentFlux.getters.selectedTemplateId
 
 
-  componentWillReceiveProps: -> @setCoordinates()
+  componentWillReceiveProps: (nextProps) ->
+
+    nextStackUnreadCount = @getStackUnreadCount nextProps.stack
+    @setState { showWidget : yes }  if nextStackUnreadCount > @getStackUnreadCount()
+
+    @setCoordinates()
 
 
   componentDidMount: -> @setCoordinates()
@@ -139,7 +145,12 @@ module.exports = class SidebarStackSection extends React.Component
       left : coordinates.left + 6
       top : coordinates.top - 2
 
-    <StackUpdatedWidget coordinates={coordinates} stack={@props.stack} show={showWidget} />
+    <StackUpdatedWidget
+      coordinates={coordinates}
+      stack={@props.stack}
+      visible={showWidget}
+      onClose={@bound 'onWidgetClose'}
+    />
 
 
   unreadCountClickHandler: ->
@@ -147,9 +158,14 @@ module.exports = class SidebarStackSection extends React.Component
     @setState { showWidget: yes }
 
 
-  getStackUnreadCount: ->
+  onWidgetClose: ->
 
-    @props.stack.getIn [ '_revisionStatus', 'status', 'code' ]
+    @setState { showWidget: no }
+
+
+  getStackUnreadCount: (stack = @props.stack) ->
+
+    stack?.getIn [ '_revisionStatus', 'status', 'code' ]
 
 
   render: ->

--- a/client/app/lib/components/sidebarstacksection/stackupdatedwidget.coffee
+++ b/client/app/lib/components/sidebarstacksection/stackupdatedwidget.coffee
@@ -1,4 +1,5 @@
-kd = require 'kd'
+kd            = require 'kd'
+immutable     = require 'immutable'
 React         = require 'kd-react'
 actions       = require 'app/flux/environment/actions'
 SidebarWidget = require 'app/components/sidebarmachineslistitem/sidebarwidget'
@@ -8,36 +9,24 @@ module.exports = class StackUpdatedWidget extends React.Component
 
   @defaultProps =
     className   : 'StackUpdated'
-
-
-  constructor: ->
-
-    @state    =
-      isShown : no
-
-
-  componentWillReceiveProps: (nextProps) ->
-
-    @setState { isShown : not nextProps.show }
+    visible     : no
+    onClose     : kd.noop
+    stack       : immutable.Map()
 
 
   handleOnClick : ->
+
     { appManager, router } = kd.singletons
     templateId =  @props.stack.get 'baseStackId'
     actions.reinitStackFromWidget(@props.stack).then ->
       appManager.tell 'Stackeditor', 'reloadEditor', templateId
 
 
-  handleOnClose: ->
-
-    @setState { isShown : yes }
-
-
   render: ->
 
-    return null  if @state.isShown
+    return null  unless @props.visible
 
-    <SidebarWidget {...@props} onClose={@bound 'handleOnClose'}>
+    <SidebarWidget {...@props} onClose={@props.onClose}>
       <span>STACK UPDATED</span>
       <p className='SidebarWidget-Title'>You need to reinitialize your machines before booting.</p>
       <button className='kdbutton solid medium green reinit-stack' onClick={@bound 'handleOnClick'}>

--- a/client/home/lib/stacks/components/stacktemplateitem/index.coffee
+++ b/client/home/lib/stacks/components/stacktemplateitem/index.coffee
@@ -21,10 +21,16 @@ module.exports = class StackTemplateItem extends React.Component
       showWidget  : no
 
 
-  componentWillReceiveProps: -> @setCoordinates()
+  componentWillReceiveProps: (nextProps) ->
+
+    nextStackUnreadCount = @getStackUnreadCount nextProps.stack
+    @setState { showWidget : yes }  if nextStackUnreadCount > @getStackUnreadCount()
+
+    @setCoordinates()
 
 
   componentDidMount: ->
+
     $('.kdscrollview').on 'scroll', _.debounce @bound('scrollOnPage'), 500, { leading: yes, trailing: no }
     @setCoordinates()
 
@@ -52,9 +58,9 @@ module.exports = class StackTemplateItem extends React.Component
       <a href="#" className="HomeAppView--button primary" onClick={onAddToSidebar}>ADD TO SIDEBAR</a>
 
 
-  getStackUnreadCount: ->
+  getStackUnreadCount: (stack = @props.stack) ->
 
-    @props.stack?.getIn [ '_revisionStatus', 'status', 'code' ]
+    stack?.getIn [ '_revisionStatus', 'status', 'code' ]
 
 
   renderUnreadCount: ->
@@ -72,6 +78,11 @@ module.exports = class StackTemplateItem extends React.Component
     @setState { showWidget: yes }
 
 
+  onWidgetClose: ->
+
+    @setState { showWidget: no }
+
+
   renderStackUpdatedWidget: ->
 
     { coordinates, showWidget } = @state
@@ -81,7 +92,14 @@ module.exports = class StackTemplateItem extends React.Component
 
     coordinates.top = coordinates.top - 160
     coordinates.left = coordinates.left - 22
-    <StackUpdatedWidget className={'StackTemplate'} coordinates={coordinates} stack={@props.stack} show={showWidget} />
+
+    <StackUpdatedWidget
+      className='StackTemplate'
+      coordinates={coordinates}
+      stack={@props.stack}
+      visible={showWidget}
+      onClose={@bound 'onWidgetClose'}
+    />
 
 
   render: ->


### PR DESCRIPTION
## Description

The main goal of this PR is to show `StackUpdatedWidget` when stack unread count increases.
Also, I removed the state of `StackUpdatedWidget` since it strongly correlates with the state of parent component. I replaced `isShown` state prop with simple prop `visible` which is set by parent. Parent knows when to show `StackUpdatedWidget` and it listens to widget's `onClose` callback in order to hide it. Visibility of `StackUpdatedWidget` is set by parent's `state.showWidget` value.
## Motivation and Context

https://github.com/koding/koding/issues/8971
## Screenshots (if appropriate):

http://recordit.co/sWsMY6JOvf
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
