### PR TITLE
CredentialListItem: error message format fix

### DIFF
--- a/client/stack-editor/lib/credentials/credentiallistitem.coffee
+++ b/client/stack-editor/lib/credentials/credentiallistitem.coffee
@@ -95,7 +95,8 @@ module.exports = class CredentialListItem extends kd.ListItemView
       .then (response) =>
         if status = response?[identifier]
           if message = status.message
-            message = message.split('\n')[..-2].join ''
+            messageLines = message.split('\n')
+            message = messageLines[..-2].join ''  if messageLines.length > 1
           @setVerified status.verified, message
           HomeActions.markAsDone 'enterCredentials'
         else


### PR DESCRIPTION
## Description

It fixes a case when credential error message is just a one line text. In this case we can show it as is without any formatting
## Motivation and Context

https://github.com/koding/koding/issues/8996
## Screenshots (if appropriate):

http://recordit.co/w4Ftj1ZsAo
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
