### PR TITLE
Handle error when stack template is not shared with team

### DIFF
--- a/client/app/lib/util/isstacktemplatesharedwithteam.coffee
+++ b/client/app/lib/util/isstacktemplatesharedwithteam.coffee
@@ -3,6 +3,6 @@ kd = require 'kd'
 module.exports = isStackTemplateSharedWithTeam = (baseStackId) ->
 
   { groupsController } = kd.singletons
-  { stackTemplates } = groupsController.getCurrentGroup()
+  stackTemplates = groupsController.getCurrentGroup().stackTemplates ? []
 
   return baseStackId in stackTemplates


### PR DESCRIPTION
Handle if stack template is not shared with team
