### PR TITLE
ResourceStateModal: show machine name on the modal when turning VM on

### DIFF
--- a/client/app/lib/providers/resourcestatemodal/controllers/machineflowcontroller.coffee
+++ b/client/app/lib/providers/resourcestatemodal/controllers/machineflowcontroller.coffee
@@ -68,7 +68,7 @@ module.exports = class MachineFlowController extends kd.Controller
     { container } = @getOptions()
     machine = @getData()
 
-    @startMachinePage = new StartMachinePageView()
+    @startMachinePage = new StartMachinePageView {}, machine
     @startMachineProgressPage = new StartMachineProgressPageView {}, machine
     @startMachineSuccessPage = new StartMachineSuccessPageView()
     @startMachineErrorPage = new StartMachineErrorPageView()

--- a/client/app/lib/providers/resourcestatemodal/views/machineflow/startmachinepageview.coffee
+++ b/client/app/lib/providers/resourcestatemodal/views/machineflow/startmachinepageview.coffee
@@ -15,16 +15,19 @@ module.exports = class StartMachinePageView extends JView
 
   pistachio: ->
 
-    '''
+    machine = @getData()
+    title   = machine.jMachine.label
+
+    """
       <div class="start-machine-flow start-machine-page">
         <header>
           <h1>Boot Virtual Machine</h1>
         </header>
         <section class="main">
           <div class="background"></div>
-          <h2>Let's Boot up your VM</h2>
+          <h2>Let's Boot up #{title}</h2>
           <p>One click and your flawless dev environment<br />will be ready to use</p>
           {{> @startButton}}
         </section>
       </div>
-    '''
+    """


### PR DESCRIPTION
It shows selected machine's name on the modal with `TURN VM ON` button (as khaled requested)

![vm-name-on-modal](https://cloud.githubusercontent.com/assets/492219/18508760/27f7ef7e-7a7e-11e6-8e34-aabcb50bed0c.png)
