### PR TITLE
client: adds 'beta' tag to providers

### DIFF
--- a/client/stack-editor/lib/onboarding/providerselectionview.coffee
+++ b/client/stack-editor/lib/onboarding/providerselectionview.coffee
@@ -34,8 +34,7 @@ module.exports = class ProviderSelectionView extends JView
       if provider in enabledProviders
         extraClass = ''
         label      = ''
-        beta       = ''
-        betaLabel  = ''
+        
         if provider in betaProviders
           beta       = 'beta'
           betaLabel  = 'BETA'

--- a/client/stack-editor/lib/onboarding/providerselectionview.coffee
+++ b/client/stack-editor/lib/onboarding/providerselectionview.coffee
@@ -21,16 +21,25 @@ module.exports = class ProviderSelectionView extends JView
       'aws', 'vagrant', 'azure', 'digitalocean', 'googlecloud', 'rackspace'
     ]
     enabledProviders = ['aws', 'vagrant']
+    betaProviders = ['vagrant']
 
     @providers = new kd.CustomHTMLView { cssClass: 'providers box-wrapper clearfix' }
 
     providers.forEach (provider) =>
       extraClass = 'coming-soon'
       label      = 'Coming Soon'
+      beta       = ''
+      betaLabel  = ''
 
       if provider in enabledProviders
         extraClass = ''
         label      = ''
+        beta       = ''
+        betaLabel  = ''
+        if provider in betaProviders
+          beta       = 'beta'
+          betaLabel  = 'BETA'
+
 
       @providers.addSubView providerView = new kd.CustomHTMLView
         cssClass : "provider box #{extraClass} #{provider}"
@@ -38,6 +47,7 @@ module.exports = class ProviderSelectionView extends JView
         partial  : """
           <img class="#{provider}" src="/a/images/providers/stacks/#{provider}.png" />
           <div class="label">#{label}</div>
+          <div class="#{beta}">#{betaLabel}</div>
         """
         click: =>
           return if extraClass is 'coming-soon'

--- a/client/stack-editor/lib/styl/stackwizard.styl
+++ b/client/stack-editor/lib/styl/stackwizard.styl
@@ -236,6 +236,18 @@ $accentColor                = #F2778A
       font-weight           300
       font-size             12px
 
+  .beta
+    color                   white
+    background              #A8CEFD
+    height                  18px
+    width                   42px
+    position                absolute
+    font-size               10px
+    line-height             1.8
+    left                    213px
+    top                     10px
+    letter-spacing          0.7px
+
   .box.selected
     shadow                  0 0 0 3px $accentColor
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

If a provider is working as in the beta state, this PR adds 'beta' tag to it.
## Motivation and Context

Solves #9025 
## How Has This Been Tested?

Manually.
## Screenshots (if appropriate):

![image](https://cloud.githubusercontent.com/assets/8138047/18607845/a1d191c8-7ce1-11e6-8372-657c4f190018.png)
## Types of changes
- [x] New feature (non-breaking change which adds functionality)
