### PR TITLE
kloud: fix user-data interpolations

### DIFF
--- a/go/src/koding/kites/kloud/provider/aws/stackplan.go
+++ b/go/src/koding/kites/kloud/provider/aws/stackplan.go
@@ -119,6 +119,8 @@ func (s *Stack) InjectAWSData() (stackplan.KiteMap, error) {
 			Hostname: s.Req.Username, // no typo here. hostname = username
 		}
 
+		s.Builder.InterpolateField(instance, resourceName, "user_data")
+
 		if b, ok := instance["debug"].(bool); ok && b {
 			s.Debug = true
 			delete(instance, "debug")
@@ -139,8 +141,6 @@ func (s *Stack) InjectAWSData() (stackplan.KiteMap, error) {
 		}
 
 		instance["user_data"] = string(userdata)
-
-		s.Builder.InterpolateField(instance, resourceName, "user_data")
 
 		// create independent kiteKey for each machine and create a Terraform
 		// lookup map, which is used in conjuctuon with the `count.index`


### PR DESCRIPTION
Broken by:

```
d0f097d
```

Fixes:

```
[10:36:52] Starting to process the template...
[10:36:52] Something went wrong with the template:
[10:36:52] Cloudinit template is not a valid YAML file. Debugfile:
/tmp/kloud-cloudinit539095275 (error code: 900)
[10:36:52] Parsing failed, please check your template and try again
```
