### PR TITLE
Change team modal: minor updates

### DIFF
--- a/client/app/lib/changeteam/controller.coffee
+++ b/client/app/lib/changeteam/controller.coffee
@@ -15,6 +15,16 @@ module.exports = class ChangeTeamController extends KodingListController
       whoami().fetchRelativeGroups (err, groups) ->
         return  if showError err
         groups = groups.filter (group) -> group.slug isnt 'koding'
+
+        { groupsController } = kd.singletons
+        currentGroup = groupsController.getCurrentGroup()
+        groups = groups.sort (group1, group2) ->
+          return -1  if group1.slug is currentGroup.slug
+          return 1  if group2.slug is currentGroup.slug
+          return -1  if group1.slug < group2.slug
+          return 1  if group1.slug > group2.slug
+          return 0
+
         callback null, groups
     options.noItemFoundWidget = new kd.CustomHTMLView
       tagName  : 'p'

--- a/client/app/lib/changeteam/controller.coffee
+++ b/client/app/lib/changeteam/controller.coffee
@@ -1,4 +1,5 @@
 kd = require 'kd'
+_ = require 'lodash'
 async = require 'async'
 whoami = require 'app/util/whoami'
 KodingListController = require 'app/kodinglist/kodinglistcontroller'
@@ -14,16 +15,16 @@ module.exports = class ChangeTeamController extends KodingListController
     options.fetcherMethod  = (query, options, callback) ->
       whoami().fetchRelativeGroups (err, groups) ->
         return  if showError err
-        groups = groups.filter (group) -> group.slug isnt 'koding'
 
         { groupsController } = kd.singletons
-        currentGroup = groupsController.getCurrentGroup()
-        groups = groups.sort (group1, group2) ->
-          return -1  if group1.slug is currentGroup.slug
-          return 1  if group2.slug is currentGroup.slug
-          return -1  if group1.slug < group2.slug
-          return 1  if group1.slug > group2.slug
-          return 0
+        currentGroup = _.find groups, (group) ->
+          group.slug is groupsController.getCurrentGroup().slug
+
+        rejectedSlugs = [ 'koding', currentGroup.slug ]
+        groups = _.reject groups, (group) -> group.slug in rejectedSlugs
+        groups = _.sortBy groups, 'slug'
+
+        groups.unshift currentGroup
 
         callback null, groups
     options.noItemFoundWidget = new kd.CustomHTMLView

--- a/client/app/lib/styl/changeteammodal.styl
+++ b/client/app/lib/styl/changeteammodal.styl
@@ -55,6 +55,9 @@
     styleScrollBars         rgba(0, 0, 0, .15)
     margin-left             38px
 
+  .lazy-loader
+    margin-bottom           40px
+
   .loaded
     .kdcustomscrollview.has-vertical
       height                332px
@@ -64,7 +67,9 @@
 
   .kdscrollview
     width                   400px
-    margin-bottom           40px
+
+  .no-item-found
+    padding                 10px 0 55px 0
 
   div.change-team-item
     height                  68px
@@ -87,6 +92,7 @@
       border-bottom-left-radius  4px
       border-bottom-right-radius 4px
       border-bottom              1px solid #dcdcdc
+      margin-bottom              40px
 
   .team-logo-wrapper
     size                    40px, 40px


### PR DESCRIPTION
This PR includes the following changes on `Change Team` modal:
- it fixes a lack of bottom indent if the list is scrollable
- it puts the current team at the top of the list, other teams are sorted alphabetically

/cc @ftasdelen 

![](http://g.recordit.co/Xzm6lukzQD.gif)
