### PR TITLE
Allow members to see stack scripts 'read-only'

### DIFF
--- a/client/app/lib/components/sidebarstacksection/index.coffee
+++ b/client/app/lib/components/sidebarstacksection/index.coffee
@@ -87,7 +87,7 @@ module.exports = class SidebarStackSection extends React.Component
 
 
     switch title
-      when 'Edit' then router.handleRoute "/Stack-Editor/#{templateId}"
+      when 'Edit', 'View Stack' then router.handleRoute "/Stack-Editor/#{templateId}"
       when 'Reinitialize', 'Update'
         reinitStackFromWidget(stack).then ->
           # invalidate editor cache
@@ -127,6 +127,8 @@ module.exports = class SidebarStackSection extends React.Component
     else
       if isAdmin() or @props.stack.get('accessLevel') is 'private'
         menuItems['Edit'] = { callback }
+      else
+        menuItems['View Stack'] = { callback }
       ['Reinitialize', 'VMs', 'Destroy VMs'].forEach (name) ->
         menuItems[name] = { callback }
       if isAdmin() and not isStackTemplateSharedWithTeam @props.stack.get 'baseStackId'

--- a/client/home/lib/stacks/components/stacktemplateitem/index.coffee
+++ b/client/home/lib/stacks/components/stacktemplateitem/index.coffee
@@ -111,14 +111,12 @@ module.exports = class StackTemplateItem extends React.Component
 
 
     editorUrl = "/Stack-Editor/#{template.get '_id'}"
-    listItemClassName = 'HomeAppViewListItem-label'
-    unless isAdmin() or template.get('originId') is whoami()._id
-      listItemClassName = 'HomeAppViewListItem-label member'
+
     <div className='HomeAppViewListItem StackTemplateItem'>
       <a
         ref='stackTemplateItem'
         href={editorUrl}
-        className={listItemClassName}
+        className='HomeAppViewListItem-label'
         onClick={onOpen}>
         { makeTitle { template, stack } }
       </a>

--- a/client/home/lib/styl/home.styl
+++ b/client/home/lib/styl/home.styl
@@ -151,8 +151,7 @@ $subtleColor                = #A59999
   pointer()
   text-decoration           none
   fontPrecisionForSoleil()
-  &.member
-    pointer-events          none
+
 
 .HomeAppViewListItem-description
   font-style                italic

--- a/client/stack-editor/lib/routehandler.coffee
+++ b/client/stack-editor/lib/routehandler.coffee
@@ -5,7 +5,7 @@ isAdmin = require 'app/util/isAdmin'
 
 module.exports = -> lazyrouter.bind 'stackeditor', (type, info, state, path, ctx) ->
 
-  unless canCreateStacks()
+  unless canCreateStacks() or type is 'edit-stack'
     new kd.NotificationView { title: 'You are not allowed to create/edit stacks!' }
     return kd.singletons.router.back()
 


### PR DESCRIPTION
Aim of this pr is giving chance to members to see stack template which can not be edited by member.
## Description

Add view stack menu item to stacks which are can not be edited by members.
And also give ability to see stack template from dashboard/stack section
## Motivation and Context
#9078
## How Has This Been Tested?

Manually
## Screenshots (if appropriate):

http://recordit.co/S4zo5YF7Vm
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
