### PR TITLE
terraformer: enable all providers

### DIFF
--- a/go/build.sh
+++ b/go/build.sh
@@ -75,12 +75,7 @@ export COMMANDS=(
 )
 
 export TERRAFORM_COMMANDS=(
-	vendor/github.com/hashicorp/terraform/builtin/bins/provider-aws
-	vendor/github.com/hashicorp/terraform/builtin/bins/provider-terraform
-	vendor/github.com/hashicorp/terraform/builtin/bins/provider-null
-	vendor/github.com/hashicorp/terraform/builtin/bins/provisioner-file
-	vendor/github.com/hashicorp/terraform/builtin/bins/provisioner-local-exec
-	vendor/github.com/hashicorp/terraform/builtin/bins/provisioner-remote-exec
+	vendor/github.com/hashicorp/terraform/builtin/bins/...
 	koding/kites/cmd/provider-vagrant
 	vendor/github.com/koding/terraform-provider-github/cmd/provider-github
 )
@@ -103,7 +98,7 @@ koding-go-install ${COMMANDS[@]} ${TERRAFORM_COMMANDS[@]}
 mkdir -p $GOPATH/build/broker
 cp -f $GOBIN/broker $GOPATH/build/broker/broker
 
-for cmd in "${TERRAFORM_COMMANDS[@]}"; do
+for cmd in $GOBIN/provider-* $GOBIN/provisioner-*; do
 	NAME=$(echo $cmd | rev | cut -d/ -f1 | rev)
 
 	ln -sf $GOBIN/$NAME $GOBIN/terraform-$NAME

--- a/go/src/vendor/github.com/hashicorp/terraform/builtin/providers/azurerm/resource_arm_storage_blob.go
+++ b/go/src/vendor/github.com/hashicorp/terraform/builtin/providers/azurerm/resource_arm_storage_blob.go
@@ -187,7 +187,7 @@ func resourceArmStorageBlobDelete(d *schema.ResourceData, meta interface{}) erro
 	storageContainerName := d.Get("storage_container_name").(string)
 
 	log.Printf("[INFO] Deleting storage blob %q", name)
-	if _, err = blobClient.DeleteBlobIfExists(storageContainerName, name); err != nil {
+	if _, err = blobClient.DeleteBlobIfExists(storageContainerName, name, nil); err != nil {
 		return fmt.Errorf("Error deleting storage blob %q: %s", name, err)
 	}
 


### PR DESCRIPTION
This PR enables all providers for terraformer.

Context: https://koding.slack.com/files/devrim/F2DFJQY5S/pasted_image_at_2016_09_19_21_12.png

@szkl @cihangir Building all providers increases size of /opt/koding/go/bin from 855M to 1.3G, just FYI as I remember we were running close to the limit of current production block device size.

Related work is to update terraform/terraformer, currently it's blocked by:

https://github.com/koding/koding/issues/9084

Which is going to be done separately to this PR.
