### PR TITLE
Create plan on team create

### DIFF
--- a/servers/lib/server/handlers/createpaymentplan.coffee
+++ b/servers/lib/server/handlers/createpaymentplan.coffee
@@ -1,0 +1,28 @@
+{ createCustomer
+  createSubscription } = require '../../../models/socialapi/requests'
+
+{ Plan } = require '../../../../client/app/lib/redux/modules/payment/constants'
+
+getDefaultTrialEnd = ->
+
+  now = (new Date()).getTime()
+  after30Days = 30 * 24 * 60 * 60 * 1000
+
+  return Math.round (now + after30Days) / 1000
+
+
+module.exports = createPaymentPlan = (params = {}, callback) ->
+
+  params.trialEnd ?= getDefaultTrialEnd()
+
+  { sessionToken } = params
+
+  createCustomer { sessionToken }, (err, customer) ->
+    return callback err  if err
+
+    params.customer = customer.id
+    params.plan = Plan.UP_TO_10_USERS
+
+    createSubscription params, (err, subscription) ->
+      return callback err  if err
+      return callback null

--- a/servers/lib/server/handlers/createpaymentplan.coffee
+++ b/servers/lib/server/handlers/createpaymentplan.coffee
@@ -3,6 +3,8 @@
 
 { Plan } = require '../../../../client/app/lib/redux/modules/payment/constants'
 
+{ environment } = require 'koding-config-manager'
+
 getDefaultTrialEnd = ->
 
   now = (new Date()).getTime()
@@ -12,6 +14,9 @@ getDefaultTrialEnd = ->
 
 
 module.exports = createPaymentPlan = (params = {}, callback) ->
+
+  # don't try to create plan for default environment
+  return callback null  if environment is 'default'
 
   params.trialEnd ?= getDefaultTrialEnd()
 

--- a/servers/lib/server/handlers/createteam.test.coffee
+++ b/servers/lib/server/handlers/createteam.test.coffee
@@ -14,6 +14,7 @@ KONFIG                              = require 'koding-config-manager'
 { testCsrfToken }                   = require '../../../testhelper/handler'
 { generateRegisterRequestParams }   = require '../../../testhelper/handler/registerhelper'
 { generateCreateTeamRequestParams } = require '../../../testhelper/handler/teamhelper'
+{ Status }                          = require '../../../../client/app/lib/redux/modules/payment/constants'
 
 
 JUser               = require '../../../models/user'
@@ -84,6 +85,10 @@ runTests = -> describe 'server.handlers.createteam', ->
         JGroup.one { slug }, (err, group) ->
           expect(err).to.not.exist
           expect(group.title).to.be.equal companyName
+
+          expect(group.payment).to.exist
+          expect(group.payment.subscription).to.exist
+          expect(group.payment.subscription.status).to.be.equal Status.TRIALING
 
           allowedDomains.forEach (domain) ->
             expect(group.allowedDomains).to.include domain

--- a/workers/social/lib/social/models/socialapi/requests.coffee
+++ b/workers/social/lib/social/models/socialapi/requests.coffee
@@ -416,6 +416,14 @@ deleteNotificationSetting = (data, callback) ->
   url = "#{socialProxyUrl}/notificationsetting/#{data.id}"
   deleteReq url, data, callback
 
+createCustomer = (data, callback) ->
+  url = "#{socialProxyUrl}/payment/customer/create"
+  post url, data, callback
+
+createSubscription = (data, callback) ->
+  url = "#{socialProxyUrl}/payment/subscription/create"
+  post url, data, callback
+
 expireSubscription = (accountId, callback) ->
   url = "#{socialProxyUrl}/payments/customers/#{accountId}/expire"
   post url, {}, callback
@@ -600,6 +608,8 @@ module.exports = {
   getNotificationSetting
   updateNotificationSetting
   deleteNotificationSetting
+  createCustomer
+  createSubscription
   expireSubscription
   dispatchEvent
   storeCredential


### PR DESCRIPTION
Right now team plan is not created at team creation, this PR makes sure that team has a plan if the config is not `default`
## How Has This Been Tested?

Manually and with unit tests
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

/cc @gokmen @sinan @szkl 
