### PR TITLE
Workers: Disable gowebserver and use node web server instead

### DIFF
--- a/config/generateKonfig.coffee
+++ b/config/generateKonfig.coffee
@@ -284,7 +284,6 @@ module.exports = (options, credentials) ->
     boxproxy                      : { port: parseInt(options.publicPort, 10) }
     sourcemaps                    : { port: 3526 }
     rerouting                     : { port: 9500 }
-    gowebserver                   : { port: 6500 }
     gatheringestor                : { port: 6800 }
     sessionCookie                 : { maxAge: 1000 * 60 * 60 * 24 * 14, secure: options.secureCookie }
     troubleshoot                  : { recipientEmail: "can@koding.com" }

--- a/config/main.sandbox.coffee
+++ b/config/main.sandbox.coffee
@@ -84,13 +84,6 @@ Configuration = (options = {}) ->
   workers = require('./workers')(KONFIG, options, credentials)
 
   KONFIG.workers = require('./customextend') workers,
-    gowebserver         :
-      nginx             :
-        locations       : [
-          location      : "~^/IDE/.*"
-          auth          : yes
-      ]
-
     webserver           :
       instances         : 2
       supervisord       :

--- a/config/workers.coffee
+++ b/config/workers.coffee
@@ -6,22 +6,6 @@ module.exports = (KONFIG, options, credentials) ->
   GOPATH = "%(ENV_KONFIG_PROJECTROOT)s/go"
 
   workers =
-    gowebserver         :
-      group             : "webserver"
-      ports             :
-        incoming       : "#{KONFIG.gowebserver.port}"
-      supervisord       :
-        command         :
-          run           : "#{GOBIN}/go-webserver"
-          watch         : "#{GOBIN}/watcher -run koding/go-webserver"
-      nginx             :
-        locations       : [
-          location      : "~^/IDE/.*"
-      ]
-
-      healthCheckURL    : "http://localhost:#{KONFIG.gowebserver.port}/healthCheck"
-      versionURL        : "http://localhost:#{KONFIG.gowebserver.port}/version"
-
     kontrol             :
       group             : "environment"
       ports             :

--- a/deployment/nginx.coffee
+++ b/deployment/nginx.coffee
@@ -165,7 +165,7 @@ createRootLocation = (KONFIG) ->
 
   proxy = KONFIG.hubspotPageURL
   if KONFIG.environment in ["dev", "default", "sandbox"]
-    proxy = "http://gowebserver"
+    proxy = "http://webserver"
 
   return """
       location ~*(^(\/(Pricing|About|Legal|Features|Blog|Docs))) {


### PR DESCRIPTION
Currently gowebserver is not using updated model data and this causing some unexpected issues for client side application. To prevent that until we fix those issues or decide on something else this PR disables gowebserver in config and make the node webserver as default handler for all requests.

cc/ @szkl @usirin @hakankaradis 
