### PR TITLE
client: use global.currentGroup instead of bongo module

### DIFF
--- a/client/app/lib/redux/dispatchInitialActions.coffee
+++ b/client/app/lib/redux/dispatchInitialActions.coffee
@@ -36,9 +36,7 @@ loadUserDetails = ({ dispatch, getState }) ->
 # if there is no payment information for that group, just create one
 ensureCustomer = ({ dispatch, getState }) ->
 
-  { _id } = globals.currentGroup
-
-  group = bongo.byId('JGroup', _id)(getState())
+  { currentGroup: group } = globals
 
   if group.payment
   then dispatch(loadCustomer())
@@ -47,11 +45,9 @@ ensureCustomer = ({ dispatch, getState }) ->
 
 ensureSubscription = ({ dispatch, getState }) ->
 
-  { _id } = globals.currentGroup
+  { currentGroup: group } = globals
 
   state = getState()
-
-  group = bongo.byId('JGroup', _id)(state)
 
   if group.payment?.subscription
   then dispatch(loadSubscription())
@@ -73,6 +69,6 @@ module.exports = dispatchInitialActions = (store) ->
       .then -> ensureCustomer(store)
       .then -> ensureSubscription(store)
 
-  promise.then(console.log.bind(console, 'finished dispactching initial actions'))
+  promise.then(console.log.bind(console, 'finished dispatching initial actions'))
 
 

--- a/client/webpack.config.coffee
+++ b/client/webpack.config.coffee
@@ -214,6 +214,8 @@ else if __PROD__
     new webpack.optimize.OccurrenceOrderPlugin()
     new webpack.optimize.DedupePlugin()
     new webpack.optimize.UglifyJsPlugin
+      mangle:
+        keep_fnames: yes
       compress:
         unused: yes
         dead_code: yes


### PR DESCRIPTION
In sandbox, group is not revived and hasn't been put to the `bongo` reducer's state.

This pr makes it so that it only reads from the `globals.currentGroup` so; no `ReferenceError`
