### PR TITLE
Add Clone option to MenuItem for Stack and Stack Templates

### DIFF
--- a/client/app/lib/components/sidebar/index.coffee
+++ b/client/app/lib/components/sidebar/index.coffee
@@ -20,6 +20,7 @@ TeamFlux = require 'app/flux/teams'
 DEFAULT_LOGOPATH = '/a/images/logos/sidebar_footer_logo.svg'
 MENU = null
 isAdmin = require 'app/util/isAdmin'
+canCreateStacks = require 'app/util/canCreateStacks'
 
 require './styl/sidebar.styl'
 require './styl/sidebarmenu.styl'
@@ -96,6 +97,9 @@ module.exports = class Sidebar extends React.Component
       when 'Initialize'
         EnvironmentFlux.actions.generateStack(id).then ({ template }) ->
           appManager.tell 'Stackeditor', 'reloadEditor', template._id
+      when 'Clone'
+        new kd.NotificationView { title: 'Cloning Stack Template' }
+        computeController.cloneStackTemplate draft.toJS(), yes
       when 'Open on GitLab'
         remoteUrl = draft.getIn ['config', 'remoteDetails', 'originalUrl']
         linkController.openOrFocus remoteUrl
@@ -121,7 +125,7 @@ module.exports = class Sidebar extends React.Component
       menuItems['Open on GitLab'] = { callback }
 
     ['Edit', 'Initialize'].forEach (name) => menuItems[name] = { callback }
-
+    menuItems['Clone'] = { callback }  if canCreateStacks() or isAdmin()
     menuItems['Make Team Default'] = { callback } if isAdmin() and draft.get('machines').length
 
     { top } = findDOMNode(@refs["draft-#{id}"]).getBoundingClientRect()

--- a/client/app/lib/components/sidebar/index.coffee
+++ b/client/app/lib/components/sidebar/index.coffee
@@ -98,8 +98,7 @@ module.exports = class Sidebar extends React.Component
         EnvironmentFlux.actions.generateStack(id).then ({ template }) ->
           appManager.tell 'Stackeditor', 'reloadEditor', template._id
       when 'Clone'
-        new kd.NotificationView { title: 'Cloning Stack Template' }
-        computeController.cloneStackTemplate draft.toJS(), yes
+        EnvironmentFlux.actions.cloneStackTemplate draft.toJS(), yes
       when 'Open on GitLab'
         remoteUrl = draft.getIn ['config', 'remoteDetails', 'originalUrl']
         linkController.openOrFocus remoteUrl

--- a/client/app/lib/components/sidebarstacksection/index.coffee
+++ b/client/app/lib/components/sidebarstacksection/index.coffee
@@ -95,6 +95,8 @@ module.exports = class SidebarStackSection extends React.Component
           appManager.tell 'Stackeditor', 'reloadEditor', templateId
       when 'Clone'
         remote.api.JStackTemplate.one { _id: templateId }, (err, template) ->
+          if err
+            return new kd.NotificationView { title: 'Error occured while cloning template' }
           EnvironmentFlux.actions.cloneStackTemplate template, no
       when 'Destroy VMs' then deleteStack { stack }
       when 'VMs' then router.handleRoute "/Home/Stacks/virtual-machines"

--- a/client/app/lib/components/sidebarstacksection/index.coffee
+++ b/client/app/lib/components/sidebarstacksection/index.coffee
@@ -7,6 +7,7 @@ EnvironmentFlux           = require 'app/flux/environment'
 StackUpdatedWidget        = require './stackupdatedwidget'
 getBoundingClientReact    = require 'app/util/getBoundingClientReact'
 SidebarMachinesListItem   = require 'app/components/sidebarmachineslistitem'
+canCreateStacks = require 'app/util/canCreateStacks'
 isAdmin = require 'app/util/isAdmin'
 remote = require 'app/remote'
 isStackTemplateSharedWithTeam = require 'app/util/isstacktemplatesharedwithteam'
@@ -92,6 +93,10 @@ module.exports = class SidebarStackSection extends React.Component
         reinitStackFromWidget(stack).then ->
           # invalidate editor cache
           appManager.tell 'Stackeditor', 'reloadEditor', templateId
+      when 'Clone'
+        remote.api.JStackTemplate.one { _id: templateId }, (err, template) ->
+          new kd.NotificationView { title: 'Cloning Stack Template' }
+          computeController.cloneStackTemplate template, no
       when 'Destroy VMs' then deleteStack { stack }
       when 'VMs' then router.handleRoute "/Home/Stacks/virtual-machines"
       when 'Open on GitLab'
@@ -127,6 +132,7 @@ module.exports = class SidebarStackSection extends React.Component
     else
       if isAdmin() or @props.stack.get('accessLevel') is 'private'
         menuItems['Edit'] = { callback }
+        menuItems['Clone'] = { callback }  if canCreateStacks()
       else
         menuItems['View Stack'] = { callback }
       ['Reinitialize', 'VMs', 'Destroy VMs'].forEach (name) ->

--- a/client/app/lib/components/sidebarstacksection/index.coffee
+++ b/client/app/lib/components/sidebarstacksection/index.coffee
@@ -95,8 +95,7 @@ module.exports = class SidebarStackSection extends React.Component
           appManager.tell 'Stackeditor', 'reloadEditor', templateId
       when 'Clone'
         remote.api.JStackTemplate.one { _id: templateId }, (err, template) ->
-          new kd.NotificationView { title: 'Cloning Stack Template' }
-          computeController.cloneStackTemplate template, no
+          EnvironmentFlux.actions.cloneStackTemplate template, no
       when 'Destroy VMs' then deleteStack { stack }
       when 'VMs' then router.handleRoute "/Home/Stacks/virtual-machines"
       when 'Open on GitLab'

--- a/client/app/lib/flux/environment/actions.coffee
+++ b/client/app/lib/flux/environment/actions.coffee
@@ -806,6 +806,22 @@ setLabel = (machineUId, label) ->
         return reject err  if err
         resolve newLabel
 
+cloneStackTemplate = (template, revive) ->
+
+    new kd.NotificationView { title: 'Cloning Stack Template' }
+
+    { reactor } = kd.singletons
+    template = remote.revive template  if revive
+
+    template.clone (err, stackTemplate) ->
+      if err
+        return new kd.NotificationView
+          title: 'Error Occured while Cloning Template'
+
+      Tracker.track Tracker.STACKS_CLONED_TEMPLATE
+      reactor.dispatch actions.UPDATE_STACK_TEMPLATE_SUCCESS, { stackTemplate }
+      kd.singletons.router.handleRoute "/Stack-Editor/#{stackTemplate._id}"
+
 
 module.exports = {
   loadMachines
@@ -853,4 +869,5 @@ module.exports = {
   disconnectMachine
   setLabel
   fetchAndUpdateStackTemplate
+  cloneStackTemplate
 }

--- a/client/app/lib/flux/environment/actions.coffee
+++ b/client/app/lib/flux/environment/actions.coffee
@@ -816,7 +816,7 @@ cloneStackTemplate = (template, revive) ->
     template.clone (err, stackTemplate) ->
       if err
         return new kd.NotificationView
-          title: 'Error Occured while Cloning Template'
+          title: 'Error occured while cloning template'
 
       Tracker.track Tracker.STACKS_CLONED_TEMPLATE
       reactor.dispatch actions.UPDATE_STACK_TEMPLATE_SUCCESS, { stackTemplate }

--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -1360,7 +1360,7 @@ module.exports = class ComputeController extends KDController
     template.clone (err, stackTemplate) ->
       if err
         return new kd.NotificationView
-          title: "Error Occured while Cloning Template"
+          title: 'Error Occured while Cloning Template'
 
       Tracker.track Tracker.STACKS_CLONED_TEMPLATE
       reactor.dispatch actionTypes.UPDATE_STACK_TEMPLATE_SUCCESS, { stackTemplate }

--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -26,7 +26,6 @@ createShareModal     = require 'stack-editor/editor/createShareModal'
 isGroupDisabled      = require 'app/util/isGroupDisabled'
 
 { actions : HomeActions } = require 'home/flux'
-actionTypes = require 'app/flux/environment/actiontypes'
 require './config'
 
 module.exports = class ComputeController extends KDController
@@ -1350,18 +1349,3 @@ module.exports = class ComputeController extends KDController
       @_soloMachines = res?.machines ? []
       kd.warn err  if err
       callback null, @_soloMachines
-
-
-  cloneStackTemplate: (template, revive) ->
-
-    { reactor } = kd.singletons
-    template = remote.revive template  if revive
-
-    template.clone (err, stackTemplate) ->
-      if err
-        return new kd.NotificationView
-          title: 'Error Occured while Cloning Template'
-
-      Tracker.track Tracker.STACKS_CLONED_TEMPLATE
-      reactor.dispatch actionTypes.UPDATE_STACK_TEMPLATE_SUCCESS, { stackTemplate }
-      kd.singletons.router.handleRoute "/Stack-Editor/#{stackTemplate._id}"

--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -26,7 +26,7 @@ createShareModal     = require 'stack-editor/editor/createShareModal'
 isGroupDisabled      = require 'app/util/isGroupDisabled'
 
 { actions : HomeActions } = require 'home/flux'
-
+actionTypes = require 'app/flux/environment/actiontypes'
 require './config'
 
 module.exports = class ComputeController extends KDController
@@ -1351,3 +1351,17 @@ module.exports = class ComputeController extends KDController
       kd.warn err  if err
       callback null, @_soloMachines
 
+
+  cloneStackTemplate: (template, revive) ->
+
+    { reactor } = kd.singletons
+    template = remote.revive template  if revive
+
+    template.clone (err, stackTemplate) ->
+      if err
+        return new kd.NotificationView
+          title: "Error Occured while Cloning Template"
+
+      Tracker.track Tracker.STACKS_CLONED_TEMPLATE
+      reactor.dispatch actionTypes.UPDATE_STACK_TEMPLATE_SUCCESS, { stackTemplate }
+      kd.singletons.router.handleRoute "/Stack-Editor/#{stackTemplate._id}"

--- a/client/app/lib/util/checkclonedstacktemplateexist.coffee
+++ b/client/app/lib/util/checkclonedstacktemplateexist.coffee
@@ -4,7 +4,7 @@ module.exports = CheckClonedStackTemplateExist = (stackTemplate) ->
   return no  unless stackTemplate
 
   originalStackTemplateId = stackTemplate.config?.clonedFrom
-  console.log 'originalStackTemplateId', originalStackTemplateId
+
   return no  unless originalStackTemplateId
   remote.api.JStackTemplate.one { _id: originalStackTemplateId }, (err, template) ->
     return yes  if template

--- a/client/app/lib/util/checkclonedstacktemplateexist.coffee
+++ b/client/app/lib/util/checkclonedstacktemplateexist.coffee
@@ -1,0 +1,11 @@
+remote = require 'app/remote'
+
+module.exports = CheckClonedStackTemplateExist = (stackTemplate) ->
+  return no  unless stackTemplate
+
+  originalStackTemplateId = stackTemplate.config?.clonedFrom
+  console.log 'originalStackTemplateId', originalStackTemplateId
+  return no  unless originalStackTemplateId
+  remote.api.JStackTemplate.one { _id: originalStackTemplateId }, (err, template) ->
+    return yes  if template
+    return no

--- a/client/app/lib/util/isclonedtemplate.coffee
+++ b/client/app/lib/util/isclonedtemplate.coffee
@@ -1,10 +1,9 @@
 remote = require 'app/remote'
 
 module.exports = isClonedTemplate = (stackTemplate, callback) ->
-    return  unless stackTemplate
+  return callback no unless stackTemplate
 
-    originalStackTemplateId = stackTemplate.config?.clonedFrom
-    return  unless originalStackTemplateId
-    remote.api.JStackTemplate.one { _id: originalStackTemplateId }, (err, template) ->
-      return callback()  if template
-      return
+  originalStackTemplateId = stackTemplate.config?.clonedFrom
+  return callback no unless originalStackTemplateId
+  remote.api.JStackTemplate.one { _id: originalStackTemplateId }, (err, template) ->
+    return callback template?

--- a/client/app/lib/util/isclonedtemplate.coffee
+++ b/client/app/lib/util/isclonedtemplate.coffee
@@ -1,6 +1,6 @@
 remote = require 'app/remote'
 
-module.exports = CheckClonedStackTemplateExist = (stackTemplate) ->
+module.exports = isClonedTemplate = (stackTemplate) ->
   return no  unless stackTemplate
 
   originalStackTemplateId = stackTemplate.config?.clonedFrom

--- a/client/app/lib/util/isclonedtemplate.coffee
+++ b/client/app/lib/util/isclonedtemplate.coffee
@@ -1,11 +1,10 @@
 remote = require 'app/remote'
 
-module.exports = isClonedTemplate = (stackTemplate) ->
-  return no  unless stackTemplate
+module.exports = isClonedTemplate = (stackTemplate, callback) ->
+    return  unless stackTemplate
 
-  originalStackTemplateId = stackTemplate.config?.clonedFrom
-
-  return no  unless originalStackTemplateId
-  remote.api.JStackTemplate.one { _id: originalStackTemplateId }, (err, template) ->
-    return yes  if template
-    return no
+    originalStackTemplateId = stackTemplate.config?.clonedFrom
+    return  unless originalStackTemplateId
+    remote.api.JStackTemplate.one { _id: originalStackTemplateId }, (err, template) ->
+      return callback()  if template
+      return

--- a/client/stack-editor/lib/editor/index.coffee
+++ b/client/stack-editor/lib/editor/index.coffee
@@ -298,7 +298,7 @@ module.exports = class StackEditorView extends kd.View
       title: 'Save Name'
       click : @inputTitle.bound 'setBlur'
 
-    if isClonedTemplate stackTemplate
+    isClonedTemplate stackTemplate, =>
       @titleActionsWrapper.addSubView @clonedFrom = new kd.CustomHTMLView
         cssClass: 'cloned-from-text'
         partial: 'Clone Of'

--- a/client/stack-editor/lib/editor/index.coffee
+++ b/client/stack-editor/lib/editor/index.coffee
@@ -19,7 +19,7 @@ parseTerraformOutput = require 'app/util/stacks/parseterraformoutput'
 providersParser = require 'app/util/stacks/providersparser'
 updateCustomVariable = require 'app/util/stacks/updatecustomvariable'
 addUserInputOptions = require 'app/util/stacks/adduserinputoptions'
-checkClonedStackTemplateExist = require 'app/util/checkclonedstacktemplateexist'
+isClonedTemplate = require 'app/util/isclonedtemplate'
 CustomLinkView = require 'app/customlinkview'
 
 OutputView = require './outputview'
@@ -68,7 +68,7 @@ module.exports = class StackEditorView extends kd.View
         @deleteStack.hide()
         @saveButton.setClass 'isntMine'
         @inputTitle.setClass 'template-title isntMine'
-        @subHeaderWrapper.hide()
+        @titleActionsWrapper.hide()
 
 
 
@@ -285,21 +285,21 @@ module.exports = class StackEditorView extends kd.View
     @header.addSubView @inputTitle = new kd.InputView options
     @inputTitle.resize()
 
-    @header.addSubView @subHeaderWrapper = new kd.CustomHTMLView
+    @header.addSubView @titleActionsWrapper = new kd.CustomHTMLView
       cssClass: 'StackEditorView--header-subHeader'
 
-    @subHeaderWrapper.addSubView @editName = new CustomLinkView
+    @titleActionsWrapper.addSubView @editName = new CustomLinkView
       cssClass: 'edit-name'
       title: 'Edit Name'
       click : @inputTitle.bound 'setFocus'
 
-    @subHeaderWrapper.addSubView @saveName = new CustomLinkView
+    @titleActionsWrapper.addSubView @saveName = new CustomLinkView
       cssClass: 'edit-name hidden'
       title: 'Save Name'
       click : @inputTitle.bound 'setBlur'
 
-    if checkClonedStackTemplateExist stackTemplate
-      @subHeaderWrapper.addSubView @clonedFrom = new kd.CustomHTMLView
+    if isClonedTemplate stackTemplate
+      @titleActionsWrapper.addSubView @clonedFrom = new kd.CustomHTMLView
         cssClass: 'cloned-from-text'
         partial: 'Clone Of'
 
@@ -323,7 +323,7 @@ module.exports = class StackEditorView extends kd.View
       @inputTitle.resize()
 
     @inputTitle.on 'blur', =>
-      @subHeaderWrapper.bound 'show'
+      @titleActionsWrapper.bound 'show'
       @saveName.hide()
       @editName.show()
 

--- a/client/stack-editor/lib/editor/index.coffee
+++ b/client/stack-editor/lib/editor/index.coffee
@@ -19,7 +19,7 @@ parseTerraformOutput = require 'app/util/stacks/parseterraformoutput'
 providersParser = require 'app/util/stacks/providersparser'
 updateCustomVariable = require 'app/util/stacks/updatecustomvariable'
 addUserInputOptions = require 'app/util/stacks/adduserinputoptions'
-
+checkClonedStackTemplateExist = require 'app/util/checkclonedstacktemplateexist'
 CustomLinkView = require 'app/customlinkview'
 
 OutputView = require './outputview'
@@ -288,6 +288,17 @@ module.exports = class StackEditorView extends kd.View
       cssClass: 'edit-name'
       title: 'Edit Name'
       click : @inputTitle.bound 'setFocus'
+
+    if checkClonedStackTemplateExist stackTemplate
+      @header.addSubView @clonedFrom = new kd.CustomHTMLView
+        cssClass: 'cloned-from-text'
+        partial: 'Cloned Of'
+      @clonedFrom.addSubView new kd.CustomHTMLView
+        cssClass: 'cloned-from'
+        partial: "  #{stackTemplate.title}"
+        click: -> kd.singletons.router.handleRoute "/Stack-Editor/#{stackTemplate.config.clonedFrom}"
+
+
 
     kd.singletons.reactor.observe valueGetter, (value) =>
 

--- a/client/stack-editor/lib/editor/index.coffee
+++ b/client/stack-editor/lib/editor/index.coffee
@@ -298,15 +298,16 @@ module.exports = class StackEditorView extends kd.View
       title: 'Save Name'
       click : @inputTitle.bound 'setBlur'
 
-    isClonedTemplate stackTemplate, =>
-      @titleActionsWrapper.addSubView @clonedFrom = new kd.CustomHTMLView
-        cssClass: 'cloned-from-text'
-        partial: 'Clone Of'
+    isClonedTemplate stackTemplate, (isCloned) =>
+      if isCloned
+        @titleActionsWrapper.addSubView @clonedFrom = new kd.CustomHTMLView
+          cssClass: 'cloned-from-text'
+          partial: 'Clone Of'
 
-      @clonedFrom.addSubView new kd.CustomHTMLView
-        cssClass: 'cloned-from'
-        partial: "  #{stackTemplate.title}"
-        click: -> kd.singletons.router.handleRoute "/Stack-Editor/#{stackTemplate.config.clonedFrom}"
+        @clonedFrom.addSubView new kd.CustomHTMLView
+          cssClass: 'cloned-from'
+          partial: "  #{stackTemplate.title}"
+          click: -> kd.singletons.router.handleRoute "/Stack-Editor/#{stackTemplate.config.clonedFrom}"
 
 
 

--- a/client/stack-editor/lib/editor/index.coffee
+++ b/client/stack-editor/lib/editor/index.coffee
@@ -68,7 +68,7 @@ module.exports = class StackEditorView extends kd.View
         @deleteStack.hide()
         @saveButton.setClass 'isntMine'
         @inputTitle.setClass 'template-title isntMine'
-        @editName.hide()
+        @subHeaderWrapper.hide()
 
 
 
@@ -283,16 +283,26 @@ module.exports = class StackEditorView extends kd.View
         changeTemplateTitle stackTemplate?._id, e.target.value
 
     @header.addSubView @inputTitle = new kd.InputView options
+    @inputTitle.resize()
 
-    @header.addSubView @editName = new CustomLinkView
+    @header.addSubView @subHeaderWrapper = new kd.CustomHTMLView
+      cssClass: 'StackEditorView--header-subHeader'
+
+    @subHeaderWrapper.addSubView @editName = new CustomLinkView
       cssClass: 'edit-name'
       title: 'Edit Name'
       click : @inputTitle.bound 'setFocus'
 
+    @subHeaderWrapper.addSubView @saveName = new CustomLinkView
+      cssClass: 'edit-name hidden'
+      title: 'Save Name'
+      click : @inputTitle.bound 'setBlur'
+
     if checkClonedStackTemplateExist stackTemplate
-      @header.addSubView @clonedFrom = new kd.CustomHTMLView
+      @subHeaderWrapper.addSubView @clonedFrom = new kd.CustomHTMLView
         cssClass: 'cloned-from-text'
-        partial: 'Cloned Of'
+        partial: 'Clone Of'
+
       @clonedFrom.addSubView new kd.CustomHTMLView
         cssClass: 'cloned-from'
         partial: "  #{stackTemplate.title}"
@@ -312,7 +322,10 @@ module.exports = class StackEditorView extends kd.View
       @inputTitle.prepareClone()
       @inputTitle.resize()
 
-    @inputTitle.on 'blur', @editName.bound 'show'
+    @inputTitle.on 'blur', =>
+      @subHeaderWrapper.bound 'show'
+      @saveName.hide()
+      @editName.show()
 
     @inputTitle.on 'keydown', (event) =>
       return  unless event.keyCode is 13
@@ -321,6 +334,7 @@ module.exports = class StackEditorView extends kd.View
     @inputTitle.on 'focus', =>
       @inputTitle.resize()
       @editName.hide()
+      @saveName.show()
 
 
   createOutputView: ->

--- a/client/stack-editor/lib/styl/stackeditorheader.styl
+++ b/client/stack-editor/lib/styl/stackeditorheader.styl
@@ -16,38 +16,37 @@ $borderColor                = #E3E3E3
   justify-content           space-around
   margin-bottom             33px
 
-  .edit-name
-    color #67A2EE
-    text-decoration none
-    font-size 13px
-    font-weight 300
-    abs 81px 0 0 42px
+  .StackEditorView--header-subHeader
+    abs 83px 0 0 41px
+    display flex
+    font-size               13px
+    font-weight             300
+    .edit-name
+      color                 #67A2EE
+      text-decoration       none
+      margin-right          10px
 
-  .cloned-from-text
-    color #A59999
-    abs()
-    top 81px
-    left 120px
-    font-size 12px
-    max-width 300px
-    ellipsis()
+    .cloned-from-text
+      color                 #A59999
+      max-width             300px
+      ellipsis()
 
-    &:before
-      content               ''
-      rel()
-      borderBox()
-      dIBlock()
-      border                3px solid #A59999
-      rounded               100%
-      top                   -1px
-      margin-right          5px
+      &:before
+        content               ''
+        rel()
+        borderBox()
+        dIBlock()
+        border              3px solid #A59999
+        rounded             100%
+        top                 -1px
+        margin-right        5px
 
 
-  .cloned-from
-    color #67A2EE
-    cursor pointer
-    display initial
-    font-size 14px
+    .cloned-from
+      color #67A2EE
+      cursor pointer
+      display initial
+      font-size 13px
 
   .buttons
     flex                    1 0 auto

--- a/client/stack-editor/lib/styl/stackeditorheader.styl
+++ b/client/stack-editor/lib/styl/stackeditorheader.styl
@@ -16,38 +16,6 @@ $borderColor                = #E3E3E3
   justify-content           space-around
   margin-bottom             33px
 
-  .StackEditorView--header-subHeader
-    abs 83px 0 0 41px
-    display flex
-    font-size               13px
-    font-weight             300
-    .edit-name
-      color                 #67A2EE
-      text-decoration       none
-      margin-right          10px
-
-    .cloned-from-text
-      color                 #A59999
-      max-width             300px
-      ellipsis()
-
-      &:before
-        content               ''
-        rel()
-        borderBox()
-        dIBlock()
-        border              3px solid #A59999
-        rounded             100%
-        top                 -1px
-        margin-right        5px
-
-
-    .cloned-from
-      color #67A2EE
-      cursor pointer
-      display initial
-      font-size 13px
-
   .buttons
     flex                    1 0 auto
 
@@ -89,4 +57,35 @@ $borderColor                = #E3E3E3
       outline               inherit
       bg                    color #FFFFFF
       border                1px solid $borderColor
+
+.StackEditorView--header-subHeader
+    abs 83px 0 0 41px
+    display flex
+    font-size               13px
+    font-weight             300
+    .edit-name
+      color                 #67A2EE
+      text-decoration       none
+      margin-right          10px
+
+    .cloned-from-text
+      color                 #A59999
+      max-width             300px
+      ellipsis()
+
+      &:before
+        content               ''
+        rel()
+        borderBox()
+        dIBlock()
+        border              3px solid #A59999
+        rounded             100%
+        top                 -1px
+        margin-right        5px
+
+    .cloned-from
+      color #67A2EE
+      cursor pointer
+      display initial
+      font-size 13px
 

--- a/client/stack-editor/lib/styl/stackeditorheader.styl
+++ b/client/stack-editor/lib/styl/stackeditorheader.styl
@@ -23,6 +23,32 @@ $borderColor                = #E3E3E3
     font-weight 300
     abs 81px 0 0 42px
 
+  .cloned-from-text
+    color #A59999
+    abs()
+    top 81px
+    left 120px
+    font-size 12px
+    max-width 300px
+    ellipsis()
+
+    &:before
+      content               ''
+      rel()
+      borderBox()
+      dIBlock()
+      border                3px solid #A59999
+      rounded               100%
+      top                   -1px
+      margin-right          5px
+
+
+  .cloned-from
+    color #67A2EE
+    cursor pointer
+    display initial
+    font-size 14px
+
   .buttons
     flex                    1 0 auto
 


### PR DESCRIPTION
## Description

This feature give chance users to clone their stack template.
Members are not able to clone team stack. 
Member will be able to see clone option when it is allowed to create stack by admin.
## Motivation and Context
#9122
## How Has This Been Tested?

Click clone option from menu items section from sidebar. You will be redirected to cloned stack editor.
## Screenshots (if appropriate):

http://recordit.co/s3iU1vfXeC
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
