### PR TITLE
Start charging after first month free & Cancelling should charge immediately.

### DIFF
--- a/go/src/koding/db/models/group.go
+++ b/go/src/koding/db/models/group.go
@@ -4,6 +4,14 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
+const (
+	// PaymentStatusActive holds active payment status
+	PaymentStatusActive = "active"
+
+	// PaymentStatusTrailing holds trailing payment status
+	PaymentStatusTrailing = "trialing"
+)
+
 type Group struct {
 	Id                             bson.ObjectId            `bson:"_id" json:"-"`
 	Body                           string                   `bson:"body" json:"body"`
@@ -26,35 +34,28 @@ type Group struct {
 	Payment         Payment  `bson:"payment" json:"payment"`
 }
 
+// Payment is general container for payment info
 type Payment struct {
 	Subscription Subscription
 	Customer     Customer
 }
 
+// Subscription holds customer-plan subscription related info
 type Subscription struct {
 	// Allowed values are "trialing", "active", "past_due", "canceled", "unpaid".
 	Status string `bson:"status" json:"status"`
 	ID     string `bson:"id" json:"id"`
 }
 
+// Customer is the group's customer info from payment provider
 type Customer struct {
 	ID string `bson:"id" json:"id"`
-}
-
-// DeletedMember holds information about deleted members from a group.
-type DeletedMember struct {
-	Id        bson.ObjectId `bson:"_id" json:"-"`
-	AccountID bson.ObjectId `bson:"accountId" json:"accountId"`
-	GroupID   bson.ObjectId `bson:"groupId" json:"groupId"`
-	// these will be read only during query/modify time, otherwise do not access
-	// SubscriptionID string
-	// UpdatedAt time.Time
 }
 
 // IsSubActive checks if subscription is in valid state for operation
 func (g *Group) IsSubActive() bool {
 	switch g.Payment.Subscription.Status {
-	case "active", "trialing":
+	case PaymentStatusActive, PaymentStatusTrailing:
 		return true
 	default:
 		return false

--- a/go/src/socialapi/Makefile
+++ b/go/src/socialapi/Makefile
@@ -227,6 +227,12 @@ testwebhook:
 	@./tests.test $(DBG) $(EXTRAS) -c $(CONFIG)
 	@rm ./tests.test
 
+testpresence:
+	@echo "$(OK_COLOR)--> presence tests... $(NO_COLOR)"
+	@`which go` test -race -c workers/presence/*.go
+	@./presence.test $(DBG) $(EXTRAS) -c $(CONFIG)
+	@rm ./presence.test
+
 testeventsender:
 	@echo "$(OK_COLOR)--> eventsender tests... $(NO_COLOR)"
 	@`which go` test -c workers/integration/eventsender/*.go
@@ -379,7 +385,7 @@ testrealtime:
 
 testapi: testcollaboration testmailsender testmail testmodels testemailworker \
 	testmoderation testtopicfeeed testnotification testtrollmode \
-	testteam testintegration testrealtime testwebhook
+	testteam testintegration testrealtime testwebhook testpresence
 
 	@echo "$(OK_COLOR)==> Running Unit tests $(NO_COLOR)"
 

--- a/go/src/socialapi/workers/payment/api/handlers.go
+++ b/go/src/socialapi/workers/payment/api/handlers.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	EndpointSubscriptionDelete = "/payment/subscription/delete"
+	EndpointSubscriptionCancel = "/payment/subscription/delete"
 	EndpointSubscriptionGet    = "/payment/subscription/get"
 	EndpointSubscriptionCreate = "/payment/subscription/create"
 	EndpointCustomerCreate     = "/payment/customer/create"
@@ -23,10 +23,10 @@ const (
 func AddHandlers(m *mux.Mux) {
 	m.AddHandler(
 		handler.Request{
-			Handler:  DeleteSubscription,
+			Handler:  CancelSubscription,
 			Name:     "payment-delete-subscription",
 			Type:     handler.DeleteRequest,
-			Endpoint: EndpointSubscriptionDelete,
+			Endpoint: EndpointSubscriptionCancel,
 		},
 	)
 

--- a/go/src/socialapi/workers/payment/api/invoice_test.go
+++ b/go/src/socialapi/workers/payment/api/invoice_test.go
@@ -19,7 +19,7 @@ func TestInvoiceList(t *testing.T) {
 			withStubData(endpoint, func(username, groupName, sessionID string) {
 				withTestPlan(func(planID string) {
 					createURL := fmt.Sprintf("%s%s", endpoint, EndpointSubscriptionCreate)
-					deleteURL := fmt.Sprintf("%s%s", endpoint, EndpointSubscriptionDelete)
+					deleteURL := fmt.Sprintf("%s%s", endpoint, EndpointSubscriptionCancel)
 
 					group, err := modelhelper.GetGroup(groupName)
 					tests.ResultedWithNoErrorCheck(group, err)

--- a/go/src/socialapi/workers/payment/api/subscription.go
+++ b/go/src/socialapi/workers/payment/api/subscription.go
@@ -10,14 +10,14 @@ import (
 	"github.com/stripe/stripe-go"
 )
 
-// DeleteSubscription deletes the subscription of group
-func DeleteSubscription(u *url.URL, h http.Header, _ interface{}, context *models.Context) (int, http.Header, interface{}, error) {
+// CancelSubscription cancels the subscription of group
+func CancelSubscription(u *url.URL, h http.Header, _ interface{}, context *models.Context) (int, http.Header, interface{}, error) {
 	if err := checkContext(context); err != nil {
 		return response.NewBadRequest(err)
 	}
 
 	return response.HandleResultAndError(
-		payment.DeleteSubscriptionForGroup(context.GroupName),
+		payment.CancelSubscriptionForGroup(context.GroupName),
 	)
 }
 

--- a/go/src/socialapi/workers/payment/api/subscription_test.go
+++ b/go/src/socialapi/workers/payment/api/subscription_test.go
@@ -128,7 +128,7 @@ func TestSubscribingToPaidPlanWithWithDifferentTrialPeriodThanDefault(t *testing
 		withTestServer(t, func(endpoint string) {
 			withStubData(endpoint, func(username, groupName, sessionID string) {
 				createURL := fmt.Sprintf("%s%s", endpoint, EndpointSubscriptionCreate)
-				deleteURL := fmt.Sprintf("%s%s", endpoint, EndpointSubscriptionDelete)
+				deleteURL := fmt.Sprintf("%s%s", endpoint, EndpointSubscriptionCancel)
 				group, err := modelhelper.GetGroup(groupName)
 				tests.ResultedWithNoErrorCheck(group, err)
 

--- a/go/src/socialapi/workers/payment/api/util_test.go
+++ b/go/src/socialapi/workers/payment/api/util_test.go
@@ -126,7 +126,7 @@ func withTestCoupon(f func(string)) {
 
 func withSubscription(endpoint, groupName, sessionID, planID string, f func(subscriptionID string)) {
 	createURL := fmt.Sprintf("%s%s", endpoint, EndpointSubscriptionCreate)
-	deleteURL := fmt.Sprintf("%s%s", endpoint, EndpointSubscriptionDelete)
+	deleteURL := fmt.Sprintf("%s%s", endpoint, EndpointSubscriptionCancel)
 
 	group, err := modelhelper.GetGroup(groupName)
 	tests.ResultedWithNoErrorCheck(group, err)

--- a/go/src/socialapi/workers/payment/customer.go
+++ b/go/src/socialapi/workers/payment/customer.go
@@ -28,17 +28,17 @@ var (
 
 // Usage holds current usage information, which will be calculated on the fly
 type Usage struct {
-	User            *UserInfo
-	ExpectedPlan    *stripe.Plan
-	Due             uint64
-	NextBillingDate time.Time
-	Subscription    *stripe.Sub
-	Customer        *stripe.Customer
+	User            *UserInfo        `json:"user"`
+	ExpectedPlan    *stripe.Plan     `json:"expectedPlan"`
+	Due             uint64           `json:"due"`
+	NextBillingDate time.Time        `json:"nextBillingDate"`
+	Subscription    *stripe.Sub      `json:"subscription"`
+	Customer        *stripe.Customer `json:"customer"`
 }
 
 // UserInfo holds current info about team's user info
 type UserInfo struct {
-	Total int
+	Total int `json:"total"`
 }
 
 // DeleteCustomerForGroup deletes the customer for a given group. If customer is

--- a/go/src/socialapi/workers/payment/customer.go
+++ b/go/src/socialapi/workers/payment/customer.go
@@ -38,9 +38,7 @@ type Usage struct {
 
 // UserInfo holds current info about team's user info
 type UserInfo struct {
-	Total   int
-	Active  int
-	Deleted int
+	Total int
 }
 
 // DeleteCustomerForGroup deletes the customer for a given group. If customer is

--- a/go/src/socialapi/workers/presence/ping.go
+++ b/go/src/socialapi/workers/presence/ping.go
@@ -12,6 +12,9 @@ type Ping struct {
 
 	// CreatedAt holds the ping time
 	CreatedAt time.Time `json:"createdAt"`
+
+	// paymentStatus is populated on handler
+	paymentStatus string
 }
 
 // NewPing creates an empty ping


### PR DESCRIPTION
## Description

We should start charging our users after their ~~trial~~ free period ends. So their presence info will be collected after first moth ends. During free month, set presence info's is processed as true.

On cancelling subscription, we should immediately charge and cancel the sub.
## Motivation and Context

See pricing SRS
## How Has This Been Tested?

Has unit tests
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
