### PR TITLE
Landing: hide alien icon if team has a logo on team login page

### DIFF
--- a/client/landing/site.landing/coffee/team/tabs/teamlogintab.coffee
+++ b/client/landing/site.landing/coffee/team/tabs/teamlogintab.coffee
@@ -29,6 +29,7 @@ module.exports = class TeamLoginTab extends kd.TabPaneView
 
     @logo = utils.getGroupLogo()
 
+
     # keep the prop name @form it is used in AppView to focus to the form if there is any - SY
     @form = new LoginInlineForm
       cssClass : 'login-form clearfix'
@@ -81,11 +82,12 @@ module.exports = class TeamLoginTab extends kd.TabPaneView
 
     # this is to make sure that already created teams with problematic names
     # are not causing any problems as well. ~Umut
-    title = Encoder.htmlEncode Encoder.htmlDecode kd.config.group.title
+    title   = Encoder.htmlEncode Encoder.htmlDecode kd.config.group.title
+    hasLogo = not @logo.hasClass 'hidden'
 
     """
     {{> @header }}
-    <div class="TeamsModal TeamsModal--login">
+    <div class="TeamsModal TeamsModal--login #{if hasLogo then 'with-avatar' else ''}">
       {{> @logo}}
       <h4><span>Sign in to</span> #{title}</h4>
       {{> @form}}

--- a/client/landing/site.landing/styl/team.creation.styl
+++ b/client/landing/site.landing/styl/team.creation.styl
@@ -14,9 +14,6 @@ team.group.creation.styl
 
   .kdtabpaneview .TeamsModal.TeamsModal--groupCreation
 
-    &.alreadyMember:after
-      hidden()
-
     > h5 i
       color                 #56a2d3
 

--- a/client/landing/site.landing/styl/team.styl
+++ b/client/landing/site.landing/styl/team.styl
@@ -112,6 +112,9 @@ body.teams #kdmaincontainer #main-tab-view
   borderBox()
   rel()
 
+  &.with-avatar:after
+    hidden()
+
   &:after
     content                 ''
     r-sprite                teams, alien


### PR DESCRIPTION
This PR fixes alien icon bug on team login page - http://take.ms/1Wij8

Login with logo:
![login-with-logo](https://cloud.githubusercontent.com/assets/492219/18991336/8d7e1856-8720-11e6-94f5-b09f105adf00.png)

Login without logo:
![login-without-logo](https://cloud.githubusercontent.com/assets/492219/18991341/9acef390-8720-11e6-87d4-8eccc39ac80c.png)
