### PR TITLE
koding: fix TokenRenewer leaks in GetKites

### DIFF
--- a/go/src/glide.lock
+++ b/go/src/glide.lock
@@ -561,7 +561,7 @@ imports:
   - helpers
   - services
 - name: github.com/koding/kite
-  version: c81a54521915fd3f4a8b9ee20d10bf2c158dc500
+  version: b1c6c9bff431511eb6fcc62a9d44b9ee90ade1f5
   subpackages:
   - config
   - dnode

--- a/go/src/koding/kites/kloud/klient/klient.go
+++ b/go/src/koding/kites/kloud/klient/klient.go
@@ -112,10 +112,11 @@ func Exists(k *kite.Kite, queryString string) error {
 	k.Log.Debug("Checking whether %s exists in Kontrol", queryString)
 
 	// an error indicates a non existing klient or another error.
-	_, err = k.GetKites(query.Query())
+	kites, err := k.GetKites(query.Query())
 	if err != nil {
 		return err
 	}
+	kite.Close(kites)
 
 	return nil
 }
@@ -142,6 +143,7 @@ func ConnectTimeout(k *kite.Kite, queryString string, t time.Duration) (*Klient,
 	if err != nil {
 		return nil, err
 	}
+	defer kite.Close(kites[1:])
 
 	remoteKite := kites[0]
 	remoteKite.ReadBufferSize = 512

--- a/go/src/vendor/github.com/koding/kite/.travis.yml
+++ b/go/src/vendor/github.com/koding/kite/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 go:
   - 1.4.3
   - 1.6.3
-  - 1.7
+  - 1.7.1
 install:
   - go get -d -v -t ./...
 script:

--- a/go/src/vendor/github.com/koding/kite/examples/exp2-query/exp2-query.go
+++ b/go/src/vendor/github.com/koding/kite/examples/exp2-query/exp2-query.go
@@ -30,6 +30,8 @@ func main() {
 	}
 
 	// Connect to remote kite
+	defer kite.Close(kites[1:])
+
 	mathWorker := kites[0]
 	connected, err := mathWorker.DialForever()
 	if err != nil {

--- a/go/src/vendor/github.com/koding/kite/kontrolclient.go
+++ b/go/src/vendor/github.com/koding/kite/kontrolclient.go
@@ -109,6 +109,22 @@ func (k *Kite) SetupKontrolClient() error {
 // contains Ready to connect Client instances. The caller must connect
 // with Client.Dial() before using each Kite. An error is returned when no
 // kites are available.
+//
+// The returned clients have token renewer running, which is leaked
+// when a single *Client is not closed. A handy utility to ease closing
+// the clients is a Close function:
+//
+//   clients, err := k.GetKites(&protocol.KontrolQuery{Name: "foo"})
+//   if err != nil {
+//       panic(err)
+//   }
+//
+//   // If we want to only use the first result and discard the rest,
+//   // we need to close the rest explicitely.
+//   defer kite.Close(clients[1:])
+//
+//   return clients[0]
+//
 func (k *Kite) GetKites(query *protocol.KontrolQuery) ([]*Client, error) {
 	if err := k.SetupKontrolClient(); err != nil {
 		return nil, err
@@ -154,13 +170,15 @@ func (k *Kite) getKites(args protocol.GetKitesArgs) ([]*Client, error) {
 	}
 
 	// Renew tokens
-	for _, r := range clients {
-		token, err := NewTokenRenewer(r, k)
+	for _, c := range clients {
+		token, err := NewTokenRenewer(c, k)
 		if err != nil {
-			k.Log.Error("Error in token. Token will not be renewed when it expires: %s", err.Error())
+			k.Log.Error("Error in token. Token will not be renewed when it expires: %s", err)
 			continue
 		}
+
 		token.RenewWhenExpires()
+		c.closeRenewer = token.disconnect
 	}
 
 	return clients, nil


### PR DESCRIPTION
There're are also GetKites leaks in [getkodingkites.go](https://github.com/koding/koding/blob/master/go/src/koding/klient/remote/getkodingkites.go).

For some reason the GetKites method body was copy'n'pasted there and since there's no access to `token.disconnect`, it's not possible to find a trivial fix there. The method should be rewritten to use vanilla `(*kite.Kite).GetKites` instead. This is a TODO.
