### PR TITLE
Pricing/Payment Frontend improvements

### DIFF
--- a/client/app/lib/components/disabledmodals/member.coffee
+++ b/client/app/lib/components/disabledmodals/member.coffee
@@ -7,6 +7,9 @@ getGroupStatus = require 'app/util/getGroupStatus'
 TrialEndedMemberModal = require 'lab/TrialEndedMemberModal'
 TrialEndedNotifySuccessModal = require 'lab/TrialEndedNotifySuccessModal'
 
+UpgradeNeededMemberModal = require 'lab/UpgradeNeededMemberModal'
+UpgradeNeededNotifySuccessModal = require 'lab/UpgradeNeededNotifySuccessModal'
+
 SuspendedMemberModal = require 'lab/SuspendedMemberModal'
 SuspendedNotifySuccessModal = require 'lab/SuspendedNotifySuccessModal'
 
@@ -38,6 +41,14 @@ module.exports = class DisabledMemberModal extends ReactView
           isOpen={yes}
           onButtonClick={onClick} />
 
+      when Status.NEEDS_UPGRADE
+        onClick = =>
+          @destroy()
+          router.handleRoute '/Disabled/Member/upgrade-notify-success'
+        <UpgradeNeededMemberModal
+          isOpen={yes}
+          onButtonClick={onClick} />
+
       when 'suspended-notify-success'
         onClick = -> console.log 'support link clicked'
         <SuspendedNotifySuccessModal
@@ -47,6 +58,12 @@ module.exports = class DisabledMemberModal extends ReactView
       when 'notify-success'
         onClick = -> console.log 'support link clicked'
         <TrialEndedNotifySuccessModal
+          isOpen={yes}
+          onButtonClick={onClick} />
+
+      when 'upgrade-notify-success'
+        onClick = -> console.log 'support link clicked'
+        <UpgradeNeededNotifySuccessModal
           isOpen={yes}
           onButtonClick={onClick} />
 

--- a/client/app/lib/components/disabledmodals/member.coffee
+++ b/client/app/lib/components/disabledmodals/member.coffee
@@ -2,9 +2,13 @@ kd = require 'kd'
 React = require 'react'
 ReactView = require 'app/react/reactview'
 getGroupStatus = require 'app/util/getGroupStatus'
+{ Status } = require 'app/redux/modules/payment/constants'
 
 TrialEndedMemberModal = require 'lab/TrialEndedMemberModal'
 TrialEndedNotifySuccessModal = require 'lab/TrialEndedNotifySuccessModal'
+
+SuspendedMemberModal = require 'lab/SuspendedMemberModal'
+SuspendedNotifySuccessModal = require 'lab/SuspendedNotifySuccessModal'
 
 module.exports = class DisabledMemberModal extends ReactView
 
@@ -18,11 +22,25 @@ module.exports = class DisabledMemberModal extends ReactView
 
     switch status
 
-      when 'expired'
+      when Status.EXPIRED
         onClick = =>
           @destroy()
           router.handleRoute '/Disabled/Member/notify-success'
         <TrialEndedMemberModal
+          isOpen={yes}
+          onButtonClick={onClick} />
+
+      when Status.PAST_DUE, Status.CANCELED
+        onClick = =>
+          @destroy()
+          router.handleRoute '/Disabled/Member/suspended-notify-success'
+        <SuspendedMemberModal
+          isOpen={yes}
+          onButtonClick={onClick} />
+
+      when 'suspended-notify-success'
+        onClick = -> console.log 'support link clicked'
+        <SuspendedNotifySuccessModal
           isOpen={yes}
           onButtonClick={onClick} />
 

--- a/client/app/lib/components/headermessage/container.coffee
+++ b/client/app/lib/components/headermessage/container.coffee
@@ -14,13 +14,13 @@ subscription = require 'app/redux/modules/payment/subscription'
 
 HeaderMessage = require './headermessage'
 
-makeHeaderMessages = (daysLeft) ->
+makeHeaderMessages = (trialDays, daysLeft) ->
   admin:
     expiring:
       type: 'danger'
       title: 'Your trial is about to expire.'
       description: "
-        Your 1 week trial is about to expire. You have only #{pluralize 'day', daysLeft, yes}
+        Your 1 #{if trialDays is 7 then 'week' else 'month'} trial is about to expire. You have only #{pluralize 'day', daysLeft, yes}
         left. Enter your credit card to avoid any suspension.
       "
     past_due:
@@ -35,7 +35,7 @@ makeHeaderMessages = (daysLeft) ->
       type: 'danger'
       title: 'Your trial is about to expire.'
       description: "
-        Your 1 week trial is about to expire. You have only #{pluralize 'day', daysLeft, yes}
+        Your 1 #{if trialDays is 7 then 'week' else 'month'} trial is about to expire. You have only #{pluralize 'day', daysLeft, yes}
         left. Have an admin enter a credit card to avoid any suspension.
       "
     past_due:
@@ -62,7 +62,8 @@ headerMessage = (state) ->
 
   status   = groupStatus state
   daysLeft = subscription.daysLeft state
-  messages = makeHeaderMessages daysLeft
+  trialDays = subscription.trialDays state
+  messages = makeHeaderMessages trialDays, daysLeft
 
   return messages[getRole()][status]
 

--- a/client/app/lib/index.coffee
+++ b/client/app/lib/index.coffee
@@ -15,7 +15,7 @@ localStorage           = require './localstorage'
 isStarted = false
 
 require './styl/require-styles'
-require './util/ping'
+require('./util/ping')()
 
 run = (defaults) ->
 

--- a/client/app/lib/kodingrouter.coffee
+++ b/client/app/lib/kodingrouter.coffee
@@ -116,6 +116,7 @@ module.exports = class KodingRouter extends kd.Router
       member: [
         '/Disabled/Member'
         '/Disabled/Member/notify-success'
+        '/Disabled/Member/upgrade-notify-success'
         '/Disabled/Member/suspended-notify-success'
       ]
 

--- a/client/app/lib/kodingrouter.coffee
+++ b/client/app/lib/kodingrouter.coffee
@@ -116,6 +116,7 @@ module.exports = class KodingRouter extends kd.Router
       member: [
         '/Disabled/Member'
         '/Disabled/Member/notify-success'
+        '/Disabled/Member/suspended-notify-success'
       ]
 
     return route in allowedRoutes[getRole()]

--- a/client/app/lib/redux/dispatchInitialActions.coffee
+++ b/client/app/lib/redux/dispatchInitialActions.coffee
@@ -7,6 +7,7 @@ customer = require 'app/redux/modules/payment/customer'
 
 { load: loadPaymentInfo } = require 'app/redux/modules/payment/info'
 { load: loadSubscription } = require 'app/redux/modules/payment/subscription'
+{ load: loadInvoices } = require 'app/redux/modules/payment/invoices'
 
 loadAccount = ({ dispatch, getState }) ->
   dispatch {
@@ -29,7 +30,7 @@ loadUserDetails = ({ dispatch, getState }) ->
 ensurePaymentDetails = ({ dispatch, getState }) ->
 
   if isAdmin()
-  then dispatch(loadPaymentInfo())
+  then dispatch(loadPaymentInfo()).then -> dispatch(loadInvoices())
   else dispatch(loadSubscription())
 
 

--- a/client/app/lib/redux/dispatchInitialActions.coffee
+++ b/client/app/lib/redux/dispatchInitialActions.coffee
@@ -5,13 +5,8 @@ isAdmin = require 'app/util/isAdmin'
 customer = require 'app/redux/modules/payment/customer'
 { Plan } = require 'app/redux/modules/payment/constants'
 
-{
-  load: loadCustomer
-  create: createCustomer } = require 'app/redux/modules/payment/customer'
-
-{
-  load: loadSubscription
-  create: createSubscription } = require 'app/redux/modules/payment/subscription'
+{ load: loadPaymentInfo } = require 'app/redux/modules/payment/info'
+{ load: loadSubscription } = require 'app/redux/modules/payment/subscription'
 
 loadAccount = ({ dispatch, getState }) ->
   dispatch {
@@ -31,27 +26,11 @@ loadUserDetails = ({ dispatch, getState }) ->
     bongo: (remote) -> remote.api.JUser.fetchUser()
   }
 
-# TODO(umut):
-# right now there is no default customer coming from backend.
-# if there is no payment information for that group, just create one
-ensureCustomer = ({ dispatch, getState }) ->
+ensurePaymentDetails = ({ dispatch, getState }) ->
 
-  { currentGroup: group } = globals
-
-  if group.payment
-  then dispatch(loadCustomer())
-  else dispatch(createCustomer())
-
-
-ensureSubscription = ({ dispatch, getState }) ->
-
-  { currentGroup: group } = globals
-
-  state = getState()
-
-  if group.payment?.subscription
-  then dispatch(loadSubscription())
-  else dispatch(createSubscription(state.customer.id, Plan.UP_TO_10_USERS))
+  if isAdmin()
+  then dispatch(loadPaymentInfo())
+  else dispatch(loadSubscription())
 
 
 module.exports = dispatchInitialActions = (store) ->
@@ -63,11 +42,7 @@ module.exports = dispatchInitialActions = (store) ->
   promise = loadAccount(store)
     .then -> loadGroup(store)
     .then -> loadUserDetails(store)
-
-  if isAdmin()
-    promise = promise
-      .then -> ensureCustomer(store)
-      .then -> ensureSubscription(store)
+    .then -> ensurePaymentDetails(store)
 
   promise.then(console.log.bind(console, 'finished dispatching initial actions'))
 

--- a/client/app/lib/redux/modules/bongo.coffee
+++ b/client/app/lib/redux/modules/bongo.coffee
@@ -68,7 +68,7 @@ byId = (constructorName, id) -> (state) -> state.bongo[constructorName]?[id]
 all = (constructorName) -> (state) -> state.bongo[constructorName]
 
 
-module.exports = _.assign reducer, {
+module.exports = {
   namespace: withNamespace()
   reducer
   load, loadAll, update, remove, byId, all

--- a/client/app/lib/redux/modules/payment/constants.coffee
+++ b/client/app/lib/redux/modules/payment/constants.coffee
@@ -1,16 +1,27 @@
 
 module.exports =
   Status:
+    # allowed statuses
+    ACTIVE: 'active'
     TRIALING: 'trialing'
     EXPIRING: 'expiring'
+
+    # not allowed stripe statuses
     EXPIRED: 'expired'
     PAST_DUE: 'past_due'
-    CANCELED: 'canceled'
     UNPAID: 'unpaid'
+
+    # not allowed koding statuses
+    CANCELED: 'no status'
+    NEEDS_UPGRADE: 'no payment'
+    UNKNOWN: 'unknown'
+
   Plan:
     FREE_FOREVER: 'p_free_forever'
     UP_TO_10_USERS: 'p_up_to_10'
     UP_TO_50_USERS: 'p_up_to_50'
     OVER_50_USERS: 'p_over_50'
+  Trial:
+    ALMOST_EXPIRED_DAYS_LEFT: 4
 
 

--- a/client/app/lib/redux/modules/payment/creditcard.coffee
+++ b/client/app/lib/redux/modules/payment/creditcard.coffee
@@ -67,7 +67,7 @@ remove = ->
   }
 
 
-module.exports = _.assign reducer, {
+module.exports = {
   namespace: withNamespace()
   reducer
 

--- a/client/app/lib/redux/modules/payment/creditcard.coffee
+++ b/client/app/lib/redux/modules/payment/creditcard.coffee
@@ -4,18 +4,28 @@ immutable = require 'app/util/immutable'
 { makeNamespace, expandActionType,
   normalize, defineSchema } = require 'app/redux/helper'
 
+{ info: infoSchema, customer: customerSchema } = require './schemas'
+
 withNamespace = makeNamespace 'koding', 'payment', 'creditcard'
 
 REMOVE = expandActionType withNamespace 'REMOVE'
 
 customer = require './customer'
+info = require './info'
 
 reducer = (state = null, action) ->
 
   switch action.type
 
     when customer.LOAD.SUCCESS, customer.CREATE.SUCCESS, customer.UPDATE.SUCCESS
-      normalized = normalize action.result, customer.schema
+      normalized = normalize action.result, customerSchema
+      c = normalized.first 'customer'
+
+      if c.default_source
+        return normalized.entities.sources[c.default_source]
+
+    when info.LOAD.SUCCESS
+      normalized = normalize action.result, infoSchema
       c = normalized.first 'customer'
 
       if c.default_source

--- a/client/app/lib/redux/modules/payment/creditcard.coffee
+++ b/client/app/lib/redux/modules/payment/creditcard.coffee
@@ -1,31 +1,32 @@
 _ = require 'lodash'
 immutable = require 'app/util/immutable'
 
-{ makeNamespace, expandActionType,
-  normalize, defineSchema } = require 'app/redux/helper'
+reduxHelper = require 'app/redux/helper'
 
-{ info: infoSchema, customer: customerSchema } = require './schemas'
-
-withNamespace = makeNamespace 'koding', 'payment', 'creditcard'
-
-REMOVE = expandActionType withNamespace 'REMOVE'
+schemas = require './schemas'
 
 customer = require './customer'
 info = require './info'
 
+withNamespace = reduxHelper.makeNamespace 'koding', 'payment', 'creditcard'
+
+REMOVE = reduxHelper.expandActionType withNamespace 'REMOVE'
+
 reducer = (state = null, action) ->
+
+  { normalize } = reduxHelper
 
   switch action.type
 
     when customer.LOAD.SUCCESS, customer.CREATE.SUCCESS, customer.UPDATE.SUCCESS
-      normalized = normalize action.result, customerSchema
+      normalized = normalize action.result, schemas.customer
       c = normalized.first 'customer'
 
       if c.default_source
         return normalized.entities.sources[c.default_source]
 
     when info.LOAD.SUCCESS
-      normalized = normalize action.result, infoSchema
+      normalized = normalize action.result, schemas.info
       c = normalized.first 'customer'
 
       if c.default_source

--- a/client/app/lib/redux/modules/payment/customer.coffee
+++ b/client/app/lib/redux/modules/payment/customer.coffee
@@ -1,4 +1,3 @@
-_ = require 'lodash'
 immutable = require 'app/util/immutable'
 
 { makeNamespace, expandActionType, normalize } = require 'app/redux/helper'
@@ -63,7 +62,7 @@ coupon = (state) -> state.customer?.discount?.coupon
 email = (state) -> state.customer?.email
 
 
-module.exports = _.assign reducer, {
+module.exports = {
   namespace: withNamespace()
   schema
   reducer

--- a/client/app/lib/redux/modules/payment/customer.coffee
+++ b/client/app/lib/redux/modules/payment/customer.coffee
@@ -1,27 +1,29 @@
 immutable = require 'app/util/immutable'
 
-{ makeNamespace, expandActionType, normalize } = require 'app/redux/helper'
+reduxHelper = require 'app/redux/helper'
 
-{ customer: schema, info: infoSchema } = require './schemas'
+schemas = require './schemas'
 
 info = require './info'
 
-withNamespace = makeNamespace 'koding', 'payment', 'customer'
+withNamespace = reduxHelper.makeNamespace 'koding', 'payment', 'customer'
 
-LOAD = expandActionType withNamespace 'LOAD'
-CREATE = expandActionType withNamespace 'CREATE'
-UPDATE = expandActionType withNamespace 'UPDATE'
-REMOVE = expandActionType withNamespace 'REMOVE'
+LOAD = reduxHelper.expandActionType withNamespace 'LOAD'
+CREATE = reduxHelper.expandActionType withNamespace 'CREATE'
+UPDATE = reduxHelper.expandActionType withNamespace 'UPDATE'
+REMOVE = reduxHelper.expandActionType withNamespace 'REMOVE'
 
 
 reducer = (state = null, action = {}) ->
 
+  { normalize } = reduxHelper
+
   switch action.type
     when info.LOAD.SUCCESS
-      normalized = normalize action.result, infoSchema
+      normalized = normalize action.result, schemas.info
       return immutable normalized.first 'customer'
     when LOAD.SUCCESS, CREATE.SUCCESS, UPDATE.SUCCESS
-      normalized = normalize action.result, schema
+      normalized = normalize action.result, schemas.customer
       return immutable normalized.first 'customer'
     when REMOVE.SUCCESS
       return null
@@ -64,7 +66,6 @@ email = (state) -> state.customer?.email
 
 module.exports = {
   namespace: withNamespace()
-  schema
   reducer
 
   coupon, email

--- a/client/app/lib/redux/modules/payment/customer.coffee
+++ b/client/app/lib/redux/modules/payment/customer.coffee
@@ -1,17 +1,13 @@
 _ = require 'lodash'
 immutable = require 'app/util/immutable'
 
-{ makeNamespace, expandActionType,
-  normalize, defineSchema } = require 'app/redux/helper'
+{ makeNamespace, expandActionType, normalize } = require 'app/redux/helper'
+
+{ customer: schema, info: infoSchema } = require './schemas'
+
+info = require './info'
 
 withNamespace = makeNamespace 'koding', 'payment', 'customer'
-
-schema = defineSchema 'customer',
-  sources:
-    data: defineSchema 'sources', []
-  subscriptions:
-    data: defineSchema 'subscriptions', []
-
 
 LOAD = expandActionType withNamespace 'LOAD'
 CREATE = expandActionType withNamespace 'CREATE'
@@ -22,6 +18,9 @@ REMOVE = expandActionType withNamespace 'REMOVE'
 reducer = (state = null, action = {}) ->
 
   switch action.type
+    when info.LOAD.SUCCESS
+      normalized = normalize action.result, infoSchema
+      return immutable normalized.first 'customer'
     when LOAD.SUCCESS, CREATE.SUCCESS, UPDATE.SUCCESS
       normalized = normalize action.result, schema
       return immutable normalized.first 'customer'

--- a/client/app/lib/redux/modules/payment/info.coffee
+++ b/client/app/lib/redux/modules/payment/info.coffee
@@ -1,4 +1,3 @@
-_ = require 'lodash'
 immutable = require 'app/util/immutable'
 dateDiffInDays = require 'app/util/dateDiffInDays'
 { createSelector } = require 'reselect'
@@ -47,7 +46,7 @@ endsAt = createSelector(
 )
 
 
-module.exports = _.assign reducer, {
+module.exports = {
   namespace: withNamespace()
   schema
   reducer

--- a/client/app/lib/redux/modules/payment/info.coffee
+++ b/client/app/lib/redux/modules/payment/info.coffee
@@ -1,0 +1,61 @@
+_ = require 'lodash'
+immutable = require 'app/util/immutable'
+dateDiffInDays = require 'app/util/dateDiffInDays'
+{ createSelector } = require 'reselect'
+
+{ makeNamespace, expandActionType,
+  normalize, defineSchema } = require 'app/redux/helper'
+
+{ info: schema } = require './schemas'
+
+withNamespace = makeNamespace 'koding', 'payment', 'info'
+
+LOAD = expandActionType withNamespace 'LOAD'
+
+reducer = (state = null, action = {}) ->
+
+  switch action.type
+    when LOAD.SUCCESS
+      normalized = normalize action.result, schema
+      return immutable normalized.first 'info'
+
+    else
+      return state
+
+
+load = ->
+  return {
+    types: [LOAD.BEGIN, LOAD.SUCCESS, LOAD.FAIL]
+    payment: (service) -> service.fetchInfo()
+  }
+
+
+due = (state) -> state.paymentInfo?.due
+
+nextBillingDate = (state) -> state.paymentInfo?.nextBillingDate
+
+userCount = (state) -> state.paymentInfo?.user.total
+
+daysLeft = createSelector(
+  nextBillingDate
+  (billingDate) -> dateDiffInDays(new Date(billingDate), new Date)
+)
+
+endsAt = createSelector(
+  nextBillingDate
+  (billingDate) -> (new Date billingDate).getTime()
+)
+
+
+module.exports = _.assign reducer, {
+  namespace: withNamespace()
+  schema
+  reducer
+
+  due, nextBillingDate, daysLeft, userCount, endsAt
+
+  load
+  LOAD
+}
+
+

--- a/client/app/lib/redux/modules/payment/info.coffee
+++ b/client/app/lib/redux/modules/payment/info.coffee
@@ -2,20 +2,20 @@ immutable = require 'app/util/immutable'
 dateDiffInDays = require 'app/util/dateDiffInDays'
 { createSelector } = require 'reselect'
 
-{ makeNamespace, expandActionType,
-  normalize, defineSchema } = require 'app/redux/helper'
+reduxHelper = require 'app/redux/helper'
+schemas = require './schemas'
 
-{ info: schema } = require './schemas'
+withNamespace = reduxHelper.makeNamespace 'koding', 'payment', 'info'
 
-withNamespace = makeNamespace 'koding', 'payment', 'info'
-
-LOAD = expandActionType withNamespace 'LOAD'
+LOAD = reduxHelper.expandActionType withNamespace 'LOAD'
 
 reducer = (state = null, action = {}) ->
 
+  { normalize } = reduxHelper
+
   switch action.type
     when LOAD.SUCCESS
-      normalized = normalize action.result, schema
+      normalized = normalize action.result, schemas.info
       return immutable normalized.first 'info'
 
     else
@@ -48,7 +48,6 @@ endsAt = createSelector(
 
 module.exports = {
   namespace: withNamespace()
-  schema
   reducer
 
   due, nextBillingDate, daysLeft, userCount, endsAt

--- a/client/app/lib/redux/modules/payment/invoices.coffee
+++ b/client/app/lib/redux/modules/payment/invoices.coffee
@@ -1,8 +1,5 @@
 immutable = require 'app/util/immutable'
 
-_ = require 'lodash'
-immutable = require 'app/util/immutable'
-
 { makeNamespace, expandActionType,
   normalize, defineSchema } = require 'app/redux/helper'
 
@@ -35,7 +32,7 @@ exports.load = load = ->
   }
 
 
-module.exports = _.assign reducer, {
+module.exports = {
   namespace: withNamespace()
   reducer
   load

--- a/client/app/lib/redux/modules/payment/invoices.coffee
+++ b/client/app/lib/redux/modules/payment/invoices.coffee
@@ -1,19 +1,21 @@
 immutable = require 'app/util/immutable'
 
-{ makeNamespace, expandActionType,
-  normalize, defineSchema } = require 'app/redux/helper'
+reduxHelper = require 'app/redux/helper'
 
-withNamespace = makeNamespace 'koding', 'payment', 'invoices'
+schemas = require './schemas'
+withNamespace = reduxHelper.makeNamespace 'koding', 'payment', 'invoices'
 
-LOAD = expandActionType withNamespace 'LOAD'
+LOAD = reduxHelper.expandActionType withNamespace 'LOAD'
 
 initialState = immutable { invoices: {}, items: {} }
 
 reducer = (state = initialState, action) ->
 
+  { normalize } = reduxHelper
+
   switch action.type
     when LOAD.SUCCESS
-      normalized = normalize action.result, schema
+      normalized = normalize action.result, schemas.invoices
       return immutable normalized.entities
 
   return state
@@ -29,6 +31,7 @@ exports.load = load = ->
 module.exports = {
   namespace: withNamespace()
   reducer
+
   load
   LOAD
 }

--- a/client/app/lib/redux/modules/payment/invoices.coffee
+++ b/client/app/lib/redux/modules/payment/invoices.coffee
@@ -7,12 +7,6 @@ withNamespace = makeNamespace 'koding', 'payment', 'invoices'
 
 LOAD = expandActionType withNamespace 'LOAD'
 
-schema =
-  data: defineSchema 'invoices', [
-    lines:
-      data: defineSchema 'items', []
-  ]
-
 initialState = immutable { invoices: {}, items: {} }
 
 reducer = (state = initialState, action) ->

--- a/client/app/lib/redux/modules/payment/schemas.coffee
+++ b/client/app/lib/redux/modules/payment/schemas.coffee
@@ -15,10 +15,16 @@ info = defineSchema 'info',
   subscription: subscription
   expectedPlan: defineSchema 'expectedPlan'
 
+invoices = defineSchema 'invoices', [
+  lines:
+    data: defineSchema 'items', []
+]
+
 
 module.exports = {
   plan
   subscription
   customer
   info
+  invoices
 }

--- a/client/app/lib/redux/modules/payment/schemas.coffee
+++ b/client/app/lib/redux/modules/payment/schemas.coffee
@@ -1,0 +1,24 @@
+{ defineSchema } = require 'app/redux/helper'
+
+plan = defineSchema 'plan'
+
+subscription = defineSchema 'subscription'
+
+customer = defineSchema 'customer',
+  sources:
+    data: defineSchema 'sources', []
+  subscriptions:
+    data: defineSchema 'subscriptions', []
+
+info = defineSchema 'info',
+  customer: customer
+  subscription: subscription
+  expectedPlan: defineSchema 'expectedPlan'
+
+
+module.exports = {
+  plan
+  subscription
+  customer
+  info
+}

--- a/client/app/lib/redux/modules/payment/subscription.coffee
+++ b/client/app/lib/redux/modules/payment/subscription.coffee
@@ -1,34 +1,34 @@
 _ = require 'lodash'
-immutable = require 'app/util/immutable'
 { createSelector } = require 'reselect'
+
+immutable = require 'app/util/immutable'
 dateDiffInDays = require 'app/util/dateDiffInDays'
 
-{ makeNamespace, expandActionType, normalize } = require 'app/redux/helper'
-
-{
-  subscription: schema, info: infoSchema, customer: customerSchema
-} = require './schemas'
-
-withNamespace = makeNamespace 'koding', 'payment', 'subscription'
+reduxHelper = require 'app/redux/helper'
+schemas = require './schemas'
 
 customer = require './customer'
 info = require './info'
 
-LOAD = expandActionType withNamespace 'LOAD'
-CREATE = expandActionType withNamespace 'CREATE'
-REMOVE = expandActionType withNamespace 'REMOVE'
+withNamespace = reduxHelper.makeNamespace 'koding', 'payment', 'subscription'
+
+LOAD = reduxHelper.expandActionType withNamespace 'LOAD'
+CREATE = reduxHelper.expandActionType withNamespace 'CREATE'
+REMOVE = reduxHelper.expandActionType withNamespace 'REMOVE'
 
 
 reducer = (state = null, action) ->
 
+  { normalize } = reduxHelper
+
   switch action.type
 
     when LOAD.SUCCESS, CREATE.SUCCESS
-      normalized = normalize action.result, schema
+      normalized = normalize action.result, schemas.subscription
       return immutable normalized.first 'subscription'
 
     when customer.LOAD.SUCCESS, customer.CREATE.SUCCESS, customer.UPDATE.SUCCESS
-      normalized = normalize action.result, customerSchema
+      normalized = normalize action.result, schemas.customer
 
       if subscription = normalized.first 'subscriptions'
         return immutable subscription
@@ -36,7 +36,7 @@ reducer = (state = null, action) ->
       return null
 
     when info.LOAD.SUCCESS
-      normalized = normalize action.result, infoSchema
+      normalized = normalize action.result, schemas.info
       subscription = _.assign {}, normalized.first('subscription'),
         plan: normalized.first 'expectedPlan'
 
@@ -129,7 +129,6 @@ daysLeft = createSelector(
 
 module.exports = {
   namespace: withNamespace()
-  schema
   reducer
   load, create, remove
   LOAD, CREATE, REMOVE

--- a/client/app/lib/redux/modules/payment/subscription.coffee
+++ b/client/app/lib/redux/modules/payment/subscription.coffee
@@ -76,6 +76,11 @@ remove = ->
 # Selectors
 ##
 
+makePlanAmount = (userCount) ->
+  switch
+    when userCount < 10 then ''
+
+
 plan = (state) -> state.subscription?.plan
 
 
@@ -122,7 +127,7 @@ daysLeft = createSelector(
 )
 
 
-module.exports = _.assign reducer, {
+module.exports = {
   namespace: withNamespace()
   schema
   reducer

--- a/client/app/lib/redux/modules/stripe.coffee
+++ b/client/app/lib/redux/modules/stripe.coffee
@@ -49,7 +49,7 @@ createToken = (options) ->
   }
 
 
-module.exports = _.assign reducer, {
+module.exports = {
   namespace: withNamespace()
   reducer
 

--- a/client/app/lib/redux/reducers.coffee
+++ b/client/app/lib/redux/reducers.coffee
@@ -4,13 +4,13 @@ _ = require 'lodash'
 exports.make = make = (reducers = {}) ->
 
   customReducers = {
-    stripe: require './modules/stripe'
-    bongo: require './modules/bongo'
-    creditCard: require './modules/payment/creditcard'
-    invoices: require './modules/payment/invoices'
-    subscription: require './modules/payment/subscription'
-    customer: require './modules/payment/customer'
-    paymentInfo: require './modules/payment/info'
+    stripe: require('./modules/stripe').reducer
+    bongo: require('./modules/bongo').reducer
+    creditCard: require('./modules/payment/creditcard').reducer
+    invoices: require('./modules/payment/invoices').reducer
+    subscription: require('./modules/payment/subscription').reducer
+    customer: require('./modules/payment/customer').reducer
+    paymentInfo: require('./modules/payment/info').reducer
     form: require('redux-form').reducer
   }
 

--- a/client/app/lib/redux/reducers.coffee
+++ b/client/app/lib/redux/reducers.coffee
@@ -10,6 +10,7 @@ exports.make = make = (reducers = {}) ->
     invoices: require './modules/payment/invoices'
     subscription: require './modules/payment/subscription'
     customer: require './modules/payment/customer'
+    paymentInfo: require './modules/payment/info'
     form: require('redux-form').reducer
   }
 

--- a/client/app/lib/redux/services/payment.coffee
+++ b/client/app/lib/redux/services/payment.coffee
@@ -1,3 +1,4 @@
+_ = require 'lodash'
 makeHttpClient = require 'app/util/makeHttpClient'
 { pickData } = makeHttpClient.helpers
 
@@ -50,8 +51,12 @@ exports.deleteCreditCard = deleteCreditCard = pickData ->
 exports.fetchInvoices = fetchInvoices = pickData ->
   client.get Endpoints.InvoiceList
 
-exports.fetchInfo = fetchInfo = pickData ->
-  client.get Endpoints.Info
+exports.fetchInfo = fetchInfo = ->
+  client.get(Endpoints.Info).then ({ data: info }) ->
+    # if status is trialing, use `trialInfo`
+    if info.subscription.status is 'trialing'
+      info = _.assign(_.omit(info, 'trialInfo'), info.trialInfo)
+    return info
 
 
 getTimestamp = (date) ->

--- a/client/app/lib/redux/services/payment.coffee
+++ b/client/app/lib/redux/services/payment.coffee
@@ -36,8 +36,9 @@ exports.fetchSubscription = fetchSubscription = pickData ->
   client.get Endpoints.SubscriptionGet
 
 exports.createSubscription = createSubscription = pickData (params = {}) ->
-  if not params.trialEnd
-    params.trialEnd = Math.round ((new Date()).getTime() + (30 * 24 * 60 * 60 * 1000)) / 1000
+
+  params.trialEnd ?= getTimestamp(new Date)
+
   client.post Endpoints.SubscriptionCreate, params
 
 exports.deleteSubscription = deleteSubscription = pickData (params = {}) ->
@@ -51,4 +52,9 @@ exports.fetchInvoices = fetchInvoices = pickData ->
 
 exports.fetchInfo = fetchInfo = pickData ->
   client.get Endpoints.Info
+
+
+getTimestamp = (date) ->
+
+  Math.round (date.getTime() + (30 * 24 * 60 * 60 * 1000)) / 1000
 

--- a/client/app/lib/redux/services/payment.coffee
+++ b/client/app/lib/redux/services/payment.coffee
@@ -2,6 +2,8 @@ _ = require 'lodash'
 makeHttpClient = require 'app/util/makeHttpClient'
 { pickData } = makeHttpClient.helpers
 
+{ Status } = require 'app/redux/modules/payment/constants'
+
 exports.client = client = makeHttpClient { baseURL: '/api/social/payment' }
 
 exports.Endpoints = Endpoints =
@@ -54,12 +56,14 @@ exports.fetchInvoices = fetchInvoices = pickData ->
 exports.fetchInfo = fetchInfo = ->
   client.get(Endpoints.Info).then ({ data: info }) ->
     # if status is trialing, use `trialInfo`
-    if info.subscription.status is 'trialing'
+    if info.subscription.status is Status.TRIALING
       info = _.assign(_.omit(info, 'trialInfo'), info.trialInfo)
     return info
 
 
 getTimestamp = (date) ->
 
-  Math.round (date.getTime() + (30 * 24 * 60 * 60 * 1000)) / 1000
+  thirtyDaysInMs = (30 * 24 * 60 * 60 * 1000)
+
+  Math.round (date.getTime() + thirtyDaysInMs) / 1000
 

--- a/client/app/lib/redux/services/payment.coffee
+++ b/client/app/lib/redux/services/payment.coffee
@@ -49,3 +49,6 @@ exports.deleteCreditCard = deleteCreditCard = pickData ->
 exports.fetchInvoices = fetchInvoices = pickData ->
   client.get Endpoints.InvoiceList
 
+exports.fetchInfo = fetchInfo = pickData ->
+  client.get Endpoints.Info
+

--- a/client/app/lib/util/getGroupStatus.coffee
+++ b/client/app/lib/util/getGroupStatus.coffee
@@ -1,14 +1,24 @@
+{ config } = require 'globals'
+{ Status } = require 'app/redux/modules/payment/constants'
 
 module.exports = getGroupStatus = (group) ->
 
-  # return 'unlimited'  if global.config.environment is 'default'
+  switch
+    # if stripe token is not set don't try to validate.
+    # This is mainly for default environment
+    when not config.stripe.token then Status.ACTIVE
 
-  return 'no payment'  unless group.payment
+    # This state is to identify teams before payment update.
+    # This state is only possible for members.
+    when not group.payment then Status.NEEDS_UPGRADE
 
-  return 'no subscription'  unless group.payment.subscription
+    # This state should never be here.
+    when not group.payment.subscription then Status.UNKNOWN
 
-  return 'no status'  unless group.payment.subscription.status
+    # This can only happen when a team fails to enter a credit card or we
+    # couldn't charge the credit card they entered.
+    when not group.payment.subscription.status then Status.CANCELED
 
-  return group.payment.subscription.status
-
+    # happy path. use info from group.
+    else group.payment.subscription.status
 

--- a/client/app/lib/util/isGroupDisabled.coffee
+++ b/client/app/lib/util/isGroupDisabled.coffee
@@ -2,14 +2,16 @@ getGroupStatus = require './getGroupStatus'
 
 { Status } = require 'app/redux/modules/payment/constants'
 
-expiredStatuses = [
-  Status.EXPIRED
-  Status.PAST_DUE
-  Status.CANCELED
+allowedStatuses = [
+  Status.TRIALING
+  Status.EXPIRING
+  Status.ACTIVE
 ]
 
 module.exports = isGroupDisabled = (group) ->
 
   status = getGroupStatus group
 
-  status and status in expiredStatuses
+  isAllowed = status and status in allowedStatuses
+
+  return not isAllowed

--- a/client/app/lib/util/ping.coffee
+++ b/client/app/lib/util/ping.coffee
@@ -1,6 +1,10 @@
 kd           = require 'kd'
 doXhrRequest = require './doXhrRequest'
 
-kd.utils.repeat 30000, ->
+module.exports = ping = ->
+  makePingRequest()
+  kd.utils.repeat 30000, makePingRequest
+
+makePingRequest = ->
   doXhrRequest { endPoint: '/api/social/presence/ping', type: 'GET' }, (err) ->
     console.log err  if err

--- a/client/component-lab/GroupSuspendedMemberModal/index.coffee
+++ b/client/component-lab/GroupSuspendedMemberModal/index.coffee
@@ -1,1 +1,0 @@
-module.exports = require './GroupSuspendedMemberModal'

--- a/client/component-lab/Subscription/Subscription.coffee
+++ b/client/component-lab/Subscription/Subscription.coffee
@@ -15,7 +15,7 @@ module.exports = class Subscription extends Component
 
   renderHeader: ->
 
-    { loading, teamSize, pricePerSeat
+    { loading, teamSize, pricePerSeat, daysLeft
       isTrial, freeCredit, endsAt, title } = @props
 
     nextAmount = Number(teamSize) * Number(pricePerSeat)
@@ -27,6 +27,7 @@ module.exports = class Subscription extends Component
       teamSize={teamSize}
       freeCredit={freeCredit}
       nextBillingAmount={nextAmount}
+      daysLeft={daysLeft}
       endsAt={endsAt} />
 
 
@@ -34,11 +35,14 @@ module.exports = class Subscription extends Component
 
     return  unless @props.isTrial
 
+    { daysLeft, endsAt, teamSize, pricePerSeat, onClickInfo } = @props
+
     <TrialChargeInfo
-      endsAt={@props.endsAt}
-      teamSize={@props.teamSize}
-      pricePerSeat={@props.pricePerSeat}
-      onClick={@props.onClickInfo} />
+      daysLeft={daysLeft}
+      endsAt={endsAt}
+      teamSize={teamSize}
+      pricePerSeat={pricePerSeat}
+      onClick={onClickInfo} />
 
 
   renderExtras: ->

--- a/client/component-lab/SubscriptionHeader/SubscriptionHeader.coffee
+++ b/client/component-lab/SubscriptionHeader/SubscriptionHeader.coffee
@@ -37,7 +37,7 @@ module.exports = class SubscriptionHeader extends Component
 
   renderSubtitle: ->
 
-    { loading, isTrial, endsAt } = @props
+    { loading, isTrial, endsAt, daysLeft } = @props
 
     isDanger = no
     subtitle = switch
@@ -45,7 +45,6 @@ module.exports = class SubscriptionHeader extends Component
         "Loading subscription info..."
 
       when isTrial
-        daysLeft = Math.max 0, dateDiffInDays(new Date(Number endsAt), new Date)
         isDanger = daysLeft < 4
         "You have #{daysLeft} days left in your trial."
 

--- a/client/component-lab/SuspendedMemberModal/SuspendedMemberModal.coffee
+++ b/client/component-lab/SuspendedMemberModal/SuspendedMemberModal.coffee
@@ -2,7 +2,7 @@ React = require 'react'
 
 Dialog = require 'lab/Dialog'
 
-module.exports = GroupSuspendedMemberModal = ({ isOpen, onButtonClick }) ->
+module.exports = SuspendedMemberModal = ({ isOpen, onButtonClick }) ->
 
   message = "
     We were unable to charge your credit card on file. Please notify your

--- a/client/component-lab/SuspendedMemberModal/SuspendedMemberModal.story.coffee
+++ b/client/component-lab/SuspendedMemberModal/SuspendedMemberModal.story.coffee
@@ -1,11 +1,11 @@
 React = require 'react'
 { storiesOf, action } = require '@kadira/storybook'
 
-GroupSuspendedMemberModal = require './GroupSuspendedMemberModal'
+SuspendedMemberModal = require './SuspendedMemberModal'
 
-storiesOf 'GroupSuspendedMemberModal', module
+storiesOf 'SuspendedMemberModal', module
   .add 'default', ->
-    <GroupSuspendedMemberModal
+    <SuspendedMemberModal
       isOpen={yes}
       onButtonClick={action 'button clicked'} />
 

--- a/client/component-lab/SuspendedMemberModal/index.coffee
+++ b/client/component-lab/SuspendedMemberModal/index.coffee
@@ -1,0 +1,1 @@
+module.exports = require './SuspendedMemberModal'

--- a/client/component-lab/SuspendedNotifySuccessModal/SuspendedNotifySuccessModal.coffee
+++ b/client/component-lab/SuspendedNotifySuccessModal/SuspendedNotifySuccessModal.coffee
@@ -1,0 +1,25 @@
+React = require 'react'
+
+Dialog = require 'lab/Dialog'
+
+module.exports = SuspendedNotifySuccess = ({ isOpen, onButtonClick, daysLeft }) ->
+
+  message = "
+    We have sent an email to your team admins about your subscription
+    expiration. When they enter a valid credit card, you will regain access to
+    Koding. We will send you an email when it is complete.
+  "
+
+  <Dialog
+    isOpen={isOpen}
+    showAlien={yes}
+    type='success'
+    title='Email Sent to Admins'
+    subtitle='Now you should wait until they take an action'
+    message={message}
+    buttonType='link'
+    buttonTitle='Have another issue? Contact us.'
+    onButtonClick={onButtonClick}
+  />
+
+

--- a/client/component-lab/SuspendedNotifySuccessModal/SuspendedNotifySuccessModal.story.coffee
+++ b/client/component-lab/SuspendedNotifySuccessModal/SuspendedNotifySuccessModal.story.coffee
@@ -1,0 +1,12 @@
+React = require 'react'
+{ storiesOf, action } = require '@kadira/storybook'
+
+SuspendedNotifySuccessModal = require './SuspendedNotifySuccessModal'
+
+storiesOf 'SuspendedNotifySuccessModal', module
+  .add 'default', ->
+    <SuspendedNotifySuccessModal
+      isOpen={yes}
+      onButtonClick={action 'link clicked'} />
+
+

--- a/client/component-lab/SuspendedNotifySuccessModal/index.coffee
+++ b/client/component-lab/SuspendedNotifySuccessModal/index.coffee
@@ -1,0 +1,1 @@
+module.exports = require './SuspendedNotifySuccessModal'

--- a/client/component-lab/TrialChargeInfo/TrialChargeInfo.coffee
+++ b/client/component-lab/TrialChargeInfo/TrialChargeInfo.coffee
@@ -1,6 +1,7 @@
 kd = require 'kd'
 { PropTypes } = React = require 'react'
 generateClassName = require 'classnames'
+pluralize = require 'pluralize'
 { Grid, Row, Col } = require 'react-flexbox-grid'
 dateDiffInDays = require 'app/util/dateDiffInDays'
 
@@ -14,7 +15,7 @@ ExpirationMessage = ({ daysLeft }) ->
 
   daysLeft ?= 100
 
-  title = if daysLeft > 0
+  title = if daysLeft >= 0
   then "Your trial period is about to expire"
   else "Your trial period has expired"
 
@@ -35,9 +36,8 @@ ExpirationMessage = ({ daysLeft }) ->
   </Row>
 
 
-TrialChargeInfo = ({ teamSize, pricePerSeat, endsAt }) ->
+TrialChargeInfo = ({ teamSize, pricePerSeat, daysLeft }) ->
 
-  daysLeft = Math.max 0, dateDiffInDays(new Date(Number endsAt), new Date)
   isDanger = daysLeft < 4
 
   <Box border={1} type={if isDanger then 'danger' else 'secondary'}>
@@ -49,7 +49,7 @@ TrialChargeInfo = ({ teamSize, pricePerSeat, endsAt }) ->
       }
       <Col xs={4}>
         <Label size="small">
-          Team Size: <strong>{teamSize} Developers</strong>
+          Team Size: <strong>{pluralize 'Developer', teamSize, yes}</strong>
         </Label>
       </Col>
       <Col xs={8} className={textStyles.right}>
@@ -64,7 +64,6 @@ TrialChargeInfo = ({ teamSize, pricePerSeat, endsAt }) ->
 TrialChargeInfo.propTypes =
   teamSize: PropTypes.number
   pricePerSeat: PropTypes.number
-  endsAt: PropTypes.number.isRequired
 
 TrialChargeInfo.defaultProps =
   teamSize: 1

--- a/client/component-lab/UpgradeNeededMemberModal/UpgradeNeededMemberModal.coffee
+++ b/client/component-lab/UpgradeNeededMemberModal/UpgradeNeededMemberModal.coffee
@@ -1,0 +1,25 @@
+React = require 'react'
+
+Dialog = require 'lab/Dialog'
+
+module.exports = UpgradeNeededMemberModal = ({ isOpen, onButtonClick }) ->
+
+  message = "
+    Thank you for being a loyal Koding user. We recently activated a new
+    payment system. Please ask one of your admins to login to upgrade your
+    team.
+  "
+
+  <Dialog
+    isOpen={isOpen}
+    showAlien={yes}
+    type='danger'
+    title='Important Message'
+    subtitle="Your team needs to be upgraded."
+    message={message}
+    buttonTitle='NOTIFY MY ADMINS'
+    onButtonClick={onButtonClick}
+  />
+
+
+

--- a/client/component-lab/UpgradeNeededMemberModal/UpgradeNeededMemberModal.story.coffee
+++ b/client/component-lab/UpgradeNeededMemberModal/UpgradeNeededMemberModal.story.coffee
@@ -1,0 +1,13 @@
+React = require 'react'
+{ storiesOf, action } = require '@kadira/storybook'
+
+UpgradeNeededMemberModal = require './UpgradeNeededMemberModal'
+
+storiesOf 'UpgradeNeededMemberModal', module
+  .add 'default', ->
+    <UpgradeNeededMemberModal
+      isOpen={yes}
+      onButtonClick={action 'button clicked'} />
+
+
+

--- a/client/component-lab/UpgradeNeededMemberModal/index.coffee
+++ b/client/component-lab/UpgradeNeededMemberModal/index.coffee
@@ -1,0 +1,1 @@
+module.exports = require './UpgradeNeededMemberModal'

--- a/client/component-lab/UpgradeNeededNotifySuccessModal/UpgradeNeededNotifySuccessModal.coffee
+++ b/client/component-lab/UpgradeNeededNotifySuccessModal/UpgradeNeededNotifySuccessModal.coffee
@@ -1,0 +1,27 @@
+React = require 'react'
+
+Dialog = require 'lab/Dialog'
+
+module.exports = UpgradeNeededNotifySuccessModal = (props) ->
+
+  { isOpen, onButtonClick, daysLeft } = props
+
+  message = "
+    We have sent an email to your team admins about your upgrade requirements.
+    When they login, you will regain access to Koding. We will send you an
+    email when it is complete.
+  "
+
+  <Dialog
+    isOpen={isOpen}
+    showAlien={yes}
+    type='success'
+    title='Email Sent to Admins'
+    subtitle='Now you should wait until they take an action'
+    message={message}
+    buttonType='link'
+    buttonTitle='Have another issue? Contact us.'
+    onButtonClick={onButtonClick}
+  />
+
+

--- a/client/component-lab/UpgradeNeededNotifySuccessModal/UpgradeNeededNotifySuccessModal.story.coffee
+++ b/client/component-lab/UpgradeNeededNotifySuccessModal/UpgradeNeededNotifySuccessModal.story.coffee
@@ -1,0 +1,12 @@
+React = require 'react'
+{ storiesOf, action } = require '@kadira/storybook'
+
+UpgradeNeededNotifySuccessModal = require './UpgradeNeededNotifySuccessModal'
+
+storiesOf 'UpgradeNeededNotifySuccessModal', module
+  .add 'default', ->
+    <UpgradeNeededNotifySuccessModal
+      isOpen={yes}
+      onButtonClick={action 'link clicked'} />
+
+

--- a/client/component-lab/UpgradeNeededNotifySuccessModal/index.coffee
+++ b/client/component-lab/UpgradeNeededNotifySuccessModal/index.coffee
@@ -1,0 +1,1 @@
+module.exports = require './UpgradeNeededNotifySuccessModal'

--- a/client/home/lib/billing/components/paymentsectioncontainer.coffee
+++ b/client/home/lib/billing/components/paymentsectioncontainer.coffee
@@ -2,8 +2,12 @@
 { connect } = require 'react-redux'
 { createSelector } = require 'reselect'
 
+getGroupStatus = require 'app/util/getGroupStatus'
+
 { CREATE_TOKEN } = stripe = require 'app/redux/modules/stripe'
 creditCard = require 'app/redux/modules/payment/creditcard'
+
+{ Status } = require 'app/redux/modules/payment/constants'
 
 PaymentSection = require './paymentsection'
 
@@ -21,9 +25,17 @@ formMessages[CREATE_TOKEN.FAIL] =
     below and try again.
   '
 
+formMessages[Status.PAST_DUE] = formMessages[Status.CANCELED] =
+  type: 'danger'
+  title: 'Credit Card Error'
+  description: '
+    Your account is suspended because we were unable to charge your card on
+    file. Please enter a new card to continue using Koding.
+  '
+
 formMessage = createSelector(
   stripe.lastAction
-  (lastAction) -> lastAction and formMessages[lastAction]
+  (lastAction) -> formMessages[lastAction or getGroupStatus()]
 )
 
 submitting = (formName) -> (state) -> state.form[formName]?.submitting

--- a/client/home/lib/billing/components/subscriptioncontainer.coffee
+++ b/client/home/lib/billing/components/subscriptioncontainer.coffee
@@ -7,12 +7,11 @@ pluralize = require 'pluralize'
 
 subscription = require 'app/redux/modules/payment/subscription'
 customer = require 'app/redux/modules/payment/customer'
+info = require 'app/redux/modules/payment/info'
 bongo = require 'app/redux/modules/bongo'
 
 SubscriptionSection = require './subscriptionsection'
 
-
-teamSize = -> globals.currentGroup?.counts?.member ? 1
 
 trialTitles =
   7: "Koding Basic Trial (1 Week)"
@@ -23,11 +22,11 @@ subscriptionTitle = createSelector(
   subscription.pricePerSeat
   subscription.isTrial
   subscription.trialDays
-  teamSize
-  (pricePerSeat, isTrial, trialDays, size) ->
+  info.userCount
+  (pricePerSeat, isTrial, trialDays, userCount) ->
     if isTrial
     then trialTitles[trialDays]
-    else "$#{pricePerSeat} per Developer (#{pluralize 'Developer', size, yes})"
+    else "$#{pricePerSeat} per Developer (#{pluralize 'Developer', userCount, yes})"
 )
 
 
@@ -60,8 +59,9 @@ mapStateToProps = (state) ->
   return {
     title: subscriptionTitle(state)
     pricePerSeat: subscription.pricePerSeat(state)
-    teamSize: teamSize()
-    endsAt: subscription.endsAt(state)
+    teamSize: info.userCount(state)
+    endsAt: info.endsAt(state)
+    daysLeft: info.daysLeft(state)
     isTrial: subscription.isTrial(state)
     freeCredit: freeCredit(state)
     # TODO(umut): activate this when we have coupon support.

--- a/workers/social/lib/social/models/group/index.coffee
+++ b/workers/social/lib/social/models/group/index.coffee
@@ -272,7 +272,9 @@ module.exports = class JGroup extends Module
         ]]
       # parent        : ObjectRef
       counts        :
-        members     : Number
+        members     :
+          type      : Number
+          default   : -> 1
       customize     :
         coverPhoto  : String
         logo        : String


### PR DESCRIPTION
There are couple of issues at current version, this PR aims to fix all of those. Please see below for detailed description:
- [x] Use payment/info backend for admins to fetch the real info about team's payment status.
- [x] Use subscription/get backend for members to fetch subscription details 
  - [x] Make a decision to show an alert banner on top for members to notify their admins.
  - [x] Make a decision to show an alert modal for members to notify their admins when they logged in to the site after a group's plan gets expired.
- [x] Change the assumption about trial period days from `1 week` to `1 month`
- [x] Modify all redux modules to export a POJO instead of the `reducer` itself.
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
