### PR TITLE
Closing Welcome Modal redirect to wrong URL

### DIFF
--- a/client/home/lib/welcome/welcomemodal.coffee
+++ b/client/home/lib/welcome/welcomemodal.coffee
@@ -2,6 +2,7 @@ kd = require 'kd'
 HomeWelcome = require './'
 LocalStorage = require 'app/localstorage'
 globals = require 'globals'
+_ = require 'lodash'
 
 module.exports = class WelcomeModal extends kd.ModalView
 
@@ -82,10 +83,14 @@ module.exports = class WelcomeModal extends kd.ModalView
 
     { router } = kd.singletons
     { visitedRoutes: tempVisitedRoutes } = router
-    # To remove infinite loop between these 2 routes
-    # which are `/Welcome` and `/Home` and We are going to
-    # redirect to `Any route` after destroying Welcome Modal
-    # `Any route` -> `/Welcome` -> `/Home` -> `/Welcome`
+    # In case of visitedRoutes comes like this
+    # `Any route` -> `/Welcome` -> `/Home` -> `/Welcome` ->
+    # `/Home` -> `/Welcome` -> `/Home` -> `/Welcome`
+    # to findout correct back route and prevent infinite loop
+    # between `/Welcome` and `/Home` routes, we need to remove
+    # those unnecessary paths to access `/Any Route`
+    # FIXME: ~HK
+    tempVisitedRoutes =  _.flatten _.uniqWith _.chunk(tempVisitedRoutes, 2), _.isEqual
     [..., beforeLast, last] = tempVisitedRoutes
 
     tempVisitedRoutes.pop()  if last is '/Welcome' and beforeLast.indexOf('/Home') > -1

--- a/client/home/lib/welcome/welcomemodal.coffee
+++ b/client/home/lib/welcome/welcomemodal.coffee
@@ -80,7 +80,18 @@ module.exports = class WelcomeModal extends kd.ModalView
 
     @setClass 'out'
 
-    kd.singletons.router.handleRoute '/IDE'  if selfInitiated
+    { router } = kd.singletons
+    { visitedRoutes: tempVisitedRoutes } = router
+    # To remove infinite loop between these 2 routes
+    # which are `/Welcome` and `/Home` and We are going to
+    # redirect to `Any route` after destroying Welcome Modal
+    # `Any route` -> `/Welcome` -> `/Home` -> `/Welcome`
+    [..., beforeLast, last] = tempVisitedRoutes
+
+    tempVisitedRoutes.pop()  if last is '/Welcome' and beforeLast.indexOf('/Home') > -1
+
+    welcomeIndex = tempVisitedRoutes.lastIndexOf('/Welcome')
+    router.handleRoute tempVisitedRoutes[welcomeIndex - 1]  if selfInitiated
 
     # fat arrow is not unnecessary - sy
     kd.utils.wait 400, => super

--- a/client/home/lib/welcome/welcomemodal.coffee
+++ b/client/home/lib/welcome/welcomemodal.coffee
@@ -2,7 +2,6 @@ kd = require 'kd'
 HomeWelcome = require './'
 LocalStorage = require 'app/localstorage'
 globals = require 'globals'
-_ = require 'lodash'
 
 module.exports = class WelcomeModal extends kd.ModalView
 
@@ -82,22 +81,12 @@ module.exports = class WelcomeModal extends kd.ModalView
     @setClass 'out'
 
     { router } = kd.singletons
-    { visitedRoutes: tempVisitedRoutes } = router
-    # In case of visitedRoutes comes like this
-    # `Any route` -> `/Welcome` -> `/Home` -> `/Welcome` ->
-    # `/Home` -> `/Welcome` -> `/Home` -> `/Welcome`
-    # to findout correct back route and prevent infinite loop
-    # between `/Welcome` and `/Home` routes, we need to remove
-    # those unnecessary paths to access `/Any Route`
-    # FIXME: ~HK
-    tempVisitedRoutes =  _.flatten _.uniqWith _.chunk(tempVisitedRoutes, 2), _.isEqual
-    [..., beforeLast, last] = tempVisitedRoutes
-
-    tempVisitedRoutes.pop()  if last is '/Welcome' and beforeLast.indexOf('/Home') > -1
-
-    welcomeIndex = tempVisitedRoutes.lastIndexOf('/Welcome')
-    router.handleRoute tempVisitedRoutes[welcomeIndex - 1]  if selfInitiated
+    previousRoutes = router.visitedRoutes.filter (route) => not @checkRoute route
+    route = previousRoutes.last
+    router.handleRoute route  if selfInitiated
 
     # fat arrow is not unnecessary - sy
     kd.utils.wait 400, => super
 
+  checkRoute: (route) ->
+    /^\/(?:Home).*/.test(route) or /^\/(?:Welcome).*/.test route


### PR DESCRIPTION
`\Welcome` and `\Home` routes cause infinite loops when user close the `Welcome Modal` after going Home directory and going back to Welcome Modal again.
User will be redirected to correct route when this case occurs.

Here is the screencast:
http://recordit.co/YF2UbeTjEi
I tried to cover all possible cases that might produce bug by closing `Welcome Modal`.

fixes: #9143 
