### PR TITLE
Don't install python and pip during application deployment

### DIFF
--- a/.ebextensions/001_serversettings.config
+++ b/.ebextensions/001_serversettings.config
@@ -13,14 +13,6 @@ commands:
     command: "yum install nodejs npm --enablerepo=epel -y || echo node already installed"
   06-command-npm:
     command: "npm install --global npm@2.9.1 --unsafe-perm"
-
-  07-install-python26-pip:
-    command: "yum -y install python26-pip || echo python26-pip installed"
-  07-install-python-pip:
-    command: "yum -y install python-pip || echo python-pip installed"
-  07-install-python-devel:
-    command: "yum -y install python-devel || echo python-devel installed"
-
   08-command:
     command: "npm install -g coffee-script@1.8.0 || echo coffeescript already installed"
   09-command:


### PR DESCRIPTION
It overwrites existing installation and breaks deployment in newer Elastic Beanstalk platforms.

Signed-off-by: Sonmez Kartal sonmez@koding.com
