### PR TITLE
Resource state modal: bug fixes

### DIFF
--- a/client/app/lib/providers/resourcestatemodal/controllers/machineflowcontroller.coffee
+++ b/client/app/lib/providers/resourcestatemodal/controllers/machineflowcontroller.coffee
@@ -34,7 +34,7 @@ module.exports = class MachineFlowController extends kd.Controller
       .then (response) =>
         @onDataLoaded()
         @updateStatus
-          status     : response.state
+          status     : response.State
           eventId    : machineId
       .catch (err) =>
         @onDataLoaded()

--- a/client/app/lib/providers/resourcestatemodal/controllers/machineflowcontroller.coffee
+++ b/client/app/lib/providers/resourcestatemodal/controllers/machineflowcontroller.coffee
@@ -136,7 +136,8 @@ module.exports = class MachineFlowController extends kd.Controller
 
     if status is 'NotInitialized'
       event.error ?= '''
-        Your VM doesn\'t respond. Please try again reloading the page or rebuild your stack.
+        Your VM doesn\'t respond and it looks like it\'s broken. Please try again
+        reloading the page or rebuild your stack.
       '''
 
     return event

--- a/client/app/lib/providers/resourcestatemodal/views/baseerrorpageview.coffee
+++ b/client/app/lib/providers/resourcestatemodal/views/baseerrorpageview.coffee
@@ -1,4 +1,5 @@
 kd = require 'kd'
+_  = require 'lodash'
 JView = require 'app/jview'
 copyToClipboard = require 'app/util/copyToClipboard'
 getCopyToClipboardShortcut = require 'app/util/getCopyToClipboardShortcut'
@@ -33,8 +34,8 @@ module.exports = class BaseErrorPageView extends JView
       """
 
     errorPartial = if isSingleError
-    then errs.first
-    else (errs.map (err) -> "<li>#{err}</li>").join ''
+    then _.escape errs.first
+    else (errs.map (err) -> "<li>#{_.escape err}</li>").join ''
     @errorContent.addSubView new kd.CustomHTMLView
       tagName  : if isSingleError then 'p' else 'ul'
       partial  : errorPartial

--- a/client/app/lib/providers/resourcestatemodal/views/machineflow/machineerrorpageview.coffee
+++ b/client/app/lib/providers/resourcestatemodal/views/machineflow/machineerrorpageview.coffee
@@ -1,0 +1,17 @@
+kd = require 'kd'
+BaseErrorPageView = require '../baseerrorpageview'
+
+module.exports = class MachineErrorPageView extends BaseErrorPageView
+
+  pistachio: ->
+
+    '''
+      <div class="stop-machine-flow error-page stop-machine-error-page">
+        <section class="main">
+          <div class="background"></div>
+          <h2>Something went wrong</h2>
+          <p>There was an error while processing your VM.</p>
+          {{> @errorContainer}}
+        </section>
+      </div>
+    '''

--- a/client/app/lib/styl/resourcestatemodal.styl
+++ b/client/app/lib/styl/resourcestatemodal.styl
@@ -250,6 +250,7 @@ $regularColor               = #989898
 
         p
           padding-top       12px
+          white-space       pre-line
 
         ul
           list-style-type   disc


### PR DESCRIPTION
## Description

This PR contains error handling fixes in `ResourceStateModal`
## Motivation and Context
- https://github.com/koding/koding/issues/9118
- It fixes VM endless loading animation after team cleanup process. In this case stack status is `Initialized` but VM status is `NotInitialized`. A fix correctly handles such case and shows a proper error message
## Screenshots:

![](http://g.recordit.co/8mNnQSfP6h.gif)
