### PR TITLE
AppStorage and Welcome modal routing fixes

### DIFF
--- a/client/app/lib/appstorage.coffee
+++ b/client/app/lib/appstorage.coffee
@@ -21,17 +21,20 @@ class AppStorage extends kd.Object
     super
 
 
-  fetchStorage: do (queue = []) -> (callback, force = no) ->
+  fetchStorage: do (queue = {}) -> (callback, force = no) ->
 
     [ appId, version ] = [ @_applicationID, @_applicationVersion ]
+
+    key = "#{appId}-#{version}"
+    queue[key] ?= []
 
     if not @_storage or force
 
       { mainController } = kd.singletons
 
-      queue.push callback
+      queue[key].push callback
 
-      return  if queue.length > 1
+      return  if queue[key].length > 1
 
       mainController.ready =>
 
@@ -43,8 +46,8 @@ class AppStorage extends kd.Object
 
             @_setReady()
 
-          cb? storage  for cb in queue
-          queue = []
+          cb? @_storage  for cb in queue[key]
+          queue[key] = []
 
     else
 

--- a/client/app/lib/kodingrouter.coffee
+++ b/client/app/lib/kodingrouter.coffee
@@ -36,7 +36,7 @@ module.exports = class KodingRouter extends kd.Router
         entryPoint      : globals.config.entryPoint
 
 
-  handleRoute: (route, options = {}) ->
+  handleRoute: (route = '', options = {}) ->
 
     @breadcrumb.push route
 

--- a/client/home/lib/welcome/welcomemodal.coffee
+++ b/client/home/lib/welcome/welcomemodal.coffee
@@ -80,13 +80,12 @@ module.exports = class WelcomeModal extends kd.ModalView
 
     @setClass 'out'
 
-    { router } = kd.singletons
-    previousRoutes = router.visitedRoutes.filter (route) => not @checkRoute route
-    route = previousRoutes.last
+    { router, computeController } = kd.singletons
+
+    previousRoutes = router.visitedRoutes.filter (route) ->
+      not (/^\/(?:Home).*/.test(route) or /^\/(?:Welcome).*/.test(route))
+    route = previousRoutes.last ? '/IDE'
     router.handleRoute route  if selfInitiated
 
     # fat arrow is not unnecessary - sy
     kd.utils.wait 400, => super
-
-  checkRoute: (route) ->
-    /^\/(?:Home).*/.test(route) or /^\/(?:Welcome).*/.test route


### PR DESCRIPTION
AppStorage queue up system wasn't taking into account `appId`'s and `version`s and Welcome modal routing fixes was designed for the old router which is also fixed with in this PR.
