### PR TITLE
object: preserve case of the field name

### DIFF
--- a/go/src/koding/kites/kloud/stack/provider/stackplan.go
+++ b/go/src/koding/kites/kloud/stack/provider/stackplan.go
@@ -246,10 +246,11 @@ func (p *Planner) checkSingleKlient(k *kite.Kite, label, kiteID string) *DialSta
 	}
 
 	return &DialState{
-		Label:  label,
-		KiteID: kiteID,
-		State:  "provider",
-		Err:    err,
+		Label:   label,
+		KiteID:  kiteID,
+		KiteURL: c.Client.URL,
+		State:   "provider",
+		Err:     err,
 	}
 }
 

--- a/go/src/koding/kites/kloud/utils/object/object.go
+++ b/go/src/koding/kites/kloud/utils/object/object.go
@@ -44,21 +44,22 @@ type Builder struct {
 
 	// Recursive tells when struct fields should be processed as well.
 	Recursive bool
+
+	// FieldFunc is used to format struct's field name.
+	//
+	// By default struct's field name is used as-is.
+	FieldFunc func(string) string
 }
 
 // New creates new child builder for the given prefix.
 func (b *Builder) New(prefix string) *Builder {
-	newB := &Builder{
-		Tag:       b.Tag,
-		Sep:       b.Sep,
-		Recursive: b.Recursive,
-	}
+	newB := *b
 	if b.Prefix != "" {
 		newB.Prefix = b.Prefix + newB.Sep + prefix
 	} else {
 		newB.Prefix = prefix
 	}
-	return newB
+	return &newB
 }
 
 // Build creates flat object representation of the given value v ignoring
@@ -200,10 +201,17 @@ func (b *Builder) keyFromField(f *structs.Field) string {
 	case "-":
 		return ""
 	case "":
-		return strings.ToLower(f.Name())
+		return b.fieldFunc(f.Name())
 	}
 
 	return tag
+}
+
+func (b *Builder) fieldFunc(s string) string {
+	if b.FieldFunc != nil {
+		return b.FieldFunc(s)
+	}
+	return s
 }
 
 func isMapObject(v interface{}) bool {

--- a/go/src/koding/kites/kloud/utils/object/object_test.go
+++ b/go/src/koding/kites/kloud/utils/object/object_test.go
@@ -3,6 +3,7 @@ package object_test
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 
 	"koding/kites/kloud/provider/aws"
@@ -32,6 +33,7 @@ func TestBuilder(t *testing.T) {
 		Sep:       "+",
 		Prefix:    "prefix",
 		Recursive: true,
+		FieldFunc: strings.ToLower,
 	}
 
 	cases := []struct {


### PR DESCRIPTION
This PR changes previous behavior, which created
objects by lowering the case of struct's field.

In order to keep previous behavior set FieldFunc
to a strings.ToLower while creating Builder, like:

  var b = &Builder{
    FieldFunc: strings.ToLower,
  }

Fixes #9219.
