### PR TITLE
config: escape nginx variables in .env.sh script

### DIFF
--- a/config/generateShellEnv.coffee
+++ b/config/generateShellEnv.coffee
@@ -4,6 +4,10 @@ module.exports.create = (KONFIG, options = {}) ->
   env = ''
 
   add = (name, value) ->
+    # Escape $ sign when it precedes lower-case character which means that this
+    # is not a bash variable but nginx one.
+    value = (value.replace /(\$)[a-z0-9]/g, (match) -> "\\#{match}") if typeof value is 'string'
+
     env += "export #{name}=${#{name}:-#{value}}\n"
 
   traverse.paths(KONFIG).forEach (path) ->

--- a/config/generateShellEnv.coffee
+++ b/config/generateShellEnv.coffee
@@ -6,7 +6,7 @@ module.exports.create = (KONFIG, options = {}) ->
   add = (name, value) ->
     # Escape $ sign when it precedes lower-case character which means that this
     # is not a bash variable but nginx one.
-    value = (value.replace /(\$)[a-z0-9]/g, (match) -> "\\#{match}") if typeof value is 'string'
+    value = (value.replace /\$[a-z0-9]/g, (match) -> "\\#{match}") if typeof value is 'string'
 
     env += "export #{name}=${#{name}:-#{value}}\n"
 


### PR DESCRIPTION
This PR escapes '$' character for nginx-like variables in .env.sh. 
## Motivation and Context

Currently, `generateShellEnv.coffee` doesn't escape '$' character in nginx-like variables which generates invalid values. Eg.

``` shell
$ export KONFIG_WORKERS_KONTROL_NGINX_LOCATIONS_0_PROXYPASS=${KONFIG_WORKERS_KONTROL_NGINX_LOCATIONS_0_PROXYPASS:-http://kontrol/$1$is_args$args}
$ env | grep KONFIG_WORKERS_KONTROL_NGINX_LOCATIONS_0_PROXYPASS
KONFIG_WORKERS_KONTROL_NGINX_LOCATIONS_0_PROXYPASS=http://kontrol/
```

This fix will escape all `$` characters that precede either a lower case character or a digit(`.env.sh` is not meant to be called with command line arguments)

Without escaping it is also not possible to `source .env.sh`
## How Has This Been Tested?

Manually.
## Screenshots (if appropriate):
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
