### PR TITLE
ResourceStateModal: reset stack state while going away from build error view

### DIFF
--- a/client/app/lib/providers/resourcestatemodal/controllers/buildstackcontroller.coffee
+++ b/client/app/lib/providers/resourcestatemodal/controllers/buildstackcontroller.coffee
@@ -27,16 +27,23 @@ module.exports = class BuildStackController extends kd.Controller
 
     @buildStackPage.on 'BuildDone', @bound 'completePostBuildProcess'
     @forwardEvent @buildStackPage, 'ClosingRequested'
-    @forwardEvent @errorPage, 'CredentialsRequested'
-    @errorPage.on 'RebuildRequested', =>
-      @buildStackPage.reset()
-      @emit 'RebuildRequested', stack
     @forwardEvent @successPage, 'ClosingRequested'
+    @forwardErrorPageEvent 'CredentialsRequested'
+    @forwardErrorPageEvent 'RebuildRequested'
     @successPage.on 'LogsRequested', @bound 'showLogs'
     @forwardEvent @logsPage, 'ClosingRequested'
     @forwardEvent @timeoutPage, 'ClosingRequested'
 
     container.appendPages @buildStackPage, @errorPage, @successPage, @logsPage, @timeoutPage
+
+
+  forwardErrorPageEvent: (eventName) ->
+
+    @errorPage.on eventName, =>
+      { stack } = @getData()
+      stack.status.state = 'NotInitialized'
+      @buildStackPage.reset()
+      @emit eventName, stack
 
 
   getLogFile: ->

--- a/client/app/lib/providers/resourcestatemodal/controllers/stackflowcontroller.coffee
+++ b/client/app/lib/providers/resourcestatemodal/controllers/stackflowcontroller.coffee
@@ -68,10 +68,10 @@ module.exports = class StackFlowController extends kd.Controller
     @instructions.on 'NextPageRequested', => @credentials.show()
     @credentials.on 'InstructionsRequested', => @instructions.show()
     @credentials.on 'StartBuild', @bound 'startBuild'
-    @buildStack.on 'CredentialsRequested', => @credentials.show()
-
+    @buildStack.on 'CredentialsRequested', (stack) =>
+      @credentials.setData stack
+      @credentials.show()
     @buildStack.on 'RebuildRequested', (stack) =>
-      stack.status.state = 'NotInitialized'
       @credentials.setData stack
       @credentials.submit()
 


### PR DESCRIPTION
## Description

The issue happens when credential was successfully verified but then build stack process fails for some reason (for example, credential was deleted or deactivated on AWS). In this case stack state should be reset to `NotInitialized` so build with other credential won't fail
## Motivation and Context

https://github.com/koding/koding/issues/9226
## Screenshots:

http://recordit.co/EyYfHsysTI
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
