### PR TITLE
'View Members' link under 'Koding Subscription' is not directing to 'Teammates' section.

### DIFF
--- a/client/app/lib/components/sidebarstacksection/index.coffee
+++ b/client/app/lib/components/sidebarstacksection/index.coffee
@@ -10,7 +10,7 @@ SidebarMachinesListItem   = require 'app/components/sidebarmachineslistitem'
 canCreateStacks = require 'app/util/canCreateStacks'
 isAdmin = require 'app/util/isAdmin'
 remote = require 'app/remote'
-isStackTemplateSharedWithTeam = require 'app/util/isstacktemplatesharedwithteam'
+isDefaultTeamStack = require 'app/util/isdefaultteamstack'
 { findDOMNode } = require 'react-dom'
 
 require './styl/sidebarstacksection.styl'
@@ -143,7 +143,7 @@ module.exports = class SidebarStackSection extends React.Component
         menuItems['View Stack'] = { callback }
       ['Reinitialize', 'VMs', 'Destroy VMs'].forEach (name) ->
         menuItems[name] = { callback }
-      if isAdmin() and not isStackTemplateSharedWithTeam @props.stack.get 'baseStackId'
+      if isAdmin() and not isDefaultTeamStack @props.stack.get 'baseStackId'
         menuItems['Make Team Default'] = { callback }
 
     { top } = findDOMNode(this).getBoundingClientRect()

--- a/client/app/lib/util/isdefaultteamstack.coffee
+++ b/client/app/lib/util/isdefaultteamstack.coffee
@@ -1,6 +1,6 @@
 kd = require 'kd'
 
-module.exports = isStackTemplateSharedWithTeam = (baseStackId) ->
+module.exports = isDefaultTeamStack = (baseStackId) ->
 
   { groupsController } = kd.singletons
   stackTemplates = groupsController.getCurrentGroup().stackTemplates ? []

--- a/client/home/lib/billing/components/planslist/container.coffee
+++ b/client/home/lib/billing/components/planslist/container.coffee
@@ -23,7 +23,7 @@ module.exports = class PlansListContainer extends React.Component
   onMembersClick: (event) ->
 
     kd.utils.stopDOMEvent event
-    kd.singletons.router.handleRoute '/Home/my-team/teammates'
+    kd.singletons.router.handleRoute '/Home/my-team#teammates'
 
 
   onDetailsClick: (event) ->

--- a/client/home/lib/billing/components/subscriptioncontainer.coffee
+++ b/client/home/lib/billing/components/subscriptioncontainer.coffee
@@ -73,7 +73,7 @@ mapStateToProps = (state) ->
 mapDispatchToProps = (dispatch) ->
   return {
     onClickPricingDetails: -> window.open 'https://www.koding.com/pricing', '_blank'
-    onClickViewMembers: -> kd.singletons.router.handleRoute '/Home/my-team/teammates'
+    onClickViewMembers: -> kd.singletons.router.handleRoute '/Home/my-team#teammates'
   }
 
 

--- a/client/home/lib/stacks/components/stacktemplateitem/index.coffee
+++ b/client/home/lib/stacks/components/stacktemplateitem/index.coffee
@@ -8,7 +8,7 @@ getBoundingClientReact = require 'app/util/getBoundingClientReact'
 StackUpdatedWidget = require 'app/components/sidebarstacksection/stackupdatedwidget'
 isAdmin = require 'app/util/isAdmin'
 whoami = require 'app/util/whoami'
-isStackTemplateSharedWithTeam = require 'app/util/isstacktemplatesharedwithteam'
+isDefaultTeamStack = require 'app/util/isdefaultteamstack'
 
 module.exports = class StackTemplateItem extends React.Component
 
@@ -126,7 +126,7 @@ module.exports = class StackTemplateItem extends React.Component
 
   renderDefaultTag: ->
     { template } = @props
-    if isStackTemplateSharedWithTeam template.get '_id'
+    if isDefaultTeamStack template.get '_id'
       <div className='tag'>DEFAULT</div>
     else
       null

--- a/client/home/lib/stacks/components/stacktemplateitem/index.coffee
+++ b/client/home/lib/stacks/components/stacktemplateitem/index.coffee
@@ -8,6 +8,7 @@ getBoundingClientReact = require 'app/util/getBoundingClientReact'
 StackUpdatedWidget = require 'app/components/sidebarstacksection/stackupdatedwidget'
 isAdmin = require 'app/util/isAdmin'
 whoami = require 'app/util/whoami'
+isStackTemplateSharedWithTeam = require 'app/util/isstacktemplatesharedwithteam'
 
 module.exports = class StackTemplateItem extends React.Component
 
@@ -123,6 +124,13 @@ module.exports = class StackTemplateItem extends React.Component
       </div>
     </div>
 
+  renderDefaultTag: ->
+    { template } = @props
+    if isStackTemplateSharedWithTeam template.get '_id'
+      <div className='tag'>DEFAULT</div>
+    else
+      null
+
 
   render: ->
 
@@ -134,13 +142,16 @@ module.exports = class StackTemplateItem extends React.Component
     editorUrl = "/Stack-Editor/#{template.get '_id'}"
 
     <div className='HomeAppViewListItem StackTemplateItem'>
-      <a
-        ref='stackTemplateItem'
-        href={editorUrl}
-        className='HomeAppViewListItem-label'
-        onClick={onOpen}>
-        { makeTitle { template, stack } }
-      </a>
+      <div className='HomeAppViewListItem-label--wrapper'>
+        <a
+          ref='stackTemplateItem'
+          href={editorUrl}
+          className='HomeAppViewListItem-label'
+          onClick={onOpen}>
+          { makeTitle { template, stack } }
+        </a>
+        {@renderDefaultTag()}
+      </div>
       {@renderUnreadCount()}
       {@renderStackUpdatedWidget()}
       <div className='HomeAppViewListItem-description'>

--- a/client/home/lib/styl/home.styl
+++ b/client/home/lib/styl/home.styl
@@ -143,18 +143,30 @@ $subtleColor                = #A59999
 .HomeAppViewListItem-label
   width                     50%
   &.disabled
-    opacity 0.5
-    pointer-events none
+    opacity                 0.5
+    pointer-events          none
 
-.HomeAppViewListItem-label
-  font-weight               600
-  font-size                 16px
-  color                     #769ECC
-  line-height               25px
-  pointer()
-  text-decoration           none
-  fontPrecisionForSoleil()
-
+.HomeAppViewListItem-label--wrapper
+  width                     400px
+  .HomeAppViewListItem-label
+    font-weight             600
+    font-size               16px
+    line-height             25px
+    color                   #769ECC
+    text-decoration         none
+    margin-right            20px
+    pointer()
+    fontPrecisionForSoleil()
+  .tag
+    rel()
+    display                 inline-block
+    top                     -1px
+    padding                 2px 10px
+    color                   #fff
+    bg                      color #2dbea1
+    font-size               12px
+    line-height             13px
+    font-weight             300
 
 .HomeAppViewListItem-description
   font-style                italic

--- a/client/home/lib/styl/home.styl
+++ b/client/home/lib/styl/home.styl
@@ -163,7 +163,7 @@ $subtleColor                = #A59999
     top                     -1px
     padding                 2px 10px
     color                   #fff
-    bg                      color #2dbea1
+    bg                      color #48BA7D
     font-size               12px
     line-height             13px
     font-weight             300


### PR DESCRIPTION
Fix routes for teammates button links
Add `DEFAULT` tag to default team stack

![](https://monosnap.com/file/7rPe9RzS3anbt8wUs8Yun2SJVVaVK5.png)
fixes: #9269 
