### PR TITLE
Landing: clear stored team data while opening public team join page

### DIFF
--- a/client/landing/site.landing/coffee/core/routes.coffee
+++ b/client/landing/site.landing/coffee/core/routes.coffee
@@ -33,6 +33,14 @@ do ->
 
   handleInvitation = ({ params : { token }, query }) ->
 
+    { router } = kd.singletons
+
+    # remove stored team data so previous invitation token won't be used
+    # if user joins a public team which doesn't require token
+    if not token
+      utils.clearTeamData()
+      return router.handleRoute '/Join'
+
     utils.routeIfInvitationTokenIsValid token,
       success   : ({ email }) ->
         utils.storeNewTeamData 'invitation', { token, email }
@@ -41,7 +49,7 @@ do ->
         go = ->
           utils.storeNewTeamData 'signup', formData
           utils.storeNewTeamData 'welcome', yes
-          kd.singletons.router.handleRoute '/Join'
+          router.handleRoute '/Join'
 
         formData          = {}
         formData.join     = yes
@@ -57,7 +65,7 @@ do ->
             go()
       error     : ({ responseText }) ->
         new kd.NotificationView { title : responseText }
-        kd.singletons.router.handleRoute '/'
+        router.handleRoute '/'
 
 
   handleTeamOnboardingRoute = (section, { params, query }) ->
@@ -101,7 +109,7 @@ do ->
     ''                     : handleRoot
     # the routes below are subdomain routes
     # e.g. team.koding.com/Invitation
-    '/Invitation/:token'   : handleInvitation
+    '/Invitation/:token?'  : handleInvitation
     '/Home/Oauth'          : handleOauth
     # '/Welcome'             : handleTeamOnboardingRoute.bind this, 'welcome'
     '/Join'                : handleTeamOnboardingRoute.bind this, 'join'

--- a/client/landing/site.landing/coffee/team/tabs/teamlogintab.coffee
+++ b/client/landing/site.landing/coffee/team/tabs/teamlogintab.coffee
@@ -68,7 +68,7 @@ module.exports = class TeamLoginTab extends kd.TabPaneView
 
     partial =
     if /\*/.test kd.config.group.allowedDomains
-      "If you don't have a Koding account <a href='/Team/Join'>sign up here</a> so you can join #{kd.config.groupName}!"
+      "If you don't have a Koding account <a href='/Invitation'>sign up here</a> so you can join #{kd.config.groupName}!"
     else if domains.length > 1
       domainsPartial = utils.getAllowedDomainsPartial domains
       "If you have an email address from one of these domains #{domainsPartial}, you can <a href='/Team/Join'>join here</a>."


### PR DESCRIPTION
## Description

This PR avoids using old stored invitation token when user joins a public team opening join page from sign in page (in this case invitation token is empty). In the screenshot if not to clear previous invitation data stored in local storage, it will be used by https://github.com/koding/koding/blob/master/client/landing/site.landing/coffee/core/utils.coffee#L281 and sent to the server. As result, user won't be able to join with error `Invalid inivtation code` (see the linked bug)
## Motivation and Context

https://github.com/koding/koding/issues/9281
## Screenshots (if appropriate):

http://recordit.co/yIcO8fnN0b
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
