### PR TITLE
provider/google: workaround for hcl parser not supporting struct types behind raw interface

### DIFF
--- a/go/src/koding/kites/kloud/provider/google/stack.go
+++ b/go/src/koding/kites/kloud/provider/google/stack.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	defaultMachineType  = "n1-standard-1"   // 1vCPU, 3.75GB memory.
-	defualtMachineImage = "ubuntu-1404-lts" // From image family, size: 10GB.
+	defaultMachineImage = "ubuntu-1404-lts" // From image family, size: 10GB.
 )
 
 var bootstrap = template.Must(template.New("").Parse(mustAsset("bootstrap.json.tmpl")))
@@ -115,21 +115,16 @@ func (s *Stack) ApplyTemplate(c *stack.Credential) (*stack.Template, error) {
 
 		// Set default image for disk if user didn't define it herself.
 		if _, ok := instance["disk"]; !ok {
-			instance["disk"] = struct {
-				Image string `json:"image" bson:"image" hcl:"image"`
-			}{
-				Image: defualtMachineImage,
+			instance["disk"] = map[string]interface{}{
+				"image": defaultMachineImage,
 			}
 		}
 
 		// Set default network interface if user didn't define it herself.
 		if _, ok := instance["network_interface"]; !ok {
-			instance["network_interface"] = struct {
-				Network      string   `json:"network" bson:"network" hcl:"network"`
-				AccessConfig struct{} `json:"access_config" bson:"access_config" hcl:"access_config"`
-			}{
-				Network:      "default",
-				AccessConfig: struct{}{},
+			instance["network_interface"] = map[string]interface{}{
+				"network":       "default",
+				"access_config": map[string]interface{}{},
 			}
 		}
 


### PR DESCRIPTION
Replace `struct` objects with raw `map[string]interface{}` in google stack.
## Description

Terraform hcl decoder has a bug which causes panics during parsing to structures that contain interfaces pointing to struct types `var x := interface{}(T{})`. This PR replaces structures with `map[string]interface{}` type that is not affected by this bug.
## Motivation and Context

ref: https://github.com/koding/koding/issues/9266
## How Has This Been Tested?

Manually.
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
