### PR TITLE
Collaboration: show tooltip on collaboration start

### DIFF
--- a/client/app/lib/providers/resourcestatemodal/controllers/buildstackcontroller.coffee
+++ b/client/app/lib/providers/resourcestatemodal/controllers/buildstackcontroller.coffee
@@ -31,7 +31,11 @@ module.exports = class BuildStackController extends kd.Controller
       router.handleRoute '/Home/koding-utilities#kd-cli'
       @emit 'ClosingRequested'
     @successPage.on 'CollaborationInvite', =>
-      appManager.tell 'IDE', 'startCollaborationSession'
+      tooltipContent = '''
+        <h3>Collaboration is starting...</h3>
+        <p>You can invite your teammates when collaboration is started.</p>
+      '''
+      appManager.tell 'IDE', 'startCollaborationSession', { tooltipContent }
       @emit 'ClosingRequested'
     @forwardErrorPageEvent 'CredentialsRequested'
     @forwardErrorPageEvent 'RebuildRequested'

--- a/client/app/lib/styl/tooltip.styl
+++ b/client/app/lib/styl/tooltip.styl
@@ -59,3 +59,11 @@ div.kdtooltip.is-light
 
       font-size               12px
       font-weight             300
+
+  &.collaboration-start-tooltip
+
+    h3
+      color                   #555
+
+    p
+      margin-top              0

--- a/client/ide/lib/collaborationcontroller.coffee
+++ b/client/ide/lib/collaborationcontroller.coffee
@@ -811,7 +811,9 @@ module.exports = CollaborationController =
 
   onCollaborationPreparing: ->
 
-    @statusBar.emit 'CollaborationPreparing'
+    { tooltipContent } = @collaborationStartOptions ? {}
+    @statusBar.emit 'CollaborationPreparing', tooltipContent
+
     @prepareSocialChannel
       success : => @stateMachine.transition 'Prepared'
       error   : => @stateMachine.transition 'ErrorPreparing'
@@ -819,14 +821,16 @@ module.exports = CollaborationController =
 
   onCollaborationPrepared: ->
 
-    @startCollaborationSession()
+    @startCollaborationSession @collaborationStartOptions
 
 
-  startCollaborationSession: ->
+  startCollaborationSession: (options = {}) ->
 
     # Show this message while "@stateMachine" is preparing when a session is over just now.
     # It will be ready in a few seconds.
     return showError 'Please wait a few seconds.'  unless @stateMachine
+
+    @collaborationStartOptions = options
 
     switch @stateMachine.state
       when 'Prepared'   then @stateMachine.transition 'Creating'

--- a/client/ide/lib/views/statusbar/idestatusbar.coffee
+++ b/client/ide/lib/views/statusbar/idestatusbar.coffee
@@ -109,7 +109,6 @@ module.exports = class IDEStatusBar extends kd.View
         cssClass      : 'start-session transparent'
         callback      : @bound 'handleShareButtonClick'
 
-
     if isKoding() and isSoloProductLite()
       isPlanFree (err, isFree) =>
         return  if err
@@ -148,11 +147,13 @@ module.exports = class IDEStatusBar extends kd.View
 
   startSession: ->
 
-    kd.singletons.appManager.tell 'IDE', 'startCollaborationSession', (err) =>
-      @resetProgress()  if err
+    kd.singletons.appManager.tell 'IDE', 'startCollaborationSession'
 
 
-  resetProgress: -> @share.resetProgress()
+  resetProgress: ->
+
+    @share.resetProgress()
+    @share.unsetTooltip()
 
 
   showInformation: ->
@@ -251,7 +252,7 @@ module.exports = class IDEStatusBar extends kd.View
     avatarView.showRequestPermissionView()
 
 
-  handleCollaborationPreparing: ->
+  handleCollaborationPreparing: (tooltipContent) ->
 
     @share.startProgress()
     @share.updateProgress 0 # Make sure initial value is 0
@@ -259,6 +260,16 @@ module.exports = class IDEStatusBar extends kd.View
     PROGRESS_DELAYS.forEach (item) =>
       kd.utils.killWait item.timer  if item.timer # Kill already defined waits
       item.timer = kd.utils.wait item.delay, => @share.updateProgress item.progress
+
+    return  unless tooltipContent
+
+    @share.setTooltip
+      view      : new kd.CustomHTMLView
+        partial : tooltipContent
+      cssClass  : 'is-light collaboration-start-tooltip'
+      placement : 'above'
+      sticky    : yes
+    @share.getTooltip().show()
 
 
   handleCollaborationLoading: ->


### PR DESCRIPTION
## Description

It shows a tooltip above collaboration progress bar while starting collaboration from build stack success modal
## Motivation and Context

https://github.com/koding/koding/pull/9287#issuecomment-254290725
## Screenshots (if appropriate):

http://recordit.co/NmrCIMo0CX
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
