### PR TITLE
Add support for image families in google provider.

### DIFF
--- a/go/src/koding/kites/kloud/provider/google/imgfamily.go
+++ b/go/src/koding/kites/kloud/provider/google/imgfamily.go
@@ -1,9 +1,6 @@
 package google
 
-import (
-	"log"
-	"strings"
-)
+import "strings"
 
 // Family2Image is used to map image families into their latest images.
 type Family2Image struct {
@@ -24,17 +21,26 @@ func (f *Family2Image) Replace(disks interface{}) interface{} {
 		f.cache = make(map[string]string)
 	}
 
-	log.Println("=====================================")
-	log.Printf("%#v\n\n", disks)
+	items, ok := disks.([]map[string]interface{})
+	if !ok {
+		return disks
+	}
 
-	log.Println("=====================================")
-	m, ok := disks.(map[string]interface{})
-	log.Printf("%#v\n==== %t\n", m, ok)
+	for i := range items {
+		if items[i] == nil {
+			continue
+		}
 
-	a, ok := disks.([]interface{})
-	log.Printf("%#v\n==== %t\n", a, ok)
+		// User doesn't have to provide image name.
+		image, ok := items[i]["image"]
+		if !ok {
+			continue
+		}
 
-	return disks
+		items[i]["image"] = f.getImage(image)
+	}
+
+	return items
 }
 
 func (f *Family2Image) getImage(name interface{}) interface{} {
@@ -78,8 +84,8 @@ var family2project = map[string]string{
 }
 
 // familyProject checks if provided string is an image family name. If yes, this
-// functions looks up for the respective image project. It return zero value and
-// false if provide string is not image family identifier.
+// functions looks up for the respective image project. It returns zero value
+// and `false` status if provided string is not image family identifier.
 func familyProject(family string) (string, bool) {
 	// Check for images with version. That has form name-additional-vYYYYMMDD
 	toks := strings.Split(family, "-")

--- a/go/src/koding/kites/kloud/provider/google/imgfamily.go
+++ b/go/src/koding/kites/kloud/provider/google/imgfamily.go
@@ -1,0 +1,97 @@
+package google
+
+import (
+	"log"
+	"strings"
+)
+
+// Family2Image is used to map image families into their latest images.
+type Family2Image struct {
+	GetFromFamily func(project, family string) string
+
+	// cache is used to avoid looking for images that were already found.
+	cache map[string]string
+}
+
+// Replace gets disk data and replaces each image fields that contain image
+// family with the lasted image that is a part of that family.
+func (f *Family2Image) Replace(disks interface{}) interface{} {
+	if f.GetFromFamily == nil {
+		return disks
+	}
+
+	if f.cache == nil {
+		f.cache = make(map[string]string)
+	}
+
+	log.Println("=====================================")
+	log.Printf("%#v\n\n", disks)
+
+	log.Println("=====================================")
+	m, ok := disks.(map[string]interface{})
+	log.Printf("%#v\n==== %t\n", m, ok)
+
+	a, ok := disks.([]interface{})
+	log.Printf("%#v\n==== %t\n", a, ok)
+
+	return disks
+}
+
+func (f *Family2Image) getImage(name interface{}) interface{} {
+	// Invalid value will be caught later by terraform.
+	if name == nil {
+		return name
+	}
+
+	family, ok := name.(string)
+	if !ok {
+		return name
+	}
+
+	// Get from cache.
+	if image, ok := f.cache[family]; ok {
+		return image
+	}
+
+	project, ok := familyProject(family)
+	if !ok {
+		return name
+	}
+
+	image := f.GetFromFamily(project, family)
+	if image == "" {
+		return name
+	}
+
+	f.cache[family] = image
+	return image
+}
+
+var family2project = map[string]string{
+	"windows": "windows-cloud",
+	"ubuntu":  "ubuntu-os-cloud",
+	"rhel":    "rhel-cloud",
+	"sql":     "windows-sql-cloud",
+	"debian":  "debian-cloud",
+	"coreos":  "coreos-cloud",
+	"centos":  "centos-cloud",
+}
+
+// familyProject checks if provided string is an image family name. If yes, this
+// functions looks up for the respective image project. It return zero value and
+// false if provide string is not image family identifier.
+func familyProject(family string) (string, bool) {
+	// Check for images with version. That has form name-additional-vYYYYMMDD
+	toks := strings.Split(family, "-")
+	if len(toks) > 1 && len(toks[len(toks)-1]) > 0 && toks[len(toks)-1][0] == 'v' {
+		return "", false
+	}
+
+	for prefix, project := range family2project {
+		if strings.HasPrefix(family, prefix) {
+			return project, true
+		}
+	}
+
+	return "", false
+}

--- a/go/src/koding/kites/kloud/provider/google/imgfamily_test.go
+++ b/go/src/koding/kites/kloud/provider/google/imgfamily_test.go
@@ -1,0 +1,158 @@
+package google
+
+import (
+	"reflect"
+	"testing"
+)
+
+var getFromFamilyFixture = map[string]string{
+	"ubuntu-os-cloud/ubuntu-1404-lts":            "ubuntu-1404-trusty-v20161010",
+	"ubuntu-os-cloud/ubuntu-1604-lts":            "ubuntu-1604-xenial-v20161013",
+	"windows-sql-cloud/sql-std-2016-win-2012-r2": "sql-2016-standard-windows-2012-r2-dc-v20161012",
+	"rhel-cloud/rhel-7":                          "rhel-7-v20160921",
+	"coreos-cloud/coreos-stable":                 "coreos-stable-1122-2-0-v20160906",
+}
+
+var getFromFamilyTestFunc = func(project, family string) string {
+	return getFromFamilyFixture[project+"/"+family]
+}
+
+func TestFamily2Image(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Disks    interface{}
+		Expected interface{}
+	}{
+		{
+			Name: "non map array",
+			Disks: map[string]interface{}{
+				"image": "ubuntu-1604-lts",
+			},
+			Expected: map[string]interface{}{
+				"image": "ubuntu-1604-lts",
+			},
+		},
+		{
+			Name: "no image family",
+			Disks: []map[string]interface{}{
+				{
+					"image": "ubuntu-1204-precise-v20161010",
+				},
+			},
+			Expected: []map[string]interface{}{
+				{
+					"image": "ubuntu-1204-precise-v20161010",
+				},
+			},
+		},
+		{
+			Name: "ubuntu family",
+			Disks: []map[string]interface{}{
+				{
+					"image": "ubuntu-1404-lts",
+				},
+			},
+			Expected: []map[string]interface{}{
+				{
+					"image": "ubuntu-1404-trusty-v20161010",
+				},
+			},
+		},
+		{
+			Name: "multi images with family",
+			Disks: []map[string]interface{}{
+				{
+					"image": "sql-std-2016-win-2012-r2",
+				},
+				{
+					"image": "rhel-7",
+				},
+			},
+			Expected: []map[string]interface{}{
+				{
+					"image": "sql-2016-standard-windows-2012-r2-dc-v20161012",
+				},
+				{
+					"image": "rhel-7-v20160921",
+				},
+			},
+		},
+		{
+			Name: "unknown coreos family",
+			Disks: []map[string]interface{}{
+				{
+					"image": "coreos-gamma",
+				},
+			},
+			Expected: []map[string]interface{}{
+				{
+					"image": "coreos-gamma",
+				},
+			},
+		},
+		{
+			Name: "unknown coreos family",
+			Disks: []map[string]interface{}{
+				{
+					"image": "coreos-gamma",
+				},
+			},
+			Expected: []map[string]interface{}{
+				{
+					"image": "coreos-gamma",
+				},
+			},
+		},
+		{
+			Name: "mixed family non family",
+			Disks: []map[string]interface{}{
+				{
+					"image": "coreos-stable",
+				},
+				{
+					"image": "coreos-stable-1122-2-0-v20160906",
+				},
+			},
+			Expected: []map[string]interface{}{
+				{
+					"image": "coreos-stable-1122-2-0-v20160906",
+				},
+				{
+					"image": "coreos-stable-1122-2-0-v20160906",
+				},
+			},
+		},
+		{
+			Name: "reused cache",
+			Disks: []map[string]interface{}{
+				{
+					"image": "ubuntu-1404-lts",
+				},
+				{
+					"image": "ubuntu-1404-lts",
+				},
+			},
+			Expected: []map[string]interface{}{
+				{
+					"image": "ubuntu-1404-trusty-v20161010",
+				},
+				{
+					"image": "ubuntu-1404-trusty-v20161010",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			f2i := Family2Image{
+				GetFromFamily: getFromFamilyTestFunc,
+			}
+
+			disks := f2i.Replace(test.Disks)
+			if !reflect.DeepEqual(disks, test.Expected) {
+				t.Fatalf("want disks = %#v; got %#v", test.Expected, disks)
+			}
+		})
+	}
+}

--- a/go/src/koding/kites/kloud/provider/google/stack.go
+++ b/go/src/koding/kites/kloud/provider/google/stack.go
@@ -114,11 +114,13 @@ func (s *Stack) ApplyTemplate(c *stack.Credential) (*stack.Template, error) {
 
 		// Set default image for disk if user didn't define it herself.
 		if _, ok := instance["disk"]; !ok {
-			instance["disk"] = map[string]interface{}{
-				"image": defaultMachineImage,
+			instance["disk"] = []map[string]interface{}{
+				{
+					"image": defaultMachineImage,
+				},
 			}
 		}
-		instance["disk"] = f2i.Replace(instance["disks"])
+		instance["disk"] = f2i.Replace(instance["disk"])
 
 		// Set default network interface if user didn't define it herself.
 		if _, ok := instance["network_interface"]; !ok {


### PR DESCRIPTION
This PR enables support for image families in google provider.
## Description

When google provider recognize image family disk, it will use Google API to find the latest image that is part of an image family and is not deprecated. Provided solution should work for all known image families.
## Motivation and Context

Koding's version of terraform doesn't support image families. However, the newest one does. So, these changes should be reverted as soon as Koding's terraform package is updated.
## How Has This Been Tested?

Manually.
Unit tests.
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
