### PR TITLE
kloud: explicitely log authenticate failures

### DIFF
--- a/go/src/koding/kites/kloud/credential/mongo.go
+++ b/go/src/koding/kites/kloud/credential/mongo.go
@@ -88,7 +88,7 @@ func (db *mongoStore) Fetch(_ string, creds map[string]interface{}) error {
 			creds[ident] = data.Meta
 		}
 
-		db.Log.Debug("fetched credential data for %q: %+v", ident, creds[ident])
+		db.Log.Debug("fetched credential data for %q: %v", ident, creds[ident])
 	}
 
 	if len(missing) != 0 {

--- a/go/src/koding/kites/kloud/credential/socialapi.go
+++ b/go/src/koding/kites/kloud/credential/socialapi.go
@@ -71,7 +71,7 @@ func (s *socialStore) Fetch(username string, creds map[string]interface{}) error
 			creds[ident] = req.resp
 		}
 
-		s.Log.Debug("fetched credential data for %q: %+v", ident, creds[ident])
+		s.Log.Debug("fetched credential data for %q: %v", ident, creds[ident])
 	}
 
 	if len(missing) != 0 {

--- a/go/src/koding/kites/kloud/stack/provider/authenticate.go
+++ b/go/src/koding/kites/kloud/stack/provider/authenticate.go
@@ -35,6 +35,8 @@ func (bs *BaseStack) HandleAuthenticate(ctx context.Context) (interface{}, error
 		res := &stack.AuthenticateResult{}
 		resp[cred.Identifier] = res
 
+		bs.Log.Debug("Checking credentials for %q (%s): %# v", cred.Provider, bs.Planner.Provider, cred.Credential)
+
 		if cred.Provider != bs.Planner.Provider {
 			continue // ignore not ours credentials
 		}

--- a/go/src/koding/kites/kloud/stack/provider/authenticate.go
+++ b/go/src/koding/kites/kloud/stack/provider/authenticate.go
@@ -1,11 +1,15 @@
 package provider
 
 import (
+	"strings"
+
 	"koding/db/mongodb/modelhelper"
 	"koding/kites/kloud/stack"
 
 	"golang.org/x/net/context"
 )
+
+var removeNL = strings.NewReplacer("\n", " ", "\t", "")
 
 func (bs *BaseStack) HandleAuthenticate(ctx context.Context) (interface{}, error) {
 	arg, ok := ctx.Value(stack.AuthenticateRequestKey).(*stack.AuthenticateRequest)
@@ -43,6 +47,11 @@ func (bs *BaseStack) HandleAuthenticate(ctx context.Context) (interface{}, error
 
 		if err := bs.stack.VerifyCredential(cred); err != nil {
 			res.Message = err.Error()
+
+			if _, ok := err.(*stack.Error); ok {
+				bs.Log.Warning("authenticate: %s (team=%s, user=%s, provider=%s)", removeNL.Replace(err.Error()), arg.GroupName, bs.Req.Username, cred.Provider)
+			}
+
 			continue
 		}
 

--- a/go/src/koding/kites/kloud/stack/provider/authenticate.go
+++ b/go/src/koding/kites/kloud/stack/provider/authenticate.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-var removeNL = strings.NewReplacer("\n", " ", "\t", "")
+var removeNewLines = strings.NewReplacer("\n", " ", "\t", "")
 
 func (bs *BaseStack) HandleAuthenticate(ctx context.Context) (interface{}, error) {
 	arg, ok := ctx.Value(stack.AuthenticateRequestKey).(*stack.AuthenticateRequest)
@@ -49,7 +49,7 @@ func (bs *BaseStack) HandleAuthenticate(ctx context.Context) (interface{}, error
 			res.Message = err.Error()
 
 			if _, ok := err.(*stack.Error); ok {
-				bs.Log.Warning("authenticate: %s (team=%s, user=%s, provider=%s)", removeNL.Replace(err.Error()), arg.GroupName, bs.Req.Username, cred.Provider)
+				bs.Log.Warning("authenticate: %s (team=%s, user=%s, provider=%s)", removeNewLines.Replace(err.Error()), arg.GroupName, bs.Req.Username, cred.Provider)
 			}
 
 			continue

--- a/go/src/koding/kites/kloud/stack/provider/builder.go
+++ b/go/src/koding/kites/kloud/stack/provider/builder.go
@@ -450,7 +450,9 @@ func (b *Builder) BuildCredentials(method, username, groupname string, identifie
 
 	b.Credentials = append(b.Credentials, creds...)
 
-	b.Log.Debug("Built credentials: %# v", b.Credentials)
+	for i, cred := range b.Credentials {
+		b.Log.Debug("Built credential #%d: %# v (%+v, %+v)", i, cred, cred.Credential, cred.Bootstrap)
+	}
 
 	return nil
 }

--- a/go/src/koding/kites/kloud/utils/object/inliner.go
+++ b/go/src/koding/kites/kloud/utils/object/inliner.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"gopkg.in/mgo.v2/bson"
 )
@@ -53,6 +54,10 @@ func (in *Inliner) UnmarshalJSON(p []byte) error {
 	}
 
 	return json.Unmarshal(p, in.SecondAddr())
+}
+
+func (in *Inliner) String() string {
+	return fmt.Sprintf("{first: %#v, second: %#v}", in.InlineFirst, in.InlineSecond)
 }
 
 func (in *Inliner) Inline() (Object, error) {


### PR DESCRIPTION
Fix for https://github.com/koding/koding/pull/9357, authenticate errors needs to be logged explicitely, since the API does not return errors in the handler (probably we may want to change it in future, for now we always return AuthResponse which contains eventual error strings).
