### PR TITLE
kloud/userdata: write Koding metadata

### DIFF
--- a/go/src/koding/kites/config/konfig.go
+++ b/go/src/koding/kites/config/konfig.go
@@ -49,9 +49,7 @@ func (k *Konfig) KiteHome() string {
 }
 
 func (k *Konfig) KiteConfig() *konfig.Config {
-	cfg := k.buildKiteConfig()
-	cfg.KontrolURL = k.KontrolURL
-	return cfg
+	return k.buildKiteConfig()
 }
 
 func (k *Konfig) buildKiteConfig() *konfig.Config {

--- a/go/src/koding/kites/keygen/keygentest/keygentest.go
+++ b/go/src/koding/kites/keygen/keygentest/keygentest.go
@@ -27,7 +27,7 @@ import (
 //   $ go test koding/kites/gateway -- -accesskey abc -secretkey def
 //
 type Flags struct {
-	EnvPrefix string        `default:"gateway"`
+	EnvPrefix string        `default:"keygen"`
 	AccessKey string        `required:"true"`
 	SecretKey string        `required:"true"`
 	Bucket    string        `default:"kodingdev-publiclogs"`

--- a/go/src/koding/kites/keygen/s3.go
+++ b/go/src/koding/kites/keygen/s3.go
@@ -121,22 +121,11 @@ func (ub *UserBucket) userPut(path string, rs io.ReadSeeker) (*url.URL, error) {
 		return nil, err
 	}
 
-	u := &url.URL{
+	return &url.URL{
 		Scheme: "https",
 		Path:   "/" + path,
-	}
-
-	// S3 bucket endpoints, for more details see:
-	//
-	//   http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html
-	//
-	if ub.cfg.Region == "us-east-1" {
-		u.Host = ub.cfg.Bucket + ".s3.amazonaws.com"
-	} else {
-		u.Host = ub.cfg.Bucket + ".s3-" + ub.cfg.Region + ".amazonaws.com"
-	}
-
-	return u, nil
+		Host:   ub.cfg.Bucket + ".s3.amazonaws.com",
+	}, nil
 }
 
 // mustJSON returns a JSON representation of v as a string,

--- a/go/src/koding/kites/kloud/kloud/kloud.go
+++ b/go/src/koding/kites/kloud/kloud/kloud.go
@@ -356,6 +356,7 @@ func newSession(conf *Config, k *kite.Kite) (*session.Session, error) {
 				KontrolPublicKey:  kontrolPublicKey,
 			},
 			KlientURL: conf.KlientURL,
+			TunnelURL: conf.TunnelURL,
 			Bucket:    userdata.NewBucket("koding-klient", klientFolder, c),
 		},
 		Terraformer: &terraformer.Options{

--- a/go/src/koding/kites/kloud/main.go
+++ b/go/src/koding/kites/kloud/main.go
@@ -26,6 +26,10 @@ func init() {
 }
 
 func main() {
+	var cfg kloud.Config
+
+	kloudErr := config.Load(&cfg)
+
 	var schemaCfg SchemaConfig
 
 	if err := config.Load(&schemaCfg); err == nil && schemaCfg.GenSchema != "" {
@@ -36,10 +40,8 @@ func main() {
 		return
 	}
 
-	var cfg kloud.Config
-
-	if err := config.Load(&cfg); err != nil {
-		log.Fatal(err)
+	if kloudErr != nil {
+		log.Fatal(kloudErr)
 	}
 
 	// Load the config, it's reads environment variables or from flags

--- a/go/src/koding/kites/kloud/userdata/userdata.go
+++ b/go/src/koding/kites/kloud/userdata/userdata.go
@@ -114,6 +114,8 @@ runcmd:
   # - [sh, -c, 'echo "127.0.0.1 {{.Hostname}}" >> /etc/hosts']
 
   # Install & Configure klient
+  - [touch, /var/log/upstart/klient.log, /var/log/cloud-init-output.log, /var/log/cloud-init.log, /var/lib/koding/user-data.sh]
+  - [chmod, +r, /var/log/upstart/klient.log, /var/log/cloud-init-output.log, /var/log/cloud-init.log, /var/lib/koding/user-data.sh]
   - [wget, "{{.LatestKlientURL}}", --retry-connrefused, --tries, 5, -O, /tmp/latest-klient.deb]
   - [dpkg, -i, /tmp/latest-klient.deb]
   - [chown, -R, '{{.Username}}:{{.Username}}', /opt/kite/klient]

--- a/go/src/koding/kites/kloud/userdata/userdata.go
+++ b/go/src/koding/kites/kloud/userdata/userdata.go
@@ -23,6 +23,9 @@ type Userdata struct {
 	// KlientURL url of klient deb. When non-empty it's used instead of
 	// looking for a latest deb with Bucket.
 	KlientURL string
+
+	// TunnelURL is an tunnelserver endpoint.
+	TunnelURL string
 }
 
 // CloudInitConfig is used as source for the cloudInit template.
@@ -46,6 +49,8 @@ type CloudInitConfig struct {
 	KiteKey string
 
 	LatestKlientURL string // URL of the latest version of the Klient package
+	KontrolURL      string // kontrol kite URL
+	TunnelURL       string // tunnelserver kite URL
 
 	// DisableEC2Metadata adds a nul route to AWS's metadata service so it
 	// can't be accessed from the instance
@@ -101,6 +106,17 @@ write_files:
     content: |
       {{.KiteKey}}
 
+  # Create Koding metadata file.
+  - path: /var/lib/koding/metadata.json
+    permissions: '0644'
+    content: |-
+      {
+          "konfig": {
+              "kontrolURL": "{{.KontrolURL}}",
+              "tunnelURL": "{{.TunnelURL}}"
+          }
+      }
+
 {{if .UserData}}
   # Create user script.
   - path: /var/lib/koding/user-data.sh
@@ -119,6 +135,7 @@ runcmd:
   - [wget, "{{.LatestKlientURL}}", --retry-connrefused, --tries, 5, -O, /tmp/latest-klient.deb]
   - [dpkg, -i, /tmp/latest-klient.deb]
   - [chown, -R, '{{.Username}}:{{.Username}}', /opt/kite/klient]
+  - [sudo, -E, -u, "{{.Username}}", /opt/kite/klient/klient, -metadata-file, /var/lib/koding/metadata.json]
   - [service, klient, stop]
   - [sed, -i, 's/\.\/klient/sudo -E -u {{.Username}} \.\/klient/g', /etc/init/klient.conf]
   - [service, klient, start]
@@ -177,6 +194,14 @@ func (u *Userdata) Create(c *CloudInitConfig) ([]byte, error) {
 	}
 
 	c.UserSSHKeys = validatedKeys
+
+	if c.KontrolURL == "" {
+		c.KontrolURL = u.Keycreator.KontrolURL
+	}
+
+	if c.TunnelURL == "" {
+		c.TunnelURL = u.TunnelURL
+	}
 
 	var udata bytes.Buffer
 	err = cloudInitTemplate.Funcs(funcMap).Execute(&udata, c)

--- a/go/src/koding/klient/app/klient.go
+++ b/go/src/koding/klient/app/klient.go
@@ -262,6 +262,7 @@ func NewKlient(conf *KlientConfig) (*Klient, error) {
 	}
 
 	k := newKite(conf)
+	k.Config.VerifyAudienceFunc = verifyAudience
 	term := terminal.New(k.Log, conf.ScreenrcPath)
 	term.InputHook = usg.Reset
 
@@ -846,4 +847,82 @@ func userIn(user string, users ...string) bool {
 		}
 	}
 	return false
+}
+
+// TODO(rjeczalik): Remove managed/devmanaged channels
+// and remove custom verifyAudience function.
+var (
+	prodEnvs = map[string]struct{}{
+		"managed":    {},
+		"production": {},
+	}
+	devEnvs = map[string]struct{}{
+		"devmanaged":  {},
+		"development": {},
+	}
+	kiteNames = map[string]struct{}{
+		"kd":     {},
+		"klient": {},
+	}
+)
+
+func match(allowed map[string]struct{}, values ...string) bool {
+	for _, v := range values {
+		if _, ok := allowed[v]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+func verifyAudience(kite *kiteproto.Kite, audience string) error {
+	switch audience {
+	case "/":
+		// The root audience is like superuser - it has access to everything.
+		return nil
+	case "":
+		return errors.New("invalid empty audience")
+	}
+
+	aud, err := kiteproto.KiteFromString(audience)
+	if err != nil {
+		return fmt.Errorf("invalid audience: %s (%s)", err, audience)
+	}
+
+	if kite.Username != aud.Username {
+		return fmt.Errorf("audience: username %q not allowed (%s)", aud.Username, audience)
+	}
+
+	// Verify environment - managed environment means production klient
+	// running on a user's laptop; devmanaged is for development/sandobx
+	// environments.
+	//
+	// TODO(rjeczalik): klient should always have development/production
+	// values for the environment fields - the managed flag should be
+	// set elsewhere; it'd also make the deployment process easier
+	// (2 delivery channels instead of 4).
+	switch {
+	case aud.Environment == "":
+		// ok - empty matches all
+	case kite.Environment == aud.Environment:
+		// ok - environment matches
+	case match(prodEnvs, kite.Environment, aud.Environment):
+		// ok - either remote or local is managed kite from development channel
+	case match(devEnvs, kite.Environment, aud.Environment):
+		// ok - either remote or local is managed kite from development channel
+	default:
+		return fmt.Errorf("audience: environment %q not allowed (%s)", aud.Environment, audience)
+	}
+
+	switch {
+	case aud.Name == "":
+		// ok - empty matches all
+	case kite.Name == aud.Name:
+	case match(kiteNames, kite.Name, aud.Name):
+	default:
+		return fmt.Errorf("audience: kite %q not allowed (%s)", aud.Name, audience)
+	}
+
+	return nil
 }

--- a/go/src/koding/klient/app/klient.go
+++ b/go/src/koding/klient/app/klient.go
@@ -261,6 +261,17 @@ func NewKlient(conf *KlientConfig) (*Klient, error) {
 		konfig.Konfig = konfig.ReadKonfig() // re-read konfig after dumping metadata
 	}
 
+	// TODO(rjeczalik): Once klient installation method is reworked,
+	// ensure flags are stored alongside konfig and do not
+	// overwrite konfig here.
+	if conf.KontrolURL != "" {
+		konfig.Konfig.KontrolURL = conf.KontrolURL
+	}
+
+	if conf.TunnelKiteURL != "" {
+		konfig.Konfig.TunnelURL = conf.TunnelKiteURL
+	}
+
 	k := newKite(conf)
 	k.Config.VerifyAudienceFunc = verifyAudience
 	term := terminal.New(k.Log, conf.ScreenrcPath)

--- a/go/src/koding/klient/app/klient.go
+++ b/go/src/koding/klient/app/klient.go
@@ -314,10 +314,11 @@ func NewKlient(conf *KlientConfig) (*Klient, error) {
 	}
 
 	tunOpts := &tunnel.Options{
-		DB:      db,
-		Log:     k.Log,
-		Kite:    k,
-		NoProxy: conf.NoProxy,
+		DB:            db,
+		Log:           k.Log,
+		Kite:          k,
+		NoProxy:       conf.NoProxy,
+		TunnelKiteURL: konfig.Konfig.TunnelURL,
 	}
 
 	t, err := tunnel.New(tunOpts)

--- a/go/src/koding/klient/config/config.go
+++ b/go/src/koding/klient/config/config.go
@@ -16,12 +16,16 @@ const (
 	Region = "public-region"
 )
 
+var envs = &konfig.Environments{
+	Env: Environment,
+}
+
 // Konfig represents a klient configuration.
 var Konfig = ReadKonfig()
 
+var Builtin = konfig.NewKonfig(envs)
+
 // ReadKonfig reads klient configuration.
 func ReadKonfig() *konfig.Konfig {
-	return konfig.ReadKonfig(&konfig.Environments{
-		Env: Environment,
-	})
+	return konfig.ReadKonfig(envs)
 }

--- a/go/src/koding/klient/main.go
+++ b/go/src/koding/klient/main.go
@@ -59,6 +59,7 @@ var (
 	// Metadata flags.
 	flagMetadata     = flag.String("metadata", "", "Base64-encoded Koding metadata")
 	flagMetadataFile = flag.String("metadata-file", "", "Koding metadata file")
+	flagNoExit       = flag.Bool("no-exit", false, "Keeps klient running after dumping metadata")
 )
 
 func defaultKiteHome() string {
@@ -159,9 +160,13 @@ func realMain() int {
 		LogUploadInterval: *flagLogUploadInterval,
 		Metadata:          *flagMetadata,
 		MetadataFile:      *flagMetadataFile,
+		NoExit:            *flagNoExit,
 	}
 
 	a, err := app.NewKlient(conf)
+	if err == app.ErrExit {
+		return 0
+	}
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go/src/koding/klient/main.go
+++ b/go/src/koding/klient/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"time"
@@ -27,7 +26,7 @@ var (
 	flagDBPath      = flag.String("dbpath", "", "Bolt DB database path. Must be absolute)")
 
 	// Registration flags
-	flagKiteHome   = flag.String("kite-home", defaultKiteHome(), "Change kite home path")
+	flagKiteHome   = flag.String("kite-home", "", "Change kite home path")
 	flagUsername   = flag.String("username", "", "Username to be registered to Kontrol")
 	flagToken      = flag.String("token", "", "Token to be passed to Kontrol to register")
 	flagRegister   = flag.Bool("register", false, "Register to Kontrol with your Koding Password")
@@ -61,13 +60,6 @@ var (
 	flagMetadataFile = flag.String("metadata-file", "", "Koding metadata file")
 	flagNoExit       = flag.Bool("no-exit", false, "Keeps klient running after dumping metadata")
 )
-
-func defaultKiteHome() string {
-	if u, err := user.Current(); err == nil {
-		return filepath.Join(u.HomeDir, ".kite")
-	}
-	return "."
-}
 
 func defaultNoTunnel() bool {
 	return os.Getenv("KITE_NO_TUNNEL") == "1"

--- a/go/src/koding/klientctl/lazy.go
+++ b/go/src/koding/klientctl/lazy.go
@@ -45,6 +45,7 @@ func Kite() *kite.Kite {
 
 	k = kite.New(config.Name, config.KiteVersion)
 	k.Config = config.Konfig.KiteConfig()
+	k.Config.KontrolURL = config.Konfig.KontrolURL
 	k.Config.Environment = config.Environment
 	k.Log = log
 

--- a/go/src/vendor/github.com/koding/multiconfig/flag.go
+++ b/go/src/vendor/github.com/koding/multiconfig/flag.go
@@ -55,7 +55,7 @@ func (f *FlagLoader) Load(s interface{}) error {
 	strct := structs.New(s)
 	structName := strct.Name()
 
-	flagSet := flag.NewFlagSet(structName, flag.ExitOnError)
+	flagSet := flag.NewFlagSet(structName, flag.ContinueOnError)
 	f.flagSet = flagSet
 
 	for _, field := range strct.Fields() {


### PR DESCRIPTION
This PR improves klient metadata support introduced by #9328, brings back custom verifyAudience func for klient (as long as we have managed channels we need to keep it around unfortunately) and makes kloud dump metadata during cloud-init provisioning.
