### PR TITLE
tunnelproxy: use XHRPolling transport for server

### DIFF
--- a/go/src/koding/kites/tunnelproxy/server.go
+++ b/go/src/koding/kites/tunnelproxy/server.go
@@ -831,6 +831,7 @@ func NewServerKite(s *Server, name, version string) (*kite.Kite, error) {
 	}
 
 	s.opts.Config.KontrolURL = s.opts.kontrolURL()
+	s.opts.Config.Transport = config.XHRPolling
 
 	if s.opts.Port != 0 {
 		s.opts.Config.Port = s.opts.Port


### PR DESCRIPTION
Fixes:

```
ESC[0mESC[37m2016-10-25T11:42:01.929Z INFO     [tunnelserver   ][PID:25813][kite/client.go:293] Dialing 'kontrol' kite: https://sandbox.koding.com/kontrol/kite
ESC[0mESC[37m2016-10-25T11:42:58.091Z INFO     [tunnelserver   ][PID:25813][kite/client.go:293] Dialing 'kontrol' kite: https://sandbox.koding.com/kontrol/kite
ESC[0mESC[37m2016-10-25T11:44:05.556Z INFO     [tunnelserver   ][PID:25813][kite/client.go:293] Dialing 'kontrol' kite: https://sandbox.koding.com/kontrol/kite
```
