### PR TITLE
Mock Machine IDE (MemoryFsKite, MemoryFsKlient)

### DIFF
--- a/.coffeelintignore
+++ b/.coffeelintignore
@@ -6,6 +6,7 @@ admin/lib/views/members/adminmembersview.coffee
 ide/lib/index.coffee
 ide/lib/collaborationcontroller.coffee
 ide/lib/views/contentsearch/idecontentsearch.coffee
+ide/lib/test/browser/index.coffee
 admin/lib/views/integrations/adminintegrationdetailsview.coffee
 app/lib/applicationmanager.coffee
 app/lib/providers/environmentsmachinestatemodal.coffee

--- a/client/app/lib/flux/environment/stores/machinesstore.coffee
+++ b/client/app/lib/flux/environment/stores/machinesstore.coffee
@@ -19,6 +19,7 @@ module.exports = class MachinesStore extends KodingFluxStore
     @on actions.SET_MACHINE_ALWAYS_ON_FAIL, @setAlwaysOnFail
     @on actions.LOAD_MACHINE_SHARED_USERS, @loadSharedUsers
     @on actions.SHARED_VM_INVITATION_REJECTED, @removeSharedUser
+    @on actions.ADD_TEST_MACHINE, @set
 
 
 
@@ -85,3 +86,6 @@ module.exports = class MachinesStore extends KodingFluxStore
   loadSharedUsers: (machines, { id, users }) ->
 
     machines.setIn [id, 'sharedUsers'], toImmutable users
+
+  set: (machines, machine) -> machines.set machine._id, toImmutable machine
+

--- a/client/app/lib/flux/environment/stores/ownmachinesstore.coffee
+++ b/client/app/lib/flux/environment/stores/ownmachinesstore.coffee
@@ -11,6 +11,7 @@ module.exports = class OwnMachinesStore extends KodingFluxStore
   initialize: ->
 
     @on actions.LOAD_USER_ENVIRONMENT_SUCCESS, @load
+    @on actions.ADD_TEST_MACHINE, @set
 
 
   load: (machines, { own }) ->
@@ -18,3 +19,6 @@ module.exports = class OwnMachinesStore extends KodingFluxStore
     machines.withMutations (machines) ->
       own.forEach ({ machine }) ->
         machines.set machine._id, machine._id
+
+
+  set: (machines, machine) -> machines.set machine._id, machine._id

--- a/client/app/lib/index.coffee
+++ b/client/app/lib/index.coffee
@@ -41,6 +41,7 @@ bootup = ->
   if globals.config.environment in ['dev', 'default', 'sandbox']
     global._kd      = kd
     global._remote  = remote
+    global._createTestMachine = require 'app/util/createTestMachine'
 
   if globals.currentGroup?
     globals.config.entryPoint.slug = globals.currentGroup.slug

--- a/client/app/lib/kite/kitecommandbuffer.coffee
+++ b/client/app/lib/kite/kitecommandbuffer.coffee
@@ -1,0 +1,51 @@
+_ = require 'lodash'
+kd = require 'kd'
+
+debug = (type, args...) ->
+  if _.isObject obj = args[0]
+  then console[type] JSON.stringify obj, null, 2
+  else console[type] args...
+
+
+module.exports = class KiteCommandBuffer extends kd.Object
+
+  constructor: (options = {}) ->
+
+    super options
+
+    { kite } = options
+
+    @kite = kite
+    @storage = kd.utils.dict()
+
+    @bindKiteEvents()
+
+
+  bindKiteEvents: ->
+
+    @kite.on 'tell', @bound 'onTellBegin'
+    @kite.on 'tell.success', @bound 'onTellSuccess'
+    @kite.on 'tell.fail', @bound 'onTellFail'
+
+
+  onTellBegin: (id, method, args) ->
+
+    @storage[id] = { method, args }
+    @emit 'change'
+
+
+  onTellSuccess: (id, method, result) ->
+
+    debug 'log', "~~~~~ SUCCESS (#{@kite.options.name}) ~~~~~"
+    @storage[id] = _.assign {}, @storage[id], { result }
+    @emit 'change'
+    debug 'log', @storage[id]
+
+
+  onTellFail: (id, method, error) ->
+
+    debug 'error', '~~~~~ ERROR ~~~~~'
+    @storage[id] = _.assign {}, @storage[id], { error }
+    @emit 'change'
+    debug 'error', error
+

--- a/client/app/lib/kite/kitecommandbuffer.coffee
+++ b/client/app/lib/kite/kitecommandbuffer.coffee
@@ -11,6 +11,10 @@ module.exports = class KiteCommandBuffer extends kd.Object
 
   constructor: (options = {}) ->
 
+    # activating this will start logging to console.
+    # use `commandBuffer.setOption('debug', yes)` to activate it on runtime.
+    options.debug ?= no
+
     super options
 
     { kite } = options
@@ -19,6 +23,9 @@ module.exports = class KiteCommandBuffer extends kd.Object
     @storage = kd.utils.dict()
 
     @bindKiteEvents()
+
+
+  debug: (args...) -> @getOption('debug') and debug args...
 
 
   bindKiteEvents: ->
@@ -36,16 +43,20 @@ module.exports = class KiteCommandBuffer extends kd.Object
 
   onTellSuccess: (id, method, result) ->
 
-    debug 'log', "~~~~~ SUCCESS (#{@kite.options.name}) ~~~~~"
+    @debug 'log', "~~~~~ SUCCESS (#{@kite.options.name}) ~~~~~"
+
     @storage[id] = _.assign {}, @storage[id], { result }
     @emit 'change'
-    debug 'log', @storage[id]
+
+    @debug 'log', @storage[id]
 
 
   onTellFail: (id, method, error) ->
 
-    debug 'error', '~~~~~ ERROR ~~~~~'
+    @debug 'error', '~~~~~ ERROR ~~~~~'
+
     @storage[id] = _.assign {}, @storage[id], { error }
     @emit 'change'
-    debug 'error', error
+
+    @debug 'error', error
 

--- a/client/app/lib/kite/kites/helper.coffee
+++ b/client/app/lib/kite/kites/helper.coffee
@@ -160,6 +160,22 @@ generateFileSystem = (username) ->
   return new MemoryFileSystem config
 
 
+generateNewPath = (path) ->
+
+  [folders..., file] = path.split '/'
+  [name, ext] = file.split '.'
+  [name, seq] = name.split '_'
+
+  seq ?= 0
+
+  name = [name, ++seq].join '_'
+  file = [name, ext].join '.'
+  path = [folders..., file].join '/'
+
+  return path
+
+
 module.exports = {
   generateFileSystem
+  generateNewPath
 }

--- a/client/app/lib/kite/kites/helper.coffee
+++ b/client/app/lib/kite/kites/helper.coffee
@@ -1,6 +1,6 @@
 MemoryFileSystem = require 'memory-fs'
 
-PROFILE = """
+PROFILE = '''
   # ~/.profile: executed by the command interpreter for login shells.
   # This file is not read by bash(1), if ~/.bash_profile or ~/.bash_login
   # exists.
@@ -23,9 +23,9 @@ PROFILE = """
   if [ -d "$HOME/bin" ] ; then
       PATH="$HOME/bin:$PATH"
   fi
-"""
+'''
 
-BASH_LOGOUT = """
+BASH_LOGOUT = '''
   # ~/.bash_logout: executed by bash(1) when login shell exits.
 
   # when leaving the console clear the screen to increase privacy
@@ -33,9 +33,9 @@ BASH_LOGOUT = """
   if [ "$SHLVL" = 1 ]; then
       [ -x /usr/bin/clear_console ] && /usr/bin/clear_console -q
   fi
-"""
+'''
 
-BASH_RC = """
+BASH_RC = '''
   # ~/.bashrc: executed by bash(1) for non-login shells.
   # see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
   # for examples
@@ -137,7 +137,7 @@ BASH_RC = """
     fi
   fi
 
-"""
+'''
 
 generateFileSystem = (username) ->
 

--- a/client/app/lib/kite/kites/helper.coffee
+++ b/client/app/lib/kite/kites/helper.coffee
@@ -1,0 +1,165 @@
+MemoryFileSystem = require 'memory-fs'
+
+PROFILE = """
+  # ~/.profile: executed by the command interpreter for login shells.
+  # This file is not read by bash(1), if ~/.bash_profile or ~/.bash_login
+  # exists.
+  # see /usr/share/doc/bash/examples/startup-files for examples.
+  # the files are located in the bash-doc package.
+
+  # the default umask is set in /etc/profile; for setting the umask
+  # for ssh logins, install and configure the libpam-umask package.
+  #umask 022
+
+  # if running bash
+  if [ -n "$BASH_VERSION" ]; then
+      # include .bashrc if it exists
+      if [ -f "$HOME/.bashrc" ]; then
+    . "$HOME/.bashrc"
+      fi
+  fi
+
+  # set PATH so it includes user's private bin if it exists
+  if [ -d "$HOME/bin" ] ; then
+      PATH="$HOME/bin:$PATH"
+  fi
+"""
+
+BASH_LOGOUT = """
+  # ~/.bash_logout: executed by bash(1) when login shell exits.
+
+  # when leaving the console clear the screen to increase privacy
+
+  if [ "$SHLVL" = 1 ]; then
+      [ -x /usr/bin/clear_console ] && /usr/bin/clear_console -q
+  fi
+"""
+
+BASH_RC = """
+  # ~/.bashrc: executed by bash(1) for non-login shells.
+  # see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
+  # for examples
+
+  # If not running interactively, don't do anything
+  case $- in
+      *i*) ;;
+        *) return;;
+  esac
+
+  # don't put duplicate lines or lines starting with space in the history.
+  # See bash(1) for more options
+  HISTCONTROL=ignoreboth
+
+  # append to the history file, don't overwrite it
+  shopt -s histappend
+
+  # for setting history length see HISTSIZE and HISTFILESIZE in bash(1)
+  HISTSIZE=1000
+  HISTFILESIZE=2000
+
+  # check the window size after each command and, if necessary,
+  # update the values of LINES and COLUMNS.
+  shopt -s checkwinsize
+
+  # If set, the pattern "**" used in a pathname expansion context will
+  # match all files and zero or more directories and subdirectories.
+  #shopt -s globstar
+
+  # make less more friendly for non-text input files, see lesspipe(1)
+  [ -x /usr/bin/lesspipe ] && eval "$(SHELL=/bin/sh lesspipe)"
+
+  # set variable identifying the chroot you work in (used in the prompt below)
+  if [ -z "${debian_chroot:-}" ] && [ -r /etc/debian_chroot ]; then
+      debian_chroot=$(cat /etc/debian_chroot)
+  fi
+
+  # set a fancy prompt (non-color, unless we know we "want" color)
+  case "$TERM" in
+      xterm-color) color_prompt=yes;;
+  esac
+
+  # uncomment for a colored prompt, if the terminal has the capability; turned
+  # off by default to not distract the user: the focus in a terminal window
+  # should be on the output of commands, not on the prompt
+  #force_color_prompt=yes
+
+  if [ -n "$force_color_prompt" ]; then
+      if [ -x /usr/bin/tput ] && tput setaf 1 >&/dev/null; then
+    # We have color support; assume it's compliant with Ecma-48
+    # (ISO/IEC-6429). (Lack of such support is extremely rare, and such
+    # a case would tend to support setf rather than setaf.)
+    color_prompt=yes
+      else
+    color_prompt=
+      fi
+  fi
+
+  unset color_prompt force_color_prompt
+
+  # enable color support of ls and also add handy aliases
+  if [ -x /usr/bin/dircolors ]; then
+      test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
+      alias ls='ls --color=auto'
+      #alias dir='dir --color=auto'
+      #alias vdir='vdir --color=auto'
+
+      alias grep='grep --color=auto'
+      alias fgrep='fgrep --color=auto'
+      alias egrep='egrep --color=auto'
+  fi
+
+  # some more ls aliases
+  alias ll='ls -alF'
+  alias la='ls -A'
+  alias l='ls -CF'
+
+  # Add an "alert" alias for long running commands.  Use like so:
+  #   sleep 10; alert
+  alias alert='notify-send --urgency=low -i "$([ $? = 0 ] && echo terminal || echo error)" "$(history|tail -n1|sed -e '\''s/^\s*[0-9]\+\s*//;s/[;&|]\s*alert$//'\'')"'
+
+  # Alias definitions.
+  # You may want to put all your additions into a separate file like
+  # ~/.bash_aliases, instead of adding them here directly.
+  # See /usr/share/doc/bash-doc/examples in the bash-doc package.
+
+  if [ -f ~/.bash_aliases ]; then
+      . ~/.bash_aliases
+  fi
+
+  # enable programmable completion features (you don't need to enable
+  # this, if it's already enabled in /etc/bash.bashrc and /etc/profile
+  # sources /etc/bash.bashrc).
+  if ! shopt -oq posix; then
+    if [ -f /usr/share/bash-completion/bash_completion ]; then
+      . /usr/share/bash-completion/bash_completion
+    elif [ -f /etc/bash_completion ]; then
+      . /etc/bash_completion
+    fi
+  fi
+
+"""
+
+generateFileSystem = (username) ->
+
+  makeFolder = -> { "": yes }
+
+  config = makeFolder()
+  config.home = makeFolder()
+  config.home[username] = home = makeFolder()
+
+  home['.config'] = dotConfig = makeFolder()
+
+  dotConfig['koding'] = makeFolder()
+  dotConfig['koding']['klient.bolt'] = new Buffer 'klient.bolt inside'
+
+  home['.bash_logout'] = new Buffer BASH_LOGOUT
+  home['.bash_rc'] = new Buffer BASH_RC
+  home['.profile'] = new Buffer PROFILE
+  home['NewFile.txt'] = new Buffer 'Hello world!'
+
+  return new MemoryFileSystem config
+
+
+module.exports = {
+  generateFileSystem
+}

--- a/client/app/lib/kite/kites/helper.coffee
+++ b/client/app/lib/kite/kites/helper.coffee
@@ -141,7 +141,7 @@ BASH_RC = '''
 
 generateFileSystem = (username) ->
 
-  makeFolder = -> { "": yes }
+  makeFolder = -> { '': yes }
 
   config = makeFolder()
   config.home = makeFolder()

--- a/client/app/lib/kite/kites/memoryfs.coffee
+++ b/client/app/lib/kite/kites/memoryfs.coffee
@@ -1,0 +1,162 @@
+kd = require 'kd'
+helper = require './helper'
+
+module.exports = class MemoryFsKite extends kd.Object
+
+  createMapping = (api) ->
+    map = {}
+    map[rpcMethod] = method  for own method, rpcMethod of api
+    return map
+
+  constructor: (options = {}) ->
+
+    super options
+
+    @fs = helper.generateFileSystem(options.username)
+    @api = createMapping options.api
+
+  connect: ->
+    @emit 'open'
+    Promise.resolve()
+
+
+  disconnect: ->
+    @emit 'close'
+    Promise.resolve()
+
+
+  read: (path) -> @fs.readFileSync(path).toString()
+
+
+  clientSubscribe: (args) ->
+    { eventName, onPublish } = args
+    kd.utils.defer -> onPublish { files: [] }
+
+    Promise.resolve { id: 'memory-fs-kite' }
+
+
+  fsReadDirectory: (args, callback) ->
+
+    [{ path: base }] = args
+    files = @fs.readdirSync(base).map (path) =>
+      fullPath = [base, path].join '/'
+      stat = @fs.statSync(fullPath)
+
+      return if stat.isDirectory()
+      then wrapDir path, fullPath
+      else wrapFile path, fullPath, @read(fullPath).length
+
+    Promise.resolve(Promise.all(files)).then (files) -> { files }
+
+
+  fsReadFile: (args, callback) ->
+
+    [{ path }] = args
+
+    return wrapFileInstance @read(path)
+
+
+  fsGetInfo: (args, callback) ->
+
+    [{ path }] = args
+
+    return wrapFile path, '', @read(path).length
+
+
+  fsSetPermissions: (args, callback) -> Promise.resolve yes
+
+
+  fsUniquePath: (args, callback) ->
+
+    [{ path }] = args
+
+    path = generateNewPath(path)  if @fs.existsSync(path)
+
+    Promise.resolve path
+
+
+  fsWriteFile: (args, callback) ->
+
+    [{ path, content }] = args
+
+    encrypted = atob content
+
+    @fs.writeFileSync(path, new Buffer encrypted)
+
+    Promise.resolve(encrypted.length)
+
+
+  fsRemove: (args, callback) ->
+
+    [{ path }] = args
+
+    @fs.unlinkSync(path)
+
+    Promise.resolve yes
+
+
+  fsMove: (args, callback) ->
+
+    [{ oldpath, newpath }] = args
+
+    content = btoa @read oldpath
+    @fsWriteFile([{ path: newpath, content }]).then =>
+      @fsRemove([{ path: oldpath }])
+
+
+  fsRename: (args...) -> @fsMove args...
+
+
+  fsCreateDirectory: (args, callback) ->
+
+    [{ path }] = args
+
+    @fs.mkdirpSync path
+
+    Promise.resolve yes
+
+
+  webtermGetSessions: (args, callback) -> Promise.resolve []
+
+
+  tell: (rpcMethod, args, callback) ->
+
+    method = @api[rpcMethod]
+
+    promise = if this[method]
+    then this[method].call this, args, callback
+    else Promise.reject(new Error "not implemented: #{rpcMethod}")
+
+    return promise.catch (e) -> console.warn 'failing silently', e
+
+
+wrapDir = (path, fullPath = '') -> Promise.resolve
+  name: path,
+  fullPath: fullPath,
+  isDir: true,
+  exists: true,
+  size: 4096,
+  mode: 2147484141,
+  time: "2016-10-08T03:00:28.996121999Z",
+  isBroken: false,
+  readable: true,
+  writable: false
+
+
+wrapFile = (path, fullPath, length) -> Promise.resolve
+  name: path,
+  fullPath: fullPath,
+  isDir: false,
+  exists: true,
+  size: length,
+  mode: 777,
+  time: "2016-10-08T03:00:28.996121999Z",
+  isBroken: false,
+  readable: true,
+  writable: true
+
+
+wrapFileInstance = (content) -> Promise.resolve { content: btoa content }
+
+
+

--- a/client/app/lib/kite/kites/memoryfs.coffee
+++ b/client/app/lib/kite/kites/memoryfs.coffee
@@ -137,7 +137,7 @@ wrapDir = (path, fullPath = '') -> Promise.resolve
   exists: true,
   size: 4096,
   mode: 2147484141,
-  time: "2016-10-08T03:00:28.996121999Z",
+  time: '2016-10-08T03:00:28.996121999Z',
   isBroken: false,
   readable: true,
   writable: false
@@ -150,7 +150,7 @@ wrapFile = (path, fullPath, length) -> Promise.resolve
   exists: true,
   size: length,
   mode: 777,
-  time: "2016-10-08T03:00:28.996121999Z",
+  time: '2016-10-08T03:00:28.996121999Z',
   isBroken: false,
   readable: true,
   writable: true

--- a/client/app/lib/kite/kites/memoryfsklient.coffee
+++ b/client/app/lib/kite/kites/memoryfsklient.coffee
@@ -1,0 +1,76 @@
+kd = require 'kd'
+Promise = require 'bluebird'
+KodingKite = require '../kodingkite'
+Klient = require './klient'
+nick = require 'app/util/nick'
+MemoryFsKite = require './memoryfs'
+
+module.exports = class MemoryFsKlient extends KodingKite
+
+  # implements the same interface with KodingKlientKite
+  @api =
+    exec                : 'exec'
+    ping                : 'kite.ping'
+    systemInfo          : 'kite.systemInfo'
+    clientSubscribe     : 'client.Subscribe'
+    clientUnsubscribe   : 'client.Unsubscribe'
+    fsReadDirectory     : 'fs.readDirectory'
+    fsGlob              : 'fs.glob'
+    fsReadFile          : 'fs.readFile'
+    fsGetInfo           : 'fs.getInfo'
+    fsSetPermissions    : 'fs.setPermissions'
+    fsRemove            : 'fs.remove'
+    fsUniquePath        : 'fs.uniquePath'
+    fsWriteFile         : 'fs.writeFile'
+    fsRename            : 'fs.rename'
+    fsMove              : 'fs.move'
+    fsCreateDirectory   : 'fs.createDirectory'
+    tail                : 'log.tail'
+    webtermKillSessions : 'webterm.killSessions'
+    webtermGetSessions  : 'webterm.getSessions'
+    webtermPing         : 'webterm.ping'
+    webtermRename       : 'webterm.rename'
+    klientDisable       : 'klient.disable'
+    klientInfo          : 'klient.info'
+    klientShare         : 'klient.share'
+    klientUnshare       : 'klient.unshare'
+    klientShared        : 'klient.shared'
+    sshKeysAdd          : 'sshkeys.add'
+
+    # extras in klient
+
+    # storageGet { key }
+    storageGet          : 'storage.get'
+    # storageSet { key, value}
+    storageSet          : 'storage.set'
+    # storageDelete { key }
+    storageDelete       : 'storage.delete'
+    # TODO
+    webtermConnect      : 'webterm.connect'
+    # webtermKillSession { session }
+    webtermKillSession  : 'webterm.killSession'
+
+  @createApiMapping @api
+
+
+  constructor: (options = {}) ->
+    options.name = 'mockklient'
+    super options
+
+
+  setTransport: ->
+
+    mockTransport = new MemoryFsKite
+      api: MemoryFsKlient.api
+      username: nick()
+
+    super mockTransport
+
+
+  fetchTerminalSessions: -> @transport?.webtermGetSessions?()
+
+
+  clientSubscribe: (options) -> @transport?.clientSubscribe options
+
+
+

--- a/client/app/lib/kite/kodingkite.coffee
+++ b/client/app/lib/kite/kodingkite.coffee
@@ -91,12 +91,13 @@ module.exports = class KodingKite extends kd.Object
 
             resolve (@transport?.tell args...
 
-              .then (res) =>
+              .then (res) ->
 
                 KiteLogger.success name, rpcMethod
                 return res
 
               .catch (err) =>
+
                 if _errPromise = @handleKiteError err, args
                   return _errPromise
 

--- a/client/app/lib/kite/kodingkite.coffee
+++ b/client/app/lib/kite/kodingkite.coffee
@@ -3,8 +3,6 @@ kitejs     = require 'kite.js'
 Promise    = require 'bluebird'
 KiteCache  = require './kitecache'
 KiteLogger = require '../kitelogger'
-KiteCommandBuffer = require './kitecommandbuffer'
-uuid = require 'node-uuid'
 
 
 module.exports = class KodingKite extends kd.Object
@@ -30,8 +28,6 @@ module.exports = class KodingKite extends kd.Object
     super options
 
     { name } = options
-
-    @commandBuffer = new KiteCommandBuffer { kite: this }
 
     @on 'open', =>
       @isDisconnected = no # This one is for the manual disconnect request ~ GG
@@ -93,21 +89,14 @@ module.exports = class KodingKite extends kd.Object
 
             KiteLogger.started name, rpcMethod
 
-            # label the calls, doesn't mean anything, just to track
-            # tell states (tell.success, tell.fail)
-            id = uuid.v4()
-            @emit 'tell', id, rpcMethod, args
-
             resolve (@transport?.tell args...
 
               .then (res) =>
 
                 KiteLogger.success name, rpcMethod
-                @emit 'tell.success', id, rpcMethod, res
                 return res
 
               .catch (err) =>
-                @emit 'tell.fail', id, rpcMethod, err
                 if _errPromise = @handleKiteError err, args
                   return _errPromise
 

--- a/client/app/lib/kite/kodingkite.coffee
+++ b/client/app/lib/kite/kodingkite.coffee
@@ -31,7 +31,7 @@ module.exports = class KodingKite extends kd.Object
 
     { name } = options
 
-    @commandBuffer = new KiteCommandBuffer kite: this
+    @commandBuffer = new KiteCommandBuffer { kite: this }
 
     @on 'open', =>
       @isDisconnected = no # This one is for the manual disconnect request ~ GG

--- a/client/app/lib/providers/machine.coffee
+++ b/client/app/lib/providers/machine.coffee
@@ -4,9 +4,17 @@ KDObject              = kd.Object
 doesQueryStringValid  = require '../util/doesQueryStringValid'
 nick                  = require '../util/nick'
 globals               = require 'globals'
+runMiddlewares        = require 'app/util/runMiddlewares'
+TestMachineMiddleware = require './middlewares/testmachine'
 
 
 module.exports = class Machine extends KDObject
+
+  @getMiddlewares = ->
+    return [
+      TestMachineMiddleware.Machine
+    ]
+
 
   @State = {
 
@@ -114,6 +122,11 @@ module.exports = class Machine extends KDObject
 
     { kontrol } = kd.singletons
 
+    # this is a chance for other middlewares to inject their own kite/klient.
+    klient = runMiddlewares.sync this, 'getBaseKite', createIfNotExists
+
+    return klient  if klient
+
     klient = kontrol.kites?.klient?[@uid]
     return klient  if klient
 
@@ -159,3 +172,4 @@ module.exports = class Machine extends KDObject
   isStopped   : -> @status?.state is Machine.State.Stopped
   isUsable    : -> @isRunning() or @isStopped()
   getOldOwner : -> @jMachine.meta.oldOwner
+

--- a/client/app/lib/providers/machine.coffee
+++ b/client/app/lib/providers/machine.coffee
@@ -123,9 +123,9 @@ module.exports = class Machine extends KDObject
     { kontrol } = kd.singletons
 
     # this is a chance for other middlewares to inject their own kite/klient.
-    klient = runMiddlewares.sync this, 'getBaseKite', createIfNotExists
+    testKlient = runMiddlewares.sync this, 'getBaseKite', createIfNotExists
 
-    return klient  if klient
+    return testKlient  if testKlient
 
     klient = kontrol.kites?.klient?[@uid]
     return klient  if klient

--- a/client/app/lib/providers/managed/helpers.coffee
+++ b/client/app/lib/providers/managed/helpers.coffee
@@ -42,7 +42,7 @@ queryKites = ->
         return []
 
 
-fetchStack = (callback) ->
+ensureManagedStack = (callback) ->
 
   { computeController } = kd.singletons
 
@@ -60,7 +60,7 @@ fetchStack = (callback) ->
 
 createMachine = (kite, callback) ->
 
-  fetchStack (err, stack) ->
+  ensureManagedStack (err, stack) ->
 
     return callback err  if err
 
@@ -83,6 +83,7 @@ updateMachineData = ({ machine, kite }, callback) ->
 
 
 module.exports = {
+  ensureManagedStack
   createMachine
   updateMachineData
   queryKites

--- a/client/app/lib/providers/middlewares/testmachine.coffee
+++ b/client/app/lib/providers/middlewares/testmachine.coffee
@@ -1,0 +1,40 @@
+{ assign } = require 'lodash'
+isTestMachine = require 'app/util/isTestMachine'
+MemoryFsKlient = require 'app/kite/kites/memoryfsklient'
+
+
+module.exports = TestMachineMiddleware =
+
+  Machine:
+    getBaseKite: ->
+      if isTestMachine @getData()
+        return @_mockKlient  if @_mockKlient
+        @_mockKlient = new MemoryFsKlient
+        @_mockKlient.setTransport()
+        return @_mockKlient
+
+  ComputeController:
+    create: (options, callback) ->
+      Machine = require 'app/providers/machine'
+      if isTestMachine options.machine
+        @_testMachine = new Machine { machine: options.machine }
+        return callback null, assign {}, options, { shouldStop: yes }
+
+      return callback null, options
+
+    fetchStacks: (stacks) ->
+      stacks.map (stack) =>
+        if stack.title is 'Managed VMs'
+          if @_testMachine and not (@_testMachine in stack.machines)
+            stack.machines.push @_testMachine
+
+        return stack
+
+
+  EnvironmentDataProvider:
+    setDefaults_: (data) ->
+      if @_testMachine and not (@_testMachine in data.own)
+      then assign {}, data, own: data.own.concat [@_testMachine]
+      else data
+
+

--- a/client/app/lib/providers/middlewares/testmachine.coffee
+++ b/client/app/lib/providers/middlewares/testmachine.coffee
@@ -34,7 +34,7 @@ module.exports = TestMachineMiddleware =
   EnvironmentDataProvider:
     setDefaults_: (data) ->
       if @_testMachine and not (@_testMachine in data.own)
-      then assign {}, data, own: data.own.concat [@_testMachine]
+      then assign {}, data, { own: data.own.concat [@_testMachine] }
       else data
 
 

--- a/client/app/lib/providers/middlewares/testmachine.coffee
+++ b/client/app/lib/providers/middlewares/testmachine.coffee
@@ -3,6 +3,14 @@ isTestMachine = require 'app/util/isTestMachine'
 MemoryFsKlient = require 'app/kite/kites/memoryfsklient'
 
 
+# defines middleware methods to be used with given classes.
+# it uses `runMiddlewares` util to achieve that purpose
+# basically, methods accepting a completion callback will be run through
+# `async` middlewares.
+#
+# This middleware's specific purpose is to provide a mock machine
+# implementation to be used by IDE instances, so that, we can run tests without
+# thinking about making network requests.
 module.exports = TestMachineMiddleware =
 
   Machine:

--- a/client/app/lib/userenvironmentdataprovider.coffee
+++ b/client/app/lib/userenvironmentdataprovider.coffee
@@ -103,9 +103,7 @@ module.exports =
 
   getMachineWithPredicate: (fn, predicate) ->
 
-    filtered = @getAllMachines().filter predicate
-
-    if filtered.length then filtered[0] else null
+    @getAllMachines().filter(predicate)[0]
 
 
   fetchMachine: (identifier, callback) ->

--- a/client/app/lib/userenvironmentdataprovider.coffee
+++ b/client/app/lib/userenvironmentdataprovider.coffee
@@ -1,13 +1,22 @@
+_       = require 'lodash'
 kd      = require 'kd'
 globals = require 'globals'
 remote  = require 'app/remote'
 Machine = require 'app/providers/machine'
 async   = require 'async'
 
+runMiddlewares = require 'app/util/runMiddlewares'
+TestMachineMiddleware = require 'app/providers/middlewares/testmachine'
+
 KDNotificationView = kd.NotificationView
 
 
 module.exports =
+
+  getMiddlewares: ->
+    return [
+      TestMachineMiddleware.EnvironmentDataProvider
+    ]
 
 
   fetch: (callback, ensureDefaultWorkspace = no) ->
@@ -23,6 +32,11 @@ module.exports =
       else callback data
 
 
+  addTestMachine: (machine, workspaces) ->
+    @_testMachine = { machine, workspaces }
+    @revive()
+
+
   get: ->
     return @setDefaults_ globals.userEnvironmentData
 
@@ -33,7 +47,7 @@ module.exports =
     data.shared        or= []
     data.collaboration or= []
 
-    return data
+    return runMiddlewares.sync this, 'setDefaults_', data
 
 
   hasData: ->
@@ -85,6 +99,13 @@ module.exports =
   getRunningMachines: ->
 
     @getAllMachines().filter (vm) -> vm.machine.status.state is 'Running'
+
+
+  getMachineWithPredicate: (fn, predicate) ->
+
+    filtered = @getAllMachines().filter predicate
+
+    if filtered.length then filtered[0] else null
 
 
   fetchMachine: (identifier, callback) ->

--- a/client/app/lib/util/createTestMachine.coffee
+++ b/client/app/lib/util/createTestMachine.coffee
@@ -5,10 +5,10 @@ managedHelper = require 'app/providers/managed/helpers'
 _machine = null
 _workspaces = null
 
-module.exports = createTestMachine = ->
+module.exports = createTestMachine = -> new Promise (resolve, reject) ->
 
   if _machine and _workspaces
-    return Promise.resolve { machine: _machine, workspaces: _workspaces }
+    return resolve { machine: _machine, workspaces: _workspaces }
 
   machine = require('mocks/mockmanagedmachine')()
   { reactor, computeController } = kd.singletons
@@ -16,13 +16,14 @@ module.exports = createTestMachine = ->
   { workspaces } = machine
   delete machine.workspaces
 
-  managedHelper.ensureManagedStack (err) ->
-    computeController.create { machine }, (err, machine) ->
-      return Promise.reject(err)  if err
-      dataProvider.addTestMachine machine, workspaces
-      reactor.dispatch 'LOAD_USER_ENVIRONMENT_SUCCESS', dataProvider.get()
-      reactor.dispatch 'ADD_TEST_MACHINE', { machine, workspaces }
-      _machine = machine
-      _workspaces = workspaces
-      Promise.resolve { machine, workspaces }
+  computeController.ready ->
+    managedHelper.ensureManagedStack (err) ->
+      computeController.create { machine }, (err, machine) ->
+        return reject(err)  if err
+        dataProvider.addTestMachine machine, workspaces
+        reactor.dispatch 'LOAD_USER_ENVIRONMENT_SUCCESS', dataProvider.get()
+        reactor.dispatch 'ADD_TEST_MACHINE', { machine, workspaces }
+        _machine = machine
+        _workspaces = workspaces
+        resolve { machine, workspaces }
 

--- a/client/app/lib/util/createTestMachine.coffee
+++ b/client/app/lib/util/createTestMachine.coffee
@@ -1,0 +1,18 @@
+kd = require 'kd'
+dataProvider = require 'app/userenvironmentdataprovider'
+managedHelper = require 'app/providers/managed/helpers'
+
+module.exports = createTestMachine = ->
+
+  machine = require('mocks/mockmanagedmachine')()
+  { reactor, computeController } = kd.singletons
+
+  { workspaces } = machine
+  delete machine.workspaces
+
+  managedHelper.ensureManagedStack (err) ->
+    computeController.create { machine }, ->
+      dataProvider.addTestMachine machine, workspaces
+      reactor.dispatch 'LOAD_USER_ENVIRONMENT_SUCCESS', dataProvider.get()
+      reactor.dispatch 'ADD_TEST_MACHINE', { machine, workspaces }
+

--- a/client/app/lib/util/createTestMachine.coffee
+++ b/client/app/lib/util/createTestMachine.coffee
@@ -2,7 +2,13 @@ kd = require 'kd'
 dataProvider = require 'app/userenvironmentdataprovider'
 managedHelper = require 'app/providers/managed/helpers'
 
+_machine = null
+_workspaces = null
+
 module.exports = createTestMachine = ->
+
+  if _machine and _workspaces
+    return Promise.resolve { machine: _machine, workspaces: _workspaces }
 
   machine = require('mocks/mockmanagedmachine')()
   { reactor, computeController } = kd.singletons
@@ -11,8 +17,12 @@ module.exports = createTestMachine = ->
   delete machine.workspaces
 
   managedHelper.ensureManagedStack (err) ->
-    computeController.create { machine }, ->
+    computeController.create { machine }, (err, machine) ->
+      return Promise.reject(err)  if err
       dataProvider.addTestMachine machine, workspaces
       reactor.dispatch 'LOAD_USER_ENVIRONMENT_SUCCESS', dataProvider.get()
       reactor.dispatch 'ADD_TEST_MACHINE', { machine, workspaces }
+      _machine = machine
+      _workspaces = workspaces
+      Promise.resolve { machine, workspaces }
 

--- a/client/app/lib/util/isTestMachine.coffee
+++ b/client/app/lib/util/isTestMachine.coffee
@@ -1,0 +1,2 @@
+
+module.exports = isTestMachine = (machine) -> !!machine.isTestMachine

--- a/client/app/lib/util/middlewares.test.coffee
+++ b/client/app/lib/util/middlewares.test.coffee
@@ -1,0 +1,100 @@
+{ assign } = require 'lodash'
+expect = require 'expect'
+runMiddlewares = require './runMiddlewares'
+
+describe 'middleware utils', ->
+
+  Bar =
+    create: (options, callback) ->
+      callback null, assign {}, options, { bar: this }
+
+  Baz =
+    create: (options, callback) ->
+      callback null, assign {}, options, { baz: this }
+
+
+  SyncBar =
+    create: (options) -> assign {}, options, { bar: this }
+
+  SyncBaz =
+    create: (options) -> assign {}, options, { baz: this }
+
+
+  describe 'runMiddlewares', ->
+
+    it 'works with constructor', (done) ->
+      class Foo
+        @getMiddlewares = -> [Bar, Baz]
+        create: (options, callback) ->
+          callback null, assign {}, options, {finished: this}
+
+      instance = new Foo
+
+      runMiddlewares instance, 'create', { foo: instance }, (err, result) ->
+        expect(result.foo).toBe instance, 'foo should be original instance'
+        expect(result.bar).toBe instance, 'bar should be original instance'
+        expect(result.baz).toBe instance, 'baz should be original instance'
+        expect(result.finished).toNotExist()
+
+        instance.create result, (err, result) ->
+          expect(result.finished).toBe instance, 'finished should be original'
+          done()
+
+
+    it 'works with regular object', (done) ->
+
+      instance =
+        getMiddlewares: -> [Bar, Baz]
+        create: (options, callback) ->
+          callback null, assign {}, options, {finished: this}
+
+      runMiddlewares instance, 'create', { foo: instance }, (err, result) ->
+        expect(result.foo).toBe instance, 'foo should be original instance'
+        expect(result.bar).toBe instance, 'bar should be original instance'
+        expect(result.baz).toBe instance, 'baz should be original instance'
+        expect(result.finished).toNotExist()
+
+        instance.create result, (err, result) ->
+          expect(result.finished).toBe instance, 'finished should be original'
+          done()
+
+
+
+  describe 'runMiddlewaresSync', ->
+
+    it 'works', ->
+      class Foo
+        @getMiddlewares = -> [SyncBar, SyncBaz]
+        create: (options) -> assign {}, options, {finished: this}
+
+      instance = new Foo
+
+      result = runMiddlewares.sync instance, 'create', { foo: instance }
+
+      expect(result.foo).toBe instance, 'foo should be original instance'
+      expect(result.bar).toBe instance, 'bar should be original instance'
+      expect(result.baz).toBe instance, 'baz should be original instance'
+      expect(result.finished).toNotExist()
+
+      result = instance.create result
+
+      expect(result.finished).toBe instance, 'finished should be original'
+
+
+    it 'works with regular object', ->
+
+      instance =
+        getMiddlewares: -> [SyncBar, SyncBaz]
+        create: (options) -> assign {}, options, {finished: this}
+
+      result = runMiddlewares.sync instance, 'create', { foo: instance }
+
+      expect(result.foo).toBe instance, 'foo should be original instance'
+      expect(result.bar).toBe instance, 'bar should be original instance'
+      expect(result.baz).toBe instance, 'baz should be original instance'
+      expect(result.finished).toNotExist()
+
+      result = instance.create result
+
+      expect(result.finished).toBe instance, 'finished should be original'
+

--- a/client/app/lib/util/middlewares.test.coffee
+++ b/client/app/lib/util/middlewares.test.coffee
@@ -26,7 +26,7 @@ describe 'middleware utils', ->
       class Foo
         @getMiddlewares = -> [Bar, Baz]
         create: (options, callback) ->
-          callback null, assign {}, options, {finished: this}
+          callback null, assign {}, options, { finished: this }
 
       instance = new Foo
 
@@ -46,7 +46,7 @@ describe 'middleware utils', ->
       instance =
         getMiddlewares: -> [Bar, Baz]
         create: (options, callback) ->
-          callback null, assign {}, options, {finished: this}
+          callback null, assign {}, options, { finished: this }
 
       runMiddlewares instance, 'create', { foo: instance }, (err, result) ->
         expect(result.foo).toBe instance, 'foo should be original instance'
@@ -65,7 +65,7 @@ describe 'middleware utils', ->
     it 'works', ->
       class Foo
         @getMiddlewares = -> [SyncBar, SyncBaz]
-        create: (options) -> assign {}, options, {finished: this}
+        create: (options) -> assign {}, options, { finished: this }
 
       instance = new Foo
 
@@ -85,7 +85,7 @@ describe 'middleware utils', ->
 
       instance =
         getMiddlewares: -> [SyncBar, SyncBaz]
-        create: (options) -> assign {}, options, {finished: this}
+        create: (options) -> assign {}, options, { finished: this }
 
       result = runMiddlewares.sync instance, 'create', { foo: instance }
 

--- a/client/app/lib/util/runMiddlewares.coffee
+++ b/client/app/lib/util/runMiddlewares.coffee
@@ -1,0 +1,66 @@
+{ isFunction } = require 'lodash'
+async = require 'async'
+
+# This module will check for a `middlewares` array on constructor of given
+# instance.
+runMiddlewaresAsync = (instance, methodName, options, callback) ->
+
+
+  middlewares = getMiddlewares instance
+
+  filterer = hasMethod methodName
+  mapper = wrapAsync instance, methodName
+
+  queue = middlewares.filter(filterer).map(mapper)
+  queue = [async.constant options].concat queue
+
+  async.waterfall queue, callback
+
+
+runMiddlewaresSync = (instance, methodName, options) ->
+
+  middlewares = getMiddlewares instance
+
+  filterer = hasMethod methodName
+  mapper = wrapSync instance, methodName
+
+  queue = middlewares.filter(filterer).map(mapper)
+
+  queue.reduce (opts, fn) ->
+    fn opts
+  , options
+
+
+getMiddlewares = (instance) ->
+
+  middlewares = \
+    # first check to see if instance itself has defined middlewares array.
+    instance.getMiddlewares?() or \
+    # then check to see if its class has defined middlewares array.
+    instance.constructor?.getMiddlewares?() or \
+    # default it to an empty array.
+    []
+
+  return middlewares
+
+
+hasMethod = (methodName) -> (middleware) -> isFunction(middleware[methodName])
+
+
+# decorator function that accepts an instance and `methodName`. (wrap)
+# (wrap) will return another function which will accept a middleware. (wrapped)
+# (wrapped) is a function that which will be used with `async.middleware`
+wrapAsync = (instance, methodName) -> (middleware) -> (args..., callback) ->
+  method = middleware[methodName]
+
+  async.ensureAsync(method).call instance, args..., callback
+
+
+wrapSync = (instance, methodName) -> (middleware) -> (args...) ->
+  method = middleware[methodName]
+  return method.call(instance, args...)
+
+
+module.exports = runMiddlewaresAsync
+module.exports.async = runMiddlewaresAsync
+module.exports.sync = runMiddlewaresSync

--- a/client/ide/lib/index.coffee
+++ b/client/ide/lib/index.coffee
@@ -629,7 +629,7 @@ class IDEAppController extends AppController
     @getView().addSubView @noStackFoundView = new NoStackFoundView
 
 
-  mountMachineByMachineUId: (machineUId) ->
+  mountMachineByMachineUId: (machineUId, done = kd.noop) ->
 
     return  if @mountedMachine
 
@@ -637,7 +637,7 @@ class IDEAppController extends AppController
     container         = @getView()
     withFakeViews     = no
 
-    environmentDataProvider.fetchMachineByUId machineUId, (machineItem) =>
+    mount = (machineItem) =>
 
       unless machineItem
         return @showNoMachineState()
@@ -685,6 +685,10 @@ class IDEAppController extends AppController
 
       else
         return @showNoMachineState()
+
+    environmentDataProvider.fetchMachineByUId machineUId, (machineItem) ->
+      mount machineItem
+      done()
 
 
   bindMachineEvents: (machineItem) ->

--- a/client/ide/lib/index.coffee
+++ b/client/ide/lib/index.coffee
@@ -645,15 +645,6 @@ class IDEAppController extends AppController
       unless machineItem instanceof Machine
         machineItem = new Machine { machine: machineItem }
 
-      # Don't run these lines on `Teams` scope.
-      # Because `Teams` uses new Sidebar with React + Flux
-      if not isTeamReactSide() and not machineItem.isMine() and not machineItem.isApproved()
-        { activitySidebar } = kd.singletons.mainView
-        box = activitySidebar.getMachineBoxByMachineUId machineItem.uid
-        box.machineItem.showSharePopup { sticky: yes, workspaceId: @workspaceData.getId() }
-
-        withFakeViews = yes
-
       @setMountedMachine machineItem
       @prepareIDE withFakeViews
 

--- a/client/ide/lib/routes.coffee
+++ b/client/ide/lib/routes.coffee
@@ -127,7 +127,6 @@ routeToTestWorkspace = ->
 loadTestIDE = ->
 
   { workspaces } = machine = require('mocks/mockmanagedmachine')()
-  console.log {workspaces, machine}
   machine = remote.revive machine
   workspace = remote.revive workspaces[0]
 

--- a/client/ide/lib/routes.coffee
+++ b/client/ide/lib/routes.coffee
@@ -54,7 +54,7 @@ loadIDENotFound = ->
     appManager.tell 'IDE', 'showNoMachineState'
 
 
-loadIDE = (data) ->
+loadIDE = (data, done = kd.noop) ->
 
   { selectWorkspaceOnSidebar, findInstance } = module.exports
 
@@ -85,7 +85,7 @@ loadIDE = (data) ->
         # If you want it, ping Turunc or Acet.
         app.amIHost           = yes
 
-      app.mountMachineByMachineUId machineUId
+      app.mountMachineByMachineUId machineUId, done
 
   return callback()  unless ideApps?.instances
 
@@ -130,7 +130,8 @@ loadTestIDE = ->
   machine = remote.revive machine
   workspace = remote.revive workspaces[0]
 
-  return loadIDE { machine, workspace, username: nick }
+  return loadIDE { machine, workspace, username: nick }, ->
+    require('ide/test/browser').prepare(machine, workspace)
 
 
 routeToFallback = ->
@@ -265,7 +266,7 @@ routeHandler = (type, info, state, path, ctx) ->
       { params } = info
 
       if params.workspaceSlug is 'test-workspace'
-        kd.utils.defer -> loadTestIDE()
+        kd.utils.defer -> require('app/util/createTestMachine')().then loadTestIDE
 
       dataProvider.fetchMachine params.machineLabel, (machine) ->
 

--- a/client/ide/lib/routes.coffee
+++ b/client/ide/lib/routes.coffee
@@ -119,6 +119,21 @@ findInstance = (machine, workspace) ->
   return ideInstance
 
 
+routeToTestWorkspace = ->
+
+  kd.singletons.router.handleRoute '/IDE/test-machine/test-workspace'
+
+
+loadTestIDE = ->
+
+  { workspaces } = machine = require('mocks/mockmanagedmachine')()
+  console.log {workspaces, machine}
+  machine = remote.revive machine
+  workspace = remote.revive workspaces[0]
+
+  return loadIDE { machine, workspace, username: nick }
+
+
 routeToFallback = ->
 
   { routeToMachineWorkspace, loadIDENotFound } = module.exports
@@ -238,7 +253,10 @@ routeHandler = (type, info, state, path, ctx) ->
       { machineLabel } = info.params
 
       # we assume that if machineLabel is all numbers it is the channelId - SY
-      if /^[0-9]+$/.test machineLabel then loadCollaborativeIDE machineLabel
+      if /^[0-9]+$/.test machineLabel
+        loadCollaborativeIDE machineLabel
+      else if machineLabel is 'test-machine'
+        routeToTestWorkspace()
       else
         dataProvider.fetchMachine machineLabel, (machine) ->
           if machine then routeToMachineWorkspace machine
@@ -246,6 +264,9 @@ routeHandler = (type, info, state, path, ctx) ->
 
     when 'workspace'
       { params } = info
+
+      if params.workspaceSlug is 'test-workspace'
+        kd.utils.defer -> loadTestIDE()
 
       dataProvider.fetchMachine params.machineLabel, (machine) ->
 

--- a/client/ide/lib/routes.coffee
+++ b/client/ide/lib/routes.coffee
@@ -130,8 +130,9 @@ loadTestIDE = ->
   machine = remote.revive machine
   workspace = remote.revive workspaces[0]
 
-  return loadIDE { machine, workspace, username: nick }, ->
-    require('ide/test/browser').prepare(machine, workspace)
+  require('app/util/createTestMachine')().then ->
+    loadIDE { machine, workspace, username: nick }, ->
+      require('ide/test/browser').prepare(machine, workspace)
 
 
 routeToFallback = ->
@@ -266,7 +267,7 @@ routeHandler = (type, info, state, path, ctx) ->
       { params } = info
 
       if params.workspaceSlug is 'test-workspace'
-        kd.utils.defer -> require('app/util/createTestMachine')().then loadTestIDE
+        return loadTestIDE()
 
       dataProvider.fetchMachine params.machineLabel, (machine) ->
 

--- a/client/ide/lib/test/browser/example.coffee
+++ b/client/ide/lib/test/browser/example.coffee
@@ -3,8 +3,8 @@ $ = require 'jquery'
 module.exports = (expect) ->
 
   # select finder item for `.bash_rc`
-  fileItemSelector = 'kdlistitemview-finderitem span[title~=bash_rc]'
+  fileItemSelector = 'span[title*=bash_rc]'
 
   $el = $(fileItemSelector)
 
-  expect($el.val()).toBe '.bash_rc'
+  expect($el.text()).toBe '.bash_rc'

--- a/client/ide/lib/test/browser/example.coffee
+++ b/client/ide/lib/test/browser/example.coffee
@@ -1,0 +1,10 @@
+$ = require 'jquery'
+
+module.exports = (expect) ->
+
+  # select finder item for `.bash_rc`
+  fileItemSelector = 'kdlistitemview-finderitem span[title~=bash_rc]'
+
+  $el = $(fileItemSelector)
+
+  expect($el.val()).toBe '.bash_rc'

--- a/client/ide/lib/test/browser/index.coffee
+++ b/client/ide/lib/test/browser/index.coffee
@@ -1,0 +1,98 @@
+React = require 'react'
+ReactView = require 'app/react/reactview'
+Dialog = require 'lab/Dialog'
+
+expect = require 'expect'
+
+run = ->
+
+  tests = [
+    require './example.coffee'
+  ]
+
+  try
+    tests.forEach (test) -> test expect
+    showSuccessModal()
+  catch e
+    showErrorModal(e.message)
+
+
+prepare = (machine, workspace) ->
+
+  modal = new ModalView
+    title: 'IDE Browser tests'
+    type: 'success'
+    message: 'Run IDE by clicking the button below. To start over please
+              refresh your browser on this page.'
+    buttonTitle: 'Run'
+    onButtonClick: ->
+      modal.destroy()
+      run()
+
+showSuccessModal = ->
+
+  modal = new ModalView
+    title: 'Success!'
+    type: 'success'
+    message: 'All tests passed'
+    buttonTitle: 'Close'
+    onButtonClick: -> modal.destroy()
+
+
+showErrorModal = (message) ->
+
+  modal = new ModalView
+    title: 'Error!'
+    subtitle: 'There is an error'
+    type: 'danger'
+    message: message
+    buttonTitle: 'Close'
+    onButtonClick: -> modal.destroy()
+
+# /cc @gokmen: this might be a strong possible replacement for
+# pistachio. KDViews will be where we write logic, React components will always
+# be small enough to be treated as a pistachio string.
+# This way, each ReactView wrapping kd view can implement what the f*ck it
+# wants, either bongo model, or a redux store. KDViews could be the solutions
+# of colocating data with view components.
+#
+# tl;dr: KDViews will do the fetching data in the way we are used to it right now.
+# Once they have the data, we can stop thinking about efficient rendering but
+# let React handle updating the DOM.
+#
+# Only missing part is creating a React Component that can render a KDView,
+# which is a pretty easy thing to do.
+#
+# I think we might be looking at *the best* solution out there, with KDView &
+# ReactComponent duo combined, as a data fetching & business logic abstraction
+# solution. ~Umut
+class ModalView extends ReactView
+
+  constructor: (options = {}, data) ->
+    options.isOpen ?= yes
+    options.alien ?= yes
+    options.type ?= 'success'
+    options.subtitle ?= ''
+    options.appendToDomBody ?= yes
+    super options
+    @appendToDomBody()  if @getOptions().appendToDomBody
+
+  onButtonClick: ->
+    @options.onButtonClick()
+
+  renderReact: ->
+    <Dialog
+      isOpen={@options.isOpen}
+      showAlien={@options.alien}
+      type={@options.type}
+      title={@options.title}
+      subtitle={@options.subtitle}
+      message={@options.message}
+      buttonTitle={@options.buttonTitle}
+      onButtonClick={@bound 'onButtonClick'}
+    />
+
+module.exports = {
+  run
+  prepare
+}

--- a/client/ide/lib/test/browser/index.coffee
+++ b/client/ide/lib/test/browser/index.coffee
@@ -7,7 +7,7 @@ expect = require 'expect'
 run = ->
 
   tests = [
-    require './example.coffee'
+    require './example'
   ]
 
   try

--- a/client/mocks/mockmanagedmachine.coffee
+++ b/client/mocks/mockmanagedmachine.coffee
@@ -1,0 +1,130 @@
+{ assign } = require 'lodash'
+
+username = require('app/util/nick')()
+{ _id: userId } = require('app/util/whoami')()
+{ _id: groupId } = require('app/util/getGroup')()
+
+label = 'test-machine'
+domain = [label, username].join '.'
+
+module.exports = mockManagedMachine = -> {
+  "isApproved": true,
+  "isTestMachine": true,
+  "_conf": {
+    "domain": domain,
+    "meta": {
+      "alwaysOn": false,
+      "managedProvider": "UnknownProvider",
+      "storage_size": 0,
+      "type": "managed"
+    },
+    "users": [
+      {
+        "id": userId,
+        "sudo": true,
+        "owner": true,
+        "username": username
+      }
+    ],
+    "slug": label,
+    "ipAddress": domain,
+    "assignee": {
+      "inProgress": false,
+      "assignedAt": "2016-10-12T07:13:23.305Z"
+    },
+    "uid": label,
+    "provisioners": [],
+    "provider": "managed",
+    "status": {
+      "state": "Running"
+    },
+    "groups": [
+      {
+        "id": groupId
+      }
+    ],
+    "label": label,
+    "credential": username,
+    "generatedFrom": null,
+    "queryString": "///////98a941fb-62aa-428e-9d2d-5eabfc7fedc7",
+    "_id": label,
+    "createdAt": "2016-10-12T07:13:23.305Z"
+  },
+  "domain": domain,
+  "meta": {
+    "alwaysOn": false,
+    "managedProvider": "UnknownProvider",
+    "storage_size": 0,
+    "type": "managed"
+  },
+  "hasOldOwner": false,
+  "users": [
+    {
+      "id": userId,
+      "sudo": true,
+      "owner": true,
+      "username": username
+    }
+  ],
+  "slug": label,
+  "ipAddress": domain,
+  "assignee": {
+    "inProgress": false,
+    "assignedAt": "2016-10-12T07:13:23.305Z"
+  },
+  "isShared": false,
+  "uid": label,
+  "provisioners": [],
+  "provider": "managed",
+  "status": {
+    "state": "Running"
+  },
+  "owner": username,
+  "groups": [
+    {
+      "id": groupId
+    }
+  ],
+  "newListener": false,
+  "label": label,
+  "bongo_": {
+    "constructorName": "JMachine",
+    "instanceId": label,
+  },
+  "credential": username,
+  "watchers": {},
+  "queryString": "///////98a941fb-62aa-428e-9d2d-5eabfc7fedc7",
+  "_id": label,
+  "percentage": 100,
+  "type": "own",
+  "createdAt": "2016-10-12T07:13:23.305Z",
+  "workspaces": [{
+    "originId": label,
+    "_conf": {
+      "originId": label,
+      "rootPath": "/",
+      "machineUId": label,
+      "layout": {},
+      "name": "My Workspace",
+      "slug": "my-workspace",
+      "machineLabel": domain,
+      "isDefault": true,
+      "_id": 'test-workspace'
+    },
+    "rootPath": "/",
+    "machineUId": label,
+    "layout": {},
+    "name": "My Workspace",
+    "slug": "my-workspace",
+    "machineLabel": domain,
+    "newListener": false,
+    "bongo_": {
+      "constructorName": "JWorkspace",
+      "instanceId": 'test-workspace'
+    },
+    "isDefault": true,
+    "watchers": {},
+    "_id": 'test-workspace'
+  }]
+}
+

--- a/client/package.json
+++ b/client/package.json
@@ -127,6 +127,7 @@
     "inject-loader": "2.0.1",
     "json-loader": "0.5.4",
     "loader-utils": "0.2.15",
+    "memory-fs": "0.3.0",
     "mocha": "3.0.2",
     "mocha-webpack": "0.6.0",
     "nib": "1.1.2",

--- a/client/webpack.config.coffee
+++ b/client/webpack.config.coffee
@@ -21,6 +21,7 @@ COMMON_STYLES_PATH = path.join CLIENT_PATH, 'app/styl/**/*.styl'
 PUBNUB_PATH        = path.join THIRD_PARTY_PATH, 'pubnub.min.js'
 IMAGES_PATH        = path.join WEBSITE_PATH, 'a', 'images'
 COMPONENT_LAB_PATH = path.join CLIENT_PATH, 'component-lab'
+MOCKS_PATH         = path.join CLIENT_PATH, 'mocks'
 
 # we are gonna set NODE_ENV to either `production` or `development` to figure
 # out the compile target.
@@ -73,6 +74,7 @@ webpackConfig.resolve =
     assets: ASSETS_PATH
     images: IMAGES_PATH
     lab: COMPONENT_LAB_PATH
+    mocks: MOCKS_PATH
 
 # Loader config
 


### PR DESCRIPTION
This PR introduces a new concept to create an IDE with a mock klient/kite instances. It uses the `memory-fs` npm module to create a fs like object in memory, and provides the same api as node.js `fs` module.

This is really a bare bones implementation to see if it's feasible for tests (especially for rainforest) to use, but we can use this as a base fs kite implementation, and build up on it.

/cc @devrim @diclee 

Review can start I am done with 98% of the implementation.
