### PR TITLE
provider/google: machine cannot stop when its disk size metadata is set to zero

### DIFF
--- a/go/src/koding/kites/kloud/provider/google/google.go
+++ b/go/src/koding/kites/kloud/provider/google/google.go
@@ -160,9 +160,6 @@ func (m *Meta) Valid() error {
 	if m.Image == "" {
 		return errors.New(`metadata value for "image" is empty`)
 	}
-	if m.StorageSize == 0 {
-		return errors.New(`metadata value for "storage_size" is 0`)
-	}
 	if m.MachineType == "" {
 		return errors.New(`metadata value for "machie_type" is empty`)
 	}

--- a/go/src/koding/kites/kloud/provider/google/google_test.go
+++ b/go/src/koding/kites/kloud/provider/google/google_test.go
@@ -126,7 +126,7 @@ func TestValidators(t *testing.T) {
 				StorageSize: 0,
 				MachineType: `f1-micro`,
 			},
-			IsValid: false,
+			IsValid: true,
 		},
 		{
 			// 11 //

--- a/go/src/koding/kites/kloud/provider/google/imgfamily.go
+++ b/go/src/koding/kites/kloud/provider/google/imgfamily.go
@@ -81,6 +81,7 @@ var family2project = map[string]string{
 	"debian":  "debian-cloud",
 	"coreos":  "coreos-cloud",
 	"centos":  "centos-cloud",
+	"sles":    "suse-cloud",
 }
 
 // familyProject checks if provided string is an image family name. If yes, this

--- a/go/src/koding/kites/kloud/provider/google/machine.go
+++ b/go/src/koding/kites/kloud/provider/google/machine.go
@@ -130,6 +130,17 @@ func (m *Machine) Stop(ctx context.Context) (interface{}, error) {
 		}
 
 		state, _, err := m.Info(nil)
+		if err != nil {
+			return machinestate.Unknown, err
+		}
+
+		// WaitState expects machinestate.Stopped. However, the machine can also
+		// be reported as terminated. So, if we want WaitState work, we need to
+		// replace terminated state with stopped one.
+		if state == machinestate.Terminated {
+			state = machinestate.Stopped
+		}
+
 		return state, err
 	}
 


### PR DESCRIPTION
This PR fixes the problem with google instance not stopping after requested to do so from Koding UI.
## Description

We check if metadata is valid before stopping the machine and we treated 0 disk size as an error. Thus, it was not possible to stop machine when disc size was not explicitly set in stack template.
## Motivation and Context

Fix reported bug.
## How Has This Been Tested?

Manually.
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

/cc @gokmen @rjeczalik 

@gokmen In described case, kloud kite returns an error to kite's caller (not valid metadata). Probably, you should check if you receive this error on your end. 
