### PR TITLE
provider/google: autodiscovery for image disks sizes

### DIFF
--- a/go/src/koding/kites/kloud/provider/google/disksize.go
+++ b/go/src/koding/kites/kloud/provider/google/disksize.go
@@ -1,0 +1,118 @@
+package google
+
+import "strings"
+
+// Image2Size is used to find and map image disk sizes when they are not
+// provided. This structure was created in order to discover and attach image
+// sizes to terraform template. Thus, they will be visible(and valid as
+// metadata) when user run terraform plan.
+type Image2Size struct {
+	GetDiskSize func(project, image string) int
+
+	// cache is used to avoid looking for image disk sizes that were already
+	// found.
+	cache map[string]int
+}
+
+// Replace gets disk data and adds `size` field for all images which don't
+// explicitly specify their sizes. This function is not intended to add `size`
+// field when either `disk` field or `local-ssd` type is specified.
+func (is *Image2Size) Replace(disks interface{}) interface{} {
+	if is.GetDiskSize == nil {
+		return disks
+	}
+
+	if is.cache == nil {
+		is.cache = make(map[string]int)
+	}
+
+	items, ok := disks.([]map[string]interface{})
+	if !ok {
+		return disks
+	}
+
+	for i := range items {
+		if items[i] == nil {
+			continue
+		}
+
+		// Skip when size is already set.
+		if _, ok := items[i]["size"]; ok {
+			continue
+		}
+
+		// Disk size discovery is not supported here.
+		if _, ok := items[i]["disk"]; ok {
+			continue
+		}
+
+		// Do not attach size field when disk type is local-ssd.
+		if typ, ok := items[i]["type"]; ok {
+			if name, ok := typ.(string); ok && name == "local-ssd" {
+				continue
+			}
+		}
+
+		// User doesn't have to provide image name.
+		image, ok := items[i]["image"]
+		if !ok {
+			continue
+		}
+
+		size := is.getSize(image)
+		if size == 0 {
+			continue
+		}
+
+		items[i]["size"] = size
+	}
+
+	return items
+}
+
+func (is *Image2Size) getSize(name interface{}) int {
+	// Invalid value will be caught later by terraform.
+	if name == nil {
+		return 0
+	}
+
+	image, ok := name.(string)
+	if !ok {
+		return 0
+	}
+
+	// Get from cache.
+	if size, ok := is.cache[image]; ok {
+		return size
+	}
+
+	size := is.GetDiskSize(imageProject(image), image)
+	if size == 0 {
+		return 0
+	}
+
+	is.cache[image] = size
+	return size
+}
+
+var image2project = map[string]string{
+	"windows": "windows-cloud",
+	"ubuntu":  "ubuntu-os-cloud",
+	"rhel":    "rhel-cloud",
+	"sql":     "windows-sql-cloud",
+	"debian":  "debian-cloud",
+	"coreos":  "coreos-cloud",
+	"centos":  "centos-cloud",
+	"sles":    "suse-cloud",
+}
+
+// imageProject looks up for the respective image project.
+func imageProject(image string) string {
+	for prefix, project := range image2project {
+		if strings.HasPrefix(image, prefix) {
+			return project
+		}
+	}
+
+	return ""
+}

--- a/go/src/koding/kites/kloud/provider/google/disksize_test.go
+++ b/go/src/koding/kites/kloud/provider/google/disksize_test.go
@@ -1,0 +1,156 @@
+package google
+
+import (
+	"reflect"
+	"testing"
+)
+
+var getDiskSizeFixture = map[string]int{
+	"ubuntu-os-cloud/ubuntu-1404-trusty-v20161010":                     10,
+	"windows-sql-cloud/sql-2016-standard-windows-2012-r2-dc-v20161012": 50,
+	"/custom_image": 24,
+}
+
+var getDiskSizeFixtureFunc = func(project, image string) int {
+	return getDiskSizeFixture[project+"/"+image]
+}
+
+func TestImage2Size(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Disks    interface{}
+		Expected interface{}
+	}{
+		{
+			Name: "non map array",
+			Disks: map[string]interface{}{
+				"image": "ubuntu-1404-trusty-v20161010",
+			},
+			Expected: map[string]interface{}{
+				"image": "ubuntu-1404-trusty-v20161010",
+			},
+		},
+		{
+			Name: "ubuntu image",
+			Disks: []map[string]interface{}{
+				{
+					"image": "ubuntu-1404-trusty-v20161010",
+					"type":  "pd-standard",
+				},
+			},
+			Expected: []map[string]interface{}{
+				{
+					"image": "ubuntu-1404-trusty-v20161010",
+					"type":  "pd-standard",
+					"size":  10,
+				},
+			},
+		},
+		{
+			Name: "disk size not supported",
+			Disks: []map[string]interface{}{
+				{
+					"disk": "custom_image",
+				},
+			},
+			Expected: []map[string]interface{}{
+				{
+					"disk": "custom_image",
+				},
+			},
+		},
+		{
+			Name: "local ssd skip",
+			Disks: []map[string]interface{}{
+				{
+					"image": "sql-2016-standard-windows-2012-r2-dc-v20161012",
+					"type":  "local-ssd",
+				},
+			},
+			Expected: []map[string]interface{}{
+				{
+					"image": "sql-2016-standard-windows-2012-r2-dc-v20161012",
+					"type":  "local-ssd",
+				},
+			},
+		},
+		{
+			Name: "size already specified",
+			Disks: []map[string]interface{}{
+				{
+					"image": "ubuntu-1404-trusty-v20161010",
+					"size":  16,
+				},
+			},
+			Expected: []map[string]interface{}{
+				{
+					"image": "ubuntu-1404-trusty-v20161010",
+					"size":  16,
+				},
+			},
+		},
+		{
+			Name: "disk and image skip",
+			Disks: []map[string]interface{}{
+				{
+					"image": "ubuntu-1404-trusty-v20161010",
+					"disk":  "custom_image",
+				},
+			},
+			Expected: []map[string]interface{}{
+				{
+					"image": "ubuntu-1404-trusty-v20161010",
+					"disk":  "custom_image",
+				},
+			},
+		},
+		{
+			Name: "custom image",
+			Disks: []map[string]interface{}{
+				{
+					"image": "custom_image",
+				},
+			},
+			Expected: []map[string]interface{}{
+				{
+					"image": "custom_image",
+					"size":  24,
+				},
+			},
+		},
+		{
+			Name: "multi disks",
+			Disks: []map[string]interface{}{
+				{
+					"image": "custom_image",
+				},
+				{
+					"image": "sql-2016-standard-windows-2012-r2-dc-v20161012",
+				},
+			},
+			Expected: []map[string]interface{}{
+				{
+					"image": "custom_image",
+					"size":  24,
+				},
+				{
+					"image": "sql-2016-standard-windows-2012-r2-dc-v20161012",
+					"size":  50,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			f2i := Image2Size{
+				GetDiskSize: getDiskSizeFixtureFunc,
+			}
+
+			disks := f2i.Replace(test.Disks)
+			if !reflect.DeepEqual(disks, test.Expected) {
+				t.Fatalf("want disks = %#v; got %#v", test.Expected, disks)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR makes possible to obtain disk size during `terraform plan` phase. With this information we are able to correctly set created instance's disk size metadata.
## Description

During machine creation we look up for image size using GCP API and if we find one, we will add that information to terraform template. Then, terraform plan/apply will correctly report disk size of the instance which is going to be created.
## Motivation and Context

Fix missing disk size metadata in Google Provider.
## How Has This Been Tested?

Manually,
Unit tests.
## Screenshots (if appropriate):

![image](https://cloud.githubusercontent.com/assets/5021246/19810219/e63dbf10-9d2c-11e6-9beb-73ba7c2ebc27.png)
## Types of changes
- [x] New feature (non-breaking change which adds functionality)
