### PR TITLE
Hide popup with 'leave shared VM' label, after opening popup with confirmation

### DIFF
--- a/client/app/lib/components/sidebarmachineslistitem/index.coffee
+++ b/client/app/lib/components/sidebarmachineslistitem/index.coffee
@@ -164,8 +164,8 @@ module.exports = class SidebarMachinesListItem extends React.Component
 
 
   renderLeaveSharedMachine: ->
-
-    return null  if @props.activeLeavingSharedMachineId isnt @machine('_id')
+    
+    return null  if @state.activeMachine isnt @machine('_id')
     return null  if @machine('type') is 'own'
     return null  unless @machine 'isApproved'
 

--- a/client/app/lib/components/sidebarmachineslistitem/leavesharedmachinewidget.coffee
+++ b/client/app/lib/components/sidebarmachineslistitem/leavesharedmachinewidget.coffee
@@ -11,18 +11,32 @@ module.exports = class LeaveSharedMachineWidget extends React.Component
   @defaultProps =
     className : 'Approved'
 
+  constructor: (props) ->
+
+    super
+
+    @state = {
+      isModalActive : true
+    }
 
   onLeaveClicked: ->
 
+    console.log('@state ', @state)
+    @setState {isModalActive: false}
     modal = new ContentModal
       title   : 'Are you sure?'
       content : "<p class='text-center'>This will remove the shared VM from your sidebar. You won't be able to access it unless you are invited again.</p>"
       cssClass : 'content-modal'
+      cancel : =>
+        @setState {isModalActive: true}
+
       buttons :
         No         :
           title    : 'Cancel'
           cssClass : 'solid cancel medium'
-          callback : -> modal.destroy()
+          callback : =>
+            @setState {isModalActive: true}
+            modal.destroy()
         Yes        :
           title    : 'Yes'
           cssClass : 'solid medium'
@@ -30,9 +44,8 @@ module.exports = class LeaveSharedMachineWidget extends React.Component
           callback : =>
             actions.rejectInvitation @props.machine
             Tracker.track Tracker.VM_LEFT_SHARED
+            @setState {isModalActive: true}
             modal.destroy()
-
-
 
   render: ->
 
@@ -40,13 +53,15 @@ module.exports = class LeaveSharedMachineWidget extends React.Component
     then 'LEAVE SESSION'
     else 'LEAVE SHARED VM'
 
-    <SidebarWidget {...@props}>
+    if @state.isModalActive
+      <SidebarWidget {...@props}>
       <p className='SidebarWidget-Title'>Shared with you by</p>
-      <InvitationWidgetUserPart
-        owner={@props.machine.get 'owner'}
-       />
+        <InvitationWidgetUserPart
+          owner={@props.machine.get 'owner'}
+        />
       <button className='kdbutton GenericButton' onClick={@bound 'onLeaveClicked'}>
         <span className='button-title'>{buttonText}</span>
       </button>
-    </SidebarWidget>
-
+      </SidebarWidget>
+    else
+      null

--- a/client/app/lib/components/sidebarmachineslistitem/leavesharedmachinewidget.coffee
+++ b/client/app/lib/components/sidebarmachineslistitem/leavesharedmachinewidget.coffee
@@ -12,30 +12,26 @@ module.exports = class LeaveSharedMachineWidget extends React.Component
     className : 'Approved'
 
   constructor: (props) ->
+      
+    @state = { isModalActive: yes }
 
-    super
-
-    @state = {
-      isModalActive : true
-    }
 
   onLeaveClicked: ->
 
-    console.log('@state ', @state)
-    @setState {isModalActive: false}
+    @setState { isModalActive: no }
     modal = new ContentModal
       title   : 'Are you sure?'
       content : "<p class='text-center'>This will remove the shared VM from your sidebar. You won't be able to access it unless you are invited again.</p>"
       cssClass : 'content-modal'
       cancel : =>
-        @setState {isModalActive: true}
+        @setState { isModalActive: yes }
 
       buttons :
         No         :
           title    : 'Cancel'
           cssClass : 'solid cancel medium'
           callback : =>
-            @setState {isModalActive: true}
+            @setState { isModalActive: yes }
             modal.destroy()
         Yes        :
           title    : 'Yes'
@@ -44,8 +40,9 @@ module.exports = class LeaveSharedMachineWidget extends React.Component
           callback : =>
             actions.rejectInvitation @props.machine
             Tracker.track Tracker.VM_LEFT_SHARED
-            @setState {isModalActive: true}
+            @setState { isModalActive: yes }
             modal.destroy()
+
 
   render: ->
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail -->

Add flag `isModalActive`. According to this flag render or not popup with 'leaved shared VM'(1). Hide this popup(1) on opening popup with confirmation(2). On close or press button 'No' popup (1) will be shown.
![alt tag](http://storage3.static.itmages.com/i/16/1028/h_1477692198_9583399_18fa16943c.png)
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fix  for #8867.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

[video](https://www.youtube.com/watch?v=s1glS2Q-Kxw&feature=youtu.be)
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
