### PR TITLE
provider/google: always report terminated state as stopped

### DIFF
--- a/go/src/koding/kites/kloud/provider/google/machine.go
+++ b/go/src/koding/kites/kloud/provider/google/machine.go
@@ -134,13 +134,6 @@ func (m *Machine) Stop(ctx context.Context) (interface{}, error) {
 			return machinestate.Unknown, err
 		}
 
-		// WaitState expects machinestate.Stopped. However, the machine can also
-		// be reported as terminated. So, if we want WaitState work, we need to
-		// replace terminated state with stopped one.
-		if state == machinestate.Terminated {
-			state = machinestate.Stopped
-		}
-
 		return state, err
 	}
 
@@ -181,7 +174,7 @@ var status2stateMap = map[string]machinestate.State{
 	"STOPPED":      machinestate.Stopped,
 	"SUSPENDED":    machinestate.Stopped,
 	"SUSPENDING":   machinestate.Stopped,
-	"TERMINATED":   machinestate.Terminated,
+	"TERMINATED":   machinestate.Stopped,
 }
 
 func status2state(status string) (machinestate.State, error) {


### PR DESCRIPTION
Google reports stopped machines as terminated. This PR adds full support for that.
## Motivation and Context

UI calls machine.Info directly so its response needs to report proper machine status.
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
