### PR TITLE
home/billing: add space between texts

### DIFF
--- a/client/component-lab/TrialChargeInfo/TrialChargeInfo.coffee
+++ b/client/component-lab/TrialChargeInfo/TrialChargeInfo.coffee
@@ -55,7 +55,7 @@ TrialChargeInfo = ({ teamSize, pricePerSeat, daysLeft }) ->
       </Col>
       <Col xs={7} className={textStyles.right}>
         <Label size="small">
-          Monthly charge after trial:
+          Monthly charge after trial:&nbsp;
           <strong>${formatNumber pricePerSeat, 2}</strong> per user
         </Label>
       </Col>


### PR DESCRIPTION
**Before**

![image](https://cloud.githubusercontent.com/assets/1783869/19903242/3819a528-a02b-11e6-9d92-1c87b7c2e860.png)

**After**

![image](https://cloud.githubusercontent.com/assets/1783869/19903271/5210fb0c-a02b-11e6-9a6d-a005f6d38497.png)
