### PR TITLE
kites/config: prevent rebuilding all config-dependent packages after go generate.

### DIFF
--- a/go/build.sh
+++ b/go/build.sh
@@ -14,15 +14,6 @@ koding-go-install() {
 	go install -v -tags "${KODING_TAGS}" -ldflags "${KODING_LDFLAGS}" $*
 }
 
-export VENDOR_COMMANDS=(
-	vendor/github.com/koding/kite/kitectl
-	vendor/github.com/canthefason/go-watcher
-	vendor/github.com/mattes/migrate
-	vendor/github.com/alecthomas/gocyclo
-	vendor/github.com/remyoudompheng/go-misc/deadcode
-	vendor/github.com/jteeuwen/go-bindata/go-bindata
-)
-
 export COMMANDS=(
 	koding/broker
 	koding/rerouting
@@ -65,6 +56,13 @@ export COMMANDS=(
 	socialapi/workers/algoliaconnector/contentmigrator
 	socialapi/workers/cmd/integration/eventsender
 	socialapi/workers/cmd/integration/webhookmiddleware
+
+	vendor/github.com/koding/kite/kitectl
+	vendor/github.com/canthefason/go-watcher
+	vendor/github.com/mattes/migrate
+	vendor/github.com/alecthomas/gocyclo
+	vendor/github.com/remyoudompheng/go-misc/deadcode
+	vendor/github.com/jteeuwen/go-bindata/go-bindata
 )
 
 export TERRAFORM_COMMANDS=(
@@ -85,8 +83,6 @@ for provider in $KODING_REPO/go/src/koding/kites/kloud/provider/*; do
 		done
 	fi
 done
-
-koding-go-install ${VENDOR_COMMANDS[@]}
 
 go generate koding/kites/config
 go generate koding/kites/kloud/kloud

--- a/go/src/koding/kites/config/config.go
+++ b/go/src/koding/kites/config/config.go
@@ -7,9 +7,7 @@ import (
 	"github.com/koding/multiconfig"
 )
 
-//go:generate $GOPATH/bin/go-bindata -mode 420 -modtime 1476710288 -pkg config -o config.json.tmp.go config.json
-//go:generate go fmt config.json.tmp.go
-//go:generate sh -c "diff config.json.tmp.go config.json.go >/dev/null 2>&1 || mv config.json.tmp.go config.json.go && rm -f config.json.tmp.go"
+//go:generate go run genconfig.go -pkg config -i config.json -o config.json.go
 
 // Builtin stores configuration that was generated at compile time.
 var Builtin *Config

--- a/go/src/koding/kites/config/config.go
+++ b/go/src/koding/kites/config/config.go
@@ -7,8 +7,9 @@ import (
 	"github.com/koding/multiconfig"
 )
 
-//go:generate $GOPATH/bin/go-bindata -mode 420 -modtime 1476710288 -pkg config -o config.json.go config.json
-//go:generate go fmt config.json.go
+//go:generate $GOPATH/bin/go-bindata -mode 420 -modtime 1476710288 -pkg config -o config.json.tmp.go config.json
+//go:generate go fmt config.json.tmp.go
+//go:generate sh -c "diff config.json.tmp.go config.json.go >/dev/null 2>&1 || mv config.json.tmp.go config.json.go && rm -f config.json.tmp.go"
 
 // Builtin stores configuration that was generated at compile time.
 var Builtin *Config

--- a/go/src/koding/kites/config/genconfig.go
+++ b/go/src/koding/kites/config/genconfig.go
@@ -1,0 +1,72 @@
+// +build ignore
+
+package main
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"flag"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+
+	"github.com/jteeuwen/go-bindata"
+)
+
+var (
+	pkg    = flag.String("pkg", "-", "")
+	input  = flag.String("i", "-", "")
+	output = flag.String("o", "-", "")
+)
+
+func main() {
+	flag.Parse()
+
+	outputTmp := "tmp_" + *output
+
+	cfg := bindata.NewConfig()
+	cfg.Package = *pkg
+	cfg.Mode = 420
+	cfg.ModTime = 1476710288
+	cfg.Input = append(cfg.Input, bindata.InputConfig{Path: *input})
+	cfg.Output = outputTmp
+
+	if err := bindata.Translate(cfg); err != nil {
+		log.Fatalf("cannot create %s: %v", outputTmp, err)
+	}
+
+	if err := exec.Command("go", "fmt", outputTmp).Run(); err != nil {
+		log.Fatalf("cannot go fmt %s: %v", outputTmp, err)
+	}
+
+	tmpMD5, err := fileMD5(outputTmp)
+	if err != nil {
+		log.Fatalf("cannot create MD5 sum for %s: %v", outputTmp, err)
+	}
+
+	outMD5, err := fileMD5(*output)
+	if err != nil && !os.IsNotExist(err) {
+		log.Fatalf("cannot create MD5 sum for %s: %v", *output, err)
+	}
+
+	if tmpMD5 != outMD5 {
+		if err := os.Rename(outputTmp, *output); err != nil {
+			log.Fatalf("cannot rename %s -> %s: %v", outputTmp, *output, err)
+		}
+	} else {
+		if err := os.Remove(outputTmp); err != nil {
+			log.Println("cannot remove temporary file %s: %v", outputTmp, err)
+		}
+	}
+}
+
+func fileMD5(path string) (string, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	hash := md5.Sum(data)
+	return hex.EncodeToString(hash[:]), nil
+}


### PR DESCRIPTION
After `go generate`, golang build tool sees new modification time in `config.json.go` and rebuilds all dependent packages. This change forces `go generate` to create new `config.json.go` either when file doesn't exist or it was modified.

## Motivation and Context
Speed up go compilation.

## How Has This Been Tested?
Manually.