### PR TITLE
Fix Ide file and terminal icons

### DIFF
--- a/client/app/lib/styl/resurrection.commons.styl
+++ b/client/app/lib/styl/resurrection.commons.styl
@@ -315,7 +315,7 @@ a.custom-link-view.border-only-green
     font-size               14px
     font-family             'Proxima Nova'
     font-weight             300
-    max-width               145px !important
+    max-width               160px !important
     color                   #5e7074
     &:hover
       span.close-tab
@@ -336,6 +336,7 @@ a.custom-link-view.border-only-green
         r-sprite              app '20_tab_plus'
         margin              8px 9px 9px 8px
         display             block
+
     &.active
       bg                    color, #1b2224
       color                 #eeeeee

--- a/client/ide/lib/index.coffee
+++ b/client/ide/lib/index.coffee
@@ -258,6 +258,14 @@ class IDEAppController extends AppController
 
   setActiveTabView: (tabView) ->
 
+    activePane = tabView.getActivePane()
+
+    for view in @ideViews
+      for tab in view.holderView.tabs.subViews
+        if tab is activePane?.tabHandle
+        then activePane.tabHandle.setClass 'focus'
+        else tab.unsetClass 'focus'
+
     return  if tabView is @activeTabView
     return  if tabView.isDestroyed
 

--- a/client/ide/lib/styl/ide.styl
+++ b/client/ide/lib/styl/ide.styl
@@ -83,29 +83,37 @@ body.ide
           vendor            transform, translateX(-50%) translateY(-50%)
 
       .kdtabhandle
-        &:before
-          content           ''
-          position          absolute
-          top               12px
-          left              15px
-          r-sprite          'ide', 'ws_tab_file'
-          display           block
-          opacity           0.5
-        
-        &.terminal:before
-          r-sprite          'ide', 'ws_tab_terminal'
-          
-        &.plus:before
-          content           none
 
-	&.files:before
-          content           none
-          
-        &.settings:before
-          content           none
-        
-        &.active:before
-          opacity           1
+        .tab-handle-text
+          margin-left       17px
+          ellipsis()
+          max-width         90px
+
+        &.kddraggable
+          &:before
+            content         ''
+            position        absolute
+            top             12px
+            left            10px
+            r-sprite        'ide', 'ws_tab_file'
+            display         block
+            opacity         0.5
+            border-radius   0px
+
+          &.terminal:before
+            r-sprite        'ide', 'ws_tab_terminal'
+
+          &.plus:before
+            content         none
+
+  	     &.files:before
+            content         none
+
+          &.settings:before
+            content         none
+
+          &.active:before
+            opacity         1
 
         .tab-handle-input
           border-radius     1px
@@ -151,7 +159,7 @@ body.ide .dark
     r-sprite                'finder', 'expanded'
     top                     -8px !important
 
-  .kdtabhandle
+  .kdtabhandle.kddraggable
     color                   dark-tab-color
 
     &:hover .options
@@ -160,6 +168,8 @@ body.ide .dark
     &.active
       bg                    color, dark-panel-bg
       color                 dark-active-tab-color
+
+    &.active.focus
       border-top            2px solid #67A2EE
 
     &.menu-visible

--- a/client/ide/lib/styl/ide.styl
+++ b/client/ide/lib/styl/ide.styl
@@ -112,7 +112,7 @@ body.ide
           &.settings:before
             content         none
 
-          &.active:before
+          &.active.focus:before
             opacity         1
 
         .tab-handle-input
@@ -161,7 +161,7 @@ body.ide .dark
 
   .kdtabhandle.kddraggable
     color                   dark-tab-color
-
+    border-top              2px solid #2b2b30
     &:hover .options
       opacity               1
 
@@ -170,6 +170,7 @@ body.ide .dark
       color                 dark-active-tab-color
 
     &.active.focus
+      color                 #fff
       border-top            2px solid #67A2EE
 
     &.menu-visible

--- a/client/ide/lib/views/tabview/idetabhandleview.coffee
+++ b/client/ide/lib/views/tabview/idetabhandleview.coffee
@@ -95,7 +95,9 @@ module.exports = class IDETabHandleView extends KDTabHandleView
       @setClass 'edit-mode'
       @titleInput.setValue title
       @titleInput.setFocus()
-      if lastIndex = title.lastIndexOf('.') > 0
+
+      lastIndex = title.lastIndexOf('.')
+      if lastIndex > 0
         @titleInput.selectRange 0, lastIndex
       else
         @titleInput.selectAll()

--- a/client/ide/lib/views/tabview/ideview.coffee
+++ b/client/ide/lib/views/tabview/ideview.coffee
@@ -81,6 +81,7 @@ module.exports = class IDEView extends IDEWorkspaceTabView
       @focusTab()  if frontApp.isTabViewFocused @tabView
 
     @tabView.on 'PaneAdded', (pane) =>
+      pane.tabHandle.setClass 'focus'
 
       { addSplitHandlers } = @getOptions()
 


### PR DESCRIPTION
Fix styling in ide for editor and terminal icons.
Renaming file from editor fix
Add blue tag to active tab in all splits.

![](https://monosnap.com/file/z7QOBkoSGUa1TDHbeGUk1zBjrGl1MB.png)