### PR TITLE
kloud/kd: make it possible to create a stack with kd

### DIFF
--- a/go/src/koding/api/apitest/apitest.go
+++ b/go/src/koding/api/apitest/apitest.go
@@ -379,6 +379,10 @@ func (sh *StubHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var v interface{}
 	v, *sh = (*sh)[0], (*sh)[1:]
 
+	if v == nil {
+		v = make(map[string]interface{}) // return empty object instead
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 
 	if err := json.NewEncoder(w).Encode(v); err != nil {

--- a/go/src/koding/api/transport.go
+++ b/go/src/koding/api/transport.go
@@ -192,6 +192,11 @@ func (t *Transport) NewSingleUser(u *User) http.RoundTripper {
 
 // RoundTrip implements the http.RoundTripper interface.
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	type body interface {
+		io.ReadSeeker
+		io.Closer
+	}
+
 	user := t.user(req)
 	if user == nil {
 		return t.roundTripper().RoundTrip(req)
@@ -200,16 +205,19 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	reqCopy := copyRequest(req) // per RoundTripper contract
 	t.setModReq(req, reqCopy)
 
-	switch reqCopy.Body.(type) {
+	var save body
+
+	switch b := reqCopy.Body.(type) {
 	case nil:
-	case io.ReadSeeker:
+	case body:
+		save = b
 	default:
 		p, err := ioutil.ReadAll(io.LimitReader(reqCopy.Body, maxBodyLen))
 		if err != nil {
 			return nil, err // non-retryable
 		}
 
-		reqCopy.Body = nopCloser{bytes.NewReader(p)}
+		save = nopCloser{bytes.NewReader(p)}
 	}
 
 	var refresh bool
@@ -218,9 +226,17 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	for attempts := t.retryNum(); attempts >= 0; attempts-- {
 		if reqCopy.Body != nil {
-			if _, err := reqCopy.Body.(io.ReadSeeker).Seek(0, io.SeekStart); err != nil {
+			rewind := save
+
+			if b, ok := reqCopy.Body.(body); ok {
+				rewind = b
+			}
+
+			if _, err := rewind.Seek(0, io.SeekStart); err != nil {
 				return nil, err // non-retryable
 			}
+
+			reqCopy.Body = rewind
 		}
 
 		opts := &AuthOptions{

--- a/go/src/koding/api/transport.go
+++ b/go/src/koding/api/transport.go
@@ -273,7 +273,13 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 			return nil, err // non-retryable
 		}
 
-		if resp.StatusCode == http.StatusUnauthorized {
+		switch resp.StatusCode {
+		case http.StatusInternalServerError:
+			// TODO(rjeczalik): remove, this is a temporary workaround
+			// for remote.api, that return 500 when session could not
+			// be validated.
+			fallthrough
+		case http.StatusUnauthorized:
 			resp.Body.Close()
 			lastErr = errors.New(http.StatusText(resp.StatusCode))
 			refresh = true

--- a/go/src/koding/db/models/computestack.go
+++ b/go/src/koding/db/models/computestack.go
@@ -31,9 +31,10 @@ type ComputeStack struct {
 		ModifiedAt time.Time `bson:"modifiedAt"`
 	} `bson:"status"`
 
-	Config bson.M `bson:"config,omitempty"`
-	Meta   bson.M `bson:"meta,omitempty"`
-	Title  string `bson:"title,omitempty"`
+	Revision string `bson:"stackRevision"`
+	Config   bson.M `bson:"config,omitempty"`
+	Meta     bson.M `bson:"meta,omitempty"`
+	Title    string `bson:"title,omitempty"`
 }
 
 func (c *ComputeStack) State() stackstate.State {

--- a/go/src/koding/db/models/stacktemplate.go
+++ b/go/src/koding/db/models/stacktemplate.go
@@ -36,7 +36,7 @@ type StackTemplate struct {
 }
 
 func NewStackTemplate(provider, identifier string) *StackTemplate {
-	now := time.Now()
+	now := time.Now().UTC()
 
 	return &StackTemplate{
 		Id:          bson.NewObjectId(),

--- a/go/src/koding/db/mongodb/modelhelper/machine.go
+++ b/go/src/koding/db/mongodb/modelhelper/machine.go
@@ -487,6 +487,24 @@ func CreateMachine(m *models.Machine) error {
 	return Mongo.Run(MachinesColl, query)
 }
 
+func CreateMachines(m ...*models.Machine) error {
+	query := func(c *mgo.Collection) error {
+		docs := make([]interface{}, len(m))
+
+		for i := range m {
+			docs[i] = m[i]
+		}
+
+		b := c.Bulk()
+		b.Insert(docs...)
+
+		_, err := b.Run()
+		return err
+	}
+
+	return Mongo.Run(MachinesColl, query)
+}
+
 // DeleteMachine deletes the machine from mongodb, it is here just for cleaning
 // purposes(after tests), machines should not be removed from database  unless
 // you are kloud

--- a/go/src/koding/db/mongodb/modelhelper/machine.go
+++ b/go/src/koding/db/mongodb/modelhelper/machine.go
@@ -487,24 +487,6 @@ func CreateMachine(m *models.Machine) error {
 	return Mongo.Run(MachinesColl, query)
 }
 
-func CreateMachines(m ...*models.Machine) error {
-	query := func(c *mgo.Collection) error {
-		docs := make([]interface{}, len(m))
-
-		for i := range m {
-			docs[i] = m[i]
-		}
-
-		b := c.Bulk()
-		b.Insert(docs...)
-
-		_, err := b.Run()
-		return err
-	}
-
-	return Mongo.Run(MachinesColl, query)
-}
-
 // DeleteMachine deletes the machine from mongodb, it is here just for cleaning
 // purposes(after tests), machines should not be removed from database  unless
 // you are kloud

--- a/go/src/koding/kites/kloud/kloud/kloud.go
+++ b/go/src/koding/kites/kloud/kloud/kloud.go
@@ -257,7 +257,7 @@ func New(conf *Config) (*Kloud, error) {
 	kloud.Stack.RemoteClient = &remoteapi.Client{
 		Client:    storeOpts.Client,
 		Transport: transport,
-		Endpoint:  e.Remote().Private.URL,
+		Endpoint:  e.Koding.Private.URL,
 	}
 
 	kloud.Stack.ContextCreator = func(ctx context.Context) context.Context {

--- a/go/src/koding/kites/kloud/stack/controller.go
+++ b/go/src/koding/kites/kloud/stack/controller.go
@@ -223,7 +223,7 @@ func (k *Kloud) coreMethods(r *kite.Request, fn machineFunc) (result interface{}
 		k.send(ctx)
 	}()
 
-	return ControlResult{
+	return &ControlResult{
 		EventId: eventId,
 	}, nil
 }

--- a/go/src/koding/kites/kloud/stack/credential.go
+++ b/go/src/koding/kites/kloud/stack/credential.go
@@ -389,7 +389,7 @@ func (k *Kloud) CredentialAdd(r *kite.Request) (interface{}, error) {
 		Username: r.Username,
 	}
 
-	s, ctx, err := k.NewStack(p, kiteReq, teamReq)
+	s, ctx, err := k.newStack(kiteReq, teamReq)
 	if err != nil {
 		return nil, err
 	}

--- a/go/src/koding/kites/kloud/stack/import.go
+++ b/go/src/koding/kites/kloud/stack/import.go
@@ -100,6 +100,7 @@ func (k *Kloud) Import(r *kite.Request) (interface{}, error) {
 	tmpl.Template.Content = string(req.Template)
 	tmpl.Template.RawContent = string(raw)
 	tmpl.Template.Sum = hex.EncodeToString(sum[:])
+	tmpl.Title = req.Title
 
 	if err := modelhelper.CreateStackTemplate(tmpl); err != nil {
 		return nil, fmt.Errorf("error creating jStackTemplate: %s", err)

--- a/go/src/koding/kites/kloud/stack/import.go
+++ b/go/src/koding/kites/kloud/stack/import.go
@@ -50,8 +50,233 @@ type ImportResponse struct {
 	EventID    string `json:"eventId"`
 }
 
+// Import
 func (k *Kloud) Import(r *kite.Request) (interface{}, error) {
-	return &ControlResult{
-		EventId: "",
+	var req ImportRequest
+
+	if err := r.Args.One().Unmarshal(&req); err != nil {
+		return nil, err
+	}
+
+	if err := req.Valid(); err != nil {
+		return nil, err
+	}
+
+	if req.Title == "" {
+		req.Title = fmt.Sprintf("%s's Stack", strings.ToTitle(r.Username))
+	}
+
+	p, ok := k.providers[req.Provider]
+	if !ok {
+		return nil, NewError(ErrProviderNotFound)
+	}
+
+	account, err := modelhelper.GetAccount(r.Username)
+	if err != nil {
+		return nil, models.ResError(err, "jAccount")
+	}
+
+	user, err := modelhelper.GetUser(r.Username)
+	if err != nil {
+		return nil, models.ResError(err, "jUser")
+	}
+
+	team, err := modelhelper.GetGroup(req.Team)
+	if err != nil {
+		return nil, models.ResError(err, "jGroup")
+	}
+
+	sum := sha1.Sum(req.Template)
+	raw, err := yamlReencode(req.Template)
+	if err != nil {
+		return nil, fmt.Errorf("failed to YAML-encode stack template: %s", err)
+	}
+
+	tmpl := models.NewStackTemplate(req.Provider, "")
+	tmpl.Credentials = req.Credentials
+	tmpl.OriginID = account.Id
+	tmpl.Template.Details = bson.M{"lastUpdaterId": account.Id}
+	tmpl.Group = req.Team
+	tmpl.Template.Content = string(req.Template)
+	tmpl.Template.RawContent = string(raw)
+	tmpl.Template.Sum = hex.EncodeToString(sum[:])
+
+	if err := modelhelper.CreateStackTemplate(tmpl); err != nil {
+		return nil, fmt.Errorf("error creating jStackTemplate: %s", err)
+	}
+
+	teamReq := &TeamRequest{
+		Provider:   req.Provider,
+		GroupName:  req.Team,
+		Identifier: req.Credentials[req.Provider][0],
+	}
+
+	kiteReq := &kite.Request{
+		Method:   "plan",
+		Username: r.Username,
+	}
+
+	planReq := &PlanRequest{
+		Provider:        req.Provider,
+		StackTemplateID: tmpl.Id.Hex(),
+		GroupName:       req.Team,
+	}
+
+	planStack, ctx, err := k.NewStack(p, kiteReq, teamReq)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx = context.WithValue(ctx, PlanRequestKey, planReq)
+
+	v, err := planStack.HandlePlan(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error creating plan: %s", err)
+	}
+
+	k.Log.Debug("plan received %# v", v)
+
+	var machines []*Machine
+
+	if v, ok := v.(*PlanResponse); ok {
+		if m, ok := v.Machines.([]*Machine); ok {
+			machines = m
+		}
+	}
+
+	if len(machines) == 0 {
+		return nil, fmt.Errorf("stack contains no machines to build")
+	}
+
+	tmpl.Machines = make([]bson.M, len(machines))
+
+	for i, machine := range machines {
+		tmpl.Machines[i] = bson.M{
+			"provider": req.Provider,
+			"label":    machine.Label,
+		}
+	}
+
+	now := time.Now().UTC()
+	m := make([]*models.Machine, len(machines))
+
+	for i, machine := range machines {
+		uid := fmt.Sprintf("u%c%c%c%s", r.Username[0], req.Team[0],
+			req.Provider[0], utils.StringN(8))
+
+		m[i] = &models.Machine{
+			ObjectId:   bson.NewObjectId(),
+			Provider:   machine.Provider,
+			Slug:       machine.Label,
+			Label:      machine.Label,
+			Credential: r.Username,
+			Uid:        uid,
+			Status: models.MachineStatus{
+				State:      machinestate.Building.String(),
+				Reason:     "Building by Kloud",
+				ModifiedAt: now,
+			},
+			Users: []models.MachineUser{{
+				Id:       user.ObjectId,
+				Username: r.Username,
+				Sudo:     true,
+				Owner:    true,
+			}},
+			Groups: []models.MachineGroup{{
+				Id: team.Id,
+			}},
+			Meta: bson.M{
+				"alwaysOn":     false,
+				"storage_size": 0,
+				"type":         req.Provider,
+			},
+		}
+	}
+
+	if err := modelhelper.CreateMachines(m...); err != nil {
+		return nil, models.ResError(err, "jMachine")
+	}
+
+	stack := &models.ComputeStack{
+		Id:          bson.NewObjectId(),
+		BaseStackId: tmpl.Id,
+		OriginId:    account.Id,
+		Credentials: tmpl.Credentials,
+		Group:       req.Team,
+		Revision:    tmpl.Template.Sum,
+		Title:       req.Title,
+		Machines:    make([]bson.ObjectId, 0, len(m)),
+		Config: bson.M{
+			"groupStack": false,
+			"requiredData": bson.M{
+				"group": []interface{}{"slug"},
+				"user":  []interface{}{"username"},
+			},
+			"requiredProviders": []interface{}{req.Provider, "koding"},
+			"verified":          true,
+		},
+		Meta: bson.M{
+			"createdAt":  now,
+			"modifiedAt": now,
+			"tags":       nil,
+			"views":      nil,
+			"votes":      nil,
+			"likes":      0,
+		},
+	}
+
+	stack.Status.State = machinestate.NotInitialized.String()
+
+	for i := range m {
+		stack.Machines = append(stack.Machines, m[i].ObjectId)
+	}
+
+	if err := modelhelper.CreateComputeStack(stack); err != nil {
+		return nil, models.ResError(err, "jComputeStack")
+	}
+
+	kiteReq = &kite.Request{
+		Method:   "apply",
+		Username: r.Username,
+	}
+
+	applyReq := &ApplyRequest{
+		Provider:  req.Provider,
+		StackID:   stack.Id.Hex(),
+		GroupName: req.Team,
+	}
+
+	applyStack, ctx, err := k.NewStack(p, kiteReq, teamReq)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx = context.WithValue(ctx, ApplyRequestKey, applyReq)
+
+	v, err = applyStack.HandleApply(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error creating plan: %s", err)
+	}
+
+	return &ImportResponse{
+		TemplateID: tmpl.Id.Hex(),
+		StackID:    stack.Id.Hex(),
+		Title:      req.Title,
+		EventID:    v.(*ControlResult).EventId,
 	}, nil
+}
+
+func yamlReencode(template []byte) ([]byte, error) {
+	var m map[string]interface{}
+
+	if err := json.Unmarshal(template, &m); err != nil {
+		return nil, err
+	}
+
+	p, err := yaml.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+
+	return p, nil
 }

--- a/go/src/koding/kites/kloud/stack/import.go
+++ b/go/src/koding/kites/kloud/stack/import.go
@@ -58,6 +58,11 @@ type ImportResponse struct {
 	EventID    string `json:"eventId"`
 }
 
+var requiredData = map[string]interface{}{
+	"group": []interface{}{"slug"},
+	"user":  []interface{}{"username"},
+}
+
 func (k *Kloud) Import(r *kite.Request) (interface{}, error) {
 	var req ImportRequest
 
@@ -104,6 +109,11 @@ func (k *Kloud) Import(r *kite.Request) (interface{}, error) {
 			Template:    pstring(req.Template),
 			Title:       &req.Title,
 			Credentials: req.Credentials,
+			Config: map[string]interface{}{
+				"groupStack":        false,
+				"requiredProviders": []interface{}{req.Provider},
+				"requiredData":      requiredData,
+			},
 		},
 	}
 
@@ -168,10 +178,8 @@ func (k *Kloud) Import(r *kite.Request) (interface{}, error) {
 	tmplUpdateParams := &stacktemplate.PostRemoteAPIJStackTemplateUpdateIDParams{
 		ID: tmpl.ID,
 		Body: map[string]interface{}{
-			"config": map[string]interface{}{
-				"verified": true,
-			},
-			"machines": machines,
+			"config.verified": true,
+			"machines":        machines,
 		},
 	}
 

--- a/go/src/koding/kites/kloud/stack/import.go
+++ b/go/src/koding/kites/kloud/stack/import.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/koding/kite"
 	"github.com/koding/logging"
-	yaml "gopkg.in/yaml.v2"
 )
 
 // ImportRequest represents a request struct for "stack.import"
@@ -369,28 +368,4 @@ func jsonMarshal(v interface{}) ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
-}
-
-func yamlReencode(template []byte) ([]byte, error) {
-	var m map[string]interface{}
-
-	if err := json.Unmarshal(template, &m); err != nil {
-		return nil, err
-	}
-
-	p, err := yaml.Marshal(m)
-	if err != nil {
-		return nil, err
-	}
-
-	return p, nil
-}
-
-func pstring(p []byte) *string {
-	if len(p) == 0 {
-		return nil
-	}
-
-	s := string(p)
-	return &s
 }

--- a/go/src/koding/kites/kloud/stack/import.go
+++ b/go/src/koding/kites/kloud/stack/import.go
@@ -67,6 +67,15 @@ var requiredData = map[string]interface{}{
 	"user":  []interface{}{"username"},
 }
 
+// Import creates a stack from the received stack template. Upon request it:
+//
+//  - creates a JStackTemplate
+//  - updates JStackTemplate with machines obtained via terraformer plan command
+//  - generates a JComputeStack
+//  - builds a JComputeStack
+//
+// The method expects the received credentials to be already verified
+// and bootstrapped.
 func (k *Kloud) Import(r *kite.Request) (interface{}, error) {
 	var req ImportRequest
 

--- a/go/src/koding/kites/kloud/stack/import.go
+++ b/go/src/koding/kites/kloud/stack/import.go
@@ -176,7 +176,7 @@ func (k *Kloud) doPlan(r *kite.Request, p Provider, teamReq *TeamRequest, req *P
 		Username: r.Username,
 	}
 
-	stack, ctx, err := k.NewStack(p, kiteReq, teamReq)
+	stack, ctx, err := k.newStack(kiteReq, teamReq)
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +207,7 @@ func (k *Kloud) doApply(r *kite.Request, p Provider, teamReq *TeamRequest, req *
 		Username: r.Username,
 	}
 
-	stack, ctx, err := k.NewStack(p, kiteReq, teamReq)
+	stack, ctx, err := k.newStack(kiteReq, teamReq)
 	if err != nil {
 		return "", err
 	}

--- a/go/src/koding/kites/kloud/stack/import_test.go
+++ b/go/src/koding/kites/kloud/stack/import_test.go
@@ -1,0 +1,56 @@
+package stack_test
+
+import (
+	"strings"
+	"testing"
+
+	"koding/api/apitest"
+	"koding/kites/kloud/stack"
+	"koding/kites/kloud/stack/stacktest"
+	"koding/remoteapi/models"
+)
+
+func TestImport(t *testing.T) {
+	remoteapi := &apitest.StubHandler{
+		map[string]*models.JStackTemplate{"data": {ID: "mocked-template-id"}},
+		nil,
+		map[string]map[string]*models.JComputeStack{"data": {"stack": {ID: "mocked-stack-id"}}},
+	}
+
+	s := apitest.Serve(remoteapi)
+	defer s.Close()
+
+	fk := stacktest.NewFakeKloud(s.URL)
+
+	req := &stack.ImportRequest{
+		Credentials: map[string][]string{"test": {"mocked-identifier"}},
+		Template:    []byte(`{"provider":{"test":{}}}`),
+		Team:        "test-team",
+	}
+
+	resp, err := fk.Import(stacktest.NewRequest("import", "test-user", req))
+	if err != nil {
+		t.Fatalf("Import()=%s", err)
+	}
+
+	got, ok := resp.(*stack.ImportResponse)
+	if !ok {
+		t.Fatalf("got %T, want %T", resp, (*stack.ImportResponse)(nil))
+	}
+
+	if !strings.HasSuffix(got.Title, "TEST Stack") {
+		t.Fatalf("got %q, want suffix %q", got.Title, "TEST Stack")
+	}
+
+	got.Title = ""
+
+	want := &stack.ImportResponse{
+		TemplateID: "mocked-template-id",
+		StackID:    "mocked-stack-id",
+		EventID:    "mocked-event-id",
+	}
+
+	if *got != *want {
+		t.Fatalf("got %#v, want %#v", got, want)
+	}
+}

--- a/go/src/koding/kites/kloud/stack/kloud.go
+++ b/go/src/koding/kites/kloud/stack/kloud.go
@@ -171,7 +171,7 @@ func ReadProviders(template []byte) ([]string, error) {
 		return nil, err
 	}
 
-	providers := make([]string, len(v.Provider))
+	providers := make([]string, 0, len(v.Provider))
 
 	for p := range v.Provider {
 		providers = append(providers, p)

--- a/go/src/koding/kites/kloud/stack/kloud.go
+++ b/go/src/koding/kites/kloud/stack/kloud.go
@@ -24,6 +24,7 @@ import (
 	presence "socialapi/workers/presence/client"
 
 	"github.com/koding/cache"
+	"github.com/koding/kite"
 	"github.com/koding/logging"
 	"github.com/koding/metrics"
 	"github.com/satori/go.uuid"
@@ -89,6 +90,12 @@ type Kloud struct {
 	// package to kloud one in order to solve this and improve the
 	// import structure.
 	DescribeFunc func(providers ...string) map[string]*Description
+
+	// NewStack is used to create new Stacker value out of the given
+	// kite and team requests.
+	//
+	// If nil, default implementation is used.
+	NewStack func(*kite.Request, *TeamRequest) (Stacker, context.Context, error)
 
 	// CredClient handles credential.* methods.
 	CredClient *credential.Client

--- a/go/src/koding/kites/kloud/stack/kloud.go
+++ b/go/src/koding/kites/kloud/stack/kloud.go
@@ -1,7 +1,9 @@
 package stack
 
 import (
+	"encoding/json"
 	"errors"
+	"sort"
 	"sync"
 	"time"
 
@@ -157,4 +159,25 @@ func (k *Kloud) ValidateUser(req *keygen.AuthRequest) error {
 	default:
 		return errors.New("user is not active")
 	}
+}
+
+// ReadProviders reads all providers used in the given stack template.
+func ReadProviders(template []byte) ([]string, error) {
+	var v struct {
+		Provider map[string]struct{} `json:"provider"`
+	}
+
+	if err := json.Unmarshal(template, &v); err != nil {
+		return nil, err
+	}
+
+	providers := make([]string, len(v.Provider))
+
+	for p := range v.Provider {
+		providers = append(providers, p)
+	}
+
+	sort.Strings(providers)
+
+	return providers, nil
 }

--- a/go/src/koding/kites/kloud/stack/kloud_test.go
+++ b/go/src/koding/kites/kloud/stack/kloud_test.go
@@ -1,0 +1,54 @@
+package stack_test
+
+import (
+	"koding/kites/kloud/stack"
+	"reflect"
+	"testing"
+)
+
+func TestReadProviders(t *testing.T) {
+	cases := map[string]struct {
+		tmpl      string
+		providers []string
+		err       bool
+	}{
+		"single provider": {
+			`{"provider": {"google": {}}}`,
+			[]string{"google"},
+			false,
+		},
+		"multiple providers": {
+			`{"provider": {"google": {}, "aws": {}}}`,
+			[]string{"aws", "google"},
+			false,
+		},
+		"no providers": {
+			`{"provider": {}}`,
+			[]string{},
+			false,
+		},
+		"invalid template": {
+			"[]",
+			nil,
+			true,
+		},
+	}
+
+	for name, cas := range cases {
+		t.Run(name, func(t *testing.T) {
+			providers, err := stack.ReadProviders([]byte(cas.tmpl))
+
+			if cas.err {
+				if err == nil {
+					t.Fatal("expected err to be non-nil")
+				}
+
+				return
+			}
+
+			if !reflect.DeepEqual(providers, cas.providers) {
+				t.Fatalf("got %#v, want %#v", providers, cas.providers)
+			}
+		})
+	}
+}

--- a/go/src/koding/kites/kloud/stack/pokemon.go
+++ b/go/src/koding/kites/kloud/stack/pokemon.go
@@ -1,0 +1,57 @@
+package stack
+
+import (
+	"math/rand"
+	"os"
+	"sync"
+	"time"
+)
+
+var (
+	r   = rand.New(rand.NewSource(time.Now().UnixNano() + int64(os.Getpid())))
+	rmu sync.Mutex // rand.NewSource is not goroutine safe
+)
+
+// pokemons is a list of pokemon names stolen from:
+//
+//   client/app/lib/util/getPokemonName.coffee
+//
+// see todo for JStackTemplate.create at:
+//
+//   workers/social/lib/social/models/computeproviders/stacktemplate.coffee:198
+//
+// on how to get rid of this duplication.
+var pokemons = []string{
+	"Bulbasaur", "Ivysaur", "Venusaur", "Charmander", "Charmeleon", "Charizard",
+	"Squirtle", "Wartortle", "Blastoise", "Caterpie", "Metapod", "Butterfree",
+	"Weedle", "Kakuna", "Beedrill", "Pidgey", "Pidgeotto", "Pidgeot", "Rattata",
+	"Raticate", "Spearow", "Fearow", "Ekans", "Arbok", "Pikachu", "Raichu",
+	"Sandshrew", "Sandslash", "Nidoran", "Nidorina", "Nidoqueen", "Nidoran",
+	"Nidorino", "Nidoking", "Clefairy", "Clefable", "Vulpix", "Ninetales",
+	"Jigglypuff", "Wigglytuff", "Zubat", "Golbat", "Oddish", "Gloom",
+	"Vileplume", "Paras", "Parasect", "Venonat", "Venomoth", "Diglett",
+	"Dugtrio", "Meowth", "Persian", "Psyduck", "Golduck", "Mankey", "Primeape",
+	"Growlithe", "Arcanine", "Poliwag", "Poliwhirl", "Poliwrath", "Abra",
+	"Kadabra", "Alakazam", "Machop", "Machoke", "Machamp", "Bellsprout",
+	"Weepinbell", "Victreebel", "Tentacool", "Tentacruel", "Geodude", "Graveler",
+	"Golem", "Ponyta", "Rapidash", "Slowpoke", "Slowbro", "Magnemite",
+	"Magneton", "Farfetch", "Doduo", "Dodrio", "Seel", "Dewgong", "Grimer",
+	"Muk", "Shellder", "Cloyster", "Gastly", "Haunter", "Gengar", "Onix",
+	"Drowzee", "Hypno", "Krabby", "Kingler", "Voltorb", "Electrode", "Exeggcute",
+	"Exeggutor", "Cubone", "Marowak", "Hitmonlee", "Hitmonchan", "Lickitung",
+	"Koffing", "Weezing", "Rhyhorn", "Rhydon", "Chansey", "Tangela",
+	"Kangaskhan", "Horsea", "Seadra", "Goldeen", "Seaking", "Staryu", "Starmie",
+	"Mr. Mime", "Scyther", "Jynx", "Electabuzz", "Magmar", "Pinsir", "Tauros",
+	"Magikarp", "Gyarados", "Lapras", "Ditto", "Eevee", "Vaporeon", "Jolteon",
+	"Flareon", "Porygon", "Omanyte", "Omastar", "Kabuto", "Kabutops",
+	"Aerodactyl", "Snorlax", "Articuno", "Zapdos", "Moltres", "Dratini",
+	"Dragonair", "Dragonite", "Mewtwo", "Mew",
+}
+
+func Pokemon() string {
+	rmu.Lock()
+	n := r.Int31n(int32(len(pokemons)))
+	rmu.Unlock()
+
+	return pokemons[n]
+}

--- a/go/src/koding/kites/kloud/stack/provider/apply.go
+++ b/go/src/koding/kites/kloud/stack/provider/apply.go
@@ -77,7 +77,7 @@ func (bs *BaseStack) HandleApply(ctx context.Context) (interface{}, error) {
 		return nil, err
 	}
 
-	return stack.ControlResult{
+	return &stack.ControlResult{
 		EventId: bs.Eventer.ID(),
 	}, nil
 }

--- a/go/src/koding/kites/kloud/stack/stackcontroller.go
+++ b/go/src/koding/kites/kloud/stack/stackcontroller.go
@@ -83,7 +83,7 @@ func (k *Kloud) stackMethod(r *kite.Request, fn StackFunc) (interface{}, error) 
 		args.GroupName = "koding"
 	}
 
-	s, ctx, err := k.NewStack(r, &args)
+	s, ctx, err := k.newStack(r, &args)
 	if err != nil {
 		return nil, err
 	}

--- a/go/src/koding/kites/kloud/stack/stacktest/stacktest.go
+++ b/go/src/koding/kites/kloud/stack/stacktest/stacktest.go
@@ -8,7 +8,6 @@ import (
 	"koding/api"
 	"koding/kites/kloud/stack"
 	"koding/remoteapi"
-	"koding/tools/utils"
 
 	"github.com/koding/kite"
 	"github.com/koding/kite/dnode"
@@ -77,7 +76,7 @@ func (ss *SpyStacker) HandleApply(ctx context.Context) (interface{}, error) {
 	}
 
 	return &stack.ControlResult{
-		EventId: utils.StringN(12),
+		EventId: "mocked-event-id",
 	}, nil
 }
 

--- a/go/src/koding/kites/kloud/stack/stacktest/stacktest.go
+++ b/go/src/koding/kites/kloud/stack/stacktest/stacktest.go
@@ -1,0 +1,158 @@
+package stacktest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"testing"
+
+	"koding/api"
+	"koding/kites/kloud/stack"
+	"koding/remoteapi"
+	"koding/tools/utils"
+
+	"github.com/koding/kite"
+	"github.com/koding/kite/dnode"
+	"github.com/koding/logging"
+	"golang.org/x/net/context"
+)
+
+// CLEANUP(rjeczalik): The following packages should be merged into one:
+//
+//   - kloud/stack
+//   - kloud/stack/provider
+//   - kloud/kloud
+//
+// To fix Base* types abstraction leak and also simplify types, control flow
+// and enable testing of the kloud server.
+
+// DefaultLog is a default logger used in FakeKloud.
+var DefaultLog = logging.NewCustom("stacktest", testing.Verbose())
+
+// NewRequest mocks new kite.Request for the following arguments.
+func NewRequest(method, username string, arg interface{}) *kite.Request {
+	p, err := json.Marshal([]interface{}{arg})
+	if err != nil {
+		panic(fmt.Errorf("unexpected error marshaling %T: %s", arg, err))
+	}
+
+	r := &kite.Request{
+		Method:   method,
+		Username: username,
+		Args: &dnode.Partial{
+			Raw: p,
+		},
+	}
+
+	return r
+}
+
+// SpyStacker provides a stack.Stacker implementation that records
+// all calls to Handle* methods.
+type SpyStacker struct {
+	Apply     []*stack.ApplyRequest
+	Auth      []*stack.AuthenticateRequest
+	Bootstrap []*stack.BootstrapRequest
+	Plan      []*stack.PlanRequest
+}
+
+var (
+	_ stack.Stacker  = (*SpyStacker)(nil)
+	_ stack.Provider = (*SpyStacker)(nil)
+)
+
+func (*SpyStacker) VerifyCredential(*stack.Credential) error { return nil }
+func (*SpyStacker) BootstrapTemplates(*stack.Credential) ([]*stack.Template, error) {
+	return nil, nil
+}
+func (*SpyStacker) ApplyTemplate(*stack.Credential) (*stack.Template, error) { return nil, nil }
+func (ss *SpyStacker) Stack(context.Context) (interface{}, error)            { return ss, nil }
+func (*SpyStacker) Machine(context.Context, string) (interface{}, error)     { return nil, nil }
+func (*SpyStacker) NewCredential() interface{}                               { return nil }
+func (*SpyStacker) NewBootstrap() interface{}                                { return nil }
+
+// HandleApply implements the stack.Stacker interface.
+func (ss *SpyStacker) HandleApply(ctx context.Context) (interface{}, error) {
+	if req, ok := ctx.Value(stack.ApplyRequestKey).(*stack.ApplyRequest); ok {
+		ss.Apply = append(ss.Apply, req)
+	}
+
+	return &stack.ControlResult{
+		EventId: utils.StringN(12),
+	}, nil
+}
+
+// HandleAuthenticate implements the stack.Stacker interface.
+func (ss *SpyStacker) HandleAuthenticate(ctx context.Context) (interface{}, error) {
+	if req, ok := ctx.Value(stack.AuthenticateRequestKey).(*stack.AuthenticateRequest); ok {
+		ss.Auth = append(ss.Auth, req)
+	}
+
+	return make(map[string]*stack.AuthenticateResult), nil
+}
+
+// HandleBootstrap implements the stack.Stacker interface.
+func (ss *SpyStacker) HandleBootstrap(ctx context.Context) (interface{}, error) {
+	if req, ok := ctx.Value(stack.BootstrapRequestKey).(*stack.BootstrapRequest); ok {
+		ss.Bootstrap = append(ss.Bootstrap, req)
+	}
+
+	return true, nil
+}
+
+// HandlePlan implements the stack.Stacker interface.
+func (ss *SpyStacker) HandlePlan(ctx context.Context) (interface{}, error) {
+	if req, ok := ctx.Value(stack.PlanRequestKey).(*stack.PlanRequest); ok {
+		ss.Plan = append(ss.Plan, req)
+	}
+
+	return make(stack.Machines), nil
+}
+
+// FakeKloud mocks stack.Kloud value, so it can be used
+// safely in unittests.
+//
+// This is a best-effort attempt of providing a fake,
+// it is not a general purpose fake - it may be not
+// suitable for certain use-cases without further
+// refactoring.
+type FakeKloud struct {
+	*stack.Kloud
+	Stacker SpyStacker
+}
+
+// NewFakeKloud gives new FakeKloud value.
+func NewFakeKloud(remoteapiURL string) *FakeKloud {
+	u, err := url.Parse(remoteapiURL)
+	if err != nil || remoteapiURL == "" {
+		u = &url.URL{
+			Scheme: "http",
+			Host:   "127.0.0.1",
+		}
+	}
+
+	fk := &FakeKloud{
+		Kloud: stack.New(),
+	}
+
+	fk.Kloud.Log = DefaultLog
+	fk.Kloud.AddProvider("test", &fk.Stacker)
+	fk.Kloud.NewStack = func(*kite.Request, *stack.TeamRequest) (stack.Stacker, context.Context, error) {
+		return &fk.Stacker, context.Background(), nil
+	}
+	fk.Kloud.RemoteClient = &remoteapi.Client{
+		Endpoint: u,
+		Transport: &api.Transport{
+			AuthFunc: func(opts *api.AuthOptions) (*api.Session, error) {
+				return &api.Session{
+					ClientID: "mocked-client-id",
+					User:     opts.User,
+				}, nil
+			},
+			Log:   DefaultLog,
+			Debug: true,
+		},
+	}
+
+	return fk
+}

--- a/go/src/koding/kites/kloud/stack/stacktest/stacktest.go
+++ b/go/src/koding/kites/kloud/stack/stacktest/stacktest.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"testing"
 
 	"koding/api"
 	"koding/kites/kloud/stack"
@@ -27,7 +26,7 @@ import (
 // and enable testing of the kloud server.
 
 // DefaultLog is a default logger used in FakeKloud.
-var DefaultLog = logging.NewCustom("stacktest", testing.Verbose())
+var DefaultLog = logging.NewCustom("stacktest", true)
 
 // NewRequest mocks new kite.Request for the following arguments.
 func NewRequest(method, username string, arg interface{}) *kite.Request {

--- a/go/src/koding/klientctl/deploy.sh
+++ b/go/src/koding/klientctl/deploy.sh
@@ -35,10 +35,10 @@ echo "# uploading files to s3://${BUCKET}/${CHANNEL}/"
 s3cp "kd-0.1.${VERSION}.linux_amd64.gz" "s3://${BUCKET}/${CHANNEL}/"
 s3cp "kd-0.1.${VERSION}.darwin_amd64.gz" "s3://${BUCKET}/${CHANNEL}/"
 
-s3rm "s3://${BUCKET}/${CHANNEL}/kd.linux_amd64.gz"
+s3rm "s3://${BUCKET}/${CHANNEL}/kd.linux_amd64.gz" || true
 s3cp "s3://${BUCKET}/${CHANNEL}/kd-0.1.${VERSION}.linux_amd64.gz" "s3://${BUCKET}/${CHANNEL}/kd.linux_amd64.gz"
 
-s3rm "s3://${BUCKET}/${CHANNEL}/kd.darwin_amd64.gz"
+s3rm "s3://${BUCKET}/${CHANNEL}/kd.darwin_amd64.gz" || true
 s3cp "s3://${BUCKET}/${CHANNEL}/kd-0.1.${VERSION}.darwin_amd64.gz" "s3://${BUCKET}/${CHANNEL}/kd.darwin_amd64.gz"
 
 cp -f go/src/koding/klientctl/install-kd.sh install-kd.sh

--- a/go/src/koding/klientctl/endpoint/stack/stack.go
+++ b/go/src/koding/klientctl/endpoint/stack/stack.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	"koding/kites/kloud/stack"
+	kloudstack "koding/kites/kloud/stack"
 	"koding/klientctl/endpoint/credential"
 	"koding/klientctl/endpoint/kloud"
 	"koding/klientctl/endpoint/team"
@@ -52,7 +53,7 @@ func (c *Client) Create(opts *CreateOptions) (*stack.ImportResponse, error) {
 		return nil, fmt.Errorf("stack: template encoding error: %s", err)
 	}
 
-	providers, err := c.readProviders(data)
+	providers, err := kloudstack.ReadProviders(data)
 	if err != nil {
 		return nil, fmt.Errorf("stack: unable to read providers: %s", err)
 	}

--- a/go/src/koding/klientctl/endpoint/stack/stack.go
+++ b/go/src/koding/klientctl/endpoint/stack/stack.go
@@ -166,7 +166,6 @@ func (c *Client) readProviders(data []byte) ([]string, error) {
 	return providers, nil
 }
 
-// Create
 func Create(opts *CreateOptions) (*stack.ImportResponse, error) {
 	return DefaultClient.Create(opts)
 }

--- a/go/src/koding/remoteapi/remoteapi.go
+++ b/go/src/koding/remoteapi/remoteapi.go
@@ -3,6 +3,7 @@ package remoteapi
 import (
 	"net/http"
 	"net/url"
+	"time"
 
 	"koding/api"
 	"koding/remoteapi/client"
@@ -54,6 +55,13 @@ func (c *Client) New(user *api.User) *client.Koding {
 	return client.New(newRuntime(c.endpoint(), httpClient), strfmt.Default)
 }
 
+func (c *Client) Timeout() time.Duration {
+	if c.Client != nil && c.Client.Timeout != 0 {
+		return c.Client.Timeout
+	}
+	return 30 * time.Second
+}
+
 func (c *Client) endpoint() *url.URL {
 	if c.Endpoint != nil {
 		return c.Endpoint
@@ -61,7 +69,7 @@ func (c *Client) endpoint() *url.URL {
 	return &url.URL{
 		Scheme: "http",
 		Host:   "127.0.0.1",
-		Path:   "/remote.api",
+		Path:   "/",
 	}
 }
 

--- a/go/src/koding/tools/utils/utils.go
+++ b/go/src/koding/tools/utils/utils.go
@@ -3,8 +3,8 @@ package utils
 import (
 	"bytes"
 	cryptorand "crypto/rand"
-	"encoding/base64"
 	"encoding/binary"
+	"encoding/hex"
 	"io"
 	"net"
 	"sort"
@@ -16,9 +16,13 @@ const MaxInt = int(^uint(0) >> 1)
 const RandomStringLength = 24 // 144 bit base64 encoded
 
 func RandomString() string {
-	r := make([]byte, RandomStringLength*6/8)
-	cryptorand.Read(r)
-	return base64.URLEncoding.EncodeToString(r)
+	return StringN(RandomStringLength)
+}
+
+func StringN(n int) string {
+	p := make([]byte, n/2+1)
+	cryptorand.Read(p)
+	return hex.EncodeToString(p)[:n]
 }
 
 var (

--- a/wercker.yml
+++ b/wercker.yml
@@ -100,8 +100,8 @@ build:
         name: test kites
         code: scripts/wercker/run-command go/src/koding/kites/e2etest/e2etest.sh
     - script:
-        name: test providers
-        code: scripts/wercker/run-command ./scripts/gotests.sh kites koding/kites/kloud/provider/...
+        name: test kloud
+        code: scripts/wercker/run-command ./scripts/gotests.sh kites koding/kites/kloud/provider/... koding/kites/kloud/credential/... koding/kites/kloud/stack/... koding/kites/kloud/kloud/...
     - script:
         name: test koding/api
         code: env COMPILE_FLAGS="-race" scripts/wercker/run-command ./scripts/gotests.sh koding/api/...

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -210,6 +210,11 @@ module.exports = class JStackTemplate extends Module
       { group }    = client.r # we have revived JGroup and JUser here ~ GG
       { delegate } = client.connection
 
+      # TODO(rjeczalik): move app/util/getPokemonName.coffee here
+      # and refactor JStackTemplate.create to not require title;
+      # if title is missing or empty, generate pokemon name as
+      # it's done currently on client side; this way we do not
+      # need to reimplement pokemon naming in kloud as well.
       unless data?.title
         return callback new KodingError 'Title required.'
 


### PR DESCRIPTION
~deps: #10229~

This PR adds `import` kite method, which is used by kd to send kd.yml and credentials, and basing on those to:

- create a template
- create a stack
- build a stack

= import a stack.

A todo is to make it possible to use existing template instead.