### PR TITLE
provider/google: user specified data is not executed during machine bootstrap. Fixes #9540

### DIFF
--- a/go/src/koding/kites/kloud/provider/google/stack.go
+++ b/go/src/koding/kites/kloud/provider/google/stack.go
@@ -207,9 +207,9 @@ func (s *Stack) ApplyTemplate(c *stack.Credential) (*stack.Template, error) {
 
 		// Cloud-Init can be injected only via "user-data" field defined in
 		// root "metadata" object.
-		metadata, ok := instance["metadata"].(map[string]interface{})
-		if !ok {
-			metadata = make(map[string]interface{})
+		var metadata = make(map[string]interface{})
+		if meta, ok := instance["metadata"].([]map[string]interface{}); ok {
+			metadata = flatten(meta)
 		}
 		s.Builder.InterpolateField(metadata, resourceName, "user-data")
 
@@ -357,6 +357,23 @@ func (s *Stack) getDiskSize(currentProject string, computeService *compute.Servi
 
 		return int(computeImg.DiskSizeGb)
 	}
+}
+
+func flatten(data []map[string]interface{}) map[string]interface{} {
+	res := make(map[string]interface{})
+	for _, ms := range data {
+		for key, m := range ms {
+			if val, ok := m.(string); ok {
+				if res[key] == nil {
+					res[key] = val
+				} else {
+					res[key] = res[key].(string) + "\n" + val
+				}
+			}
+		}
+	}
+
+	return res
 }
 
 func mustAsset(s string) string {

--- a/go/src/koding/kites/kloud/provider/google/stack_test.go
+++ b/go/src/koding/kites/kloud/provider/google/stack_test.go
@@ -6,67 +6,152 @@ import (
 )
 
 func TestAddPublicKey(t *testing.T) {
-	tests := []struct {
+	tests := map[string]struct {
 		Name      string
 		Metadata  map[string]interface{}
 		User      string
 		PublicKey string
 		Expected  map[string]interface{}
 	}{
-		{
-			Name: `no user SSH keys`,
+		"no user SSH keys": {
 			Metadata: map[string]interface{}{
-				`unrelated`: 5,
+				"unrelated": 5,
 			},
-			User:      `user`,
-			PublicKey: `pk`,
+			User:      "user",
+			PublicKey: "pk",
 			Expected: map[string]interface{}{
-				`ssh-keys`:  `user:pk`,
-				`unrelated`: 5,
+				"ssh-keys":  "user:pk",
+				"unrelated": 5,
 			},
 		},
-		{
-			Name: `user SSH keys new format`,
+		"user SSH keys new format": {
 			Metadata: map[string]interface{}{
-				`ssh-keys`: `user_custom:pk_custom`,
+				"ssh-keys": "user_custom:pk_custom",
 			},
-			User:      `user`,
-			PublicKey: `pk`,
+			User:      "user",
+			PublicKey: "pk",
 			Expected: map[string]interface{}{
-				`ssh-keys`: `user:pk\nuser_custom:pk_custom`,
+				"ssh-keys": "user:pk\\nuser_custom:pk_custom",
 			},
 		},
-		{
-			Name: `user SSH keys deprecated format`,
+		"user SSH keys deprecated format": {
 			Metadata: map[string]interface{}{
-				`sshKeys`: `user_custom:pk_custom`,
+				"sshKeys": "user_custom:pk_custom",
 			},
-			User:      `user`,
-			PublicKey: `pk`,
+			User:      "user",
+			PublicKey: "pk",
 			Expected: map[string]interface{}{
-				`sshKeys`: `user:pk\nuser_custom:pk_custom`,
+				"sshKeys": "user:pk\\nuser_custom:pk_custom",
 			},
 		},
-		{
-			Name: `user SSH keys both formats`,
+		"user SSH keys both formats": {
 			Metadata: map[string]interface{}{
-				`ssh-keys`: `user_custom_new:pk_custom_new`,
-				`sshKeys`:  `user_custom_old:pk_custom_old`,
+				"ssh-keys": "user_custom_new:pk_custom_new",
+				"sshKeys":  "user_custom_old:pk_custom_old",
 			},
-			User:      `user`,
-			PublicKey: `pk`,
+			User:      "user",
+			PublicKey: "pk",
 			Expected: map[string]interface{}{
-				`ssh-keys`: `user:pk\nuser_custom_new:pk_custom_new`,
-				`sshKeys`:  `user_custom_old:pk_custom_old`,
+				"ssh-keys": "user:pk\\nuser_custom_new:pk_custom_new",
+				"sshKeys":  "user_custom_old:pk_custom_old",
 			},
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.Name, func(t *testing.T) {
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
 			metadata := addPublicKey(test.Metadata, test.User, test.PublicKey)
 			if !reflect.DeepEqual(metadata, test.Expected) {
-				t.Fatalf(`want metadata = %#v; got %#v`, test.Expected, metadata)
+				t.Fatalf("want metadata = %#v; got %#v", test.Expected, metadata)
+			}
+		})
+	}
+}
+
+func TestFlatten(t *testing.T) {
+	tests := map[string]struct {
+		Data     []map[string]interface{}
+		Expected map[string]interface{}
+	}{
+		"nil data": {
+			Data:     nil,
+			Expected: map[string]interface{}{},
+		},
+		"nil map": {
+			Data: []map[string]interface{}{
+				nil,
+				{
+					"user-data": "data",
+				},
+			},
+			Expected: map[string]interface{}{
+				"user-data": "data",
+			},
+		},
+		"single map": {
+			Data: []map[string]interface{}{
+				{
+					"user-data": "data",
+				},
+			},
+			Expected: map[string]interface{}{
+				"user-data": "data",
+			},
+		},
+		"redefined map fields": {
+			Data: []map[string]interface{}{
+				{
+					"user-data": "first",
+				},
+				{
+					"user-data": "second",
+				},
+			},
+			Expected: map[string]interface{}{
+				"user-data": "first\nsecond",
+			},
+		},
+		"different map fields": {
+			Data: []map[string]interface{}{
+				{
+					"aaaa": "first",
+				},
+				{
+					"bbbb": "second",
+				},
+			},
+			Expected: map[string]interface{}{
+				"aaaa": "first",
+				"bbbb": "second",
+			},
+		},
+		"map fields mix": {
+			Data: []map[string]interface{}{
+				{
+					"aaaa": "first",
+				},
+				{
+					"bbbb": "second",
+				},
+				{
+					"aaaa": "A",
+					"bbbb": "B",
+					"cccc": "C",
+				},
+			},
+			Expected: map[string]interface{}{
+				"aaaa": "first\nA",
+				"bbbb": "second\nB",
+				"cccc": "C",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			flattened := flatten(test.Data)
+			if !reflect.DeepEqual(flattened, test.Expected) {
+				t.Fatalf("want flattened = %#v; got %#v", test.Expected, flattened)
 			}
 		})
 	}


### PR DESCRIPTION
## Description
Metadata is stored as an array of `map[string]interface{}` objects. Because of this, previous type assertion didn't work. Now, we flatten this array to single `map[string]interface{}` instance.

## Motivation and Context
Bug fix.

## How Has This Been Tested?
Manually

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
