### PR TITLE
provider/google: add var.koding_stack_id variable to google templates

### DIFF
--- a/go/src/koding/kites/kloud/provider/google/stack.go
+++ b/go/src/koding/kites/kloud/provider/google/stack.go
@@ -258,7 +258,7 @@ func (s *Stack) ApplyTemplate(c *stack.Credential) (*stack.Template, error) {
 	t.Resource["google_compute_instance"] = resource.GCInstance
 
 	t.Variable["koding_stack_id"] = map[string]interface{}{
-		"default": shorten(s.id(), 8),
+		"default": shortN(s.id(), 8),
 	}
 
 	err = t.ShadowVariables("FORBIDDEN", "google_credentials")
@@ -377,7 +377,7 @@ func (s *Stack) id() string {
 	}
 }
 
-func shorten(str string, size int) string {
+func shortN(str string, size int) string {
 	sum := sha1.Sum([]byte(str))
 	hash := hex.EncodeToString(sum[:])
 

--- a/go/src/koding/kites/kloud/provider/google/stack.go
+++ b/go/src/koding/kites/kloud/provider/google/stack.go
@@ -2,10 +2,13 @@ package google
 
 import (
 	"bytes"
+	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
 	"strconv"
 	"strings"
 	"text/template"
+	"time"
 
 	"koding/kites/kloud/stack"
 	"koding/kites/kloud/stack/provider"
@@ -254,6 +257,10 @@ func (s *Stack) ApplyTemplate(c *stack.Credential) (*stack.Template, error) {
 
 	t.Resource["google_compute_instance"] = resource.GCInstance
 
+	t.Variable["koding_stack_id"] = map[string]interface{}{
+		"default": shorten(s.id(), 8),
+	}
+
 	err = t.ShadowVariables("FORBIDDEN", "google_credentials")
 	if err != nil {
 		return nil, err
@@ -357,6 +364,28 @@ func (s *Stack) getDiskSize(currentProject string, computeService *compute.Servi
 
 		return int(computeImg.DiskSizeGb)
 	}
+}
+
+func (s *Stack) id() string {
+	switch arg := s.Arg.(type) {
+	case *stack.ApplyRequest:
+		return arg.StackID
+	case *stack.PlanRequest:
+		return arg.StackTemplateID
+	default:
+		return strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
+	}
+}
+
+func shorten(str string, size int) string {
+	sum := sha1.Sum([]byte(str))
+	hash := hex.EncodeToString(sum[:])
+
+	if len(hash) < size {
+		return hash
+	}
+
+	return hash[:size]
 }
 
 func mustAsset(s string) string {


### PR DESCRIPTION
This PR introduces `koding_stack_id` variable that changes its value every time when stack is modified.

## Description
There are two facts that implies this issue:
- Google cloud platform requires unique name for its resources.
- Kloud deletes old resources and creates new ones asynchronously.

Because of this, stack re-initialization fails when resource name doesn't change:

To reproduce:
- create and initialize google stack.
- change any field(apart from name) in stack template.
- you will be asked to re-initialize it.
- during re-initialization, you will receive following error:

![image](https://cloud.githubusercontent.com/assets/5021246/20200362/127b7a98-a7b1-11e6-996c-d21c1d156899.png)

## How Has This Been Tested?
Manually.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My change requires a change to the documentation.

@gokmen in order to fix this bug, you will need to replace: [this](https://github.com/koding/koding/blob/master/client/app/lib/providers/templates/google.coffee#L17) and [this](https://github.com/koding/koding/blob/master/client/app/lib/providers/templates/google.coffee#L49) lines with:

`name: '${var.koding_user_username}-${var.koding_group_slug}-${var.koding_stack_id}'`

this change will be also consistent with AWS resource [naming](https://github.com/koding/koding/blob/master/client/app/lib/providers/templates/aws.coffee#L17).
