### PR TITLE
Fix Electron App

### DIFF
--- a/elektron/package.json
+++ b/elektron/package.json
@@ -29,8 +29,8 @@
   },
   "homepage": "https://github.com/koding/koding#readme",
   "devDependencies": {
-    "coffee-script": "^1.10.0",
-    "electron-packager": "^5.2.1",
-    "electron-prebuilt": "^0.36.5"
+    "coffee-script": "^1.11.1",
+    "electron-packager": "^8.2.0",
+    "electron-prebuilt": "^1.4.6"
   }
 }

--- a/elektron/package.json
+++ b/elektron/package.json
@@ -30,6 +30,7 @@
   "homepage": "https://github.com/koding/koding#readme",
   "devDependencies": {
     "coffee-script": "^1.11.1",
+    "electron": "^1.4.6",
     "electron-packager": "^8.2.0",
     "electron-prebuilt": "^1.4.6"
   }

--- a/elektron/package.json
+++ b/elektron/package.json
@@ -4,14 +4,14 @@
   "description": "Koding Desktop App",
   "main": "./lib/main.js",
   "scripts": {
-    "prestart": "coffee --compile --output lib/ src/",
-    "start": "electron ./lib/main.js",
+    "prestart": "./node_modules/.bin/coffee --compile --output lib/ src/",
+    "start": "./node_modules/.bin/electron ./lib/main.js",
     "preapp-mac": "rm -rf dist/ && coffee --compile --output lib/ src/",
-    "app-mac": "electron-packager . Koding --out ./dist --ignore=\"node_modules/(electron-packager|electron-prebuilt|path|coffee-script)\"  --platform=darwin --arch=x64 --version=1.4.6 --overwrite --icon=./assets/icons/koding-appIcon.icns",
+    "app-mac": "./node_modules/.bin/electron-packager . Koding --out ./dist --ignore=\"node_modules/(electron-packager|electron-prebuilt|path|coffee-script)\"  --platform=darwin --arch=x64 --version=1.4.6 --overwrite --icon=./assets/icons/koding-appIcon.icns",
     "preapp-win": "rm -rf dist/ && coffee --compile --output lib/ src/",
-    "app-win": "electron-packager . Koding --out ./dist --ignore=\"node_modules/(electron-packager|electron-prebuilt|path|coffee-script)\" --platform=win32 --arch=x64 --version=1.4.6 --overwrite --icon=./assets/icons/koding-appIcon.ico",
+    "app-win": "./node_modules/.bin/electron-packager . Koding --out ./dist --ignore=\"node_modules/(electron-packager|electron-prebuilt|path|coffee-script)\" --platform=win32 --arch=x64 --version=1.4.6 --overwrite --icon=./assets/icons/koding-appIcon.ico",
     "preapp-linux": "rm -rf dist/ && coffee --compile --output lib/ src/",
-    "app-linux": "electron-packager . Koding --out ./dist --ignore=\"node_modules/(electron-packager|electron-prebuilt|path|coffee-script)\" --platform=linux --arch=x64 --version=1.4.6 --overwrite --icon=./assets/icons/koding-appIcon-linux"
+    "app-linux": "./node_modules/.bin/electron-packager . Koding --out ./dist --ignore=\"node_modules/(electron-packager|electron-prebuilt|path|coffee-script)\" --platform=linux --arch=x64 --version=1.4.6 --overwrite --icon=./assets/icons/koding-appIcon-linux"
   },
   "repository": {
     "type": "git",

--- a/elektron/package.json
+++ b/elektron/package.json
@@ -7,11 +7,11 @@
     "prestart": "coffee --compile --output lib/ src/",
     "start": "electron ./lib/main.js",
     "preapp-mac": "rm -rf dist/ && coffee --compile --output lib/ src/",
-    "app-mac": "electron-packager . Koding --out ./dist --ignore=\"node_modules/(electron-packager|electron-prebuilt|path|coffee-script)\"  --platform=darwin --arch=x64 --version=0.36.6 --overwrite --icon=./assets/icons/koding-appIcon.icns",
+    "app-mac": "electron-packager . Koding --out ./dist --ignore=\"node_modules/(electron-packager|electron-prebuilt|path|coffee-script)\"  --platform=darwin --arch=x64 --version=1.4.6 --overwrite --icon=./assets/icons/koding-appIcon.icns",
     "preapp-win": "rm -rf dist/ && coffee --compile --output lib/ src/",
-    "app-win": "electron-packager . Koding --out ./dist --ignore=\"node_modules/(electron-packager|electron-prebuilt|path|coffee-script)\" --platform=win32 --arch=x64 --version=0.36.6 --overwrite --icon=./assets/icons/koding-appIcon.ico",
+    "app-win": "electron-packager . Koding --out ./dist --ignore=\"node_modules/(electron-packager|electron-prebuilt|path|coffee-script)\" --platform=win32 --arch=x64 --version=1.4.6 --overwrite --icon=./assets/icons/koding-appIcon.ico",
     "preapp-linux": "rm -rf dist/ && coffee --compile --output lib/ src/",
-    "app-linux": "electron-packager . Koding --out ./dist --ignore=\"node_modules/(electron-packager|electron-prebuilt|path|coffee-script)\" --platform=linux --arch=x64 --version=0.36.6 --overwrite --icon=./assets/icons/koding-appIcon-linux"
+    "app-linux": "electron-packager . Koding --out ./dist --ignore=\"node_modules/(electron-packager|electron-prebuilt|path|coffee-script)\" --platform=linux --arch=x64 --version=1.4.6 --overwrite --icon=./assets/icons/koding-appIcon-linux"
   },
   "repository": {
     "type": "git",

--- a/elektron/src/applicationmenu.coffee
+++ b/elektron/src/applicationmenu.coffee
@@ -1,5 +1,5 @@
 electron       = require 'electron'
-Menu           = require 'menu'
+Menu           = electron.Menu
 { app, shell } = electron
 
 module.exports = class ApplicationMenu

--- a/elektron/src/ipcreporter.coffee
+++ b/elektron/src/ipcreporter.coffee
@@ -1,5 +1,4 @@
 electron         = require 'electron'
-Menu             = require 'menu'
 { app, ipcMain } = electron
 
 module.exports = class IPCReporter

--- a/elektron/src/start.coffee
+++ b/elektron/src/start.coffee
@@ -1,6 +1,6 @@
 path            = require 'path'
-shell           = require 'shell'
 electron        = require 'electron'
+shell           = electron.shell
 ApplicationMenu = require './applicationmenu'
 IPCReporter     = require './ipcreporter'
 TrayIcon        = require './trayicon'


### PR DESCRIPTION
Electron app was not working due to a bug in shell and menu packages.

## Description
- Shell package was not included as a seperate module but should be inside electron module.
- Updated coffee-script, electron-packager and electron-prebuilt
- Bump Electron version to 1.4.6

## Screenshots (if appropriate):

**Before:** 
![Buggy Koding](https://s22.postimg.org/oftuts8xt/Screen_Shot_2016_11_11_at_12_58_18_PM.png)

**After:** 
![Good as new Koding](https://s18.postimg.org/fychdblh5/Screen_Shot_2016_11_11_at_1_00_48_PM.png)

Fixes #9393 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
