### PR TITLE
klient: bug fix for goroutine leaks on kite disconnect

### DIFF
--- a/go/src/koding/klient/app/defertime.go
+++ b/go/src/koding/klient/app/defertime.go
@@ -1,0 +1,82 @@
+package app
+
+import "time"
+
+// DeferTime allows to invoke registered function after provided duration. It
+// can cancel deferred function call even if internal timer was already started.
+type DeferTime struct {
+	d time.Duration
+	f func()
+
+	startC chan struct{}
+	stopC  chan struct{}
+}
+
+// NewDeferTime creates a new DeferTime instance and runs internal worker
+// go-routine. It is not possible to stop internal loop since it is meant to
+// run during the entire application's life cycle.
+func NewDeferTime(d time.Duration, f func()) *DeferTime {
+	dt := &DeferTime{
+		d:      d,
+		f:      f,
+		startC: make(chan struct{}, 1),
+		stopC:  make(chan struct{}, 1),
+	}
+
+	go dt.loop()
+
+	return dt
+}
+
+// Start runs registered function after `d` duration. If this method is called
+// multiple times before `d` duration pass, each call will reset the timer.
+// Calling Start method after registered function is invoked, will repeat the
+// process. This method is thread safe.
+func (dt *DeferTime) Start() {
+	select {
+	case dt.startC <- struct{}{}:
+	default:
+	}
+}
+
+// Stop prevents DeferTime from calling registered function even if it was
+// already scheduled by Start method. It is no-op when Start method was not
+// called. It is safe to call Stop method from multiple go-routines.
+func (dt *DeferTime) Stop() {
+	select {
+	case dt.stopC <- struct{}{}:
+	default:
+	}
+}
+
+func (dt *DeferTime) loop() {
+	var (
+		timer    *time.Timer      = nil
+		c        <-chan time.Time = nil
+		sawTimer                  = false
+	)
+
+	for {
+		select {
+		case <-c:
+			sawTimer = true
+			dt.f()
+			timer, c = nil, nil
+		case <-dt.stopC:
+			if timer != nil && !timer.Stop() && !sawTimer {
+				<-timer.C // drain previous timer since it was not triggered.
+			}
+			timer, c = nil, nil
+		case <-dt.startC:
+			if timer != nil {
+				if !timer.Stop() {
+					<-timer.C
+				}
+				timer.Reset(dt.d)
+			} else {
+				timer = time.NewTimer(dt.d)
+			}
+			c = timer.C
+		}
+	}
+}

--- a/go/src/koding/klient/app/defertime_test.go
+++ b/go/src/koding/klient/app/defertime_test.go
@@ -1,0 +1,104 @@
+package app
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDeferTimeStart(t *testing.T) {
+	const timeToWait = 500 * time.Millisecond
+	now := time.Now()
+	afterC := make(chan time.Time)
+
+	dt := NewDeferTime(timeToWait, func() {
+		afterC <- time.Now()
+	})
+
+	dt.Start()
+
+	select {
+	case after := <-afterC:
+		if passed := after.Sub(now); passed < timeToWait {
+			t.Fatalf("want passed > %v; got %v", timeToWait, passed)
+		}
+	case <-time.After(2 * timeToWait):
+		t.Fatalf("test timed out after %v", 2*timeToWait)
+	}
+}
+
+func TestDeferTimeStartStop(t *testing.T) {
+	const timeToWait = 500 * time.Millisecond
+	afterC := make(chan time.Time)
+
+	dt := NewDeferTime(timeToWait, func() {
+		afterC <- time.Now()
+	})
+
+	dt.Start()
+	time.Sleep(timeToWait / 2)
+	dt.Stop()
+	dt.Stop()
+
+	select {
+	case <-afterC:
+		t.Fatalf("test function should not be called")
+	case <-time.After(2 * timeToWait):
+	}
+}
+
+func TestDeferTimeStartTwice(t *testing.T) {
+	const timeToWait = 500 * time.Millisecond
+	now := time.Now()
+	afterC := make(chan time.Time)
+
+	dt := NewDeferTime(timeToWait, func() {
+		afterC <- time.Now()
+	})
+
+	dt.Start()
+
+	select {
+	case after := <-afterC:
+		if passed := after.Sub(now); passed < timeToWait {
+			t.Fatalf("want passed > %v; got %v", timeToWait, passed)
+		}
+	case <-time.After(2 * timeToWait):
+		t.Fatalf("test timed out after %v", 2*timeToWait)
+	}
+
+	dt.Start()
+
+	select {
+	case after := <-afterC:
+		if passed := after.Sub(now); passed < 2*timeToWait {
+			t.Fatalf("want passed > %v; got %v", 2*timeToWait, passed)
+		}
+	case <-time.After(3 * timeToWait):
+		t.Fatalf("test timed out after %v", 3*timeToWait)
+	}
+}
+
+func TestDeferTimeShift(t *testing.T) {
+	const timeToWait = 500 * time.Millisecond
+	afterC := make(chan time.Time)
+
+	dt := NewDeferTime(timeToWait, func() {
+		afterC <- time.Now()
+	})
+
+	dt.Start()
+	time.Sleep(timeToWait / 2)
+	dt.Start()
+	time.Sleep(timeToWait / 2)
+	now := time.Now()
+	dt.Start()
+
+	select {
+	case after := <-afterC:
+		if passed := after.Sub(now); passed < timeToWait {
+			t.Fatalf("want passed > %v; got %v", timeToWait, passed)
+		}
+	case <-time.After(2 * timeToWait):
+		t.Fatalf("test timed out after %v", 2*timeToWait)
+	}
+}

--- a/go/src/koding/klient/app/defertime_test.go
+++ b/go/src/koding/klient/app/defertime_test.go
@@ -6,13 +6,14 @@ import (
 )
 
 func TestDeferTimeStart(t *testing.T) {
-	const timeToWait = 500 * time.Millisecond
+	const timeToWait = 10 * time.Millisecond
 	now := time.Now()
 	afterC := make(chan time.Time)
 
 	dt := NewDeferTime(timeToWait, func() {
 		afterC <- time.Now()
 	})
+	defer dt.Close()
 
 	dt.Start()
 
@@ -27,12 +28,13 @@ func TestDeferTimeStart(t *testing.T) {
 }
 
 func TestDeferTimeStartStop(t *testing.T) {
-	const timeToWait = 500 * time.Millisecond
+	const timeToWait = 10 * time.Millisecond
 	afterC := make(chan time.Time)
 
 	dt := NewDeferTime(timeToWait, func() {
 		afterC <- time.Now()
 	})
+	defer dt.Close()
 
 	dt.Start()
 	time.Sleep(timeToWait / 2)
@@ -47,13 +49,14 @@ func TestDeferTimeStartStop(t *testing.T) {
 }
 
 func TestDeferTimeStartTwice(t *testing.T) {
-	const timeToWait = 500 * time.Millisecond
+	const timeToWait = 10 * time.Millisecond
 	now := time.Now()
 	afterC := make(chan time.Time)
 
 	dt := NewDeferTime(timeToWait, func() {
 		afterC <- time.Now()
 	})
+	defer dt.Close()
 
 	dt.Start()
 
@@ -79,12 +82,13 @@ func TestDeferTimeStartTwice(t *testing.T) {
 }
 
 func TestDeferTimeShift(t *testing.T) {
-	const timeToWait = 500 * time.Millisecond
+	const timeToWait = 10 * time.Millisecond
 	afterC := make(chan time.Time)
 
 	dt := NewDeferTime(timeToWait, func() {
 		afterC <- time.Now()
 	})
+	defer dt.Close()
 
 	dt.Start()
 	time.Sleep(timeToWait / 2)


### PR DESCRIPTION
This PR fixes klient's go-routine leak caused by invalid assumption that `timer.Stop()` closes its `C` [channel](https://github.com/koding/koding/blob/master/go/src/koding/klient/app/klient.go#L487). On the contrary, it *prevents* channel from [firing](https://golang.org/pkg/time/#Timer.Stop). This means that if the time gap between two arbitrary klient's kite function calls was less that 1 minute, go-routine created on OnDisconnect callback would be leaked.

## Motivation and Context
Fixing performance issues with KD.

## How Has This Been Tested?
Manually,
Unit tests.

## Screenshots (if appropriate):
subset of klient goroutines after few calls to `kd list`, they are not GC at all.
```sh
koding/kites/tunnelproxy.(*Client).eventloop(0xc42026a2a0)
koding/klient/app.(*Klient).RegisterMethods.func3.1(0xc42007ccf0)
koding/klient/app.(*Klient).RegisterMethods.func3.1(0xc42007ccf0)
koding/klient/app.(*Klient).RegisterMethods.func3.1(0xc42007ccf0)
koding/klient/app.(*Klient).RegisterMethods.func3.1(0xc42007ccf0)
koding/klient/app.(*Klient).RegisterMethods.func3.1(0xc42007ccf0)
koding/klient/app.(*Klient).RegisterMethods.func3.1(0xc42007ccf0)
koding/klient/app.(*Klient).RegisterMethods.func3.1(0xc42007ccf0)
koding/klient/app.(*Klient).RegisterMethods.func3.1(0xc42007ccf0)
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

