### PR TITLE
Release Bugs

### DIFF
--- a/client/app/lib/components/contentModal/styl/contentModal.styl
+++ b/client/app/lib/components/contentModal/styl/contentModal.styl
@@ -341,11 +341,11 @@ main.main-container
 
 .ContentModal.content-modal.stack-template-preview
   width                     900px !important
-  height                    800px !important
+  height                    100% !important
   main
     margin                  20px
     .preview-label
-      color #868686
+      color                 #868686
       font-weight           300
     .has-markdown
       font-size             14px
@@ -353,11 +353,13 @@ main.main-container
       font-weight           300
 
     button.expand-button
-      abs                   170px 40px 0 0
+      abs()
+      right                 40px
+      bottom                calc(100% \- 198px)
       z-index               10
 
     button.minimize-button
-      display none
+      display               none
 
     .kdtabpaneview
       height                600px !important
@@ -402,8 +404,8 @@ main.main-container
   header
   .preview-label
   .has-markdown
-    display none
+    display                 none
 
   button.minimize-button
-    abs 97px 60px 0 0
-    z-index 10
+    abs                     100px 60px 0 0
+    z-index                 10

--- a/client/app/lib/components/sidebar/index.coffee
+++ b/client/app/lib/components/sidebar/index.coffee
@@ -79,7 +79,7 @@ module.exports = class Sidebar extends React.Component
         else
           EnvironmentFlux.actions.setActiveLeavingSharedMachineId { id: null }
           EnvironmentFlux.actions.dispatchCollaborationInvitationRejected options.machineId
-          EnvironmentFlux.actions.dispatchSharedVMInvitationRejected options.machineId
+          EnvironmentFlux.actions.dispatchSharedVMInvitationRejected options.uid
 
         EnvironmentFlux.actions.loadMachines()
 

--- a/client/app/lib/components/sidebarmachineslistitem/index.coffee
+++ b/client/app/lib/components/sidebarmachineslistitem/index.coffee
@@ -164,9 +164,8 @@ module.exports = class SidebarMachinesListItem extends React.Component
 
 
   renderLeaveSharedMachine: ->
-    
-    return null  if @state.activeMachine isnt @machine('_id')
-    return null  if @machine('type') is 'own'
+
+    return null  if @machine('type') is 'own' or @machine 'hasOldOwner'
     return null  unless @machine 'isApproved'
 
     <LeaveSharedMachineWidget

--- a/client/app/lib/components/sidebarmachineslistitem/leavesharedmachinewidget.coffee
+++ b/client/app/lib/components/sidebarmachineslistitem/leavesharedmachinewidget.coffee
@@ -12,7 +12,7 @@ module.exports = class LeaveSharedMachineWidget extends React.Component
     className : 'Approved'
 
   constructor: (props) ->
-      
+
     @state = { isModalActive: yes }
 
 

--- a/client/app/lib/components/sidebarstacksection/index.coffee
+++ b/client/app/lib/components/sidebarstacksection/index.coffee
@@ -99,7 +99,9 @@ module.exports = class SidebarStackSection extends React.Component
             return new kd.NotificationView { title: 'Error occured while cloning template' }
           EnvironmentFlux.actions.cloneStackTemplate template, no
       when 'Destroy VMs' then deleteStack { stack }
-      when 'VMs' then router.handleRoute "/Home/stacks/virtual-machines"
+      when 'VMs'
+        firstMachineId = stack.get('machines').first.get '_id'
+        router.handleRoute "/Home/stacks/virtual-machines/#{firstMachineId}"
       when 'Open on GitLab'
         remoteUrl = stack.getIn ['config', 'remoteDetails', 'originalUrl']
         linkController.openOrFocus remoteUrl

--- a/client/app/lib/flux/environment/actions.coffee
+++ b/client/app/lib/flux/environment/actions.coffee
@@ -794,9 +794,9 @@ unshareMachineWithUser = (machineId, nickname) ->
         showError err  unless err.message is 'user is not in the shared list.'
 
 
-unshareMachineWihAllUsers = (machineId) ->
+unshareMachineWithAllUsers = (machineId) ->
 
-  machine = _kd.singletons.reactor.evaluate ['MachinesStore', machineId]
+  machine = kd.singletons.reactor.evaluate ['MachinesStore', machineId]
 
   new Promise (resolve, reject) ->
     queue = machine.get('sharedUsers').toJS().map (user) -> (next) ->
@@ -882,7 +882,7 @@ module.exports = {
   loadMachineSharedUsers
   shareMachineWithUser
   unshareMachineWithUser
-  unshareMachineWihAllUsers
+  unshareMachineWithAllUsers
   disconnectMachine
   setLabel
   fetchAndUpdateStackTemplate

--- a/client/app/lib/flux/environment/stores/sharedmachinesstore.coffee
+++ b/client/app/lib/flux/environment/stores/sharedmachinesstore.coffee
@@ -18,10 +18,10 @@ module.exports = class SharedMachinesStore extends KodingFluxStore
 
     machines.withMutations (machines) ->
       shared.forEach ({ machine }) ->
-        machines.set machine._id, machine._id
+        machines.set machine.uid, machine._id
 
 
-  rejectInvitation: (machines, id ) ->
+  rejectInvitation: (machines, id) ->
 
     return machines  unless machines.has id
 

--- a/client/app/lib/notificationcontroller.coffee
+++ b/client/app/lib/notificationcontroller.coffee
@@ -8,6 +8,7 @@ KDModalView        = kd.ModalView
 KDNotificationView = kd.NotificationView
 KDObject           = kd.Object
 ContentModal = require 'app/components/contentModal'
+EnvironmentFlux = require 'app/flux/environment'
 
 remote_extensions  = require 'app/remote-extensions'
 
@@ -100,12 +101,22 @@ module.exports = class NotificationController extends KDObject
         @once 'EmailConfirmed', displayEmailConfirmedNotification.bind this, modal
         modal.on 'KDObjectWillBeDestroyed', deleteUserCookie.bind this
 
+    @on 'MachineShareListUpdated', (data = {}) ->
+
+      { machineId, action, permanent } = data
+
+      switch action
+        when 'deny'
+          EnvironmentFlux.actions.loadMachineSharedUsers machineId
+
+
     @on 'MachineListUpdated', (data = {}) ->
 
       { machineUId, action, permanent } = data
 
       switch action
         when 'removed'
+          EnvironmentFlux.actions.dispatchSharedVMInvitationRejected machineUId
           if (ideInstance = envDataProvider.getIDEFromUId machineUId) and permanent
             ideInstance.showUserRemovedModal()
 

--- a/client/home/lib/styl/homevirtualmachines.styl
+++ b/client/home/lib/styl/homevirtualmachines.styl
@@ -43,7 +43,7 @@ $borderColor                = #CACACA
 
     > div
       flex                  0 0 auto
-      margin                0 30px 0 0
+      margin                0 10px 0 0
       padding               4px 0 0
 
       &:last-of-type
@@ -51,10 +51,13 @@ $borderColor                = #CACACA
 
     .MachinesListItem-machineLabel
       flex                0 1 auto
-      width               150px
-      padding-left        22px
-      ellipsis()
-      pointer()
+
+      .label
+        height              20px
+        width               150px
+        padding-left        20px
+        ellipsis()
+        pointer()
 
     .SidebarListItem-progressbar
       abs                   76px 0 0 0px
@@ -79,14 +82,15 @@ $borderColor                = #CACACA
                                       margin .3s ease
 
     .MachinesListItem-hostName
-      width                 100px
-      text-align            center
-      ellipsis()
+      .ip-address
+        width               150px
+        text-align          center
+        ellipsis()
 
     .MachinesListItem-stackLabel
       flex                  1 0 auto
       text-transform        uppercase
-      margin                0 20px 0 0
+      text-align            right
       margin-top            1px
       .HomeAppView--button
         ellipsis()

--- a/client/home/lib/virtualmachines/components/machineslist/listitem.coffee
+++ b/client/home/lib/virtualmachines/components/machineslist/listitem.coffee
@@ -83,9 +83,11 @@ module.exports = class MachinesListItem extends React.Component
 
     hasIp = @props.machine.get 'ipAddress'
     ip    = hasIp or '0.0.0.0'
-    title = if hasIp then '' else 'Actual IP address will appear here when this VM is powered on.'
+    title = if hasIp then ip else 'Actual IP address will appear here when this VM is powered on.'
 
-    <div title={title} className="MachinesListItem-hostName">{ip}</div>
+    <div className="MachinesListItem-hostName">
+      <div title={title} className='ip-address'>{ip}</div>
+    </div>
 
 
   renderDetailToggle: ->
@@ -121,7 +123,9 @@ module.exports = class MachinesListItem extends React.Component
   renderStackTitle: ->
 
     <div className="MachinesListItem-stackLabel">
-      <a href="#" className="HomeAppView--button primary">{@props.stack.get 'title'}</a>
+      <a title={@props.stack.get 'title'} href="#" className="HomeAppView--button primary">
+        {@props.stack.get 'title'}
+      </a>
     </div>
 
 
@@ -137,7 +141,9 @@ module.exports = class MachinesListItem extends React.Component
         <div
           className="MachinesListItem-machineLabel #{@props.machine.getIn ['status', 'state']}"
           onClick={@bound 'toggle'}>
-          {machineName or @props.machine.get 'label'}
+          <div title={machineName or @props.machine.get 'label'} className='label'>
+            {machineName or @props.machine.get 'label'}
+          </div>
           {@renderProgressbar()}
         </div>
         {@renderIpAddress()}

--- a/client/home/lib/virtualmachines/components/virtualmachineslist/container.coffee
+++ b/client/home/lib/virtualmachines/components/virtualmachineslist/container.coffee
@@ -21,7 +21,7 @@ module.exports = class VirtualMachinesListContainer extends React.Component
 
   onCancelSharing: (machineId) ->
 
-    EnvironmentFlux.actions.unshareMachineWihAllUsers machineId
+    EnvironmentFlux.actions.unshareMachineWithAllUsers machineId
 
 
   onSharedWithUser: (machineId, nickname) -> EnvironmentFlux.actions.shareMachineWithUser machineId, nickname

--- a/client/ide/lib/styl/ide.styl
+++ b/client/ide/lib/styl/ide.styl
@@ -72,6 +72,7 @@ body.ide
         size                20px 20px
         top                 8px
         right               4px
+        z-index             1
 
         span
           r-sprite          'ide', 'tab_close'
@@ -85,9 +86,8 @@ body.ide
       .kdtabhandle
 
         .tab-handle-text
-          margin-left       17px
           ellipsis()
-          max-width         90px
+          max-width         100px
 
         &.kddraggable
           &:before
@@ -160,8 +160,15 @@ body.ide .dark
     top                     -8px !important
 
   .kdtabhandle.kddraggable
+    display                 flex
     color                   dark-tab-color
     border-top              2px solid #2b2b30
+    padding                 0 0 0 10px
+
+    .tab-handle-tabname
+      min-width             30px
+      padding-right         34px
+      padding-left          5px
     &:hover .options
       opacity               1
 
@@ -178,12 +185,12 @@ body.ide .dark
         opacity             1
 
     .options
-      position              absolute
+      position              relative
       top                   8px
-      right                 23px
+      display               inline-block
+      right                 calc(40px \- 100%)
       size                  20px 20px
       z-index               1
-      dBlock()
       opacity               0
 
       &:before

--- a/client/ide/lib/views/statusbar/idestatusbarmenu.coffee
+++ b/client/ide/lib/views/statusbar/idestatusbarmenu.coffee
@@ -10,20 +10,20 @@ module.exports = class IDEStatusBarMenu extends KDContextMenu
 
   constructor: (options = {}) ->
 
-    { delegate, paneType } = options
+    { delegate, paneType, paneView: { file } } = options
 
     options.x              ?= delegate.getX() - 5
     options.y              ?= delegate.getY() + 20
     options.cssClass      or= "IDE-StatusBarMenu #{paneType}-context-menu"
     options.treeItemClass or= IDEStatusBarMenuItem
 
-    super options, @getItems paneType
+    super options, @getItems paneType, file.isDummyFile()
 
     @on 'ContextMenuItemReceivedClick', (view, event) =>
       @destroy()  unless event.target.parentNode.classList.contains 'kdselectbox'
 
 
-  getItems: (paneType) ->
+  getItems: (paneType, dummy = no) ->
 
     { shortcuts, appManager } = kd.singletons
 
@@ -33,7 +33,7 @@ module.exports = class IDEStatusBarMenu extends KDContextMenu
       editor: collection.find { _key: 'editor' }
       workspace: collection.find { _key: 'workspace' }
 
-    itemsData = @getItemsData paneType
+    itemsData = @getItemsData paneType, dummy
     _
       .chain itemsData
       .chunk 2
@@ -60,7 +60,7 @@ module.exports = class IDEStatusBarMenu extends KDContextMenu
       .value()
 
 
-  getItemsData: (paneType) ->
+  getItemsData: (paneType, dummy = no) ->
 
     if paneType is 'terminal'
       return [
@@ -69,8 +69,7 @@ module.exports = class IDEStatusBarMenu extends KDContextMenu
       ]
 
     @syntaxSelector = new IDESyntaxSelectorMenuItem
-    return [
-      # Shortcut                 # IDE method
+    ideShortcuts = [
       'editor.save'              , 'saveFile'
       'editor.saveas'            , 'saveAs'
       'workspace.saveallfiles'   , 'saveAllFiles'
@@ -81,5 +80,9 @@ module.exports = class IDEStatusBarMenu extends KDContextMenu
       'workspace.searchallfiles' , 'showContentSearch'
       'workspace.findfilebyname' , 'showFileFinder'
       'editor.gotoline'          , 'goToLine'
-      'Rename'                   , 'showRenameTerminalView'
     ]
+
+    ideShortcuts = ideShortcuts.concat ['Rename', 'showRenameTerminalView']  unless dummy
+
+    return ideShortcuts
+

--- a/client/ide/lib/views/tabview/idetabhandleview.coffee
+++ b/client/ide/lib/views/tabview/idetabhandleview.coffee
@@ -16,7 +16,9 @@ module.exports = class IDETabHandleView extends KDTabHandleView
 
     options.draggable ?= yes
     options.bind       = 'dragstart dblclick dragend'
-    options.view       = new KDView { tagName : 'span' }
+    options.view       = new KDView
+      tagName : 'span'
+      cssClass: 'tab-handle-tabname'
 
     { pane } = options
 

--- a/client/stack-editor/lib/editor/index.coffee
+++ b/client/stack-editor/lib/editor/index.coffee
@@ -37,6 +37,7 @@ ContentModal = require 'app/components/contentModal'
 createShareModal = require './createShareModal'
 isDefaultTeamStack = require 'app/util/isdefaultteamstack'
 { actions : HomeActions } = require 'home/flux'
+canCreateStacks = require 'app/util/canCreateStacks'
 
 module.exports = class StackEditorView extends kd.View
 
@@ -86,6 +87,9 @@ module.exports = class StackEditorView extends kd.View
         <span class='clone-button'>clone this template </span>
           and create a private stack."
       click: (event) =>
+        unless canCreateStacks()
+          return new kd.NotificationView
+            title: 'You are not allowed to create/edit stacks!'
         if event.target?.className is 'clone-button'
           @cloneStackTemplate()
 


### PR DESCRIPTION
Fixes: #9528, #9529, #9534, #9535, #9537, #9538, #9539  

for #9535, http://recordit.co/I6uVFkUof9
for #9538, http://recordit.co/kK3PXIxsoj
for #9534, I temporarily add first machine's id to url so that at least first machine will come expanded.
I think we need to remove stack title information from the row and divide it regarding stack title
Something like this cc: @ftasdelen, wdyt?
https://monosnap.com/file/XuNbCKJdxVx5ICOd3AmbGom7KtAkuo

Also virtual machines tab section style updated, added tooltip
![](https://monosnap.com/file/9pqXqYc7pXGmPGBCELaQTyobvFKXdg.png)

for #9537, http://recordit.co/7JGZTMr9li
