### PR TITLE
Leave Session and Dashboard/Stacks: jewel notification misleading

### DIFF
--- a/client/app/lib/components/sidebarmachineslistitem/index.coffee
+++ b/client/app/lib/components/sidebarmachineslistitem/index.coffee
@@ -166,6 +166,7 @@ module.exports = class SidebarMachinesListItem extends React.Component
   renderLeaveSharedMachine: ->
 
     return null  if @machine('type') is 'own' or @machine 'hasOldOwner'
+    return null  if @state.activeMachine isnt @machine('_id')
     return null  unless @machine 'isApproved'
 
     <LeaveSharedMachineWidget

--- a/client/home/lib/stacks/components/stacktemplateitem/index.coffee
+++ b/client/home/lib/stacks/components/stacktemplateitem/index.coffee
@@ -150,8 +150,8 @@ module.exports = class StackTemplateItem extends React.Component
           onClick={onOpen}>
           { makeTitle { template, stack } }
         </a>
-        {@renderDefaultTag()}
         {@renderUnreadCount()}
+        {@renderDefaultTag()}
       </div>
       {@renderStackUpdatedWidget()}
       <div className='HomeAppViewListItem-description'>

--- a/client/home/lib/styl/home.styl
+++ b/client/home/lib/styl/home.styl
@@ -156,6 +156,12 @@ $subtleColor                = #A59999
     margin-right            10px
     pointer()
 
+  .SidebarListItem-unreadCount
+    position                relative
+    display                 inline-block
+    top                     -4px
+    margin-right            10px
+
   .tag
     rel()
     display                 inline-block


### PR DESCRIPTION
Fixes: #9578, #9579 

for #9579, ![](https://monosnap.com/file/NldpFbdHAKsowvYK6ZiKycfenyjeHG.png)
for #9578, http://recordit.co/tSlHeSTOZk