### PR TITLE
Select Provider Modal: add event for cancel button to destroy modal

### DIFF
--- a/client/stack-editor/lib/index.coffee
+++ b/client/stack-editor/lib/index.coffee
@@ -96,6 +96,9 @@ module.exports = class StackEditorAppController extends AppController
       createOnce selectedProvider
       modal.destroy()
 
+    view.on 'StackOnboardingCanceled', ->
+      modal.destroy()
+
     modal.addSubView view
 
     if handleRoute

--- a/client/stack-editor/lib/onboarding/onboardingview.coffee
+++ b/client/stack-editor/lib/onboarding/onboardingview.coffee
@@ -25,7 +25,7 @@ module.exports = class OnboardingView extends JView
     @cancelButton = new kd.ButtonView
       cssClass : 'StackEditor-OnboardingModal--cancel'
       title    : 'CANCEL'
-      callback : @bound 'destroy'
+      callback : => @emit 'StackOnboardingCanceled'
 
     @createButton = new kd.ButtonView
       cssClass  : 'outline next'


### PR DESCRIPTION
fixes: #9566 

Add event to onboardingView when it is canceled, and then catch it and destroy the modal.
![](http://recordit.co/l155NrFmod.gif)