### PR TITLE
Fix Popover issue

### DIFF
--- a/client/app/lib/components/common/popover.coffee
+++ b/client/app/lib/components/common/popover.coffee
@@ -33,6 +33,8 @@ module.exports = class Popover extends React.Component
 
   render: ->
 
-    <Portal {...@props} className={kd.utils.curry 'Popover', @props.className}>
-      <div className="Popover-Wrapper" ref='Popover'>{@props.children}</div>
+    <Portal {...@props}>
+      <div className={kd.utils.curry 'Popover', @props.className}>
+        <div className="Popover-Wrapper" ref='Popover'>{@props.children}</div>
+      </div>
     </Portal>

--- a/client/app/lib/components/profile/profilefetchermixin.coffee
+++ b/client/app/lib/components/profile/profilefetchermixin.coffee
@@ -2,7 +2,7 @@ React = require 'app/react'
 helper = require './helper'
 fetchAccount = require 'app/util/fetchAccount'
 
-module.exports =
+module.exports = ProfileFetcherMixin =
 
 
   getInitialState: ->

--- a/client/app/lib/util/showSaveDialog.coffee
+++ b/client/app/lib/util/showSaveDialog.coffee
@@ -16,10 +16,12 @@ module.exports = (container, callback = kd.noop, options = {}) ->
     container     : container
     height        : 'auto'
     buttons       :
-      SAVE        :
+      save        :
+        title     : 'SAVE'
         style     : 'GenericButton primary'
         callback  : -> callback input, finderController, dialog
-      CANCEL      :
+      cancel      :
+        title     : 'CANCEL'
         style     : 'GenericButton cancel'
         callback  : ->
           finderController.stopAllWatchers()
@@ -38,7 +40,7 @@ module.exports = (container, callback = kd.noop, options = {}) ->
     label        : label
     defaultValue : options.inputDefaultValue or ''
     keydown      : (event) ->
-      dialog.buttons.Save.click()  if event.which is 13
+      dialog.buttons.save.click()  if event.which is 13
 
   dialog.on 'KDObjectWillBeDestroyed', ->
     container.ace?.focus()


### PR DESCRIPTION
With latest update of React-Portal they removed style/className support and it broke our styling.

ref: https://github.com/tajo/react-portal/commit/e02033099af03a53262bf43110b7adf84f75d273

This pr adds a wrapper on top of our Portal implementation and fixes the issue.

cc/ @usirin @hakankaradis 