### PR TITLE
welcomeModal/destory: remove unneccesary route check

### DIFF
--- a/client/home/lib/welcome/welcomemodal.coffee
+++ b/client/home/lib/welcome/welcomemodal.coffee
@@ -85,8 +85,7 @@ module.exports = class WelcomeModal extends kd.ModalView
 
     previousRoutes = router.visitedRoutes.filter (route) ->
       not (/^\/(?:Home).*/.test(route) or \
-           /^\/(?:Welcome).*/.test(route) or \
-           /\//.test(route))
+           /^\/(?:Welcome).*/.test(route))
     route = previousRoutes.last ? '/IDE'
     router.handleRoute route  if selfInitiated
 


### PR DESCRIPTION
Fixes: #9143 
Fixing the redirecting wrong url when welcome modal is closed.

`/\//.test(route))` this check was causing the remove previous route

Screencast: http://recordit.co/UfsLzFBdAT