### PR TITLE
  Edit New issue Managed VM cannot be displayed under 'Connected Machines' section of Dashboard.

### DIFF
--- a/client/app/lib/providers/config.coffee
+++ b/client/app/lib/providers/config.coffee
@@ -100,6 +100,7 @@ module.exports = globals.config.providers =
     title                  : 'Managed VM'
     color                  : '#6d119e'
     description            : 'Use your power.'
+    instanceTypes          : null
     credentialFields       : {}
 
   google                   :

--- a/client/home/lib/virtualmachines/components/machineslist/machinedetails.coffee
+++ b/client/home/lib/virtualmachines/components/machineslist/machinedetails.coffee
@@ -307,16 +307,16 @@ generateSpecs = (machine) ->
 
   configs = globals.config.providers
   { instanceTypes } = configs[providerName]
+  if instanceTypes
+    instanceType = jMachine.meta?.instance_type ? instanceTypes['base-vm']
 
-  instanceType = jMachine.meta?.instance_type ? instanceTypes['base-vm']
+    instanceData = instanceTypes[instanceType]
+    { ram, cpu } = instanceData ? instanceTypes[instanceTypes['base-vm']]
+
   size = jMachine.meta?.storage_size
+  disk = if size then "#{size}GB HDD" else null
 
-  instanceData = instanceTypes[instanceType]
-  { ram, cpu } = instanceData ? instanceTypes[instanceTypes['base-vm']]
-
-  disk = if size? then "#{size}GB HDD" else 'N/A'
-
-  return [providerName, instanceType, ram, cpu, disk]
+  return [providerName, instanceType, ram, cpu, disk].filter(Boolean)
 
 
 EditVMNameDescription = ->


### PR DESCRIPTION
## Description
Managed Vms machine instance types were not exist. Add `instanceTypes: null` to managed vm's providers config to emphasize this machine doesn't have any instance types.
Add check control while rendering machine specs

## Motivation and Context
Fixes: #9662 

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):
![](https://monosnap.com/file/UywLlgN776BpwxD9055HE1JRwoCN2H.png)
