### PR TITLE
Add a way to re-render component tree inside ReactView instances

### DIFF
--- a/client/app/lib/react/reactview.coffee
+++ b/client/app/lib/react/reactview.coffee
@@ -25,9 +25,9 @@ module.exports = class ReactView extends kd.CustomHTMLView
 
 
   viewAppended: ->
-
-    ReactDOM.render(
-      @renderReact()
-      @getElement()
-    )
+    kd.singletons.mainView.ready =>
+      ReactDOM.render(
+        @renderReact()
+        @getElement()
+      )
 

--- a/client/app/lib/react/reactview.coffee
+++ b/client/app/lib/react/reactview.coffee
@@ -1,3 +1,4 @@
+{ merge } = require 'lodash'
 kd       = require 'kd'
 ReactDOM = require 'react-dom'
 
@@ -9,6 +10,11 @@ module.exports = class ReactView extends kd.CustomHTMLView
 
     @on 'KDObjectWillBeDestroyed', =>
       ReactDOM.unmountComponentAtNode @getElement()
+
+
+  updateOptions: (newOptions) ->
+    @options = merge {}, @options, newOptions
+    @viewAppended()
 
 
   renderReact: ->


### PR DESCRIPTION
This PR introduces a new method on `ReactView` called `updateOptions`, which will trigger a re-render on the component being rendered by related `ReactView` instance.

PS: This is not optimized in any way, 2 of our issues required this one to continue. I will monitor the result, and will do extra optimization if necessary (e.g don't trigger rerender if `options` hasn't changed, etc.)

/cc @koding/frontend 