### PR TITLE
Alternative Stack editor application

### DIFF
--- a/client/app/lib/kodingappscontroller.coffee
+++ b/client/app/lib/kodingappscontroller.coffee
@@ -16,7 +16,10 @@ AppClasses =
   home: require 'home'
   ide: require 'ide'
   kites: require 'kites'
-  'stack-editor': require 'stack-editor'
+  'stack-editor': do ->
+    if Cookies.get 'use-nse'
+    then require 'new-stack-editor'
+    else require 'stack-editor'
   testrunner: require 'testrunner'
 
 

--- a/client/app/lib/styl/require-styles.coffee
+++ b/client/app/lib/styl/require-styles.coffee
@@ -13,7 +13,5 @@ require 'ide/styl'
 # require 'legal/styl'
 # require 'pricing/styl'
 require 'stack-editor/styl'
+require 'new-stack-editor/styl'
 # require 'stacks/styl'
-
-
-

--- a/client/new-stack-editor/bant.json
+++ b/client/new-stack-editor/bant.json
@@ -1,0 +1,15 @@
+{
+  "name": "new-stack-editor",
+  "main": "./lib/index.coffee",
+  "routes": {
+    "/Stack-Editor": "home",
+    "/Stack-Editor/New": "new",
+    "/Stack-Editor/:stackTemplateId": "edit-stack"
+  },
+  "sprites": [
+    "./lib/sprites"
+  ],
+  "styles": [
+    "./lib/styl/*.styl"
+  ]
+}

--- a/client/new-stack-editor/lib/helpers.coffee
+++ b/client/new-stack-editor/lib/helpers.coffee
@@ -1,0 +1,13 @@
+module.exports = helpers =
+
+  markAsLoaded: (stackTemplateId) ->
+
+    EnvironmentFlux = require 'app/flux/environment'
+
+    { setSelectedMachineId, setSelectedTemplateId } = EnvironmentFlux.actions
+    setSelectedTemplateId stackTemplateId
+    setSelectedMachineId null
+
+  log: (rest...) ->
+
+    console.log '[NewStackEditor]', rest...

--- a/client/new-stack-editor/lib/index.coffee
+++ b/client/new-stack-editor/lib/index.coffee
@@ -1,0 +1,49 @@
+kd = require 'kd'
+{ markAsLoaded, log } = require './helpers'
+AppController = require 'app/appcontroller'
+
+do require './routehandler'
+
+# Set cookie to enable new stack editor:
+#
+#  Cookies.set('use-nse', true, {path:'/'});
+#
+# And expire it to use current stack editor:
+#
+#  Cookies.expire('use-nse', {path:'/'});
+#
+module.exports = class StackEditorAppController extends AppController
+
+  @options     =
+    name       : 'Stackeditor'
+    behavior   : 'application'
+
+  constructor: (options = {}, data) ->
+
+    console.trace()
+    log '::init', options, data
+
+    super options, data
+
+
+  openEditor: (stackTemplateId) ->
+
+    console.trace()
+    log '::openEditor', stackTemplateId
+
+    markAsLoaded stackTemplateId
+
+
+  openStackWizard: (handleRoute = yes) ->
+
+    console.trace()
+    log '::openStackWizard', handleRoute
+
+    markAsLoaded null
+
+
+  reloadEditor: (templateId, skipDataUpdate) ->
+
+    console.trace()
+    log '::reloadEditor', templateId, skipDataUpdate
+

--- a/client/new-stack-editor/lib/routehandler.coffee
+++ b/client/new-stack-editor/lib/routehandler.coffee
@@ -1,0 +1,16 @@
+kd = require 'kd'
+lazyrouter = require 'app/lazyrouter'
+canCreateStacks = require 'app/util/canCreateStacks'
+isAdmin = require 'app/util/isAdmin'
+
+module.exports = -> lazyrouter.bind 'stackeditor', (type, info, state, path, ctx) ->
+
+  unless canCreateStacks() or type is 'edit-stack'
+    new kd.NotificationView { title: 'You are not allowed to create/edit stacks!' }
+    return kd.singletons.router.back()
+
+  if type in ['home', 'new']
+    kd.singletons.appManager.tell 'Stackeditor', 'openStackWizard'
+  else
+    kd.singletons.appManager.open 'Stackeditor', (app) ->
+      app.openEditor info.params.stackTemplateId

--- a/client/new-stack-editor/lib/styl/index.coffee
+++ b/client/new-stack-editor/lib/styl/index.coffee
@@ -1,0 +1,1 @@
+require './main.styl'

--- a/client/new-stack-editor/lib/styl/main.styl
+++ b/client/new-stack-editor/lib/styl/main.styl
@@ -1,0 +1,7 @@
+@css {
+/*
+New Stack Editor stylesheet
+stackeditor.styl
+*/
+}
+


### PR DESCRIPTION
We need a new Stack Editor Application which can replace the current one once it's ready, with this PR we're creating a new app called `new-stack-editor` which provides the same API for main app. This is development only, not provides anything new for users but will provide us to include each iteration without breaking existing functionality. Currently it's a blank application so nothing to show.

- Set cookie to enable new stack editor:
   `Cookies.set('use-nse', true, {path:'/'});`

 - And expire it to use current stack editor:
   `Cookies.expire('use-nse', {path:'/'});`

Completes #9690 