### PR TITLE
Update Sidebar Stack and Drafts Menu icons

### DIFF
--- a/client/app/lib/components/sidebar/index.coffee
+++ b/client/app/lib/components/sidebar/index.coffee
@@ -217,6 +217,7 @@ module.exports = class Sidebar extends React.Component
           <h4 className='SidebarSection-headerTitle'>
             <Link href="/Stack-Editor/#{id}" onClick={@onTitleClick.bind this, id}>{title}</Link>
           </h4>
+          <div onClick={@onDraftTitleClick.bind this, id} className='menu-icon'></div>
         </header>
       </section>
 

--- a/client/app/lib/components/sidebar/index.coffee
+++ b/client/app/lib/components/sidebar/index.coffee
@@ -198,6 +198,11 @@ module.exports = class Sidebar extends React.Component
       machines={stack.get 'machines'}/>
 
 
+  onTitleClick: (id) ->
+
+    kd.singletons.router.handleRoute "/Stack-Editor/#{id}"
+
+
   renderDrafts: ->
 
     @state.drafts?.toList().toJS().map (template) =>
@@ -210,7 +215,7 @@ module.exports = class Sidebar extends React.Component
           ref="draft-#{id}"
           className="SidebarSection-header">
           <h4 className='SidebarSection-headerTitle'>
-            <Link href="/Stack-Editor/#{id}" onClick={@onDraftTitleClick.bind this, id}>{title}</Link>
+            <Link href="/Stack-Editor/#{id}" onClick={@onTitleClick.bind this, id}>{title}</Link>
           </h4>
         </header>
       </section>

--- a/client/app/lib/components/sidebarsection/index.coffee
+++ b/client/app/lib/components/sidebarsection/index.coffee
@@ -36,6 +36,13 @@ module.exports = class SidebarSection extends React.Component
       href={@props.secondaryLink} />
 
 
+  renderMenuIcon: ->
+
+    return null  unless @props.onMenuIconClick
+
+    <div onClick={@props.onMenuIconClick} className='menu-icon'></div>
+
+
   renderHeader: ->
 
     return null  unless @props.title
@@ -52,6 +59,7 @@ module.exports = class SidebarSection extends React.Component
       <h4 className='SidebarSection-headerTitle'>
         <Link {...linkProps}>{@props.title}</Link>
       </h4>
+      {@renderMenuIcon()}
       {@renderSecondaryLink()}
       {@renderUnreadCount()}
     </header>

--- a/client/app/lib/components/sidebarsection/styl/sidebarsection.styl
+++ b/client/app/lib/components/sidebarsection/styl/sidebarsection.styl
@@ -7,6 +7,7 @@
 
   > .SidebarListItem-unreadCount
     top                     3px
+    right                   17px
     margin-top              -2px
 
   a
@@ -44,7 +45,7 @@
 .SidebarSection-header
   &.unread
     .SidebarSection-headerTitle
-      max-width             197px
+      max-width             195px
 
     .SidebarSection-secondaryLink
       visible()

--- a/client/app/lib/components/sidebarstacksection/index.coffee
+++ b/client/app/lib/components/sidebarstacksection/index.coffee
@@ -109,8 +109,13 @@ module.exports = class SidebarStackSection extends React.Component
         remote.api.JStackTemplate.one { _id: templateId }, (err, template) ->
           computeController.makeTeamDefault template, no  unless err
 
-
   onTitleClick: (event) ->
+
+    id = @props.stack.get 'baseStackId'
+    kd.singletons.router.handleRoute "/Stack-Editor/#{id}"
+
+
+  onMenuIconClick: (event) ->
 
     kd.utils.stopDOMEvent event
 
@@ -205,6 +210,7 @@ module.exports = class SidebarStackSection extends React.Component
       className={kd.utils.curry className, @props.className}
       title={@props.stack.get 'title'}
       onTitleClick={@bound 'onTitleClick'}
+      onMenuIconClick={@bound 'onMenuIconClick'}
       secondaryLink=''
       unreadCount={@getStackUnreadCount()}
       unreadCountClickHandler={@bound 'unreadCountClickHandler'}

--- a/client/app/lib/components/sidebarstacksection/styl/sidebarstacksection.styl
+++ b/client/app/lib/components/sidebarstacksection/styl/sidebarstacksection.styl
@@ -31,24 +31,25 @@
         .SidebarListItem-unreadCount
           margin            0
 
+  .menu-icon
+    box-shadow          0 0 15px #323232
+    content             ''
+    r-sprite            'app' '20_chevron_gray'
+    margin-left         1px
+    opacity             .7
+    position            absolute
+    right               -3px
+    top                 -3px
+    dIBlock()
+
   .SidebarSection-headerTitle
     dBlock()
     width                   100%
     text-transform          capitalize
     noTextDeco()
 
-    &:hover a
-      width                 186px
-      &:after
-        box-shadow          0 0 15px #323232
-        content             ''
-        r-sprite            'app' '20_chevron_gray'
-        margin-left         1px
-        opacity             .7
-        position            absolute
-        right               -7px
-        top                 -3px
-        dIBlock()
+    a
+      width                 182px
 
     &:hover .SidebarSection-secondaryLink
       visible()


### PR DESCRIPTION
## Description
Clicking stack or draft title will open `Stack-Editor` page.
Menu icon will be visible all time.
updated tray-icon style

## How Has This Been Tested?
Click stack or draft title, it should open the `Stack-Editor` page
Click the menu icon next to title, it will open the menu options.

## Screenshots (if appropriate):
![](https://monosnap.com/file/i8fKKgUINU4xzZmLdKXIQ5pL61GMIY.png)
