### PR TITLE
Credential improvements

### DIFF
--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -1252,7 +1252,7 @@ module.exports = class ComputeController extends KDController
     if creds.length > 0 and credential = credentials["#{selectedProvider}"]?.first
       remote.api.JCredential.one credential, (err, credential) ->
         { slug } = groupsController.getCurrentGroup()
-        credential.shareWith { target: slug }, (err) ->
+        credential.shareWith { target: slug, accessLevel: 'write' }, (err) ->
           showError 'Failed to share credential'  if err
           callback()
     else showError 'Failed to share credential'

--- a/client/app/lib/views/credentiallist/accountcredentiallistcontroller.coffee
+++ b/client/app/lib/views/credentiallist/accountcredentiallistcontroller.coffee
@@ -42,7 +42,7 @@ module.exports = class AccountCredentialListController extends KodingListControl
 
     listView.on 'ItemDeleted', @bound 'showNoItemWidget'
 
-    listView.on 'ItemAction', ({ action, item, options }) =>
+    listView.on 'ItemAction', ({ action, item, options }) ->
 
       credential    = item.getData()
       { provider }  = credential

--- a/client/app/lib/views/credentiallist/accountcredentiallistcontroller.coffee
+++ b/client/app/lib/views/credentiallist/accountcredentiallistcontroller.coffee
@@ -50,7 +50,7 @@ module.exports = class AccountCredentialListController extends KodingListControl
       switch action
 
         when 'ShowItem'
-          @fetchCredentialData credential, (err, data) ->
+          credential.fetchData (err, data) ->
             return  if showError err
 
             { meta }        = data
@@ -63,7 +63,7 @@ module.exports = class AccountCredentialListController extends KodingListControl
             listView.showCredential { credential, cred }
 
         when 'EditItem'
-          @fetchCredentialData credential, (err, data) ->
+          credential.fetchData (err, data) ->
             return  if showError err
 
             Tracker.track Tracker.USER_EDIT_CREDENTIALS
@@ -163,11 +163,6 @@ module.exports = class AccountCredentialListController extends KodingListControl
       @filterStates.query.fields ?= requiredFields.map (field) -> field.name ? field
 
     super
-
-
-  fetchCredentialData: (credential, callback) ->
-
-    credential.fetchData (err, data) -> callback err, data
 
 
   filterByProvider: (query = {}) ->

--- a/client/stack-editor/lib/index.coffee
+++ b/client/stack-editor/lib/index.coffee
@@ -168,38 +168,4 @@ module.exports = class StackEditorAppController extends AppController
     view    = new StackEditorView options, data
     view.on 'Cancel', -> kd.singletons.router.back()
 
-    confirmation = null
-
-    stackTemplate.on? 'update', =>
-
-      return  if confirmation
-      return  if view._stackSaveInAction
-
-      view.addSubView confirmation = new ContentModal
-        title: 'Stack Template is Updated'
-        cssClass: 'content-modal'
-        buttons:
-          cancel:
-            title: 'Cancel'
-            style: 'solid light-gray medium'
-            callback: ->
-              confirmation.destroy()
-              confirmation = null
-          ok:
-            title: 'OK'
-            style: 'solid green medium'
-            callback: =>
-              view.destroy()
-              delete @editors[stackTemplate._id]
-              @openEditor stackTemplate._id
-        content: '''
-          <div class='modalformline'
-            <p>This stack template is updated by another admin. Do you want to reload?</p>
-          </div>
-          '''
-
-
-    view.on 'StackSaveInAction',  -> @_stackSaveInAction = yes
-    view.on 'StackSaveCompleted', -> @_stackSaveInAction = no
-
     return view

--- a/workers/social/lib/social/models/computeproviders/aws.coffee
+++ b/workers/social/lib/social/models/computeproviders/aws.coffee
@@ -7,7 +7,7 @@ module.exports = class Aws extends ProviderInterface
 
   @bootstrapKeys = ['key_pair', 'rtb', 'acl']
 
-  @sensitiveKeys = ['access_key', 'secret_key']
+  @secretKeys = ['access_key', 'secret_key']
 
 
   @ping = (client, options, callback) ->

--- a/workers/social/lib/social/models/computeproviders/aws.test.coffee
+++ b/workers/social/lib/social/models/computeproviders/aws.test.coffee
@@ -28,11 +28,11 @@ runTests = -> describe 'workers.social.models.computeproviders.aws', ->
       expect(Aws.bootstrapKeys).to.be.deep.equal ['key_pair', 'rtb', 'acl']
 
 
-  describe '#sensitiveKeys', ->
+  describe '#secretKeys', ->
 
     it 'should be equal to aws sensitive keys', ->
 
-      expect(Aws.sensitiveKeys).to.be.deep.equal ['access_key', 'secret_key']
+      expect(Aws.secretKeys).to.be.deep.equal ['access_key', 'secret_key']
 
 
   describe '#ping()', ->

--- a/workers/social/lib/social/models/computeproviders/azure.coffee
+++ b/workers/social/lib/social/models/computeproviders/azure.coffee
@@ -6,7 +6,7 @@ module.exports = class Azure extends ProviderInterface
 
   @bootstrapKeys = ['subnet', 'hosted_service_name', 'address_space']
 
-  @sensitiveKeys = ['publish_settings', 'password', 'ssh_key_thumbprint']
+  @secretKeys    = ['publish_settings', 'password']
 
 
   @ping = (client, callback) ->

--- a/workers/social/lib/social/models/computeproviders/azure.coffee
+++ b/workers/social/lib/social/models/computeproviders/azure.coffee
@@ -8,6 +8,8 @@ module.exports = class Azure extends ProviderInterface
 
   @secretKeys    = ['publish_settings', 'password']
 
+  @sensitiveKeys = ['ssh_key_thumbprint']
+
 
   @ping = (client, callback) ->
     callback null, "Azure is cool #{ client.connection.delegate.profile.nickname }!"

--- a/workers/social/lib/social/models/computeproviders/azure.coffee
+++ b/workers/social/lib/social/models/computeproviders/azure.coffee
@@ -8,7 +8,7 @@ module.exports = class Azure extends ProviderInterface
 
   @secretKeys    = ['publish_settings', 'password']
 
-  @sensitiveKeys = ['ssh_key_thumbprint']
+  @sensitiveKeys = ProviderInterface.sensitiveKeys.concat ['ssh_key_thumbprint']
 
 
   @ping = (client, callback) ->

--- a/workers/social/lib/social/models/computeproviders/credential.coffee
+++ b/workers/social/lib/social/models/computeproviders/credential.coffee
@@ -488,6 +488,7 @@ module.exports = class JCredential extends jraphical.Module
   # Poor man's shadow function ~ GG
   shadowed = (c) ->
     return ''  unless c
+    c = c[0...(Math.min  c.length, 30)]
     r = (c) -> Math.ceil c.length / 1.5
     return "*#{Array(r c).join '*'}#{c[(r c)..]}"
 
@@ -535,6 +536,9 @@ module.exports = class JCredential extends jraphical.Module
       options =
         shadowSecretData    : yes
         shadowSensitiveData : yes
+
+      if client._allowedPermissionIndex is 0
+        options.shadowSensitiveData = no
 
       @fetchData client, options, callback
 

--- a/workers/social/lib/social/models/computeproviders/credential.test.coffee
+++ b/workers/social/lib/social/models/computeproviders/credential.test.coffee
@@ -447,10 +447,10 @@ runTests = -> describe 'workers.social.models.computeproviders.credential', ->
 
   describe 'fetchData', ->
 
-    testFetchDataFailure = (method, done) ->
+    testFetchDataFailure = (method, args, done) ->
       withConvertedUserAndCredential ({ client, credential }) ->
 
-        args  = [client]
+        args  = [client].concat args ? []
         queue = [
 
           (next) ->
@@ -469,8 +469,11 @@ runTests = -> describe 'workers.social.models.computeproviders.credential', ->
         async.series queue, done
 
 
-    testFetchDataSuccess = (method, done) ->
+    testFetchDataSuccess = (method, args, done) ->
+
       withConvertedUserAndCredential ({ client, credential }) ->
+
+        args = [client].concat args ? []
 
         checkCredData = (err, credData) ->
           expect(err).to.not.exist
@@ -478,19 +481,19 @@ runTests = -> describe 'workers.social.models.computeproviders.credential', ->
           expect(credData.identifier).to.be.equal credential.identifier
           done()
 
-        credential[method] client, checkCredData
+        credential[method] args..., checkCredData
 
 
     describe 'fetchData()', ->
 
       it 'should fail if there is no data', (done) ->
 
-        testFetchDataFailure 'fetchData', done
+        testFetchDataFailure 'fetchData', {}, done
 
 
       it 'should be able to fetch credential data', (done) ->
 
-        testFetchDataSuccess 'fetchData', done
+        testFetchDataSuccess 'fetchData', {}, done
 
 
     describe 'fetchData$()', ->
@@ -503,12 +506,12 @@ runTests = -> describe 'workers.social.models.computeproviders.credential', ->
 
       it 'should fail if there is no data', (done) ->
 
-        testFetchDataFailure 'fetchData$', done
+        testFetchDataFailure 'fetchData$', null, done
 
 
       it 'should be able to fetch credential data', (done) ->
 
-        testFetchDataSuccess 'fetchData$', done
+        testFetchDataSuccess 'fetchData$', null, done
 
 
   describe 'update$', ->

--- a/workers/social/lib/social/models/computeproviders/digitalocean.coffee
+++ b/workers/social/lib/social/models/computeproviders/digitalocean.coffee
@@ -8,7 +8,6 @@ module.exports = class DigitalOcean extends ProviderInterface
 
   @secretKeys    = ['access_token']
 
-  @sensitiveKeys = ['ssh_private_key', 'ssh_public_key']
 
   @ping = (client, options, callback) ->
 

--- a/workers/social/lib/social/models/computeproviders/digitalocean.coffee
+++ b/workers/social/lib/social/models/computeproviders/digitalocean.coffee
@@ -6,7 +6,7 @@ module.exports = class DigitalOcean extends ProviderInterface
 
   @bootstrapKeys = ['key_id', 'key_name', 'key_fingerprint']
 
-  @sensitiveKeys = ['access_token']
+  @secretKeys    = ['access_token']
 
   @ping = (client, options, callback) ->
 

--- a/workers/social/lib/social/models/computeproviders/digitalocean.coffee
+++ b/workers/social/lib/social/models/computeproviders/digitalocean.coffee
@@ -8,6 +8,8 @@ module.exports = class DigitalOcean extends ProviderInterface
 
   @secretKeys    = ['access_token']
 
+  @sensitiveKeys = ['ssh_private_key', 'ssh_public_key']
+
   @ping = (client, options, callback) ->
 
     callback null, "DigitalOcean is better #{ client.r.account.profile.nickname }!"

--- a/workers/social/lib/social/models/computeproviders/google.coffee
+++ b/workers/social/lib/social/models/computeproviders/google.coffee
@@ -8,8 +8,6 @@ module.exports = class Google extends ProviderInterface
 
   @secretKeys    = ['credentials']
 
-  @sensitiveKeys = ['ssh_private_key', 'ssh_public_key']
-
 
   @ping = (client, callback) ->
     callback null, "Google. #{ client.connection.delegate.profile.nickname }!"

--- a/workers/social/lib/social/models/computeproviders/google.coffee
+++ b/workers/social/lib/social/models/computeproviders/google.coffee
@@ -8,6 +8,8 @@ module.exports = class Google extends ProviderInterface
 
   @secretKeys    = ['credentials']
 
+  @sensitiveKeys = ['ssh_private_key', 'ssh_public_key']
+
 
   @ping = (client, callback) ->
     callback null, "Google. #{ client.connection.delegate.profile.nickname }!"

--- a/workers/social/lib/social/models/computeproviders/google.coffee
+++ b/workers/social/lib/social/models/computeproviders/google.coffee
@@ -6,7 +6,7 @@ module.exports = class Google extends ProviderInterface
 
   @bootstrapKeys = ['koding_network_id']
 
-  @sensitiveKeys = ['credentials']
+  @secretKeys    = ['credentials']
 
 
   @ping = (client, callback) ->

--- a/workers/social/lib/social/models/computeproviders/marathon.coffee
+++ b/workers/social/lib/social/models/computeproviders/marathon.coffee
@@ -14,7 +14,7 @@ module.exports = class Marathon extends ProviderInterface
 
   @bootstrapKeys = ['url']
 
-  @sensitiveKeys = ['basic_auth_user', 'basic_auth_password']
+  @secretKeys    = ['basic_auth_user', 'basic_auth_password']
 
   @ping = (client, options, callback) ->
 

--- a/workers/social/lib/social/models/computeproviders/providerinterface.coffee
+++ b/workers/social/lib/social/models/computeproviders/providerinterface.coffee
@@ -28,7 +28,7 @@ module.exports = class ProviderInterface
 
   @providerSlug   = 'baseprovider'
   @bootstrapKeys  = []
-  @sensitiveKeys  = []
+  @sensitiveKeys  = ['ssh_private_key', 'ssh_public_key']
   @secretKeys     = []
 
   @ping           = NOT_IMPLEMENTED

--- a/workers/social/lib/social/models/computeproviders/providerinterface.coffee
+++ b/workers/social/lib/social/models/computeproviders/providerinterface.coffee
@@ -53,7 +53,7 @@ module.exports = class ProviderInterface
     if not credential?.fetchData?
       return callback null, {}
 
-    credential.fetchData client, (err, credData) ->
+    credential.fetchData client, {}, (err, credData) ->
 
       if err?
         callback new KodingError 'Failed to fetch credential'

--- a/workers/social/lib/social/models/computeproviders/providerinterface.coffee
+++ b/workers/social/lib/social/models/computeproviders/providerinterface.coffee
@@ -18,9 +18,9 @@ PASS_THROUGH = (rest... , callback) -> callback null
 # @example How to subclass a provider
 #   class Aws extends ProviderInterface
 #
-#     @providerSlug  = 'aws'
+#     @providerSlug = 'aws'
 #     @bootstrapKeys = ['key_pair', 'rtb', 'acl']
-#     @sensitiveKeys = ['access_key', 'secret_key']
+#     @secretKeys = ['access_key', 'secret_key']
 #
 module.exports = class ProviderInterface
 
@@ -29,6 +29,7 @@ module.exports = class ProviderInterface
   @providerSlug   = 'baseprovider'
   @bootstrapKeys  = []
   @sensitiveKeys  = []
+  @secretKeys     = []
 
   @ping           = NOT_IMPLEMENTED
 

--- a/workers/social/lib/social/models/computeproviders/softlayer.coffee
+++ b/workers/social/lib/social/models/computeproviders/softlayer.coffee
@@ -9,11 +9,11 @@ KodingError       = require '../../error'
 
 module.exports = class Softlayer extends ProviderInterface
 
-  @providerSlug = 'softlayer'
+  @providerSlug  = 'softlayer'
 
   @bootstrapKeys = ['key_id']
 
-  @sensitiveKeys = ['api_key']
+  @secretKeys    = ['api_key']
 
 
   @ping = (client, options, callback) ->

--- a/workers/social/lib/social/models/computeproviders/softlayer.coffee
+++ b/workers/social/lib/social/models/computeproviders/softlayer.coffee
@@ -15,6 +15,8 @@ module.exports = class Softlayer extends ProviderInterface
 
   @secretKeys    = ['api_key']
 
+  @sensitiveKeys = ['ssh_private_key', 'ssh_public_key']
+
 
   @ping = (client, options, callback) ->
 

--- a/workers/social/lib/social/models/computeproviders/softlayer.coffee
+++ b/workers/social/lib/social/models/computeproviders/softlayer.coffee
@@ -15,8 +15,6 @@ module.exports = class Softlayer extends ProviderInterface
 
   @secretKeys    = ['api_key']
 
-  @sensitiveKeys = ['ssh_private_key', 'ssh_public_key']
-
 
   @ping = (client, options, callback) ->
 


### PR DESCRIPTION
With the current implementation we're shadowing sensitive keys per provider when `::fetchData` is requested. But, with new providers we have some information needs to remain visible to owners but also needs to be shadowed for others. This PR fixes that issue and introduces a new field type called `secretKeys` for `JCredential` per provider. Provider implementations defines that as we do for `sensitiveKeys`. This new `secretKeys` will be shadowed to everyone like `sensitiveKeys` before, but with this PR `sensitiveKeys` will be visible to owners but not the others.

![](http://g.recordit.co/ZC5KTwcEcq.gif)
ref: http://recordit.co/ZC5KTwcEcq