### PR TITLE
kd: add "credential describe" subcommand

### DIFF
--- a/go/src/koding/kites/kloud/stack/credential.go
+++ b/go/src/koding/kites/kloud/stack/credential.go
@@ -22,7 +22,7 @@ type CredentialDescribeRequest struct {
 // CredentialDescribeResponse represents a response
 // value from "credential.describe" kloud method.
 type CredentialDescribeResponse struct {
-	Description map[string]*Description `json:"description"`
+	Description Descriptions `json:"description"`
 }
 
 // Description describes Credential and Bootstrap
@@ -31,6 +31,30 @@ type Description struct {
 	Provider   string  `json:"provider,omitempty"`
 	Credential []Value `json:"credential"`
 	Bootstrap  []Value `json:"bootstrap,omitempty"`
+}
+
+// Descriptions maps credential description per provider.
+type Descriptions map[string]*Description
+
+// Slice converts d to *Description slice.
+func (d Descriptions) Slice() []*Description {
+	keys := make([]string, 0, len(d))
+
+	for k := range d {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	slice := make([]*Description, 0, len(d))
+
+	for _, key := range keys {
+		desc := *d[key]
+		desc.Provider = key
+		slice = append(slice, &desc)
+	}
+
+	return slice
 }
 
 // Enumer represents a value, that can have

--- a/go/src/koding/klientctl/kloud/credential/credential.go
+++ b/go/src/koding/klientctl/kloud/credential/credential.go
@@ -144,7 +144,7 @@ func (c *Client) Provider(identifier string) (provider string, err error) {
 	return "", fmt.Errorf("credential: %q does not exist or is not shared with the user", identifier)
 }
 
-func (c *Client) Describe() (map[string]*stack.Description, error) {
+func (c *Client) Describe() (stack.Descriptions, error) {
 	c.init()
 
 	var req stack.CredentialDescribeRequest
@@ -238,7 +238,7 @@ func nonil(err ...error) error {
 
 func List(opts *ListOptions) (stack.Credentials, error)         { return DefaultClient.List(opts) }
 func Create(opts *CreateOptions) (*stack.CredentialItem, error) { return DefaultClient.Create(opts) }
-func Describe() (map[string]*stack.Description, error)          { return DefaultClient.Describe() }
+func Describe() (stack.Descriptions, error)                     { return DefaultClient.Describe() }
 func Use(identifier string) error                               { return DefaultClient.Use(identifier) }
 func Used() map[string]string                                   { return DefaultClient.Used() }
 func Provider(identifier string) (string, error)                { return DefaultClient.Provider(identifier) }

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -482,6 +482,20 @@ func run(args []string) {
 							Usage: "Specify credential title.",
 						},
 					},
+				}, {
+					Name:   "describe",
+					Usage:  "Describe credential documents.",
+					Action: ctlcli.ExitErrAction(CredentialDescribe, log, "describe"),
+					Flags: []cli.Flag{
+						cli.BoolFlag{
+							Name:  "json",
+							Usage: "Output in JSON format.",
+						},
+						cli.StringFlag{
+							Name:  "provider, p",
+							Usage: "Specify credential provider.",
+						},
+					},
 				}},
 			},
 			cli.Command{


### PR DESCRIPTION
This PR adds support for `kd credential describe`. This subcommand serves purpose of listing available providers and describing their credential file, which is used when creating credentials in non-interactive mode (`kd credential create -f credential.json`).

Example output:

```
$ kd credential describe
PROVIDER      ATTRIBUTE            TYPE     SECRET
aws           access_key           string   true
aws           secret_key           string   true
aws           region               enum     false
azure         publish_settings     string   false
azure         subscription_id      string   false
azure         location             string   false
azure         storage              string   false
azure         ssh_key_thumbprint   string   false
azure         password             string   false
digitalocean  access_token         string   false
google        credentials          string   true
google        project              string   false
google        region               string   false
marathon      url                  string   false
marathon      basic_auth_user      string   false
marathon      basic_auth_password  string   false
marathon      request_timeout      integer  false
marathon      deployment_timeout   integer  false
softlayer     username             string   false
softlayer     api_key              string   true
vagrant       queryString          string   false
vagrant       memory               integer  false
vagrant       cpus                 integer  false
vagrant       box                  string   false
```

Or:

```
$ kd credential describe --provider google --json
[
        {
                "provider": "google",
                "credential": [
                        {
                                "name": "credentials",
                                "type": "string",
                                "label": "Credentials",
                                "secret": true,
                                "readOnly": false
                        },
                        {
                                "name": "project",
                                "type": "string",
                                "label": "Project",
                                "secret": false,
                                "readOnly": false
                        },
                        {
                                "name": "region",
                                "type": "string",
                                "label": "Region",
                                "secret": false,
                                "readOnly": false
                        }
                ],
                "bootstrap": [
                        {
                                "name": "koding_network_id",
                                "type": "string",
                                "label": "Koding Network ID",
                                "secret": false,
                                "readOnly": false
                        }
                ]
        }
]
```

Closes #9640.