### PR TITLE
klient: add machine abstract type

### DIFF
--- a/go/src/koding/klient/machine/machine.go
+++ b/go/src/koding/klient/machine/machine.go
@@ -1,0 +1,17 @@
+package machine
+
+import "errors"
+
+var (
+	// ErrMachineNotFound indicates that provided machine cannot be found.
+	ErrMachineNotFound = errors.New("machine not found")
+)
+
+// IsMachineNotFound is a helper function that checks if provided error
+// describes missing machine.
+func IsMachineNotFound(err error) bool {
+	return err == ErrMachineNotFound
+}
+
+// ID is a unique identifier of the machine.
+type ID string


### PR DESCRIPTION
This PR adds `machine` types.

Depends on: -

## Description
This is reworked architecture that is going to handle all `kd machine *` CLI commands. It *partially* deprecates `klient/remote` packages. There is a number of current issues which these changes are intended to solve:

- Support for multiple mounts per machine.
- Correct handling of destroyed machines.
- Correct handling of machines that changed their IP address.
- Correct handling of machines that changed their Kite.key.
- Correct handling of rsync mount processes.
- Clean ups after errors.
- Prevent machine duplication during `kd machine list` 
- Businnes logic and Kite transort separation.
- etc.

## Architecture
![image](https://cloud.githubusercontent.com/assets/5021246/20677915/11f74d30-b595-11e6-8753-5a27de2b1051.png)

- **Machine** - abstract representation of remote machine.
- **Status** - machine status whether it's dissabled/online/connected.
- **Address Book** - a set of machine addresses - including old ones.
- **Addr** - single machine address that is used to make a connection.
- **Dynamic Client** - client that can adapt its endpoint address using machine's address book.
- **Disconnected Client** - abstract client factory that describes non existing connection.
- **Kite Client** - Kite client that connects to remote machine Klient. 


- **Machine Group** - object that can manage multiple remote machines. 
- **Addresses** - a set of remote machines address books.
- **Aliases** - a set of machines nicknames.
- **Clients** - a set of machine dynamic clients.


- **Kite Handlers** - a set of factory methods that binds Kite server to `MachineGroup` instance.


## How Has This Been Tested?
Only data structures - nothing to test.

## Screenshots (if appropriate):
none

## Types of changes
- [x] New feature (non-breaking change which adds functionality)