### PR TITLE
klient: add machine status package

### DIFF
--- a/go/src/koding/klient/machine/machine.go
+++ b/go/src/koding/klient/machine/machine.go
@@ -1,0 +1,17 @@
+package machine
+
+import "errors"
+
+var (
+	// ErrMachineNotFound indicates that provided machine cannot be found.
+	ErrMachineNotFound = errors.New("machine not found")
+)
+
+// IsMachineNotFound is a helper function that checks if provided error
+// describes missing machine.
+func IsMachineNotFound(err error) bool {
+	return err == ErrMachineNotFound
+}
+
+// ID is a unique identifier of the machine.
+type ID string

--- a/go/src/koding/klient/machine/status.go
+++ b/go/src/koding/klient/machine/status.go
@@ -1,0 +1,98 @@
+package machine
+
+import (
+	"strings"
+	"time"
+)
+
+// State represents our understanding of machine state. Whether or not we can
+// communicate with it, etc.
+type State int
+
+const (
+	// StateUnknown is a zero value and represents unknown state.
+	StateUnknown State = iota
+
+	// StateOffline describes machine that is not reachable by host client.
+	StateOffline
+
+	// StateOnline describes machine that is reachable for client's pinger.
+	StateOnline
+
+	// StateConnected indicates that there is an active machine connection.
+	StateConnected
+)
+
+// String implements fmt.Stringer interface and is used for pretty-printing
+// machine state.
+func (s State) String() string {
+	switch s {
+	case StateUnknown:
+		return "<unknown>"
+	case StateOffline:
+		return "offline"
+	case StateOnline:
+		return "online"
+	case StateConnected:
+		return "connected"
+	default:
+		return "<unknown>"
+	}
+}
+
+// Status represents the current status of machine.
+type Status struct {
+	// State stores the current machine state.
+	State State `json:"state"`
+
+	// Reason is a short message that describes why machine is in current state.
+	Reason string `json:"reason"`
+
+	// Since indicates when the state was set.
+	Since time.Time `json:"since"`
+}
+
+// String implements fmt.Stringer interface and prints Status structure in
+// more human readable form.
+func (s *Status) String() string {
+	toks := []string{
+		"status: " + s.State.String(),
+	}
+
+	if s.Reason != "" {
+		toks = append(toks, "reason: "+s.Reason)
+	}
+
+	if !s.Since.IsZero() {
+		toks = append(toks, "since: <unknown>")
+	} else {
+		toks = append(toks, "since: "+s.Since.Format(time.RFC822))
+	}
+
+	return strings.Join(toks, ", ")
+}
+
+// MergeStatus is an utility function
+func MergeStatus(a, b Status) Status {
+	// Swap a with b when b is older than a.
+	if a.Since.After(b.Since) {
+		b, a = a, b
+	}
+
+	// Handle zero values.
+	if a.State == 0 && a.Reason == "" && a.Since.IsZero() {
+		return b
+	}
+
+	if a.State != b.State {
+		return b
+	}
+
+	if b.Reason == "" {
+		return a
+	}
+
+	// Copy time from older status when state did not change.
+	b.Since = a.Since
+	return b
+}

--- a/go/src/koding/klient/machine/status_test.go
+++ b/go/src/koding/klient/machine/status_test.go
@@ -1,0 +1,145 @@
+package machine
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestMergeStatus(t *testing.T) {
+	tests := map[string]struct {
+		A        Status
+		B        Status
+		Expected Status
+	}{
+		"initialization": {
+			A: Status{
+				State:  StateUnknown,
+				Reason: "",
+				Since:  time.Time{},
+			},
+			B: Status{
+				State:  StateOnline,
+				Reason: "started by stack.apply",
+				Since:  time.Date(2016, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+			Expected: Status{
+				State:  StateOnline,
+				Reason: "started by stack.apply",
+				Since:  time.Date(2016, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		"edge case older time is newer": {
+			A: Status{
+				State:  StateOnline,
+				Reason: "started by stack.apply",
+				Since:  time.Date(2016, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+			B: Status{
+				State:  StateOffline,
+				Reason: "",
+				Since:  time.Date(2010, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+			Expected: Status{
+				State:  StateOnline,
+				Reason: "started by stack.apply",
+				Since:  time.Date(2016, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		"newer time is equal to older": {
+			A: Status{
+				State:  StateConnected,
+				Reason: "",
+				Since:  time.Date(2016, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+			B: Status{
+				State:  StateOffline,
+				Reason: "machine disabled",
+				Since:  time.Date(2016, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+			Expected: Status{
+				State:  StateOffline,
+				Reason: "machine disabled",
+				Since:  time.Date(2016, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		"same state get time from older": {
+			A: Status{
+				State:  StateConnected,
+				Reason: "connected",
+				Since:  time.Date(2010, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+			B: Status{
+				State:  StateConnected,
+				Reason: "machine connected",
+				Since:  time.Date(2016, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+			Expected: Status{
+				State:  StateConnected,
+				Reason: "machine connected",
+				Since:  time.Date(2010, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		"same state newer has no reason": {
+			A: Status{
+				State:  StateConnected,
+				Reason: "connected",
+				Since:  time.Date(2010, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+			B: Status{
+				State:  StateConnected,
+				Reason: "",
+				Since:  time.Date(2016, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+			Expected: Status{
+				State:  StateConnected,
+				Reason: "connected",
+				Since:  time.Date(2010, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		"a status is zero value": {
+			A: Status{},
+			B: Status{
+				State:  StateConnected,
+				Reason: "connected",
+				Since:  time.Date(2016, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+			Expected: Status{
+				State:  StateConnected,
+				Reason: "connected",
+				Since:  time.Date(2016, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		"b status is zero value": {
+			A: Status{
+				State:  StateConnected,
+				Reason: "connected",
+				Since:  time.Date(2016, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+			B: Status{},
+			Expected: Status{
+				State:  StateConnected,
+				Reason: "connected",
+				Since:  time.Date(2016, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		"non zero value of reason": {
+			A: Status{
+				Reason: "connected",
+			},
+			B: Status{},
+			Expected: Status{
+				Reason: "connected",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			expected := MergeStatus(test.A, test.B)
+			if !reflect.DeepEqual(expected, test.Expected) {
+				t.Fatalf("want status: %s; got %s", test.Expected, expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds `status` package.

Depends on: #9789 

## Description
This is reworked architecture that is going to handle all `kd machine *` CLI commands. It *partially* deprecates `klient/remote` packages. There is a number of current issues which these changes are intended to solve:

- Support for multiple mounts per machine.
- Correct handling of destroyed machines.
- Correct handling of machines that changed their IP address.
- Correct handling of machines that changed their Kite.key.
- Correct handling of rsync mount processes.
- Clean ups after errors.
- Prevent machine duplication during `kd machine list` 
- Businnes logic and Kite transort separation.
- etc.

## Architecture
![image](https://cloud.githubusercontent.com/assets/5021246/20678149/f64c8bf8-b595-11e6-9da9-cee28ecb3d23.png)


- **Status** - machine status whether it's dissabled/online/connected.

## How Has This Been Tested?
Unit tests.

## Screenshots (if appropriate):
none

## Types of changes
- [x] New feature (non-breaking change which adds functionality)


