### PR TITLE
klient: add machine address books

### DIFF
--- a/go/src/koding/klient/machine/addr.go
+++ b/go/src/koding/klient/machine/addr.go
@@ -1,0 +1,113 @@
+package machine
+
+import (
+	"encoding/json"
+	"errors"
+	"sync"
+	"time"
+)
+
+var (
+	// ErrAddrNotFound indicates that provided address does not exist.
+	ErrAddrNotFound = errors.New("address not found")
+)
+
+// IsAddrNotFound is a helper function that checks if provided error describes
+// missing address.
+func IsAddrNotFound(err error) bool {
+	return err == ErrAddrNotFound
+}
+
+// Addr satisfies net.Addr interface. It stores external machine address and
+// a time-stamp which indicates when the address was last seen being valid.
+type Addr struct {
+	// Net represents address network like "ip", "kite" etc.
+	Net string `json:"network"`
+
+	// Val stores a string representation of an address.
+	Val string `json:"value"`
+
+	// Updated stores the address update time.
+	Updated time.Time `json:"updated"`
+}
+
+// Network returns the name of the network.
+func (a *Addr) Network() string { return a.Net }
+
+// String return a string form of stored address.
+func (a *Addr) String() string { return a.Val }
+
+// AddrBook stores and manages multiple machine addresses. Each machine can
+// can change its end point address over time. This can store all of these
+// addresses which allows to bind old resources with new address.
+type AddrBook struct {
+	mu    sync.RWMutex
+	addrs []Addr
+}
+
+// Add adds new address to address book. If provided address already exists, its
+// updated time will be updated.
+func (ab *AddrBook) Add(a Addr) {
+	ab.mu.Lock()
+	defer ab.mu.Unlock()
+
+	// If Addr already exists, update only its Updated field.
+	for i := range ab.addrs {
+		if ab.addrs[i].Net == a.Net && ab.addrs[i].Val == a.Val && ab.addrs[i].Updated.Before(a.Updated) {
+			ab.addrs[i].Updated = a.Updated
+		}
+	}
+
+	ab.addrs = append(ab.addrs, a)
+}
+
+// Has reports whether provided address is stored in address book or not.
+func (ab *AddrBook) Has(a Addr) bool {
+	ab.mu.RLock()
+	defer ab.mu.RUnlock()
+
+	for i := range ab.addrs {
+		if ab.addrs[i].Net == a.Net && ab.addrs[i].Val == a.Val {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Latest returns the latest known address for a given network. If no address
+// is found, ErrAddrNotFound error is returned.
+func (ab *AddrBook) Latest(network string) (Addr, error) {
+	ab.mu.RLock()
+	defer ab.mu.RUnlock()
+
+	t, addr, timeok := time.Time{}, (*Addr)(nil), false
+	for i := range ab.addrs {
+		timeok = t.Before(ab.addrs[i].Updated) || t.Equal(ab.addrs[i].Updated)
+		if network == ab.addrs[i].Net && timeok {
+			addr = &ab.addrs[i]
+			t = ab.addrs[i].Updated
+		}
+	}
+
+	if addr == nil {
+		return Addr{}, ErrAddrNotFound
+	}
+
+	return *addr, nil
+}
+
+// MarshalJSON satisfies json.Marshaler interface. It safely marshals address
+// book private data to JSON format.
+func (ab *AddrBook) MarshalJSON() ([]byte, error) {
+	ab.mu.RLock()
+	defer ab.mu.RUnlock()
+
+	return json.Marshal(ab.addrs)
+}
+
+// UnmarshalJSON satisfies json.Unmarshaler interface. It is used to unmarshal
+// data into private address book fields.
+func (ab *AddrBook) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &ab.addrs)
+}

--- a/go/src/koding/klient/machine/addr_test.go
+++ b/go/src/koding/klient/machine/addr_test.go
@@ -1,0 +1,173 @@
+package machine
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestAddrBookAddHas(t *testing.T) {
+	tests := map[string]struct {
+		Has  bool
+		Addr Addr
+	}{
+		"local IP empty time": {
+			Has: false,
+			Addr: Addr{
+				Net:     "ip",
+				Val:     "127.0.0.231",
+				Updated: time.Time{},
+			},
+		},
+		"local IP time after 2012": {
+			Has: false,
+			Addr: Addr{
+				Net:     "ip",
+				Val:     "127.0.0.13",
+				Updated: time.Date(2012, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		"local IP time after 2016": {
+			Has: true,
+			Addr: Addr{
+				Net:     "ip",
+				Val:     "127.0.0.1",
+				Updated: time.Date(2016, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		"local TCP address": {
+			Has: true,
+			Addr: Addr{
+				Net:     "tcp",
+				Val:     "127.0.0.1:8080",
+				Updated: time.Time{},
+			},
+		},
+	}
+
+	ab := &AddrBook{}
+
+	for _, test := range tests {
+		if test.Has {
+			ab.Add(test.Addr)
+		}
+	}
+
+	for name, test := range tests {
+		test := test // capture range variable.
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if has := ab.Has(test.Addr); has != test.Has {
+				t.Fatalf("want has = %t; got %t", test.Has, has)
+			}
+		})
+	}
+}
+
+func TestAddrLatest(t *testing.T) {
+	addrs := []Addr{
+		{
+			Net:     "ip",
+			Val:     "127.0.0.1",
+			Updated: time.Time{},
+		},
+		{
+			Net:     "ip",
+			Val:     "127.0.0.1",
+			Updated: time.Date(2012, time.May, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Net:     "ip",
+			Val:     "127.0.0.1",
+			Updated: time.Time{},
+		},
+		{
+			Net:     "tcp",
+			Val:     "127.0.0.1:80",
+			Updated: time.Date(2009, time.May, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	tests := map[string]struct {
+		Updated time.Time
+		Addr    Addr
+	}{
+		"latest IP": {
+			Updated: time.Date(2012, time.May, 1, 0, 0, 0, 0, time.UTC),
+			Addr: Addr{
+				Net: "ip",
+				Val: "127.0.0.1",
+			},
+		},
+		"latest TCP": {
+			Updated: time.Date(2009, time.May, 1, 0, 0, 0, 0, time.UTC),
+			Addr: Addr{
+				Net: "tcp",
+				Val: "127.0.0.1:80",
+			},
+		},
+	}
+
+	ab := &AddrBook{}
+
+	for _, addr := range addrs {
+		ab.Add(addr)
+	}
+
+	for name, test := range tests {
+		test := test // capture range variable.
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			addr, err := ab.Latest(test.Addr.Net)
+			if err != nil {
+				t.Fatalf("want err = nil; got %v", err)
+			}
+
+			if !addr.Updated.Equal(test.Updated) {
+				t.Fatalf("want updated = %v; got %v", test.Updated, addr.Updated)
+			}
+		})
+	}
+}
+
+func TestAddrBookJSON(t *testing.T) {
+	addrs := []Addr{
+		{
+			Net:     "ip",
+			Val:     "127.0.0.1",
+			Updated: time.Time{},
+		},
+		{
+			Net:     "tcp",
+			Val:     "127.0.0.1:80",
+			Updated: time.Date(2009, time.May, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	ab := &AddrBook{}
+
+	for _, addr := range addrs {
+		ab.Add(addr)
+	}
+
+	data, err := json.Marshal(ab)
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	ab = &AddrBook{}
+	if err = json.Unmarshal(data, ab); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	for i, addr := range addrs {
+		a, err := ab.Latest(addr.Net)
+		if err != nil {
+			t.Fatalf("want err = nil; got %v (i:%d)", err, i)
+		}
+
+		if !addr.Updated.Equal(a.Updated) {
+			t.Fatalf("want updated = %v; got %v (i:%d)", addr.Updated, a.Updated, i)
+		}
+	}
+}

--- a/go/src/koding/klient/machine/machine.go
+++ b/go/src/koding/klient/machine/machine.go
@@ -1,0 +1,17 @@
+package machine
+
+import "errors"
+
+var (
+	// ErrMachineNotFound indicates that provided machine cannot be found.
+	ErrMachineNotFound = errors.New("machine not found")
+)
+
+// IsMachineNotFound is a helper function that checks if provided error
+// describes missing machine.
+func IsMachineNotFound(err error) bool {
+	return err == ErrMachineNotFound
+}
+
+// ID is a unique identifier of the machine.
+type ID string


### PR DESCRIPTION
This PR adds machine address book type that stores machine addresses.

Depends on: #9789 

## Description
This is reworked architecture that is going to handle all `kd machine *` CLI commands. It *partially* deprecates `klient/remote` packages. There is a number of current issues which these changes are intended to solve:

- Support for multiple mounts per machine.
- Correct handling of destroyed machines.
- Correct handling of machines that changed their IP address.
- Correct handling of machines that changed their Kite.key.
- Correct handling of rsync mount processes.
- Clean ups after errors.
- Prevent machine duplication during `kd machine list` 
- Businnes logic and Kite transort separation.
- etc.

## Architecture
![image](https://cloud.githubusercontent.com/assets/5021246/20678283/6c33e3a2-b596-11e6-9ee0-d1d98ba2843f.png)


- **Address Book** - a set of machine addresses - including old ones.

## How Has This Been Tested?
Unit tests.

## Screenshots (if appropriate):
none

## Types of changes
- [x] New feature (non-breaking change which adds functionality)


