### PR TITLE
klient: add dynamic client

### DIFF
--- a/go/src/koding/klient/machine/client.go
+++ b/go/src/koding/klient/machine/client.go
@@ -1,0 +1,5 @@
+package machine
+
+// Client describes the operations that can be made on remote machine.
+type Client interface {
+}

--- a/go/src/koding/klient/machine/disconnected.go
+++ b/go/src/koding/klient/machine/disconnected.go
@@ -1,0 +1,41 @@
+package machine
+
+import (
+	"context"
+	"errors"
+)
+
+var (
+	// ErrDisconnected indicates that provided machine is unreachable by any of
+	// its clients.
+	ErrDisconnected = errors.New("machine disconnected")
+)
+
+// IsDisconnected is a helper function that checks if provided error describes
+// unreachable machine.
+func IsDisconnected(err error) bool {
+	return err == ErrDisconnected
+}
+
+var _ Client = (*DisconnectedClient)(nil)
+
+// DisconnectedClient satisfies Client interface. It indicates disconnected
+// machine and always returns
+type DisconnectedClient struct{}
+
+var _ ClientBuilder = (*DisconnectedClientBuilder)(nil)
+
+// DisconnectedClientBuilder satisfies ClientBuilder. It produces disconnected
+// clients. And will never return any errors.
+type DisconnectedClientBuilder struct{}
+
+// Ping is a stub for pinging method since we can't ping the machine when we
+// are disconnected by design.
+func (DisconnectedClientBuilder) Ping(_ DynamicAddrFunc) (Status, Addr, error) {
+	return Status{}, Addr{}, nil
+}
+
+// Build always returns disconnected client.
+func (DisconnectedClientBuilder) Build(_ context.Context, _ Addr) Client {
+	return DisconnectedClient{}
+}

--- a/go/src/koding/klient/machine/dynamic.go
+++ b/go/src/koding/klient/machine/dynamic.go
@@ -1,0 +1,228 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/koding/logging"
+)
+
+// DynamicAddrFunc is an adapter that allows to dynamically provide addresses
+// from a given network. Error should be of ErrAddrNotFound type when provided
+// network has no addresses.
+type DynamicAddrFunc func(string) (Addr, error)
+
+// ClientBuilder is an interface used to dynamically build remote machine clients.
+type ClientBuilder interface {
+	// Ping uses dynamic address provider to ping the machine. If error is nil,
+	// this method should return address which was used to ping the machine.
+	Ping(dynAddr DynamicAddrFunc) (Status, Addr, error)
+
+	// Build builds new client which will connect to machine using provided
+	// address.
+	Build(ctx context.Context, addr Addr) Client
+}
+
+// DynamicClientOpts are the options used to configure dynamic client.
+type DynamicClientOpts struct {
+	// AddrFunc is a factory for dynamic machine addresses.
+	AddrFunc DynamicAddrFunc
+
+	// Builder is a factory used to build clients.
+	Builder ClientBuilder
+
+	// DynAddrInterval indicates how often dynamic client should pull address
+	// function looking for new addresses.
+	DynAddrInterval time.Duration
+
+	// PingInterval indicates how often dynamic client should ping external
+	// machine.
+	PingInterval time.Duration
+
+	// Log is used for logging. If nil, default logger will be created.
+	Log logging.Logger
+}
+
+// Valid checks if provided options are correct.
+func (opts *DynamicClientOpts) Valid() error {
+	if opts.AddrFunc == nil {
+		return errors.New("nil dynamic address function")
+	}
+	if opts.Builder == nil {
+		return errors.New("nil client builder")
+	}
+	if opts.DynAddrInterval == 0 {
+		return errors.New("dynamic address check interval is not set")
+	}
+	if opts.PingInterval == 0 {
+		return errors.New("ping interval is not set")
+	}
+
+	return nil
+}
+
+// DynamicClient is a client that may change it's endpoint address depending
+// on client builder ping function status. It is safe to use this structure
+// concurrently.
+type DynamicClient struct {
+	opts DynamicClientOpts
+	log  logging.Logger
+
+	once sync.Once
+	stop chan struct{} // channel used to close dynamic client.
+
+	mu     sync.RWMutex
+	c      Client             // current client.
+	stat   Status             // current connection status.
+	ctx    context.Context    // context used in current client.
+	cancel context.CancelFunc // function that can close current context.
+}
+
+// NewDynamicClient starts and returns a new DynamicClient instance. The caller
+// should call Close when finished, in order to shut it down.
+func NewDynamicClient(opts DynamicClientOpts) (*DynamicClient, error) {
+	if err := opts.Valid(); err != nil {
+		return nil, err
+	}
+
+	stop := make(chan struct{}, 1) // make Close function unblocked.
+
+	dc := &DynamicClient{
+		opts: opts,
+		stop: stop,
+	}
+
+	if opts.Log != nil {
+		dc.log = opts.Log.New("monitor")
+	} else {
+		dc.log = logging.NewLogger("monitor")
+	}
+
+	dc.disconnected() // set disconnected client.
+	go dc.cron()
+
+	return dc, nil
+}
+
+// Status gets current client status. It may return zero value when client is
+// disconnected.
+func (dc *DynamicClient) Status() Status {
+	dc.mu.RLock()
+	stat := dc.stat
+	dc.mu.RUnlock()
+
+	return stat
+}
+
+// Client returns current client.
+func (dc *DynamicClient) Client() Client {
+	dc.mu.RLock()
+	c := dc.c
+	dc.mu.RUnlock()
+
+	return c
+}
+
+// Context returns current client's context. If client change, returned context
+// will be canceled. If there is no clients available in dynamic client. Already
+// canceled context is returned.
+func (dc *DynamicClient) Context() context.Context {
+	dc.mu.RLock()
+	defer dc.mu.RUnlock()
+
+	if dc.ctx == nil {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		return ctx
+	}
+
+	return dc.ctx
+}
+
+// Close stops the dynamic client. After this function is called, client is
+// in disconnected state and each contexts returned by it are closed.
+func (dc *DynamicClient) Close() {
+	dc.once.Do(func() {
+		close(dc.stop)
+	})
+}
+
+func (dc *DynamicClient) cron() {
+	var (
+		dynAddrTick = time.NewTicker(dc.opts.DynAddrInterval)
+		pingTick    = time.NewTicker(dc.opts.PingInterval)
+	)
+
+	curr := Addr{}
+	dc.tryUpdate(&curr)
+	for {
+		select {
+		case <-dynAddrTick.C:
+			// Look address cache for new addresses. This does not require
+			// pinging remote machines because it only checks current address
+			// book state. Thus, it may be run more frequently than ping.
+			a, err := dc.opts.AddrFunc(curr.Net)
+			if err != nil || (a.Net == curr.Net && a.Val == curr.Val) {
+				break
+			}
+			dc.tryUpdate(&curr)
+		case <-pingTick.C:
+			// Ping remote machine directly in order to check its status.
+			dc.tryUpdate(&curr)
+		case <-dc.stop:
+			// Client was closed.
+			dc.mu.Lock()
+			dc.disconnected()
+			dc.mu.Unlock()
+
+			// Stop tickers.
+			dynAddrTick.Stop()
+			pingTick.Stop()
+			return
+		}
+	}
+}
+
+// tryUpdate uses client builder to ping the machine and updates dynamic client
+// if machine address changes.
+func (dc *DynamicClient) tryUpdate(addr *Addr) {
+	stat, a, err := dc.opts.Builder.Ping(dc.opts.AddrFunc)
+	if err != nil {
+		dc.log.Warning("Machine ping error: %s", err)
+		return
+	}
+
+	if a.Net == addr.Net && a.Val == addr.Val {
+		// Client address did not change.
+		return
+	}
+
+	// Create new client.
+	dc.log.Info("Reinitializing client with %s address: %s", a.Net, a.Val)
+	ctx, cancel := context.WithCancel(context.Background())
+	c := dc.opts.Builder.Build(ctx, a)
+
+	// Update current address.
+	*addr = a
+
+	dc.mu.Lock()
+	if dc.cancel != nil {
+		dc.cancel()
+	}
+	dc.c, dc.stat, dc.ctx, dc.cancel = c, stat, ctx, cancel
+	dc.mu.Unlock()
+}
+
+// disconnected sets disconnected client.
+func (dc *DynamicClient) disconnected() {
+	if dc.cancel != nil {
+		dc.cancel()
+	}
+
+	dc.c = DisconnectedClient{}
+	dc.stat = Status{}
+	dc.ctx = nil
+	dc.cancel = nil
+}

--- a/go/src/koding/klient/machine/dynamic_test.go
+++ b/go/src/koding/klient/machine/dynamic_test.go
@@ -1,0 +1,106 @@
+package machine_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"koding/klient/machine"
+	"koding/klient/machine/machinetest"
+
+	"golang.org/x/sync/errgroup"
+)
+
+func TestDynamicClientOnOff(t *testing.T) {
+	var (
+		serv    = &machinetest.Server{}
+		builder = machinetest.NewNilBuilder()
+	)
+
+	dc, err := machine.NewDynamicClient(machinetest.DynamicClientOpts(serv, builder))
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	defer dc.Close()
+
+	// Server is in unknown state.
+	if status := dc.Status(); status.State != machine.StateUnknown {
+		t.Fatalf("want state = %s; got %s", machine.StateUnknown, status.State)
+	}
+
+	// Server starts responding.
+	serv.TurnOn()
+	if err := builder.WaitForBuild(time.Second); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	if n := builder.BuildsCount(); n != 1 {
+		t.Fatalf("want builds count = 1; got %d", n)
+	}
+	if status := dc.Status(); status.State != machine.StateOnline {
+		t.Fatalf("want state = %s; got %s", machine.StateOnline, status.State)
+	}
+
+	// Stop server.
+	serv.TurnOff()
+	if err := builder.WaitForBuild(time.Second); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	if n := builder.BuildsCount(); n != 2 {
+		t.Fatalf("want builds count = 2; got %d", n)
+	}
+	if status := dc.Status(); status.State != machine.StateOffline {
+		t.Fatalf("want state = %s; got %s", machine.StateOffline, status.State)
+	}
+}
+
+func TestDynamicClientContext(t *testing.T) {
+	var (
+		serv    = &machinetest.Server{}
+		builder = machinetest.NewNilBuilder()
+	)
+
+	dc, err := machine.NewDynamicClient(machinetest.DynamicClientOpts(serv, builder))
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	defer dc.Close()
+
+	serv.TurnOn()
+	if err := builder.WaitForBuild(time.Second); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	const ContextWorkers = 10
+
+	var g errgroup.Group
+	for i := 0; i < ContextWorkers; i++ {
+		g.Go(func() error {
+			select {
+			case <-dc.Context().Done():
+				return errors.New("context closed unexpectedly")
+			case <-time.After(50 * time.Microsecond):
+				return nil
+			}
+		})
+	}
+	// Machine is on so dynamic client should not close its channel.
+	if err := g.Wait(); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	serv.TurnOff()
+	for i := 0; i < ContextWorkers; i++ {
+		g.Go(func() error {
+			select {
+			case <-dc.Context().Done():
+				return nil
+			case <-time.After(time.Second):
+				return errors.New("timed out")
+			}
+		})
+	}
+	// Machine is off so its context channel should be closed by dynamic client.
+	if err := g.Wait(); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+}

--- a/go/src/koding/klient/machine/dynamic_test.go
+++ b/go/src/koding/klient/machine/dynamic_test.go
@@ -83,7 +83,7 @@ func TestDynamicClientContext(t *testing.T) {
 			}
 		})
 	}
-	// Machine is on so dynamic client should not close its channel.
+	// Machine is on so dynamic client should not close its context.
 	if err := g.Wait(); err != nil {
 		t.Fatalf("want err = nil; got %v", err)
 	}

--- a/go/src/koding/klient/machine/dynamic_test.go
+++ b/go/src/koding/klient/machine/dynamic_test.go
@@ -78,7 +78,7 @@ func TestDynamicClientContext(t *testing.T) {
 			select {
 			case <-dc.Context().Done():
 				return errors.New("context closed unexpectedly")
-			case <-time.After(50 * time.Microsecond):
+			case <-time.After(50 * time.Millisecond):
 				return nil
 			}
 		})

--- a/go/src/koding/klient/machine/machinetest/machinetest.go
+++ b/go/src/koding/klient/machine/machinetest/machinetest.go
@@ -1,0 +1,130 @@
+package machinetest
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"koding/klient/machine"
+)
+
+// DynamicClientOpts creates test-friendly options for dynamic client.
+func DynamicClientOpts(s *Server, b *NilBuilder) machine.DynamicClientOpts {
+	return machine.DynamicClientOpts{
+		AddrFunc:        s.AddrFunc(),
+		Builder:         b,
+		DynAddrInterval: 10 * time.Millisecond,
+		PingInterval:    50 * time.Millisecond,
+	}
+}
+
+// Server simulates the real server.
+type Server struct {
+	mu   sync.Mutex
+	addr machine.Addr
+}
+
+// AddrFunc returns machine.DynamicAddrFunc that can be used as addresses source.
+func (s *Server) AddrFunc() machine.DynamicAddrFunc {
+	return func(string) (machine.Addr, error) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		return s.addr, nil
+	}
+}
+
+// TurnOn simulates on-line server.
+func (s *Server) TurnOn() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	value := s.addr.Val
+	if value == "" {
+		value = "0" // initial address.
+	}
+
+	s.addr = machine.Addr{
+		Net: "on",
+		Val: value,
+	}
+}
+
+// TurnOff simulates off-line server.
+func (s *Server) TurnOff() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.addr.Net = "off"
+}
+
+// ChangeAddr generates a new address for server.
+func (s *Server) ChangeAddr() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.addr.Val += "0"
+}
+
+// NilBuilder uses Server logic to build nil clients.
+type NilBuilder struct {
+	buildsN int64
+	ch      chan struct{}
+}
+
+// NewNilBuilder creates a new NilBuilder object.
+func NewNilBuilder() *NilBuilder {
+	return &NilBuilder{
+		ch: make(chan struct{}),
+	}
+}
+
+// Ping returns machine statuses based on Server response.
+func (*NilBuilder) Ping(dynAddr machine.DynamicAddrFunc) (machine.Status, machine.Addr, error) {
+	if dynAddr == nil {
+		panic("nil dynamic function generator")
+	}
+
+	addr, err := dynAddr("")
+	if err != nil {
+		return machine.Status{}, addr, err
+	}
+
+	status := machine.Status{}
+	switch addr.Net {
+	case "on":
+		status.State = machine.StateOnline
+	case "off":
+		status.State = machine.StateOffline
+	}
+
+	return status, addr, nil
+}
+
+// Build creates a nil client and increases builds counter.
+func (n *NilBuilder) Build(_ context.Context, _ machine.Addr) machine.Client {
+	go func() {
+		atomic.AddInt64(&n.buildsN, 1)
+		n.ch <- struct{}{}
+	}()
+
+	return nil
+}
+
+// WaitForBuild waits for invocation of Build method. It times out after
+// specified duration.
+func (n *NilBuilder) WaitForBuild(timeout time.Duration) error {
+	select {
+	case <-n.ch:
+		return nil
+	case <-time.After(timeout):
+		return fmt.Errorf("timed out after %s", timeout)
+	}
+}
+
+// BuildsCount returns how many times Build method was invoked.
+func (n *NilBuilder) BuildsCount() int {
+	return int(atomic.LoadInt64(&n.buildsN))
+}

--- a/go/src/koding/klient/machine/status.go
+++ b/go/src/koding/klient/machine/status.go
@@ -72,7 +72,9 @@ func (s *Status) String() string {
 	return strings.Join(toks, ", ")
 }
 
-// MergeStatus is an utility function
+// MergeStatus is an utility function that merges two statuses into one. Younger
+// statuses have higher priority. But, if both have identical state, older
+// status may be returned as we assume that it didn't change at all.
 func MergeStatus(a, b Status) Status {
 	// Swap a with b when b is older than a.
 	if a.Since.After(b.Since) {


### PR DESCRIPTION
This PR adds dynamic client to `machine` package.

Depends on: #9790 #9791

## Description
This is reworked architecture that is going to handle all `kd machine *` CLI commands. It *partially* deprecates `klient/remote` packages. There is a number of current issues which these changes are intended to solve:

- Support for multiple mounts per machine.
- Correct handling of destroyed machines.
- Correct handling of machines that changed their IP address.
- Correct handling of machines that changed their Kite.key.
- Correct handling of rsync mount processes.
- Clean ups after errors.
- Prevent machine duplication during `kd machine list` 
- Businnes logic and Kite transort separation.
- etc.

## Architecture
![image](https://cloud.githubusercontent.com/assets/5021246/20678386/ca8a752e-b596-11e6-91e5-9846ff62dd2a.png)


- **Dynamic Client** - client that can adapt its endpoint address using machine's address book.
- **Disconnected Client** - abstract client factory that describes non existing connection.
- **Kite Client** - Kite client that connects to remote machine Klient.


## How Has This Been Tested?
:warning: WIP - unit tests.

## Screenshots (if appropriate):
none

## Types of changes
- [x] New feature (non-breaking change which adds functionality)


