### PR TITLE
klient: add machine group addresses

### DIFF
--- a/go/src/koding/klient/machine/machinegroup/addresses/addresser.go
+++ b/go/src/koding/klient/machine/machinegroup/addresses/addresser.go
@@ -1,0 +1,23 @@
+package addresses
+
+import "koding/klient/machine"
+
+// Addresser is an interface used to manage machines' network addresses.
+type Addresser interface {
+	// Add adds provided address to a given machine.
+	//
+	// TODO(ppknap): make this function variadic.
+	Add(machine.ID, machine.Addr) error
+
+	// Drop removes addresses which are binded to provided machine ID.
+	Drop(machine.ID) error
+
+	// Latests returns the latest known address for a given machine and network.
+	Latest(machine.ID, string) (machine.Addr, error)
+
+	// MachineID gets machine ID based on provided address.
+	MachineID(machine.Addr) (machine.ID, error)
+
+	// Registered returns all machines that are managed by addresser.
+	Registered() []machine.ID
+}

--- a/go/src/koding/klient/machine/machinegroup/addresses/addresses.go
+++ b/go/src/koding/klient/machine/machinegroup/addresses/addresses.go
@@ -1,0 +1,102 @@
+package addresses
+
+import (
+	"sync"
+
+	"koding/klient/machine"
+)
+
+// Addresses store addresses of all machines in the group.
+type Addresses struct {
+	mu sync.RWMutex
+	m  map[machine.ID]*machine.AddrBook
+}
+
+// New creates an empty Addresses object.
+func New() *Addresses {
+	return &Addresses{
+		m: make(map[machine.ID]*machine.AddrBook),
+	}
+}
+
+// Add adds provided address to a given machine.
+func (a *Addresses) Add(id machine.ID, addr machine.Addr) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	ab, ok := a.m[id]
+	if !ok {
+		ab = &machine.AddrBook{}
+	}
+
+	ab.Add(addr)
+	a.m[id] = ab
+
+	return nil
+}
+
+// Drop removes addresses which are binded to provided machine ID.
+func (a *Addresses) Drop(id machine.ID) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	delete(a.m, id)
+
+	return nil
+}
+
+// Latests returns the latest known address for a given machine and network.
+func (a *Addresses) Latest(id machine.ID, network string) (machine.Addr, error) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	ab, ok := a.m[id]
+	if !ok {
+		return machine.Addr{}, machine.ErrMachineNotFound
+	}
+
+	return ab.Latest(network)
+}
+
+// MachineID checks if there is a machine ID that is binded to provided address
+// If yes, the machine ID is returned. machine.ErrMachineNotFound is returned
+// if there is no machine that has provided address.
+func (a *Addresses) MachineID(addr machine.Addr) (machine.ID, error) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	for id, ab := range a.m {
+		if ab.Has(addr) {
+			return id, nil
+		}
+	}
+
+	return "", machine.ErrMachineNotFound
+}
+
+// Registered returns all machines that are stored in this object.
+func (a *Addresses) Registered() []machine.ID {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	registered := make([]machine.ID, 0, len(a.m))
+	for id, _ := range a.m {
+		registered = append(registered, id)
+	}
+
+	return registered
+}
+
+// all returns all stored address books.
+func (a *Addresses) all() map[machine.ID]*machine.AddrBook {
+	all := make(map[machine.ID]*machine.AddrBook)
+
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	for id, addrbook := range a.m {
+		// It is save to return pointer here since address book's internal
+		// fields are synchronized internally.
+		all[id] = addrbook
+	}
+
+	return all
+}

--- a/go/src/koding/klient/machine/machinegroup/addresses/addresses_test.go
+++ b/go/src/koding/klient/machine/machinegroup/addresses/addresses_test.go
@@ -1,0 +1,85 @@
+package addresses_test
+
+import (
+	"testing"
+	"time"
+
+	"koding/klient/machine"
+	"koding/klient/machine/machinegroup/addresses"
+)
+
+func TestAddressesMachineID(t *testing.T) {
+	tests := map[string]struct {
+		ID    machine.ID
+		Addr  machine.Addr
+		Valid bool
+	}{
+		"machine 1 older IP": {
+			ID: "ID_1",
+			Addr: machine.Addr{
+				Net:     "ip",
+				Val:     "52.254.159.36",
+				Updated: time.Date(2012, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+			Valid: true,
+		},
+		"machine 1 newer IP": {
+			ID: "ID_1",
+			Addr: machine.Addr{
+				Net:     "ip",
+				Val:     "52.254.159.123",
+				Updated: time.Date(2014, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+			Valid: true,
+		},
+		"machine 2 TCP": {
+			ID: "ID_2",
+			Addr: machine.Addr{
+				Net:     "tcp",
+				Val:     "127.0.0.1:80",
+				Updated: time.Date(2009, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+			Valid: true,
+		},
+		"unknown address": {
+			ID: "ID_2",
+			Addr: machine.Addr{
+				Net:     "ip",
+				Val:     "10.0.34.134",
+				Updated: time.Date(2000, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+			Valid: false,
+		},
+		"missing machine": {
+			ID: "",
+			Addr: machine.Addr{
+				Net:     "ip",
+				Val:     "10.0.34.23",
+				Updated: time.Date(2020, time.May, 1, 0, 0, 0, 0, time.UTC),
+			},
+			Valid: false,
+		},
+	}
+
+	addrs := addresses.New()
+	for name, test := range tests {
+		if test.Valid {
+			if err := addrs.Add(test.ID, test.Addr); err != nil {
+				t.Fatalf("%s: want err = nil; got %v", name, err)
+			}
+		}
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			id, err := addrs.MachineID(test.Addr)
+			if (err == nil) != test.Valid {
+				t.Fatalf("want err == nil => %t; got err %v", test.Valid, err)
+			}
+
+			if err == nil && test.ID != id {
+				t.Fatalf("want machine ID = %s; got %s", test.ID, id)
+			}
+		})
+	}
+}

--- a/go/src/koding/klient/machine/machinegroup/addresses/cached.go
+++ b/go/src/koding/klient/machine/machinegroup/addresses/cached.go
@@ -1,0 +1,75 @@
+package addresses
+
+import (
+	"sync"
+
+	"koding/klient/machine"
+	"koding/klient/storage"
+)
+
+// storageKey is a database key used to store machine addresses.
+const storageKey = "addresses"
+
+// Cached is an Addresses object with additional storage layer.
+type Cached struct {
+	mu sync.Mutex
+	st storage.ValueInterface
+
+	addresses *Addresses
+}
+
+// NewCached creates a new Cached object backed by provided storage.
+func NewCached(st storage.ValueInterface) (*Cached, error) {
+	c := &Cached{
+		st:        st,
+		addresses: New(),
+	}
+
+	if err := c.st.GetValue(storageKey, &c.addresses.m); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// Add adds provided address to a given machine and updates the cache.
+func (c *Cached) Add(id machine.ID, addr machine.Addr) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.addresses.Add(id, addr); err != nil {
+		return err
+	}
+
+	return c.st.SetValue(storageKey, c.addresses.all())
+}
+
+// Drop removes addresses which are binded to provided machine ID and updates
+// the cache.
+func (c *Cached) Drop(id machine.ID) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.addresses.Drop(id); err != nil {
+		return err
+	}
+
+	return c.st.SetValue(storageKey, c.addresses.all())
+}
+
+// Latests returns the latest known address for a given machine and network.
+func (c *Cached) Latest(id machine.ID, network string) (machine.Addr, error) {
+	return c.addresses.Latest(id, network)
+}
+
+// MachineID checks if there is a machine ID that is binded to provided address
+// If yes, the machine ID is returned. machine.ErrMachineNotFound is returned
+// if there is no machine that has provided address.
+func (c *Cached) MachineID(addr machine.Addr) (machine.ID, error) {
+	return c.addresses.MachineID(addr)
+}
+
+// Registered returns all machines that are stored in this object.
+func (c *Cached) Registered() []machine.ID {
+	return c.addresses.Registered()
+}


### PR DESCRIPTION
This PR adds `addresses` package that manages multiple machines' addresses.

Depends on: #9791

## Description
This is reworked architecture that is going to handle all `kd machine *` CLI commands. It *partially* deprecates `klient/remote` packages. There is a number of current issues which these changes are intended to solve:

- Support for multiple mounts per machine.
- Correct handling of destroyed machines.
- Correct handling of machines that changed their IP address.
- Correct handling of machines that changed their Kite.key.
- Correct handling of rsync mount processes.
- Clean ups after errors.
- Prevent machine duplication during `kd machine list` 
- Businnes logic and Kite transort separation.
- etc.

## Architecture
![image](https://cloud.githubusercontent.com/assets/5021246/20678452/131a8d92-b597-11e6-8a1c-741fdb71cc40.png)

- **Addresses** - a set of remote machines address books.


## How Has This Been Tested?
Unit tests.

## Screenshots (if appropriate):
none

## Types of changes
- [x] New feature (non-breaking change which adds functionality)


