### PR TITLE
klient: add machine group aliases

### DIFF
--- a/go/src/koding/klient/machine/machinegroup/aliases/aliaser.go
+++ b/go/src/koding/klient/machine/machinegroup/aliases/aliaser.go
@@ -1,0 +1,21 @@
+package aliases
+
+import "koding/klient/machine"
+
+// Aliaser is an interface used to manage machines' alternative names.
+type Aliaser interface {
+	// Add binds custom alias to provided machine.
+	Add(machine.ID, string) error
+
+	// Create generates a new alias for provided machine ID.
+	Create(machine.ID) (string, error)
+
+	// Drop removes alias which is binded to provided machine ID.
+	Drop(machine.ID) error
+
+	// MachineID gets machine ID from provided alias.
+	MachineID(string) (machine.ID, error)
+
+	// Registered returns all machines that are managed by aliaser.
+	Registered() []machine.ID
+}

--- a/go/src/koding/klient/machine/machinegroup/aliases/aliases.go
+++ b/go/src/koding/klient/machine/machinegroup/aliases/aliases.go
@@ -1,0 +1,157 @@
+package aliases
+
+import (
+	"math/rand"
+	"strconv"
+	"sync"
+
+	"koding/klient/machine"
+)
+
+// colors defines the available colors for aliases. The first letter of each
+// color name must be unique across the slice.
+var colors = [...]string{
+	"aqua",
+	"black",
+	"fuchsia",
+	"green",
+	"lime",
+	"maroon",
+	"navy",
+	"olive",
+	"purple",
+	"red",
+	"silver",
+	"teal",
+	"white",
+	"yellow",
+}
+
+// fruits defines the available fruits for aliases. The first letter of each
+// fruit name must be unique across the slice.
+var fruits = [...]string{
+	"apple",
+	"banana",
+	"coconut",
+	"date",
+	"fig",
+	"grape",
+	"jackfruit",
+	"kiwi",
+	"lemon",
+	"mango",
+	"nectarine",
+	"orange",
+	"peach",
+	"quince",
+	"raisin",
+	"squash",
+	"tomato",
+	"watermelon",
+}
+
+// Aliases store alternative names for the group of machines.
+type Aliases struct {
+	mu sync.RWMutex
+	m  map[machine.ID]string
+}
+
+// New creates an empty Aliases object.
+func New() *Aliases {
+	return &Aliases{
+		m: make(map[machine.ID]string),
+	}
+}
+
+// Add binds custom alias to provided machine.
+func (a *Aliases) Add(id machine.ID, alias string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.m[id] = alias
+
+	return nil
+}
+
+// Create generates a new alias for provided machine ID. If alias already
+// exists, it will not be regenerated.
+func (a *Aliases) Create(id machine.ID) (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if alias, ok := a.m[id]; ok {
+		return alias, nil
+	}
+
+	// Get current aliases.
+	current := make(map[string]struct{}, len(a.m))
+	for _, alias := range a.m {
+		current[alias] = struct{}{}
+	}
+
+	// Generate new alias.
+	for i := 0; ; i++ {
+		alias := colors[rand.Intn(len(colors))] + "_" + fruits[rand.Intn(len(fruits))]
+
+		if suffix := i / (len(colors) * len(fruits)); suffix > 0 {
+			alias += strconv.Itoa(suffix)
+		}
+
+		if _, ok := current[alias]; !ok {
+			a.m[id] = alias
+			return alias, nil
+		}
+	}
+}
+
+// Drop removes alias which is binded to provided machine ID.
+func (a *Aliases) Drop(id machine.ID) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	delete(a.m, id)
+
+	return nil
+}
+
+// MachineID checks if there is a machine ID that is binded to provided alias.
+// If yes, the machine ID is returned. machine.ErrMachineNotFound is returned
+// if there is no machine ID with provided alias.
+//
+// TODO: Add support for shortcuts like rb1 == red_banana1 etc.
+func (a *Aliases) MachineID(alias string) (machine.ID, error) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	for id, a := range a.m {
+		// provided alias can be the machine ID itself.
+		if machine.ID(alias) == id || alias == a {
+			return id, nil
+		}
+	}
+
+	return "", machine.ErrMachineNotFound
+}
+
+// Registered returns all machines that are stored in this object.
+func (a *Aliases) Registered() []machine.ID {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	registered := make([]machine.ID, 0, len(a.m))
+	for id, _ := range a.m {
+		registered = append(registered, id)
+	}
+
+	return registered
+}
+
+// all returns all stored aliases.
+func (a *Aliases) all() map[machine.ID]string {
+	all := make(map[machine.ID]string)
+
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	for id, alias := range a.m {
+		all[id] = alias
+	}
+
+	return all
+}

--- a/go/src/koding/klient/machine/machinegroup/aliases/aliases_test.go
+++ b/go/src/koding/klient/machine/machinegroup/aliases/aliases_test.go
@@ -1,0 +1,85 @@
+package aliases_test
+
+import (
+	"testing"
+
+	"koding/klient/machine"
+	"koding/klient/machine/machinegroup/aliases"
+)
+
+func TestAliasesCreate(t *testing.T) {
+	const wantAliases = 500
+	m := make(map[string]struct{})
+
+	as := aliases.New()
+	for i := 0; i < wantAliases; i++ {
+		alias, err := as.Create(machine.ID(i))
+		if err != nil {
+			t.Fatalf("want err = nil; got %v", err)
+		}
+		m[alias] = struct{}{}
+
+		// Second creation for the same ID should be no-op.
+		alias, err = as.Create(machine.ID(i))
+		if err != nil {
+			t.Fatalf("want err = nil; got %v", err)
+		}
+		m[alias] = struct{}{}
+	}
+
+	if len(m) != wantAliases {
+		t.Fatalf("want %d aliases; got %d", wantAliases, len(m))
+	}
+}
+
+func TestAliasesMachineID(t *testing.T) {
+	m := map[machine.ID]string{
+		"ID_1": "blue_banana",
+		"ID_2": "red_orange1",
+		"ID_3": "white_mango",
+		"ID_4": "black_tomato2",
+		"ID_5": "silver_kiwi",
+	}
+
+	as := aliases.New()
+	for id, alias := range m {
+		if err := as.Add(id, alias); err != nil {
+			t.Fatalf("want err = nil; got %v", err)
+		}
+	}
+
+	tests := map[string]struct {
+		Alias    string
+		Expected machine.ID
+		NotFound bool
+	}{
+		"full alias": {
+			Alias:    "white_mango",
+			Expected: machine.ID("ID_3"),
+			NotFound: false,
+		},
+		"machine id": {
+			Alias:    "ID_5",
+			Expected: machine.ID("ID_5"),
+			NotFound: false,
+		},
+		"unknown": {
+			Alias:    "green_kiwi",
+			Expected: machine.ID(""),
+			NotFound: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			id, err := as.MachineID(test.Alias)
+			if notFound := machine.IsMachineNotFound(err); notFound != test.NotFound {
+				t.Fatalf("want err alias not found = %t; got %t", test.NotFound, notFound)
+			}
+
+			if id != test.Expected {
+				t.Fatalf("want id = %v; got %v", test.Expected, id)
+			}
+		})
+	}
+}

--- a/go/src/koding/klient/machine/machinegroup/aliases/cached.go
+++ b/go/src/koding/klient/machine/machinegroup/aliases/cached.go
@@ -1,0 +1,88 @@
+package aliases
+
+import (
+	"sync"
+
+	"koding/klient/machine"
+	"koding/klient/storage"
+)
+
+// storageKey is a database key used to store aliases.
+const storageKey = "aliases"
+
+// Cached is an Aliases object with additional storage layer.
+type Cached struct {
+	mu sync.Mutex
+	st storage.ValueInterface
+
+	aliases *Aliases
+}
+
+// NewCached creates a new Cached object backed by provided storage.
+func NewCached(st storage.ValueInterface) (*Cached, error) {
+	c := &Cached{
+		st:      st,
+		aliases: New(),
+	}
+
+	if err := c.st.GetValue(storageKey, &c.aliases.m); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// Add binds custom alias to provided machine and updates the cache.
+func (c *Cached) Add(id machine.ID, alias string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.aliases.Add(id, alias); err != nil {
+		return err
+	}
+
+	return c.st.SetValue(storageKey, c.aliases.all())
+}
+
+// Create generates a new alias for provided machine ID and updates the cache.
+// If alias already exists, it will not be regenerated nor cached.
+func (c *Cached) Create(id machine.ID) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	alias, err := c.aliases.Create(id)
+	if err != nil {
+		return "", err
+	}
+
+	if err = c.st.SetValue(storageKey, c.aliases.all()); err != nil {
+		return "", err
+	}
+
+	return alias, nil
+}
+
+// Drop removes alias which is binded to provided machine ID and updates
+// the cache.
+func (c *Cached) Drop(id machine.ID) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.aliases.Drop(id); err != nil {
+		return err
+	}
+
+	return c.st.SetValue(storageKey, c.aliases.all())
+}
+
+// MachineID checks if there is a machine ID that is binded to provided alias.
+// If yes, the machine ID is returned. ErrAliasNotFound is be returned if there
+// is no machine ID with provided alias.
+func (c *Cached) MachineID(alias string) (machine.ID, error) {
+	return c.aliases.MachineID(alias)
+}
+
+// Registered returns all machines that are stored in this object.
+func (c *Cached) Registered() []machine.ID {
+	return c.aliases.Registered()
+}


### PR DESCRIPTION
This PR adds `aliases` package that maps machine ID to user friendly name.

Depends on: #9789 

## Description
This is reworked architecture that is going to handle all `kd machine *` CLI commands. It *partially* deprecates `klient/remote` packages. There is a number of current issues which these changes are intended to solve:

- Support for multiple mounts per machine.
- Correct handling of destroyed machines.
- Correct handling of machines that changed their IP address.
- Correct handling of machines that changed their Kite.key.
- Correct handling of rsync mount processes.
- Clean ups after errors.
- Prevent machine duplication during `kd machine list` 
- Businnes logic and Kite transort separation.
- etc.

## Architecture
![image](https://cloud.githubusercontent.com/assets/5021246/20679048/89f6b4f2-b599-11e6-90cb-b05eb19c0639.png)

- **Aliases** - a set of machines nicknames.

## How Has This Been Tested?
Unit tests.

## Screenshots (if appropriate):
none

## Types of changes
- [x] New feature (non-breaking change which adds functionality)


