### PR TITLE
klient: add dynamic clients group

### DIFF
--- a/go/src/koding/klient/machine/machinegroup/addresses/addresses.go
+++ b/go/src/koding/klient/machine/machinegroup/addresses/addresses.go
@@ -79,7 +79,7 @@ func (a *Addresses) Registered() []machine.ID {
 	defer a.mu.RUnlock()
 
 	registered := make([]machine.ID, 0, len(a.m))
-	for id, _ := range a.m {
+	for id := range a.m {
 		registered = append(registered, id)
 	}
 

--- a/go/src/koding/klient/machine/machinegroup/aliases/aliases.go
+++ b/go/src/koding/klient/machine/machinegroup/aliases/aliases.go
@@ -136,7 +136,7 @@ func (a *Aliases) Registered() []machine.ID {
 	defer a.mu.RUnlock()
 
 	registered := make([]machine.ID, 0, len(a.m))
-	for id, _ := range a.m {
+	for id := range a.m {
 		registered = append(registered, id)
 	}
 

--- a/go/src/koding/klient/machine/machinegroup/clients/clients.go
+++ b/go/src/koding/klient/machine/machinegroup/clients/clients.go
@@ -1,0 +1,181 @@
+package clients
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"koding/klient/machine"
+
+	"github.com/koding/logging"
+)
+
+// ClientsOpts are the options used to configure set of dynamic clients.
+type ClientsOpts struct {
+	// Builder is a factory used to build clients.
+	Builder machine.ClientBuilder
+
+	// DynAddrInterval indicates how often dynamic client should pull address
+	// function looking for new addresses.
+	DynAddrInterval time.Duration
+
+	// PingInterval indicates how often dynamic client should ping external
+	// machine.
+	PingInterval time.Duration
+
+	// Log is used for logging. If nil, default logger will be created.
+	Log logging.Logger
+}
+
+// Valid checks if provided options are correct.
+func (opts *ClientsOpts) Valid() error {
+	if opts.Builder == nil {
+		return errors.New("nil client builder")
+	}
+	if opts.DynAddrInterval == 0 {
+		return errors.New("dynamic address check interval is not set")
+	}
+	if opts.PingInterval == 0 {
+		return errors.New("ping interval is not set")
+	}
+
+	return nil
+}
+
+// Clients is a set of dynamic clients binded to unique machine ID.
+type Clients struct {
+	builder         machine.ClientBuilder
+	dynAddrInterval time.Duration
+	pingInterval    time.Duration
+
+	log logging.Logger
+
+	mu sync.RWMutex
+	m  map[machine.ID]*machine.DynamicClient
+}
+
+// New creates a new Clients object.
+func New(opts *ClientsOpts) (*Clients, error) {
+	if err := opts.Valid(); err != nil {
+		return nil, err
+	}
+
+	c := &Clients{
+		builder:         opts.Builder,
+		dynAddrInterval: opts.DynAddrInterval,
+		pingInterval:    opts.PingInterval,
+		log:             opts.Log,
+		m:               make(map[machine.ID]*machine.DynamicClient),
+	}
+
+	if c.log == nil {
+		c.log = logging.NewLogger("")
+	}
+
+	return c, nil
+}
+
+// Create generates a new dynamic client for a given machine. If machine client
+// already exists, this function is no-op.
+func (c *Clients) Create(id machine.ID, dynAddr machine.DynamicAddrFunc) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if _, ok := c.m[id]; ok {
+		return nil
+	}
+
+	dc, err := machine.NewDynamicClient(machine.DynamicClientOpts{
+		AddrFunc:        dynAddr,
+		Builder:         c.builder,
+		DynAddrInterval: c.dynAddrInterval,
+		PingInterval:    c.pingInterval,
+		Log:             c.log.New(string(id)),
+	})
+	if err != nil {
+		return err
+	}
+
+	c.m[id] = dc
+
+	return nil
+}
+
+// Drop closes and removes dynamic client binded to provided machine ID.
+func (c *Clients) Drop(id machine.ID) error {
+	c.mu.Lock()
+	dc, ok := c.m[id]
+	if !ok {
+		c.mu.Unlock()
+		return nil
+	}
+	delete(c.m, id)
+	c.mu.Unlock()
+
+	if dc != nil {
+		dc.Close()
+	} else {
+		c.log.Critical("Non existing client registered under %s ID", id)
+	}
+
+	return nil
+}
+
+// Status gets machine dynamic client status. It may return nil error and zero
+// value when client is disconnected. machine.ErrMachineNotFound is returned
+// when there are no clients for a given machine ID.
+func (c *Clients) Status(id machine.ID) (machine.Status, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	dc, ok := c.m[id]
+	if !ok {
+		return machine.Status{}, machine.ErrMachineNotFound
+	}
+
+	return dc.Status(), nil
+}
+
+// Client returns the current status of provided machine.
+// machine.ErrMachineNotFound is returned when there are no clients for a given
+// machine ID.
+func (c *Clients) Client(id machine.ID) (machine.Client, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	dc, ok := c.m[id]
+	if !ok {
+		return nil, machine.ErrMachineNotFound
+	}
+
+	return dc.Client(), nil
+}
+
+// Context returns the current context of provided machine's dynamic client.
+// machine.ErrMachineNotFound is returned when there are no clients for a given
+// machine ID.
+func (c *Clients) Context(id machine.ID) (context.Context, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	dc, ok := c.m[id]
+	if !ok {
+		return nil, machine.ErrMachineNotFound
+	}
+
+	return dc.Context(), nil
+}
+
+// Registered returns all machines that are stored in this object.
+func (c *Clients) Registered() []machine.ID {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	registered := make([]machine.ID, 0, len(c.m))
+	for id, _ := range c.m {
+		registered = append(registered, id)
+	}
+
+	return registered
+}

--- a/go/src/koding/klient/machine/machinegroup/clients/clients.go
+++ b/go/src/koding/klient/machine/machinegroup/clients/clients.go
@@ -194,7 +194,7 @@ func (c *Clients) Registered() []machine.ID {
 	defer c.mu.RUnlock()
 
 	registered := make([]machine.ID, 0, len(c.m))
-	for id, _ := range c.m {
+	for id := range c.m {
 		registered = append(registered, id)
 	}
 

--- a/go/src/koding/klient/machine/machinegroup/clients/clients.go
+++ b/go/src/koding/klient/machine/machinegroup/clients/clients.go
@@ -116,7 +116,28 @@ func (c *Clients) Drop(id machine.ID) error {
 	if dc != nil {
 		dc.Close()
 	} else {
-		c.log.Critical("Non existing client registered under %s ID", id)
+		panic("nonexistent client for " + string(id))
+	}
+
+	return nil
+}
+
+// Close closes and drops all dynamic clients registered to Clients.
+func (c *Clients) Close() error {
+	all := make(map[machine.ID]*machine.DynamicClient)
+	c.mu.Lock()
+	for id, dc := range c.m {
+		all[id] = dc
+		delete(c.m, id)
+	}
+	c.mu.Unlock()
+
+	for id, dc := range all {
+		if dc != nil {
+			dc.Close()
+		} else {
+			panic("nonexistent client for " + string(id))
+		}
 	}
 
 	return nil

--- a/go/src/koding/klient/machine/machinegroup/clients/clients_test.go
+++ b/go/src/koding/klient/machine/machinegroup/clients/clients_test.go
@@ -1,10 +1,11 @@
-package clients
+package clients_test
 
 import (
 	"testing"
 	"time"
 
 	"koding/klient/machine"
+	"koding/klient/machine/machinegroup/clients"
 	"koding/klient/machine/machinetest"
 
 	"golang.org/x/sync/errgroup"
@@ -21,7 +22,7 @@ func TestClients(t *testing.T) {
 		servB = &machinetest.Server{}
 	)
 
-	cs, err := New(&ClientsOpts{
+	cs, err := clients.New(&clients.ClientsOpts{
 		Builder:         builder,
 		DynAddrInterval: 10 * time.Millisecond,
 		PingInterval:    50 * time.Millisecond,

--- a/go/src/koding/klient/machine/machinegroup/clients/clients_test.go
+++ b/go/src/koding/klient/machine/machinegroup/clients/clients_test.go
@@ -1,0 +1,71 @@
+package clients
+
+import (
+	"testing"
+	"time"
+
+	"koding/klient/machine"
+	"koding/klient/machine/machinetest"
+
+	"golang.org/x/sync/errgroup"
+)
+
+func TestClients(t *testing.T) {
+	var (
+		builder = machinetest.NewNilBuilder()
+
+		idA = machine.ID("servA")
+		idB = machine.ID("servB")
+
+		servA = &machinetest.Server{}
+		servB = &machinetest.Server{}
+	)
+
+	cs, err := New(&ClientsOpts{
+		Builder:         builder,
+		DynAddrInterval: 10 * time.Millisecond,
+		PingInterval:    50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	defer cs.Close()
+
+	var g errgroup.Group
+	create := map[machine.ID]machine.DynamicAddrFunc{
+		idA: servA.AddrFunc(),
+		idB: servB.AddrFunc(),
+		idA: servA.AddrFunc(), // duplicate.
+		idA: servA.AddrFunc(), // duplicate.
+	}
+
+	for id, dynAddr := range create {
+		id, dynAddr := id, dynAddr // Local copy for concurrency.
+		g.Go(func() error {
+			return cs.Create(id, dynAddr)
+		})
+	}
+	if err := g.Wait(); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	if regs := cs.Registered(); len(regs) != 2 {
+		t.Fatalf("want clients count = 2; got %d", len(regs))
+	}
+
+	if _, err := cs.Context(idA); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	if err := cs.Drop(idA); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	if _, err := cs.Context(idA); err != machine.ErrMachineNotFound {
+		t.Fatalf("want machine not found; got %v", err)
+	}
+
+	if regs := cs.Registered(); len(regs) != 1 {
+		t.Fatalf("want clients count = 1; got %d", len(regs))
+	}
+}


### PR DESCRIPTION
This PR adds `clients` package that manages machines' dynamic clients.

Depends on: #9792 

## Description
This is reworked architecture that is going to handle all `kd machine *` CLI commands. It *partially* deprecates `klient/remote` packages. There is a number of current issues which these changes are intended to solve:

- Support for multiple mounts per machine.
- Correct handling of destroyed machines.
- Correct handling of machines that changed their IP address.
- Correct handling of machines that changed their Kite.key.
- Correct handling of rsync mount processes.
- Clean ups after errors.
- Prevent machine duplication during `kd machine list` 
- Businnes logic and Kite transort separation.
- etc.

## Architecture
![image](https://cloud.githubusercontent.com/assets/5021246/20678614/ac90f5ec-b597-11e6-9326-45f50ffbf8d6.png)

- **Clients** - a set of machine dynamic clients.

## How Has This Been Tested?
Unit tests.

## Screenshots (if appropriate):
none

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

