### PR TITLE
IDE, AppStorage fixes - load improvements

### DIFF
--- a/client/app/lib/appstorage.coffee
+++ b/client/app/lib/appstorage.coffee
@@ -77,9 +77,12 @@ module.exports = class AppStorage extends kd.Object
   getValue: (key, group = AppStorage.DEFAULT_GROUP_NAME) ->
 
     appId = @_applicationID
-    return unless @_storage
-    return if @_storageData[group]?[appId]?.data?[key]? then @_storageData[group][appId].data[key]
-    return if @_storage[group]?[appId]?.data?[key]?     then @_storage[group][appId].data[key]
+    data  = do =>
+      return unless @_storage
+      return if @_storageData[group]?[appId]?.data?[key]? then @_storageData[group][appId].data[key]
+      return if @_storage[group]?[appId]?.data?[key]?     then @_storage[group][appId].data[key]
+
+    _.clone data
 
 
   setValue: (key, value, callback, group = AppStorage.DEFAULT_GROUP_NAME, notify = no) ->

--- a/client/app/lib/appstorage.coffee
+++ b/client/app/lib/appstorage.coffee
@@ -1,4 +1,5 @@
 kd     = require 'kd'
+_      = require 'lodash'
 whoami = require './util/whoami'
 
 
@@ -88,6 +89,9 @@ module.exports = class AppStorage extends kd.Object
     @_storageData[group][appId]            or= {}
     @_storageData[group][appId].data       or= {}
     @_storageData[group][appId].data[key]    = value
+
+    if _.isEqual @_storage?[group]?[appId]?.data?[key], value
+      return callback?()
 
     pack = @zip key, group, value
 

--- a/client/app/lib/appstoragecontroller.coffee
+++ b/client/app/lib/appstoragecontroller.coffee
@@ -27,6 +27,5 @@ class AppStorageController extends kd.Controller
     key = "#{opts.name}-#{opts.version}"
 
     storage = @appStorages[key] or= new AppStorage opts.name, opts.version
-    storage.fetchStorage()  unless opts.fetch is false
 
     return storage

--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -1418,3 +1418,8 @@ module.exports = class ComputeController extends KDController
             callback  : -> callback { status : yes, modal }
 
       modal.setAttribute 'testpath', 'RemoveStackModal'
+
+
+  infoTest: (machine) ->
+    ComputeHelpers = require './computehelpers'
+    ComputeHelpers.infoTest machine

--- a/client/app/lib/providers/computehelpers.coffee
+++ b/client/app/lib/providers/computehelpers.coffee
@@ -227,15 +227,16 @@ module.exports = class ComputeHelpers
   # This method is not used in any place, I put it here until
   # we have a valid test suit for client side modular tests. ~ GG
   #
-  @infoTest = (count = 5) ->
+  @infoTest = (machine) ->
 
     { log } = kd
     cc      = kd.singletons.computeController
 
+    count   = 5
     kloud   = cc.getKloud()
     { now } = Date
 
-    machine      = cc.machines.first
+    machine     ?= cc.machines.first
     machineId    = machine._id
     currentState = machine.status.state
 

--- a/client/app/lib/providers/machine.coffee
+++ b/client/app/lib/providers/machine.coffee
@@ -167,7 +167,7 @@ module.exports = class Machine extends KDObject
         kite.klientInfo().then (info) =>
           callback null, @info = info
         .timeout globals.COMPUTECONTROLLER_TIMEOUT
-        .catch (err) =>
+        .catch (err) ->
           kd.warn '[Machine][fetchInfo] Failed to get klient.info', err
           setAndReturnDefault()
     else

--- a/client/app/lib/providers/machine.coffee
+++ b/client/app/lib/providers/machine.coffee
@@ -1,4 +1,5 @@
 Promise               = require 'bluebird'
+_                     = require 'lodash'
 kd                    = require 'kd'
 KDObject              = kd.Object
 doesQueryStringValid  = require '../util/doesQueryStringValid'
@@ -155,23 +156,24 @@ module.exports = class Machine extends KDObject
 
     owner = @getOwner()
 
-    setAndReturnDefault = =>
-      callback null, @info =
+    kallback = (info = {}) =>
+      callback null, @info = _.merge {},
         home     : "/home/#{owner}"
         groups   : [owner, 'sudo']
         username : owner
+      , info
 
     if @isRunning()
       kite = @getBaseKite()
-      kite.init().then =>
-        kite.klientInfo().then (info) =>
-          callback null, @info = info
+      kite.init().then ->
+        kite.klientInfo().then (info) ->
+          kallback info
         .timeout globals.COMPUTECONTROLLER_TIMEOUT
         .catch (err) ->
           kd.warn '[Machine][fetchInfo] Failed to get klient.info', err
-          setAndReturnDefault()
+          kallback()
     else
-      setAndReturnDefault()
+      kallback()
 
 
   getOwner: ->

--- a/client/app/lib/remote-extensions/account.coffee
+++ b/client/app/lib/remote-extensions/account.coffee
@@ -10,26 +10,21 @@ module.exports = class JAccount extends remote.api.JAccount
     super
 
     @_storageQueue = []
-    @_combinedStorage = null
-
-    if (cs = globals.combinedStorage) and Object.keys(cs).length
-      @_combinedStorage = remote.revive cs
 
 
   fetchCombinedStorage: (options, callback) ->
 
-    if @_combinedStorage
-      callback null, @_combinedStorage
-      return
+    if globals.combinedStorage
+      callback null, globals.combinedStorage
 
     @_storageQueue.push callback
-
     return  if @_storageQueue.length > 1
 
     @fetchAppStorage options, (err, storage) =>
-      @_combinedStorage = storage  if not err and storage
+      globals.combinedStorage = storage  if not err and storage
       cb? err, storage  for cb in @_storageQueue
       @_storageQueue = []
 
 
-  resetStorageCache: -> @_combinedStorage = null
+  resetStorageCache: ->
+    globals.combinedStorage = null

--- a/client/app/lib/remote.coffee
+++ b/client/app/lib/remote.coffee
@@ -76,6 +76,7 @@ createInstance = ->
 
 
   bongoInstance.once 'ready', ->
+    globals.combinedStorage = bongoInstance.revive globals.combinedStorage
     remote_extensions.initialize bongoInstance
 
   return bongoInstance

--- a/client/app/lib/util/showSaveDialog.coffee
+++ b/client/app/lib/util/showSaveDialog.coffee
@@ -8,7 +8,7 @@ IDEFinderItem   = require 'ide/finder/idefinderitem'
 envDataProvider = require 'app/userenvironmentdataprovider'
 
 
-module.exports = (container, callback = kd.noop, options = {}) ->
+module.exports = showSaveDialog = (container, callback = kd.noop, options = {}) ->
 
   container.addSubView dialog = new KDDialogView
     cssClass      : kd.utils.curry 'save-as-dialog', options.cssClass
@@ -53,7 +53,7 @@ module.exports = (container, callback = kd.noop, options = {}) ->
   dialog.show()
   input.setFocus()
 
-  finderController = kd.singletons['appManager'].get('Finder').create
+  finderController = kd.singletons.appManager.get('Finder').create
     addAppTitle       : no
     treeItemClass     : IDEFinderItem
     nodeIdPath        : 'path'
@@ -62,19 +62,10 @@ module.exports = (container, callback = kd.noop, options = {}) ->
     contextMenu       : yes
     loadFilesOnInit   : yes
     machineToMount    : options.machine
+    saveChanges       : no
 
   finderController.reset()
 
   form.addSubView finderWrapper = new KDView { cssClass : 'save-as-dialog save-file-container' }, null
   finderWrapper.addSubView finderController.getView()
   finderWrapper.setHeight 200
-
-  # FIXME: rootpath should be taken from options.
-  # i don't want to do it for now because this file should be
-  # refactored from the first line and should be moved to somewhere else.
-  # for now we can live with it and assuming appManager.frontApp is IDE in
-  # this case is safe because this is save/save-as modal.
-  if machine = options.machine
-    if ideApp = envDataProvider.getIDEFromUId machine.uid
-      { rootPath } = ideApp.workspaceData
-      finderController.updateMachineRoot machine.uid, rootPath

--- a/client/finder/lib/filetree/controllers/nfindercontroller.coffee
+++ b/client/finder/lib/filetree/controllers/nfindercontroller.coffee
@@ -120,8 +120,6 @@ module.exports = class NFinderController extends KDViewController
     if @getMachineNode uid
       return kd.warn "Machine #{machine.getName()} is already mounted!"
 
-    @updateMountState uid, yes
-
     @machines.push FSHelper.createFileInstance
       name           : path
       path           : "[#{uid}]#{path}"
@@ -159,7 +157,6 @@ module.exports = class NFinderController extends KDViewController
     machineItem = @getMachineNode uid
     return kd.warn 'No such Machine!'  unless machineItem
 
-    @updateMountState uid, no
     @stopWatching machineItem.data.path
     FSHelper.unregisterMachineFiles uid
     @treeController.removeNodeView machineItem
@@ -306,18 +303,6 @@ module.exports = class NFinderController extends KDViewController
 
 
   setReadOnly: (state) -> @treeController.isReadOnly = state
-
-
-  # Settings helpers
-  #
-  updateMountState: (uid, state) ->
-
-    return  if isGuest()
-
-    machines = @appStorage.getValue('mountedMachines') or {}
-    machines[uid] = state
-
-    @appStorage.setValue 'mountedMachines', machines
 
 
   # FS Watcher helpers

--- a/client/finder/lib/filetree/controllers/nfindercontroller.coffee
+++ b/client/finder/lib/filetree/controllers/nfindercontroller.coffee
@@ -230,17 +230,26 @@ module.exports = class NFinderController extends KDViewController
     recentFolders = @getRecentFolders()
     unless folderPath in recentFolders
       recentFolders.push folderPath
-    recentFolders.sort (path) -> if path is folderPath then -1 else 0
+    recentFolders
+      .sort (path) ->
+        if path is folderPath then -1 else 0
+      .sort (a, b) ->
+        a.length - b.length
+
     @store 'recentFolders', recentFolders, callback
 
 
   unsetRecentFolder: (folderPath, callback) ->
 
     recentFolders = @getRecentFolders()
-    recentFolders = recentFolders.filter (path) ->
-      path.indexOf(folderPath) isnt 0
-    recentFolders.sort (path) ->
-      if path is folderPath then -1 else 0
+    recentFolders = recentFolders
+      .filter (path) ->
+        path.indexOf(folderPath) isnt 0
+      .sort (path) ->
+        if path is folderPath then -1 else 0
+      .sort (a, b) ->
+        a.length - b.length
+
     @store 'recentFolders', recentFolders, callback
 
 
@@ -257,6 +266,9 @@ module.exports = class NFinderController extends KDViewController
 
     if typeof paths is 'string'
       paths = FSHelper.getPathHierarchy paths
+
+    paths.sort (a, b) ->
+      a.length - b.length
 
     path = paths.shift()
 

--- a/client/finder/lib/filetree/controllers/nfindercontroller.coffee
+++ b/client/finder/lib/filetree/controllers/nfindercontroller.coffee
@@ -35,10 +35,10 @@ module.exports = class NFinderController extends KDViewController
     treeOptions.maxRecentFolders  = options.maxRecentFolders  or= 10
     treeOptions.useStorage        = options.useStorage         ?= no
     treeOptions.loadFilesOnInit   = options.loadFilesOnInit    ?= no
+    treeOptions.saveChanges       = options.saveChanges        ?= yes
     treeOptions.delegate          = this
 
     super options, data
-
 
     TreeControllerClass = options.treeControllerClass or NFinderTreeController
     @treeController     = new TreeControllerClass treeOptions, []
@@ -215,7 +215,7 @@ module.exports = class NFinderController extends KDViewController
 
     prefs = @appStorage.getValue('machinesDotFileChoices') or {}
     prefs[uid] = state
-    @appStorage.setValue 'machinesDotFileChoices', prefs
+    @store 'machinesDotFileChoices', prefs
 
 
   getRecentFolders: ->
@@ -231,7 +231,7 @@ module.exports = class NFinderController extends KDViewController
     unless folderPath in recentFolders
       recentFolders.push folderPath
     recentFolders.sort (path) -> if path is folderPath then -1 else 0
-    @appStorage.setValue 'recentFolders', recentFolders, callback
+    @store 'recentFolders', recentFolders, callback
 
 
   unsetRecentFolder: (folderPath, callback) ->
@@ -241,7 +241,7 @@ module.exports = class NFinderController extends KDViewController
       path.indexOf(folderPath) isnt 0
     recentFolders.sort (path) ->
       if path is folderPath then -1 else 0
-    @appStorage.setValue 'recentFolders', recentFolders, callback
+    @store 'recentFolders', recentFolders, callback
 
 
   expandFolder: (folderPath, callback = kd.noop) ->
@@ -333,3 +333,11 @@ module.exports = class NFinderController extends KDViewController
     FSHelper.resetRegistry()
     @stopAllWatchers()
     @machines = []
+
+
+  store: (key, value, callback) ->
+
+    callback ?= kd.noop
+    if @getOption('saveChanges') is no
+      return callback null
+    @appStorage.setValue key, value, callback

--- a/client/finder/lib/filetree/controllers/nfindercontroller.coffee
+++ b/client/finder/lib/filetree/controllers/nfindercontroller.coffee
@@ -111,7 +111,7 @@ module.exports = class NFinderController extends KDViewController
 
     { uid } = machine
     mRoots  = (@appStorage.getValue 'machineRoots') or {}
-    path    = options.mountPath or mRoots[uid] or '/'
+    path    = mRoots[uid] or options.mountPath or '/'
     path   ?= '/root'  if machine.isManaged()
     path   ?= if owner = machine.getOwner()
     then "/home/#{owner}"
@@ -252,6 +252,7 @@ module.exports = class NFinderController extends KDViewController
     return  unless folderPath
     for own path, node of @treeController.nodes
       return @treeController.expandFolder node, callback  if path is folderPath
+
     callback { message:"Folder not exists: #{folderPath}" }
 
 
@@ -259,7 +260,9 @@ module.exports = class NFinderController extends KDViewController
 
     if typeof paths is 'string'
       paths = FSHelper.getPathHierarchy paths
-    path = paths.pop()
+
+    path = paths.shift()
+
     @expandFolder path, (err) =>
       @unsetRecentFolder path  if err
       if paths.length is 0
@@ -270,11 +273,15 @@ module.exports = class NFinderController extends KDViewController
   reloadPreviousState: (uid) ->
 
     recentFolders = @getRecentFolders()
+
     if uid
+
       recentFolders = recentFolders.filter (folder) ->
-        folder.indexOf "[#{uid}]" is 0
+        folder.indexOf("[#{uid}]") is 0
+
       if recentFolders.length is 0
         recentFolders = ["[#{uid}]/"]
+
     @expandFolders recentFolders
 
 

--- a/client/home/lib/welcome/welcomemodal.coffee
+++ b/client/home/lib/welcome/welcomemodal.coffee
@@ -31,33 +31,32 @@ module.exports = class WelcomeModal extends kd.ModalView
   showCongratulationModal: ->
 
     { appStorageController } = kd.singletons
+
     appStorage = appStorageController.storage "WelcomeSteps-#{globals.currentGroup.slug}"
-    buckets = appStorage.storage.bucket
-    welcomeStepsStore = buckets["WelcomeSteps-#{globals.currentGroup.slug}"]
-    isShown = welcomeStepsStore.data.OnboardingSuccessModalShown
+    appStorage.fetchValue 'OnboardingSuccessModalShown', (result) ->
 
-    return  if isShown
+      return  if result
 
-    appStorage.setValue 'OnboardingSuccessModalShown', yes
+      appStorage.setValue 'OnboardingSuccessModalShown', yes
 
-    modal = new kd.ModalView
-      title : 'Success!'
-      width : 530
-      cssClass : 'Congratulation-modal'
-      content : "<p class='description'>Congratulations. You have completed all items on your onboarding list.</p>"
+      modal = new kd.ModalView
+        title : 'Success!'
+        width : 530
+        cssClass : 'Congratulation-modal'
+        content : "<p class='description'>Congratulations. You have completed all items on your onboarding list.</p>"
 
 
-    kd.View::addSubView.call modal, new kd.CustomHTMLView
-      cssClass : 'alien'
+      kd.View::addSubView.call modal, new kd.CustomHTMLView
+        cssClass : 'alien'
 
 
-    modal.addSubView new kd.CustomHTMLView
-      cssClass : 'image-wrapper'
+      modal.addSubView new kd.CustomHTMLView
+        cssClass : 'image-wrapper'
 
-    modal.addSubView new kd.ButtonView
-      title : 'KEEP ROCKING!'
-      cssClass: 'GenericButton'
-      callback : -> modal.destroy()
+      modal.addSubView new kd.ButtonView
+        title : 'KEEP ROCKING!'
+        cssClass: 'GenericButton'
+        callback : -> modal.destroy()
 
 
   initialShow: ->

--- a/client/ide/lib/index.coffee
+++ b/client/ide/lib/index.coffee
@@ -514,10 +514,8 @@ class IDEAppController extends AppController
     panel     = @workspace.getView()
     filesPane = panel.getPaneByName 'filesPane'
 
-    path = @workspaceData?.rootPath
-
     @workspace.ready ->
-      filesPane.emit 'MachineMountRequested', machineData, path
+      filesPane.emit 'MachineMountRequested', machineData
 
 
   unmountMachine: (machineData) ->

--- a/client/ide/lib/index.coffee
+++ b/client/ide/lib/index.coffee
@@ -509,10 +509,10 @@ class IDEAppController extends AppController
   mountMachine: (machineData) ->
 
     # interrupt if workspace was changed
-    return if machineData.uid isnt @workspaceData.machineUId
+    return  if machineData.uid isnt @workspaceData.machineUId
 
-    panel        = @workspace.getView()
-    filesPane    = panel.getPaneByName 'filesPane'
+    panel     = @workspace.getView()
+    filesPane = panel.getPaneByName 'filesPane'
 
     path = @workspaceData?.rootPath
 
@@ -535,7 +535,7 @@ class IDEAppController extends AppController
 
   createInitialView: (withFakeViews) ->
 
-    @getMountedMachine (err, machine) =>
+    @getMountedMachine (err, machine) => @workspace.ready =>
 
       return  unless machine
 

--- a/client/ide/lib/index.coffee
+++ b/client/ide/lib/index.coffee
@@ -1269,13 +1269,14 @@ class IDEAppController extends AppController
     { computeController } = kd.singletons
     { finderController }  = @finderPane
 
-    if @workspaceData
-      finderController.updateMachineRoot @mountedMachine.uid, @workspaceData.rootPath
-    else
-      finderController.reset()
-
     # when MachineStateModal calls this func, we need to rebind Klient.
     @bindKlientEvents machine
+
+    machine.fetchInfo (err, info) =>
+      kd.warn '[IDE] Failed to fetch info', err  if err
+      rootPath = info?.home or @workspaceData?.rootPath or '/'
+      finderController.updateMachineRoot @mountedMachine.uid, rootPath
+
     machine.getBaseKite()?.fetchTerminalSessions?()
 
     @fetchSnapshot (snapshot) =>

--- a/client/ide/lib/index.coffee
+++ b/client/ide/lib/index.coffee
@@ -491,20 +491,6 @@ class IDEAppController extends AppController
     @activeTabView.emit 'MachineWebPageRequested', machineData
 
 
-  ensureReadme: (snapshot) ->
-
-    layout     = IDELayoutManager.convertSnapshotToFlatArray snapshot
-    readmePath = "/home/#{@mountedMachine.getOwner()}/README.md"
-
-    return @openReadme()  if layout.length is 0
-
-    hasReadme  = (layout.filter ({ context }) ->
-      path = context.file?.path
-      path and FSHelper.plainPath(path) is readmePath).length > 0
-
-    @openReadme()  unless hasReadme
-
-
   openReadme: (machine) ->
 
     machine or= @mountedMachine
@@ -580,8 +566,6 @@ class IDEAppController extends AppController
 
           @fetchSnapshot (snapshot) =>
 
-            if @mountedMachine.provider is 'softlayer'
-              @ensureReadme snapshot
 
             # Just resurrect snapshot for host or without collaboration.
             # Because we need check the `@myWatchMap` and it is not possible here.

--- a/client/ide/lib/views/tabview/idefilestabview.coffee
+++ b/client/ide/lib/views/tabview/idefilestabview.coffee
@@ -60,8 +60,8 @@ module.exports = class IDEFilesTabView extends IDEWorkspaceTabView
     { onboarding } = kd.singletons
     filesPane.on 'KDTabPaneActive', -> onboarding.refresh()
 
-    @on 'MachineMountRequested', (machineData, rootPath) =>
-      @finderPane.emit 'MachineMountRequested', machineData, rootPath
+    @on 'MachineMountRequested', (machineData) =>
+      @finderPane.emit 'MachineMountRequested', machineData
 
     @on 'MachineUnmountRequested', (machineData) =>
       @finderPane.emit 'MachineUnmountRequested', machineData

--- a/client/ide/lib/workspace/panes/idefinderpane.coffee
+++ b/client/ide/lib/workspace/panes/idefinderpane.coffee
@@ -64,8 +64,8 @@ module.exports = class IDEFinderPane extends IDEPane
     tc.on 'TerminalRequested', (machine) ->
       mgr.tell 'IDE', 'openMachineTerminal', machine
 
-    @on 'MachineMountRequested', (machine, rootPath) ->
-      fc.mountMachine machine, { mountPath: rootPath }
+    @on 'MachineMountRequested', (machine) ->
+      fc.mountMachine machine
 
     @on 'MachineUnmountRequested', (machine) ->
       fc.unmountMachine machine.uid

--- a/client/ide/lib/workspace/panes/idefinderpane.coffee
+++ b/client/ide/lib/workspace/panes/idefinderpane.coffee
@@ -61,10 +61,8 @@ module.exports = class IDEFinderPane extends IDEPane
       mgr.tell 'IDE', 'tailFile', options
       kd.getSingleton('windowController').setKeyView null
 
-
     tc.on 'TerminalRequested', (machine) ->
       mgr.tell 'IDE', 'openMachineTerminal', machine
-
 
     @on 'MachineMountRequested', (machine, rootPath) ->
       fc.mountMachine machine, { mountPath: rootPath }


### PR DESCRIPTION
This PR fixes most of the resurrection issues on IDE and it also introduces faster loads with AppStorage improvements. This is a set of required changes to make #9756 happen, I'll continue over this one.

![](http://g.recordit.co/hW8hkBkYvX.gif)

ref: http://recordit.co/hW8hkBkYvX

Marathon provider is using `/root` as home folder based on the `klient.info` response: 
![2016-11-30 00_14_59](https://cloud.githubusercontent.com/assets/42368/20729241/cd75533c-b689-11e6-9a35-b156ff6c7b4e.gif)
