### PR TITLE
'Preview' and 'Logs' links in stack editor are not displayed.

### DIFF
--- a/client/stack-editor/lib/editor/markdowneditorview.coffee
+++ b/client/stack-editor/lib/editor/markdowneditorview.coffee
@@ -1,8 +1,6 @@
 kd                  = require 'kd'
 KDButtonView        = kd.ButtonView
 BaseStackEditorView = require './basestackeditorview'
-applyMarkdown       = require 'app/util/applyMarkdown'
-ContentModal = require 'app/components/contentModal'
 
 module.exports = class MarkdownEditorView extends BaseStackEditorView
 
@@ -11,38 +9,3 @@ module.exports = class MarkdownEditorView extends BaseStackEditorView
     options.targetContentType ?= 'markdown'
 
     super options, data
-
-
-  viewAppended: ->
-
-    super
-
-    @addSubView new KDButtonView
-      title    : 'Preview'
-      cssClass : 'solid compact light-gray preview-button'
-      callback : @bound 'handlePreview'
-
-
-  handlePreview: ->
-
-    { title } = @getOptions()
-    content = @getContent()
-
-    scrollView = new kd.CustomScrollView { cssClass : 'readme-scroll' }
-
-    markdown = applyMarkdown content, { breaks: false }
-
-    scrollView.wrapper.addSubView markdown_content = new kd.CustomHTMLView
-      cssClass : 'markdown-content'
-      partial : markdown
-
-
-    new ContentModal
-      width : 600
-      overlay : yes
-      cssClass : 'readme-preview has-markdown content-modal'
-      attributes     : { testpath: 'ReadmePreviewModal' }
-      overlayOptions : { cssClass : 'second-overlay' }
-      title          : title or 'Readme Preview'
-      content        : scrollView
-

--- a/client/stack-editor/lib/editor/stacktemplateview.coffee
+++ b/client/stack-editor/lib/editor/stacktemplateview.coffee
@@ -40,27 +40,6 @@ module.exports = class StackTemplateView extends kd.View
       delegate: this, content, contentType, showHelpContent
     }
 
-    @editorView.addSubView @previewButton = new KDButtonView
-      title    : 'PREVIEW'
-      cssClass : 'HomeAppView--button secondary template-preview-button'
-      loader   : yes
-      loaderOptions: { color: '#858585' }
-      tooltip  :
-        title  : 'Generates a preview of this template with your own account information.'
-      callback : => @emit 'ShowTemplatePreview'
-
-    @editorView.addSubView new KDButtonView
-      title    : 'LOGS'
-      cssClass : 'HomeAppView--button secondary showlogs-button'
-      callback : => @emit 'ShowOutputView'
-
-    @editorView.addSubView new KDButtonView
-      cssClass : 'HomeAppView--button secondary fullscreen-button'
-      title    : ''
-      callback : =>
-        kd.singletons.appManager.tell 'Stacks', 'toggleFullscreen'
-        kd.utils.wait 250, => @editorView.resize()
-
     @editorView.on 'click', => @emit 'HideOutputView'
 
 

--- a/client/stack-editor/lib/styl/stackeditor.styl
+++ b/client/stack-editor/lib/styl/stackeditor.styl
@@ -88,6 +88,20 @@ $borderColor                = #E3E3E3
         b
           hidden()
 
+  .stack-template-action-wrapper
+  .readme-action-wrapper
+    abs                     0 120px 10px 0
+    button.kdbutton
+      margin-right          20px
+      border                0px
+      background            #fff
+      cursor                pointer
+      z-index               10
+      &:active
+      &:focus
+        border              none
+        box-shadow          none
+
 
   .indicator
     size                  18px, 18px
@@ -218,10 +232,6 @@ $borderColor                = #E3E3E3
       color                 #769ecc !important
       pointer               cursor
 
-  .editor-pane.editor-view
-    button.template-preview-button
-    button.showlogs-button
-      bottom                -76px
 
 .StackEditor-SecondaryActions
   width                     100%
@@ -505,27 +515,6 @@ $borderColor                = #E3E3E3
     .editor-view
       rounded               4px 4px 0 0
 
-    .showlogs-button
-    .template-preview-button
-    .fullscreen-button
-      z-index               13
-      right                 100px
-      bottom                -31px
-      margin                0
-      bg                    color, white !important
-      border-width          0
-      letter-spacing        .5px
-      font-weight           300
-      abs()
-      &:focus
-        vendor              box-shadow, none
-
-    .template-preview-button
-      right                 178px
-
-    .fullscreen-button
-      right                 275px
-      hidden()
 
   .kdview.output
     vendor                  transition, height .2s ease


### PR DESCRIPTION

## Description
Fix styling of Preview buttons and log button in stack-editor page

## Motivation and Context
#9785 

## Screenshots (if appropriate):
![](https://monosnap.com/file/4EwuuoVVVnGX3ElFy2zcBu9eTS8wXe.png)
![](https://monosnap.com/file/aUqxJ47Pda6uv7MprJYQBJkXGPPUMn.png)
![](https://monosnap.com/file/oLkWWliv2CtKW3bs1hmjcYXx9VGnLe.png)
