### PR TITLE
config: set default publicPort if not specified

### DIFF
--- a/configure
+++ b/configure
@@ -41,7 +41,7 @@ options.runGoWatcher = argv.hasOwnProperty 'with-go-watcher'
 options.sendEventsToSegment = if argv['disable-segment'] then off else on
 
 rest = ->
-  options.publicHostname = argv.publichostname or "http://#{options.hostname}:#{options.publicPort}"
+  options.publicHostname = argv.publichostname or "http://#{options.hostname}:#{options.publicPort or '8090'}"
   # if git commit id consists only numbers, js converts it to number
   options.version        = "#{options.version or version or "1.0"}"
   options.tag            = options.tag     or version or "1.0"


### PR DESCRIPTION
Fixes ` publicHostname: 'http://dev.koding.com:undefined',`:

```
$ ./configure
-------------------------

# ./configure assumes development environment - comes bundled with options below.
# override them as you see fit with command line arguments like --config --branch etc.

Configuring with options:
-------------------------
{ _: [],
  projectRoot: '/Users/rjeczalik/src/github.com/koding/koding',
  config: 'default',
  region: 'default',
  build: 1,
  environment: 'default',
  onlyconfigure: false,
  deploy: false,
  ebEnvName: 'default',
  envFileName: '.env',
  inheritEnvVars: true,
  runGoWatcher: false,
  sendEventsToSegment: true,
  hostname: 'dev.koding.com',
  publicHostname: 'http://dev.koding.com:undefined',
  version: '50a58cea',
  tag: '50a58cea' }
-------------------------

...
```