### PR TITLE
Add KD team list subcommand

### DIFF
--- a/go/src/koding/db/mongodb/modelhelper/group.go
+++ b/go/src/koding/db/mongodb/modelhelper/group.go
@@ -21,10 +21,6 @@ func GetGroupById(id string) (*models.Group, error) {
 
 // GetGroupsByIds returns groups by their given IDs
 func GetGroupsByIds(ids ...bson.ObjectId) ([]*models.Group, error) {
-	if len(ids) == 0 {
-		return nil, errors.New("no group id specified")
-	}
-
 	var groups []*models.Group
 
 	return groups, Mongo.Run(GroupsCollectionName, func(c *mgo.Collection) error {

--- a/go/src/koding/db/mongodb/modelhelper/group.go
+++ b/go/src/koding/db/mongodb/modelhelper/group.go
@@ -21,6 +21,10 @@ func GetGroupById(id string) (*models.Group, error) {
 
 // GetGroupsByIds returns groups by their given IDs
 func GetGroupsByIds(ids ...bson.ObjectId) ([]*models.Group, error) {
+	if len(ids) == 0 {
+		return nil, errors.New("no group id specified")
+	}
+
 	var groups []*models.Group
 
 	return groups, Mongo.Run(GroupsCollectionName, func(c *mgo.Collection) error {

--- a/go/src/koding/db/mongodb/modelhelper/relationships.go
+++ b/go/src/koding/db/mongodb/modelhelper/relationships.go
@@ -3,7 +3,7 @@ package modelhelper
 import (
 	"koding/db/models"
 
-	"gopkg.in/mgo.v2"
+	mgo "gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
 

--- a/go/src/koding/db/mongodb/modelhelper/roles.go
+++ b/go/src/koding/db/mongodb/modelhelper/roles.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"koding/db/models"
 
+	mgo "gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -103,6 +104,10 @@ func FetchAccountGroupNames(username string) ([]string, error) {
 		return nil, err
 	}
 
+	if len(rels) == 0 {
+		return nil, mgo.ErrNotFound
+	}
+
 	var ids []string
 	for _, rel := range rels {
 		ids = append(ids, rel.SourceId.Hex())
@@ -144,6 +149,10 @@ func FetchAccountGroups(username string) (groups []*models.Group, err error) {
 	rels, err := GetAllRelationships(selector)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(rels) == 0 {
+		return nil, mgo.ErrNotFound
 	}
 
 	var ids []bson.ObjectId

--- a/go/src/koding/db/mongodb/modelhelper/roles.go
+++ b/go/src/koding/db/mongodb/modelhelper/roles.go
@@ -84,8 +84,8 @@ func HasAnyRole(username, groupName string, roles ...string) (bool, error) {
 	return count > 0, nil
 }
 
-// FetchAccountGroups lists the group memberships of a given username
-func FetchAccountGroups(username string) ([]string, error) {
+// FetchAccountGroupNames lists the group memberships of a given username
+func FetchAccountGroupNames(username string) ([]string, error) {
 	account, err := GetAccount(username)
 	if err != nil {
 		return nil, err
@@ -129,4 +129,52 @@ func FetchAccountGroups(username string) ([]string, error) {
 	}
 
 	return slugList, nil
+}
+
+// FetchAccountGroups lists the groups of a given username
+func FetchAccountGroups(username string) (groups []*models.Group, err error) {
+	account, err := GetAccount(username)
+	if err != nil {
+		return nil, err
+	}
+
+	selector := Selector{
+		"sourceName": "JGroup",
+		"targetId":   account.Id,
+		"targetName": "JAccount",
+		"as":         bson.M{"$in": []string{"owner", "admin", "member"}},
+	}
+
+	rels, err := GetAllRelationships(selector)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(rels) == 0 {
+		return nil, nil
+	}
+
+	var ids []bson.ObjectId
+	for _, rel := range rels {
+		ids = append(ids, rel.SourceId)
+	}
+
+	all, err := GetGroupsByIds(ids...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unify the list.
+	slugs := make(map[string]struct{})
+	for _, group := range all {
+		// Skip already added groups.
+		if _, ok := slugs[group.Slug]; ok {
+			continue
+		}
+
+		groups = append(groups, group)
+		slugs[group.Slug] = struct{}{}
+	}
+
+	return groups, nil
 }

--- a/go/src/koding/db/mongodb/modelhelper/roles.go
+++ b/go/src/koding/db/mongodb/modelhelper/roles.go
@@ -103,10 +103,6 @@ func FetchAccountGroupNames(username string) ([]string, error) {
 		return nil, err
 	}
 
-	if len(rels) == 0 {
-		return nil, nil
-	}
-
 	var ids []string
 	for _, rel := range rels {
 		ids = append(ids, rel.SourceId.Hex())
@@ -148,10 +144,6 @@ func FetchAccountGroups(username string) (groups []*models.Group, err error) {
 	rels, err := GetAllRelationships(selector)
 	if err != nil {
 		return nil, err
-	}
-
-	if len(rels) == 0 {
-		return nil, nil
 	}
 
 	var ids []bson.ObjectId

--- a/go/src/koding/db/mongodb/modelhelper/roles_test.go
+++ b/go/src/koding/db/mongodb/modelhelper/roles_test.go
@@ -7,6 +7,7 @@ import (
 	"koding/db/mongodb/modelhelper"
 	"koding/db/mongodb/modelhelper/modeltesthelper"
 
+	mgo "gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -162,8 +163,8 @@ func TestFetchAccountGroupNames(t *testing.T) {
 	defer modelhelper.RemoveAccount(acc1.Id)
 
 	groups, err := modelhelper.FetchAccountGroupNames(acc1.Profile.Nickname)
-	if err != nil {
-		t.Fatal(err)
+	if err != mgo.ErrNotFound {
+		t.Fatalf("want err = %v; got %v", mgo.ErrNotFound, err)
 	}
 
 	if len(groups) != 0 {
@@ -241,8 +242,8 @@ func TestFetchAccountGroups(t *testing.T) {
 	defer modelhelper.RemoveAccount(acc1.Id)
 
 	groups, err := modelhelper.FetchAccountGroups(acc1.Profile.Nickname)
-	if err != nil {
-		t.Fatal(err)
+	if err != mgo.ErrNotFound {
+		t.Fatalf("want err = %v; got %v", mgo.ErrNotFound, err)
 	}
 
 	if len(groups) != 0 {

--- a/go/src/koding/db/mongodb/modelhelper/roles_test.go
+++ b/go/src/koding/db/mongodb/modelhelper/roles_test.go
@@ -154,16 +154,16 @@ func TestFetchAdminAccounts(t *testing.T) {
 	}
 }
 
-func TestFetchAccountGroups(t *testing.T) {
+func TestFetchAccountGroupNames(t *testing.T) {
 	db := modeltesthelper.NewMongoDB(t)
 	defer db.Close()
 
 	acc1 := createTestAccount(t)
 	defer modelhelper.RemoveAccount(acc1.Id)
 
-	groups, err := modelhelper.FetchAccountGroups(acc1.Profile.Nickname)
+	groups, err := modelhelper.FetchAccountGroupNames(acc1.Profile.Nickname)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	}
 
 	if len(groups) != 0 {
@@ -172,7 +172,7 @@ func TestFetchAccountGroups(t *testing.T) {
 
 	group1, err := createGroup()
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	}
 
 	if err := modelhelper.AddRelationship(&models.Relationship{
@@ -186,9 +186,9 @@ func TestFetchAccountGroups(t *testing.T) {
 		t.Error(err)
 	}
 
-	groups, err = modelhelper.FetchAccountGroups(acc1.Profile.Nickname)
+	groups, err = modelhelper.FetchAccountGroupNames(acc1.Profile.Nickname)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	}
 
 	if len(groups) != 1 {
@@ -220,16 +220,94 @@ func TestFetchAccountGroups(t *testing.T) {
 		SourceName: "JGroup",
 		As:         "member",
 	}); err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	}
 
-	groups, err = modelhelper.FetchAccountGroups(acc1.Profile.Nickname)
+	groups, err = modelhelper.FetchAccountGroupNames(acc1.Profile.Nickname)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	}
 
 	if len(groups) != 2 {
 		t.Fatalf("expected len(groups) to be 2, got groups: %+v", groups)
 	}
+}
 
+func TestFetchAccountGroups(t *testing.T) {
+	db := modeltesthelper.NewMongoDB(t)
+	defer db.Close()
+
+	acc1 := createTestAccount(t)
+	defer modelhelper.RemoveAccount(acc1.Id)
+
+	groups, err := modelhelper.FetchAccountGroups(acc1.Profile.Nickname)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(groups) != 0 {
+		t.Fatalf("expected len(groups) to be 0, got groups: %+v", groups)
+	}
+
+	group1, err := createGroup()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := modelhelper.AddRelationship(&models.Relationship{
+		Id:         bson.NewObjectId(),
+		TargetId:   acc1.Id,
+		TargetName: "JAccount",
+		SourceId:   group1.Id,
+		SourceName: "JGroup",
+		As:         "member",
+	}); err != nil {
+		t.Error(err)
+	}
+
+	groups, err = modelhelper.FetchAccountGroups(acc1.Profile.Nickname)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(groups) != 1 {
+		t.Fatalf("expected len(groups) to be 1, got groups: %+v", groups)
+	}
+
+	// test having 2 relationsips in one group
+	group2, err := createGroup()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if err := modelhelper.AddRelationship(&models.Relationship{
+		Id:         bson.NewObjectId(),
+		TargetId:   acc1.Id,
+		TargetName: "JAccount",
+		SourceId:   group2.Id,
+		SourceName: "JGroup",
+		As:         "admin",
+	}); err != nil {
+		t.Error(err)
+	}
+
+	if err := modelhelper.AddRelationship(&models.Relationship{
+		Id:         bson.NewObjectId(),
+		TargetId:   acc1.Id,
+		TargetName: "JAccount",
+		SourceId:   group2.Id,
+		SourceName: "JGroup",
+		As:         "member",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	groups, err = modelhelper.FetchAccountGroups(acc1.Profile.Nickname)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(groups) != 2 {
+		t.Fatalf("expected len(groups) to be 2, got groups: %+v", groups)
+	}
 }

--- a/go/src/koding/kites/kloud/kloud/kloud.go
+++ b/go/src/koding/kites/kloud/kloud/kloud.go
@@ -27,6 +27,7 @@ import (
 	"koding/kites/kloud/queue"
 	"koding/kites/kloud/stack"
 	"koding/kites/kloud/stack/provider"
+	"koding/kites/kloud/team"
 	"koding/kites/kloud/terraformer"
 	"koding/kites/kloud/userdata"
 	"koding/remoteapi"
@@ -238,6 +239,7 @@ func New(conf *Config) (*Kloud, error) {
 	kloud.Stack.DescribeFunc = provider.Desc
 	kloud.Stack.CredClient = credential.NewClient(storeOpts)
 	kloud.Stack.MachineClient = machine.NewClient(machine.NewMongoDatabase())
+	kloud.Stack.TeamClient = team.NewClient(team.NewMongoDatabase())
 	kloud.Stack.RemoteClient = &remoteapi.Client{
 		Endpoint: remoteURL,
 		Client:   storeOpts.Client,
@@ -303,6 +305,9 @@ func New(conf *Config) (*Kloud, error) {
 
 	// Authorization handling.
 	k.HandleFunc("auth.login", kloud.Stack.AuthLogin)
+
+	// Team handling.
+	k.HandleFunc("team.list", kloud.Stack.TeamList)
 
 	// Machine handling.
 	k.HandleFunc("machine.list", kloud.Stack.MachineList)

--- a/go/src/koding/kites/kloud/stack/kloud.go
+++ b/go/src/koding/kites/kloud/stack/kloud.go
@@ -15,6 +15,7 @@ import (
 	"koding/kites/kloud/machine"
 	"koding/kites/kloud/pkg/dnsclient"
 	"koding/kites/kloud/pkg/idlock"
+	"koding/kites/kloud/team"
 	"koding/remoteapi"
 
 	"github.com/koding/cache"
@@ -83,6 +84,9 @@ type Kloud struct {
 
 	// MachineClient handles machine.* methods.
 	MachineClient *machine.Client
+
+	// TeamClient handles team.* methods.
+	TeamClient *team.Client
 
 	// RemoteClient handles requests to "remote.api" endpoint.
 	RemoteClient *remoteapi.Client

--- a/go/src/koding/kites/kloud/stack/team.go
+++ b/go/src/koding/kites/kloud/stack/team.go
@@ -9,9 +9,9 @@ import (
 // TeamListRequest represents a request type for "team.list" kloud's
 // kite method.
 type TeamListRequest struct {
-	// Name is a filter for team name. If empty, all available teams for a
+	// Slug is a filter for team name. If empty, all available teams for a
 	// given user will be returned.
-	Name string `json:"name"`
+	Slug string `json:"slug"`
 }
 
 // TeamListResponse represents a response model for "team.list" kloud's
@@ -29,7 +29,7 @@ func (k *Kloud) TeamList(r *kite.Request) (interface{}, error) {
 
 	f := &team.Filter{
 		Username: r.Username,
-		Teamname: req.Name,
+		Slug:     req.Slug,
 	}
 
 	teams, err := k.TeamClient.Teams(f)

--- a/go/src/koding/kites/kloud/stack/team.go
+++ b/go/src/koding/kites/kloud/stack/team.go
@@ -9,9 +9,9 @@ import (
 // TeamListRequest represents a request type for "team.list" kloud's
 // kite method.
 type TeamListRequest struct {
-	// TeamName is a filter for team name. If empty, all available teams for a
+	// Name is a filter for team name. If empty, all available teams for a
 	// given user will be returned.
-	Team string `json:"team"`
+	Name string `json:"name"`
 }
 
 // TeamListResponse represents a response model for "team.list" kloud's
@@ -29,7 +29,7 @@ func (k *Kloud) TeamList(r *kite.Request) (interface{}, error) {
 
 	f := &team.Filter{
 		Username: r.Username,
-		Teamname: req.Team,
+		Teamname: req.Name,
 	}
 
 	teams, err := k.TeamClient.Teams(f)

--- a/go/src/koding/kites/kloud/stack/team.go
+++ b/go/src/koding/kites/kloud/stack/team.go
@@ -1,0 +1,41 @@
+package stack
+
+import (
+	"koding/kites/kloud/team"
+
+	"github.com/koding/kite"
+)
+
+// TeamListRequest represents a request type for "team.list" kloud's
+// kite method.
+type TeamListRequest struct {
+	// TeamName is a filter for team name. If empty, all available teams for a
+	// given user will be returned.
+	Team string `json:"team"`
+}
+
+// TeamListResponse represents a response model for "team.list" kloud's
+// kite method.
+type TeamListResponse struct {
+	Teams []*team.Team `json:"teams"`
+}
+
+// TeamList is a kite.Handler for "team.list" kite method.
+func (k *Kloud) TeamList(r *kite.Request) (interface{}, error) {
+	var req TeamListRequest
+	if err := r.Args.One().Unmarshal(&req); err != nil {
+		return nil, err
+	}
+
+	f := &team.Filter{
+		Username: r.Username,
+		Teamname: req.Team,
+	}
+
+	teams, err := k.TeamClient.Teams(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return TeamListResponse{Teams: teams}, nil
+}

--- a/go/src/koding/kites/kloud/team/client.go
+++ b/go/src/koding/kites/kloud/team/client.go
@@ -12,7 +12,7 @@ type Team struct {
 // Filter is used for filtering team records.
 type Filter struct {
 	Username string // user name.
-	Teamname string // limit response to a given team name.
+	Slug     string // limit response to a given group name.
 }
 
 // Database abstracts database read access to the machines.

--- a/go/src/koding/kites/kloud/team/client.go
+++ b/go/src/koding/kites/kloud/team/client.go
@@ -1,0 +1,39 @@
+package team
+
+// Team represents a single team.
+type Team struct {
+	Name         string `json:"Name"`         // Team name.
+	Slug         string `json:"slug"`         // Team slug.
+	Members      string `json:"members"`      // Number of team members.
+	Privacy      string `json:"privacy"`      // Whether team is public or private.
+	Subscription string `json:"subscription"` // Subscription status.
+}
+
+// Filter is used for filtering team records.
+type Filter struct {
+	Username string // user name.
+	Teamname string // limit response to a given team name.
+}
+
+// Database abstracts database read access to the machines.
+type Database interface {
+	// Teams returns all teams stored in database that matches a given filter.
+	Teams(*Filter) ([]*Team, error)
+}
+
+// Client enables communication with machine related logic.
+type Client struct {
+	db Database
+}
+
+// NewClient creates a new Client instance.
+func NewClient(db Database) *Client {
+	return &Client{
+		db: db,
+	}
+}
+
+// Teams returns all teams stored in database that matches a given filter.
+func (c *Client) Teams(f *Filter) ([]*Team, error) {
+	return c.db.Teams(f)
+}

--- a/go/src/koding/kites/kloud/team/client.go
+++ b/go/src/koding/kites/kloud/team/client.go
@@ -2,7 +2,7 @@ package team
 
 // Team represents a single team.
 type Team struct {
-	Name         string `json:"Name"`         // Team name.
+	Name         string `json:"name"`         // Team name.
 	Slug         string `json:"slug"`         // Team slug.
 	Members      string `json:"members"`      // Number of team members.
 	Privacy      string `json:"privacy"`      // Whether team is public or private.

--- a/go/src/koding/kites/kloud/team/modelhelper.go
+++ b/go/src/koding/kites/kloud/team/modelhelper.go
@@ -3,30 +3,20 @@ package team
 import (
 	"koding/db/models"
 	"koding/db/mongodb/modelhelper"
-
-	"gopkg.in/mgo.v2/bson"
 )
 
 // modelHelperAdapter wraps modelhelper package with adapter interface. Thus,
 // it allows to use it as ordinal object which satisfies adapter interface.
 type modelHelperAdapter struct{}
 
-func (modelHelperAdapter) GetAccount(username string) (*models.Account, error) {
-	return modelhelper.GetAccount(username)
-}
-
-func (modelHelperAdapter) RelationshipCount(selector modelhelper.Selector) (int, error) {
-	return modelhelper.RelationshipCount(selector)
-}
-
-func (modelHelperAdapter) GetAllRelationships(selector modelhelper.Selector) ([]models.Relationship, error) {
-	return modelhelper.GetAllRelationships(selector)
-}
-
-func (modelHelperAdapter) GetGroupsByIds(ids ...bson.ObjectId) ([]*models.Group, error) {
-	return modelhelper.GetGroupsByIds(ids...)
-}
-
 func (modelHelperAdapter) GetGroup(slugName string) (*models.Group, error) {
 	return modelhelper.GetGroup(slugName)
+}
+
+func (modelHelperAdapter) IsParticipant(username, groupName string) (bool, error) {
+	return modelhelper.IsParticipant(username, groupName)
+}
+
+func (modelHelperAdapter) FetchAccountGroups(username string) ([]*models.Group, error) {
+	return modelhelper.FetchAccountGroups(username)
 }

--- a/go/src/koding/kites/kloud/team/modelhelper.go
+++ b/go/src/koding/kites/kloud/team/modelhelper.go
@@ -1,0 +1,32 @@
+package team
+
+import (
+	"koding/db/models"
+	"koding/db/mongodb/modelhelper"
+
+	"gopkg.in/mgo.v2/bson"
+)
+
+// modelHelperAdapter wraps modelhelper package with adapter interface. Thus,
+// it allows to use it as ordinal object which satisfies adapter interface.
+type modelHelperAdapter struct{}
+
+func (modelHelperAdapter) GetAccount(username string) (*models.Account, error) {
+	return modelhelper.GetAccount(username)
+}
+
+func (modelHelperAdapter) RelationshipCount(selector modelhelper.Selector) (int, error) {
+	return modelhelper.RelationshipCount(selector)
+}
+
+func (modelHelperAdapter) GetAllRelationships(selector modelhelper.Selector) ([]models.Relationship, error) {
+	return modelhelper.GetAllRelationships(selector)
+}
+
+func (modelHelperAdapter) GetGroupsByIds(ids ...bson.ObjectId) ([]*models.Group, error) {
+	return modelhelper.GetGroupsByIds(ids...)
+}
+
+func (modelHelperAdapter) GetGroup(slugName string) (*models.Group, error) {
+	return modelhelper.GetGroup(slugName)
+}

--- a/go/src/koding/kites/kloud/team/mongo.go
+++ b/go/src/koding/kites/kloud/team/mongo.go
@@ -7,6 +7,7 @@ import (
 	"koding/db/models"
 	"koding/db/mongodb/modelhelper"
 
+	mgo "gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -56,7 +57,9 @@ func (m *MongoDatabase) Teams(f *Filter) ([]*Team, error) {
 // fetchOne returns only specified team.
 func (m *MongoDatabase) fetchOne(accID bson.ObjectId, user, slug string) ([]*Team, error) {
 	groupDB, err := m.adapter.GetGroup(slug)
-	if err != nil {
+	if err == mgo.ErrNotFound {
+		return []*Team{}, nil
+	} else if err != nil {
 		return nil, models.ResError(err, modelhelper.GroupsCollectionName)
 	}
 
@@ -96,7 +99,7 @@ func (m *MongoDatabase) fetchAll(accID bson.ObjectId) ([]*Team, error) {
 	}
 
 	groupsDB, err := modelhelper.GetGroupsByIds(ids...)
-	if err != nil {
+	if err != nil && err != mgo.ErrNotFound {
 		return nil, models.ResError(err, modelhelper.GroupsCollectionName)
 	}
 

--- a/go/src/koding/kites/kloud/team/mongo.go
+++ b/go/src/koding/kites/kloud/team/mongo.go
@@ -1,0 +1,129 @@
+package team
+
+import (
+	"fmt"
+	"strconv"
+
+	"koding/db/models"
+	"koding/db/mongodb/modelhelper"
+
+	"gopkg.in/mgo.v2/bson"
+)
+
+// adapter is a private interface used as an adapter for mongo singleton.
+type adapter interface {
+	GetAccount(username string) (*models.Account, error)          // AccountsColl
+	RelationshipCount(selector modelhelper.Selector) (int, error) // RelationshipColl
+	GetAllRelationships(selector modelhelper.Selector) ([]models.Relationship, error)
+	GetGroup(slugName string) (*models.Group, error)
+	GetGroupsByIds(ids ...bson.ObjectId) ([]*models.Group, error) // GroupsCollectionName
+}
+
+// MongoDatabase implements Database interface. This type is responsible for
+// communicating with Mongo database.
+type MongoDatabase struct {
+	adapter adapter
+}
+
+var _ Database = (*MongoDatabase)(nil)
+
+// NewMongoDatabase creates a new MongoDatabase instance.
+func NewMongoDatabase() *MongoDatabase {
+	return &MongoDatabase{
+		adapter: modelHelperAdapter{}, // use modelhelper package's singleton.
+	}
+}
+
+// Teams returns all teams stored in MongoDB database that matches a given
+// filter.
+func (m *MongoDatabase) Teams(f *Filter) ([]*Team, error) {
+	if f == nil {
+		f = &Filter{}
+	}
+
+	accountDB, err := m.adapter.GetAccount(f.Username)
+	if err != nil {
+		return nil, models.ResError(err, modelhelper.AccountsColl)
+	}
+
+	if f.Teamname != "" {
+		return m.fetchOne(accountDB.Id, f.Username, f.Teamname)
+	} else {
+		return m.fetchAll(accountDB.Id)
+	}
+}
+
+// fetchOne returns only specified team.
+func (m *MongoDatabase) fetchOne(accID bson.ObjectId, user, teamSlug string) ([]*Team, error) {
+	groupDB, err := m.adapter.GetGroup(teamSlug)
+	if err != nil {
+		return nil, models.ResError(err, modelhelper.GroupsCollectionName)
+	}
+
+	belongs := modelhelper.Selector{
+		"targetId": accID,
+		"sourceId": groupDB.Id,
+		"as":       "member",
+	}
+
+	count, err := m.adapter.RelationshipCount(belongs)
+	if err == nil && count == 0 {
+		err = fmt.Errorf("user %q does not belong to %q group", user, teamSlug)
+	}
+	if err != nil {
+		return nil, models.ResError(err, modelhelper.RelationshipColl)
+	}
+
+	return groups2teams(groupDB), nil
+}
+
+// fetchOne returns all user's teams.
+func (m *MongoDatabase) fetchAll(accID bson.ObjectId) ([]*Team, error) {
+	belongs := modelhelper.Selector{
+		"targetId":   accID,
+		"sourceName": "JGroup",
+		"as":         "member",
+	}
+
+	relsDB, err := m.adapter.GetAllRelationships(belongs)
+	if err != nil {
+		return nil, models.ResError(err, modelhelper.RelationshipColl)
+	}
+
+	ids := make([]bson.ObjectId, len(relsDB))
+	for i := range relsDB {
+		ids[i] = relsDB[i].SourceId
+	}
+
+	groupsDB, err := modelhelper.GetGroupsByIds(ids...)
+	if err != nil {
+		return nil, models.ResError(err, modelhelper.GroupsCollectionName)
+	}
+
+	return groups2teams(groupsDB...), nil
+}
+
+func groups2teams(groups ...*models.Group) []*Team {
+	teams := make([]*Team, 0, len(groups))
+	for _, group := range groups {
+		if group == nil || group.Slug == "koding" {
+			continue
+		}
+
+		// Filter teams that have empty subscription.
+		if group.Payment.Subscription.ID == "" {
+			continue
+		}
+
+		members, _ := group.Counts["members"].(int)
+		teams = append(teams, &Team{
+			Name:         group.Title,
+			Slug:         group.Slug,
+			Members:      strconv.Itoa(members),
+			Privacy:      group.Privacy,
+			Subscription: group.Payment.Subscription.Status,
+		})
+	}
+
+	return teams
+}

--- a/go/src/koding/kites/kloud/team/mongo.go
+++ b/go/src/koding/kites/kloud/team/mongo.go
@@ -46,16 +46,16 @@ func (m *MongoDatabase) Teams(f *Filter) ([]*Team, error) {
 		return nil, models.ResError(err, modelhelper.AccountsColl)
 	}
 
-	if f.Teamname != "" {
-		return m.fetchOne(accountDB.Id, f.Username, f.Teamname)
+	if f.Slug != "" {
+		return m.fetchOne(accountDB.Id, f.Username, f.Slug)
 	} else {
 		return m.fetchAll(accountDB.Id)
 	}
 }
 
 // fetchOne returns only specified team.
-func (m *MongoDatabase) fetchOne(accID bson.ObjectId, user, teamSlug string) ([]*Team, error) {
-	groupDB, err := m.adapter.GetGroup(teamSlug)
+func (m *MongoDatabase) fetchOne(accID bson.ObjectId, user, slug string) ([]*Team, error) {
+	groupDB, err := m.adapter.GetGroup(slug)
 	if err != nil {
 		return nil, models.ResError(err, modelhelper.GroupsCollectionName)
 	}
@@ -68,7 +68,7 @@ func (m *MongoDatabase) fetchOne(accID bson.ObjectId, user, teamSlug string) ([]
 
 	count, err := m.adapter.RelationshipCount(belongs)
 	if err == nil && count == 0 {
-		err = fmt.Errorf("user %q does not belong to %q group", user, teamSlug)
+		err = fmt.Errorf("user %q does not belong to %q group", user, slug)
 	}
 	if err != nil {
 		return nil, models.ResError(err, modelhelper.RelationshipColl)

--- a/go/src/koding/kites/kloud/team/mongo.go
+++ b/go/src/koding/kites/kloud/team/mongo.go
@@ -55,10 +55,10 @@ func (m *MongoDatabase) fetchOne(user, slug string) ([]*Team, error) {
 		return nil, models.ResError(err, modelhelper.GroupsCollectionName)
 	}
 
-	switch participand, err := m.adapter.IsParticipant(user, slug); {
+	switch participant, err := m.adapter.IsParticipant(user, slug); {
 	case err != nil:
 		return nil, models.ResError(err, modelhelper.RelationshipColl)
-	case !participand:
+	case !participant:
 		return nil, fmt.Errorf("user %q does not belong to %q group", user, slug)
 	}
 

--- a/go/src/koding/klientctl/endpoint/team/team.go
+++ b/go/src/koding/klientctl/endpoint/team/team.go
@@ -56,8 +56,8 @@ func (c *Client) List(opts *ListOptions) ([]*team.Team, error) {
 		req.Slug = opts.Slug
 	}
 
-	resp := &stack.TeamListResponse{}
-	if err := c.kloud().Call("team.list", req, resp); err != nil {
+	resp := stack.TeamListResponse{}
+	if err := c.kloud().Call("team.list", req, &resp); err != nil {
 		return nil, err
 	}
 

--- a/go/src/koding/klientctl/endpoint/team/team.go
+++ b/go/src/koding/klientctl/endpoint/team/team.go
@@ -4,11 +4,18 @@ import (
 	"errors"
 	"sync"
 
+	"koding/kites/kloud/stack"
+	"koding/kites/kloud/team"
 	"koding/klientctl/ctlcli"
 	"koding/klientctl/endpoint/kloud"
 )
 
 var DefaultClient = &Client{}
+
+// ListOptions are options available for `team list` command.
+type ListOptions struct {
+	Name string // Limit to a specific team with a given name.
+}
 
 type Team struct {
 	Name string `json:"name"`
@@ -40,6 +47,23 @@ func (c *Client) Used() *Team {
 	return &c.used
 }
 
+// List returns the list of user's teams.
+func (c *Client) List(opts *ListOptions) ([]*team.Team, error) {
+	c.init()
+
+	req := &stack.TeamListRequest{}
+	if opts != nil {
+		req.Name = opts.Name
+	}
+
+	resp := &stack.TeamListResponse{}
+	if err := c.kloud().Call("team.list", req, resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Teams, nil
+}
+
 func (c *Client) Close() (err error) {
 	if c.used.Valid() == nil {
 		err = c.kloud().Cache().SetValue("team.used", &c.used)
@@ -68,5 +92,6 @@ func (c *Client) kloud() *kloud.Client {
 	return kloud.DefaultClient
 }
 
-func Use(team *Team) { DefaultClient.Use(team) }
-func Used() *Team    { return DefaultClient.Used() }
+func Use(team *Team)                               { DefaultClient.Use(team) }
+func Used() *Team                                  { return DefaultClient.Used() }
+func List(opts *ListOptions) ([]*team.Team, error) { return DefaultClient.List(opts) }

--- a/go/src/koding/klientctl/endpoint/team/team.go
+++ b/go/src/koding/klientctl/endpoint/team/team.go
@@ -14,7 +14,7 @@ var DefaultClient = &Client{}
 
 // ListOptions are options available for `team list` command.
 type ListOptions struct {
-	Name string // Limit to a specific team with a given name.
+	Slug string // Limit to a specific team with a given name.
 }
 
 type Team struct {
@@ -53,7 +53,7 @@ func (c *Client) List(opts *ListOptions) ([]*team.Team, error) {
 
 	req := &stack.TeamListRequest{}
 	if opts != nil {
-		req.Name = opts.Name
+		req.Slug = opts.Slug
 	}
 
 	resp := &stack.TeamListResponse{}

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -575,6 +575,21 @@ func run(args []string) {
 							},
 						},
 					},
+					{
+						Name:   "list",
+						Usage:  "Lists user's teams.",
+						Action: ctlcli.ExitErrAction(TeamList, log, "list"),
+						Flags: []cli.Flag{
+							cli.BoolFlag{
+								Name:  "name",
+								Usage: "Limits the output to the specified team",
+							},
+							cli.BoolFlag{
+								Name:  "json",
+								Usage: "Output in JSON format.",
+							},
+						},
+					},
 				},
 			},
 		)

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -581,9 +581,9 @@ func run(args []string) {
 						Action: ctlcli.ExitErrAction(TeamList, log, "list"),
 						Flags: []cli.Flag{
 							cli.StringFlag{
-								Name:  "name",
+								Name:  "slug",
 								Value: "",
-								Usage: "Limits the output to the specified team",
+								Usage: "Limits the output to the specified team slug",
 							},
 							cli.BoolFlag{
 								Name:  "json",

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -580,8 +580,9 @@ func run(args []string) {
 						Usage:  "Lists user's teams.",
 						Action: ctlcli.ExitErrAction(TeamList, log, "list"),
 						Flags: []cli.Flag{
-							cli.BoolFlag{
+							cli.StringFlag{
 								Name:  "name",
+								Value: "",
 								Usage: "Limits the output to the specified team",
 							},
 							cli.BoolFlag{

--- a/go/src/koding/klientctl/team.go
+++ b/go/src/koding/klientctl/team.go
@@ -25,10 +25,10 @@ func TeamList(c *cli.Context, log logging.Logger, _ string) (int, error) {
 
 	if len(teams) == 0 {
 		if opts.Slug == "" {
-			fmt.Fprintln(os.Stderr, "You do not belong to any team.")
+			fmt.Fprintln(os.Stderr, "You do not belong to any team.\n")
 			return 0, nil
 		} else {
-			fmt.Fprintf(os.Stderr, "Cannot find %q team.", opts.Slug)
+			fmt.Fprintf(os.Stderr, "Cannot find %q team.\n", opts.Slug)
 			return 1, nil
 		}
 	}

--- a/go/src/koding/klientctl/team.go
+++ b/go/src/koding/klientctl/team.go
@@ -54,7 +54,7 @@ func printTeams(teams []*team.Team) {
 	fmt.Fprintln(w, "NAME\tSLUG\tPRIVACY\tMEMBERS\tSUBSCRIPTION")
 
 	for _, t := range teams {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", t.Name, t.Slug, t.Privacy, t.Subscription)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", t.Name, t.Slug, t.Privacy, t.Members, t.Subscription)
 	}
 }
 

--- a/go/src/koding/klientctl/team.go
+++ b/go/src/koding/klientctl/team.go
@@ -15,7 +15,7 @@ import (
 
 func TeamList(c *cli.Context, log logging.Logger, _ string) (int, error) {
 	opts := &epteam.ListOptions{
-		Name: c.String("name"),
+		Slug: c.String("slug"),
 	}
 
 	teams, err := epteam.List(opts)
@@ -24,11 +24,11 @@ func TeamList(c *cli.Context, log logging.Logger, _ string) (int, error) {
 	}
 
 	if len(teams) == 0 {
-		if opts.Name == "" {
+		if opts.Slug == "" {
 			fmt.Fprintln(os.Stderr, "You do not belong to any team.")
 			return 0, nil
 		} else {
-			fmt.Fprintf(os.Stderr, "Cannot find %q team.", opts.Name)
+			fmt.Fprintf(os.Stderr, "Cannot find %q team.", opts.Slug)
 			return 1, nil
 		}
 	}

--- a/go/src/koding/klientctl/team.go
+++ b/go/src/koding/klientctl/team.go
@@ -3,15 +3,63 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"koding/klientctl/endpoint/team"
 	"os"
+	"text/tabwriter"
+
+	"koding/kites/kloud/team"
+	epteam "koding/klientctl/endpoint/team"
 
 	"github.com/codegangsta/cli"
 	"github.com/koding/logging"
 )
 
+func TeamList(c *cli.Context, log logging.Logger, _ string) (int, error) {
+	opts := &epteam.ListOptions{
+		Name: c.String("name"),
+	}
+
+	teams, err := epteam.List(opts)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(teams) == 0 {
+		if opts.Name == "" {
+			fmt.Fprintln(os.Stderr, "You do not belong to any team.")
+			return 0, nil
+		} else {
+			fmt.Fprintf(os.Stderr, "Cannot find %q team.", opts.Name)
+			return 1, nil
+		}
+	}
+
+	if c.Bool("json") {
+		p, err := json.MarshalIndent(teams, "", "\t")
+		if err != nil {
+			return 1, err
+		}
+
+		fmt.Printf("%s\n", p)
+		return 0, nil
+	}
+
+	printTeams(teams)
+	return 0, nil
+}
+
+func printTeams(teams []*team.Team) {
+	w := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+	defer w.Flush()
+
+	fmt.Fprintln(w, "NAME\tSLUG\tPRIVACY\tMEMBERS\tSUBSCRIPTION")
+
+	for _, t := range teams {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", t.Name, t.Slug, t.Privacy, t.Subscription)
+	}
+}
+
 func TeamShow(c *cli.Context, log logging.Logger, _ string) (int, error) {
-	t := team.Used()
+	t := epteam.Used()
 
 	if err := t.Valid(); err != nil {
 		fmt.Fprintln(os.Stderr, `You are not currently logged in to any team. Please log in first with "kd auth login".`)

--- a/go/src/koding/klientctl/team_test.go
+++ b/go/src/koding/klientctl/team_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+
+	"koding/kites/kloud/stack"
+	"koding/kites/kloud/team"
+)
+
+func TestTeamList(t *testing.T) {
+	cases := map[string]struct {
+		args     []string
+		expected []*team.Team
+	}{
+		"all teams": {
+			nil,
+			[]*team.Team{
+				&team.Team{Name: "teamA", Slug: "teamAS", Privacy: "public", Subscription: "paid"},
+				&team.Team{Name: "teamB", Slug: "teamBS", Privacy: "private", Subscription: "trailing"},
+			},
+		},
+	}
+
+	for name, cas := range cases {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+
+			cmd := &MainCmd{
+				Stdout: &buf,
+				Stderr: os.Stderr,
+			}
+
+			cmd.FT.Add("team.list", stack.TeamListResponse{Teams: cas.expected})
+
+			args := []string{"team", "list", "--json"}
+
+			err := cmd.Run(append(args, cas.args...)...)
+			if err != nil {
+				t.Fatalf("Run()=%s", err)
+			}
+
+			var got []*team.Team
+			if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+				t.Fatalf("Unmarshal()=%s", err)
+			}
+
+			if !reflect.DeepEqual(got, cas.expected) {
+				t.Fatalf("got %#v, want %#v", got, cas.expected)
+			}
+		})
+	}
+}

--- a/go/src/koding/workers/janitor/exempt.go
+++ b/go/src/koding/workers/janitor/exempt.go
@@ -83,7 +83,7 @@ func IsUserKodingEmployeeFn(user *models.User, w *Warning) (bool, error) {
 
 // HasMultipleMemberships checks if user is only Koding group member.
 func HasMultipleMembershipsFn(user *models.User, w *Warning) (bool, error) {
-	groups, err := modelhelper.FetchAccountGroups(user.Name)
+	groups, err := modelhelper.FetchAccountGroupNames(user.Name)
 	if err == mgo.ErrNotFound {
 		return false, nil
 	}


### PR DESCRIPTION
This PR adds `kd team list` subcommand.

Part of: #9689
Depends on: #9828

```
$ ./klientctl team list
NAME    SLUG          PRIVACY  MEMBERS  SUBSCRIPTION
google  google        private  1        trialing
koding  koding-pawel  private  1        trialing
$ ./klientctl team list --json
[
	{
		"name": "google",
		"slug": "google",
		"members": "1",
		"privacy": "private",
		"subscription": "trialing"
	},
	{
		"name": "koding",
		"slug": "koding-pawel",
		"members": "1",
		"privacy": "private",
		"subscription": "trialing"
	}
]
$ ./klientctl team list --slug=google
NAME    SLUG    PRIVACY  MEMBERS  SUBSCRIPTION
google  google  private  1        trialing
$ ./klientctl team list --slug=none
Cannot find "none" team.
```
