### PR TITLE
landing: set env config var from main domain url

### DIFF
--- a/client/landing/site.landing/coffee/main.coffee
+++ b/client/landing/site.landing/coffee/main.coffee
@@ -37,7 +37,7 @@ do ->
     new MainController group
 
   kd.config             or= {}
-  kd.config.environment   = if location.hostname is 'koding.com' then 'production' else 'development'
+  kd.config.environment   = window._runtimeOptions.environment
   kd.config.recaptcha     = window._runtimeOptions.recaptcha
   kd.config.google        = window._runtimeOptions.google
   kd.config.domains       = window._runtimeOptions.domains

--- a/client/landing/site.landing/coffee/team/tabs/stripepaymenttab.coffee
+++ b/client/landing/site.landing/coffee/team/tabs/stripepaymenttab.coffee
@@ -23,7 +23,7 @@ module.exports = class StripePaymentTab extends kd.TabPaneView
       callback: @bound 'onSubmit'
 
     utils.loadStripe().then =>
-      if kd.config.environment is 'development'
+      if kd.config.environment isnt 'production'
         @submitWithDummyCard()
 
 

--- a/workers/social/lib/social/render/loggedout/kodinghome.coffee
+++ b/workers/social/lib/social/render/loggedout/kodinghome.coffee
@@ -32,7 +32,8 @@ module.exports = (options, callback) ->
           gitlab    : #{JSON.stringify KONFIG.client.runtimeOptions.gitlab},
           recaptcha : #{JSON.stringify KONFIG.client.runtimeOptions.recaptcha},
           domains   : #{JSON.stringify KONFIG.client.runtimeOptions.domains},
-          stripe    : #{JSON.stringify KONFIG.client.runtimeOptions.stripe}
+          stripe    : #{JSON.stringify KONFIG.client.runtimeOptions.stripe},
+          environment : #{JSON.stringify KONFIG.environment}
         }
       </script>
 


### PR DESCRIPTION
Right now it's being read from `location.pathname`, which causes `latest.koding.com` to think it has `development` as its `kd.config.environment` variable.

This PR addresses this issue by using the `main` domain from `kd.config.domains`.

Fixes #9833 

/cc @cihangir @sinan 