### PR TITLE
Editor bugs Fix

### DIFF
--- a/client/app/lib/providers/templates/aws.coffee
+++ b/client/app/lib/providers/templates/aws.coffee
@@ -55,7 +55,7 @@ resource:
         # once vm finishes building, you can see this file by typing
         # ls /
         #
-        # for more information please click the link below "Stack Script Docs"
+        # for more information please use the search box above
 
     '''
 

--- a/client/app/lib/providers/templates/azure.coffee
+++ b/client/app/lib/providers/templates/azure.coffee
@@ -52,6 +52,6 @@ resource:
         # once vm finishes building, you can see this file by typing
         # ls /
         #
-        # for more information please click the link below "Stack Script Docs"
+        # for more information please use the search box above
 
     '''

--- a/client/app/lib/providers/templates/digitalocean.coffee
+++ b/client/app/lib/providers/templates/digitalocean.coffee
@@ -54,6 +54,6 @@ resource:
         # once vm finishes building, you can see this file by typing
         # ls /
         #
-        # for more information please click the link below "Stack Script Docs"
+        # for more information please use the search box above
 
     '''

--- a/client/app/lib/providers/templates/google.coffee
+++ b/client/app/lib/providers/templates/google.coffee
@@ -64,6 +64,6 @@ resource:
           # once vm finishes building, you can see this file by typing
           # ls /
           #
-          # for more information please click the link below "Stack Script Docs"
+          # for more information please use the search box above
 
     '''

--- a/client/app/lib/providers/templates/softlayer.coffee
+++ b/client/app/lib/providers/templates/softlayer.coffee
@@ -74,6 +74,6 @@ resource:
         # once vm finishes building, you can see this file by typing
         # ls /
         #
-        # for more information please click the link below "Stack Script Docs"
+        # for more information please use the search box above
 
   '''

--- a/client/app/lib/providers/templates/vagrant.coffee
+++ b/client/app/lib/providers/templates/vagrant.coffee
@@ -40,6 +40,6 @@ resource:
         # once vm finishes building, you can see this file by typing
         # ls /
         #
-        # for more information please click the link below "Stack Script Docs"
+        # for more information please use the search box above
 
     '''

--- a/client/stack-editor/lib/editor/index.coffee
+++ b/client/stack-editor/lib/editor/index.coffee
@@ -341,6 +341,8 @@ module.exports = class StackEditorView extends kd.View
     @titleTabHandle.addSubView @titleActionsWrapper = new kd.CustomHTMLView
       cssClass: 'StackEditorView--header-subHeader'
 
+    @titleActionsWrapper.setClass 'readonly' unless @canUpdate
+
     @titleActionsWrapper.addSubView @inputTitle = new kd.InputView options
 
     @titleActionsWrapper.addSubView @editName = new CustomLinkView

--- a/client/stack-editor/lib/styl/stackeditor.styl
+++ b/client/stack-editor/lib/styl/stackeditor.styl
@@ -16,7 +16,6 @@ $borderColor                = #E3E3E3
 
 .StackEditorView
   bg                        color #FFF
-  min-height                600px
   min-width                 720px
   borderBox()
 

--- a/client/stack-editor/lib/styl/stackeditor.styl
+++ b/client/stack-editor/lib/styl/stackeditor.styl
@@ -132,7 +132,7 @@ $borderColor                = #E3E3E3
     transition              transform .2s ease\,
                             opacity .1s ease
     opacity                 0
-    z-index                 1
+    z-index                 2
     transform               translateX(300px)
 
   input.kdinput.searchStackInput
@@ -154,7 +154,7 @@ $borderColor                = #E3E3E3
     &:focus ~ .stack-script-search-link
       font-size             16px
       opacity               1
-      z-index               1
+      z-index               2
       transform             translateX(0px)
       &.shift
         transform           translateX(-30px)

--- a/client/stack-editor/lib/styl/stackeditor.styl
+++ b/client/stack-editor/lib/styl/stackeditor.styl
@@ -602,3 +602,11 @@ $borderColor                = #E3E3E3
       outline               inherit
       bg                    color #FFFFFF
       border                1px solid $borderColor
+
+.StackEditorView--header-subHeader.readonly
+  div.buttons
+  a.custom-link-view
+    display                 none !important
+  .kdinput.text
+    opacity                 0.5
+

--- a/client/stack-editor/lib/styl/stackeditorheader.styl
+++ b/client/stack-editor/lib/styl/stackeditorheader.styl
@@ -25,8 +25,4 @@ $borderColor                = #E3E3E3
 
 .StackEditorView--header.readonly
   .GenericButton.save-test
-  div.StackEditorView--header-subHeader
-    display                 none
-  input.kdinput.text
-    opacity                 0.5
-
+    display               none !important


### PR DESCRIPTION
## Description
- The copy in default stack templates for each provider is updated.
- Dont allow member to edit stack name
- Editor view was overlapping the links at the bottom of stack-editor page.
- add z-index to `Go To Docs` button

## Motivation and Context
Fixes: #9834, #9835, #9839 

## Screenshots (if appropriate):
![](https://monosnap.com/file/VeSXpFgWStEiM1Z6apafOSgPwT2Q6r.png)
![](https://monosnap.com/file/rIM2VN19bygKFQMA05i8IMULV7RfEA.png)
![](https://monosnap.com/file/eIT9ZUVgtc0QZJyj9CEdGKm40pC1L5.png)
