### PR TITLE
Payment fixes

### DIFF
--- a/client/app/lib/components/disabledmodals/admin.coffee
+++ b/client/app/lib/components/disabledmodals/admin.coffee
@@ -19,17 +19,11 @@ module.exports = class DisabledAdminModal extends ReactView
 
     switch status
 
-      when Status.EXPIRED
+      when Status.EXPIRED, Status.NEEDS_UPGRADE
         onClick = =>
           @destroy()
           router.handleRoute '/Home/team-billing'
         <TrialEndedAdminModal
-          isOpen={yes}
-          onButtonClick={onClick} />
-
-      when Status.NEEDS_UPGRADE
-        onClick = -> location.reload()
-        <PricingChangeModal
           isOpen={yes}
           onButtonClick={onClick} />
 

--- a/client/app/lib/components/disabledmodals/member.coffee
+++ b/client/app/lib/components/disabledmodals/member.coffee
@@ -26,7 +26,7 @@ module.exports = class DisabledMemberModal extends ReactView
 
     switch status
 
-      when Status.EXPIRED
+      when Status.EXPIRED, Status.NEEDS_UPGRADE
         onClick = =>
           @destroy()
           router.handleRoute '/Disabled/Member/notify-success'

--- a/client/app/lib/components/sidebar/groupdisabled.coffee
+++ b/client/app/lib/components/sidebar/groupdisabled.coffee
@@ -7,7 +7,7 @@ module.exports = SidebarGroupDisabled = ->
   message = if isAdmin()
     '''
     We hope you have enjoyed using Koding. Please enter a credit card
-    to continue using Koding.
+    to continue.
     '''
   else
     '''

--- a/client/app/lib/flux/environment/actions.coffee
+++ b/client/app/lib/flux/environment/actions.coffee
@@ -483,7 +483,7 @@ loadPrivateStackTemplates = ->
   remote.api.JStackTemplate.some query, { limit: 30 }, (err, templates) ->
 
     if err
-      reactor.dispatch actions.LOAD_PRIVATE_STACK_TEMPLATES_FAIL, { query, err }
+      return reactor.dispatch actions.LOAD_PRIVATE_STACK_TEMPLATES_FAIL, { query, err }
 
     templates = templates.filter (t) -> t.accessLevel is 'private'
 

--- a/client/app/lib/redux/services/payment.coffee
+++ b/client/app/lib/redux/services/payment.coffee
@@ -63,6 +63,8 @@ exports.fetchInfo = fetchInfo = ->
     return info
 
 
+exports.hasCreditCard = -> client.get Endpoints.CreditCardHas
+
 getTimestamp = (date) ->
 
   thirtyDaysInMs = (30 * 24 * 60 * 60 * 1000)

--- a/client/app/lib/util/getGroupStatus.coffee
+++ b/client/app/lib/util/getGroupStatus.coffee
@@ -1,4 +1,4 @@
-{ config } = require 'globals'
+{ config, hasCreditCard } = require 'globals'
 { Status } = require 'app/redux/modules/payment/constants'
 
 module.exports = getGroupStatus = (group) ->
@@ -7,6 +7,10 @@ module.exports = getGroupStatus = (group) ->
     # if stripe token is not set don't try to validate.
     # This is mainly for default environment
     when not config.stripe.token then Status.ACTIVE
+
+    # This state is to identify teams without credit cards.
+    # With latest changes we are forcing users to enter a cc.
+    when not hasCreditCard then Status.NEEDS_UPGRADE
 
     # This state is to identify teams before payment update.
     # This state is only possible for members.

--- a/client/component-lab/Modal/Modal.stylus
+++ b/client/component-lab/Modal/Modal.stylus
@@ -14,7 +14,7 @@ $modal-z-index              = 20000
   z-index                   $modal-z-index
 
 .wrapper
-  font-family               SoleilFamily
+  font-family               mainFontFamily
   height                    100%
   width                     100%
   display                   flex

--- a/client/component-lab/Subscription/Subscription.coffee
+++ b/client/component-lab/Subscription/Subscription.coffee
@@ -3,6 +3,7 @@ kd = require 'kd'
 { Grid, Row, Col } = require 'react-flexbox-grid'
 
 SubscriptionHeader = require 'lab/SubscriptionHeader'
+SubscriptionNoCardWarning = require 'lab/SubscriptionNoCardWarning'
 TrialChargeInfo = require 'lab/TrialChargeInfo'
 VerifyEmailWarning = require 'lab/VerifyEmailWarning'
 Survey = require 'lab/Survey'
@@ -47,9 +48,12 @@ module.exports = class Subscription extends Component
 
   renderExtras: ->
 
-    { isEmailVerified, isSurveyTaken, onClickTakeSurvey, email } = @props
+    { isEmailVerified, isSurveyTaken,
+      onClickTakeSurvey, email, hasCreditCard } = @props
 
-    if not isEmailVerified
+    if not hasCreditCard
+      <SubscriptionNoCardWarning />
+    else if not isEmailVerified
       <VerifyEmailWarning email={email} />
     else if not isSurveyTaken
       <Survey onClick={onClickTakeSurvey} />

--- a/client/component-lab/SubscriptionHeader/SubscriptionHeader.coffee
+++ b/client/component-lab/SubscriptionHeader/SubscriptionHeader.coffee
@@ -63,8 +63,6 @@ module.exports = class SubscriptionHeader extends Component
 
     { nextBillingAmount } = @props
 
-    nextBillingAmount = if @props.isTrial then 0 else nextBillingAmount
-
     <Col xs={4} className={textStyles.right}>
       <Label size="small" type="info">
         Next Bill Amount: <strong>${formatNumber(nextBillingAmount, 2) or 0}</strong>

--- a/client/component-lab/SubscriptionNoCardWarning/SubscriptionNoCardWarning.coffee
+++ b/client/component-lab/SubscriptionNoCardWarning/SubscriptionNoCardWarning.coffee
@@ -1,0 +1,29 @@
+kd = require 'kd'
+React = require 'react'
+
+Box = require 'lab/Box'
+Label = require 'lab/Text/Label'
+{ Grid, Row, Col } = require 'react-flexbox-grid'
+
+module.exports = class VerifyEmailWarning extends React.Component
+
+  render: ->
+
+    className = kd.utils.curry 'VerifyEmailWarning', @props.className
+
+    <Box type="danger" border={1}>
+      <Row>
+        <Col xs={12}>
+          <Label type="danger" size="small">
+            <strong>Please enter a credit card.</strong>
+          </Label>
+        </Col>
+        <Col xs={12}>
+          <Label size="small" type="info">
+            We hope you have enjoyed using Koding. Please enter a credit card
+            to continue.
+          </Label>
+        </Col>
+      </Row>
+    </Box>
+

--- a/client/component-lab/SubscriptionNoCardWarning/SubscriptionNoCardWarning.story.coffee
+++ b/client/component-lab/SubscriptionNoCardWarning/SubscriptionNoCardWarning.story.coffee
@@ -1,0 +1,9 @@
+React = require 'react'
+{ storiesOf, action } = require '@kadira/storybook'
+
+VerifyEmailWarning = require './VerifyEmailWarning'
+
+storiesOf 'VerifyEmailWarning', module
+  .add 'default', -> <VerifyEmailWarning />
+
+

--- a/client/component-lab/SubscriptionNoCardWarning/index.coffee
+++ b/client/component-lab/SubscriptionNoCardWarning/index.coffee
@@ -1,0 +1,1 @@
+module.exports = require './SubscriptionNoCardWarning'

--- a/client/component-lab/Survey/Survey.stylus
+++ b/client/component-lab/Survey/Survey.stylus
@@ -5,7 +5,7 @@
   align-items               center
 
   button
-    font-family             SoleilFamily
+    font-family             mainFontFamily
     padding                 12px 12px 10px
 
 .left

--- a/client/component-lab/TrialEndedAdminModal/TrialEndedAdminModal.coffee
+++ b/client/component-lab/TrialEndedAdminModal/TrialEndedAdminModal.coffee
@@ -6,7 +6,7 @@ module.exports = TrialEndedAdminModal = ({ isOpen, onButtonClick }) ->
 
   message = "
     We hope you have enjoyed using Koding. Please enter a credit card to
-    continue using Koding.
+    continue.
   "
 
   <Dialog

--- a/client/home/lib/billing/components/subscriptioncontainer.coffee
+++ b/client/home/lib/billing/components/subscriptioncontainer.coffee
@@ -67,6 +67,7 @@ mapStateToProps = (state) ->
     # TODO(umut): activate this when we have coupon support.
     isSurveyTaken: yes # !!customer.coupon(state)
     isEmailVerified: isEmailVerified(state)
+    hasCreditCard: globals.hasCreditCard
   }
 
 

--- a/client/landing/site.landing/coffee/teams/teamssignupform.coffee
+++ b/client/landing/site.landing/coffee/teams/teamssignupform.coffee
@@ -10,7 +10,7 @@ module.exports = class TeamsSignupForm extends LoginViewInlineForm
     super
 
     team        = utils.getTeamData()
-    email       = team.invitation?.email
+    email       = team.invitation?.email ? team.signup?.email
     companyName = team.signup?.companyName
 
     @email = new LoginInputView

--- a/workers/social/lib/social/models/socialapi/requests.coffee
+++ b/workers/social/lib/social/models/socialapi/requests.coffee
@@ -409,6 +409,10 @@ createSubscription = (data, callback) ->
   url = "#{socialProxyUrl}/payment/subscription/create"
   post url, data, callback
 
+hasCreditCard = (data, callback) ->
+  url = "#{socialProxyUrl}/payment/creditcard/has"
+  get url, data, callback
+
 expireSubscription = (accountId, callback) ->
   url = "#{socialProxyUrl}/payments/customers/#{accountId}/expire"
   post url, {}, callback
@@ -589,6 +593,7 @@ module.exports = {
   deleteNotificationSetting
   createCustomer
   createSubscription
+  hasCreditCard
   expireSubscription
   dispatchEvent
   storeCredential

--- a/workers/social/lib/social/render/scriptblock.coffee
+++ b/workers/social/lib/social/render/scriptblock.coffee
@@ -5,6 +5,7 @@ module.exports = (options = {}, callback) ->
   encoder   = require 'htmlencode'
   { argv }  = require 'optimist'
   _         = require 'lodash'
+  { hasCreditCard } = require '../../../../../servers/models/socialapi/requests'
 
   options.client               or= {}
   options.client.context       or= {}
@@ -22,6 +23,7 @@ module.exports = (options = {}, callback) ->
   roles               = null
   permissions         = null
   combinedStorage     = null
+  hasCard             = no
 
   { bongoModels, client, session } = options
 
@@ -67,6 +69,7 @@ module.exports = (options = {}, callback) ->
         userRoles: #{userRoles},
         userPermissions: #{userPermissions},
         currentGroup: #{currentGroup},
+        hasCreditCard: #{hasCard},
         isLoggedInOnLoad: true,
         socialApiData: #{encodedSocialApiData},
         userEnvironmentData: #{userEnvironmentData}
@@ -164,6 +167,12 @@ module.exports = (options = {}, callback) ->
         if user then userId = user.getId()
         else console.error '[scriptblock] user not found', err
         fin()
+
+    (fin) ->
+      hasCreditCard client, (err) ->
+        hasCard = not err?
+        return fin()
+
   ]
 
   async.parallel queue, -> callback null, createHTML(), socialapidata


### PR DESCRIPTION
- [x] Use `teamData.signup` along with `teamData.invitation` for user email
- [x] Expose `hasCreditCard` to globals via `kodinghome` /cc @gokmen @cihangir 
- [x] Include `hasCreditCard` check to group disabled statuses.
- [x] Show a disabled modal for admins indicating that they need to enter a credit card (copy needs to change here) /cc @devrim @sinan
![image](https://cloud.githubusercontent.com/assets/1783869/20855842/d05a7b74-b8b7-11e6-9f61-9635ecc7f5d1.png)

- [x] Show a disabled modal for members indicating that they need to ping their admins (the email link does nothing at this point, if events are connected, i can simply send an event to necessary place) /cc @cihangir (also copy needs a change here as well) /cc @devrim @sinan 
![image](https://cloud.githubusercontent.com/assets/1783869/20855870/267bdac0-b8b8-11e6-924a-3472f0e8ad07.png)

- [x] Show a message on Billing section to admins indicating that they need to enter a credit card. (copy update is required here) /cc @devrim @sinan 
![image](https://cloud.githubusercontent.com/assets/1783869/20855872/43e4f240-b8b8-11e6-9266-8a81c313d861.png)

