### PR TITLE
klient: block remote methods on unpaid subscription

### DIFF
--- a/go/src/koding/db/models/group.go
+++ b/go/src/koding/db/models/group.go
@@ -7,13 +7,23 @@ import (
 const (
 	// KDIOGroupName holds the team name of the kd.io service.
 	KDIOGroupName = "kd-io"
-
-	// PaymentStatusActive holds active payment status
-	PaymentStatusActive = "active"
-
-	// PaymentStatusTrailing holds trailing payment status
-	PaymentStatusTrailing = "trialing"
 )
+
+// SubStatus stores the current status of subscription.
+type SubStatus string
+
+const (
+	SubStatusTrailing SubStatus = "trialing"
+	SubStatusActive   SubStatus = "active"
+	SubStatusPastDue  SubStatus = "past_due"
+	SubStatusCanceled SubStatus = "canceled"
+	SubStatusUnpaid   SubStatus = "unpaid"
+)
+
+// Active returns true when subscription is considered to be active.
+func (s SubStatus) Active() bool {
+	return s == SubStatusActive || s == SubStatusTrailing
+}
 
 type Group struct {
 	Id                             bson.ObjectId            `bson:"_id" json:"-"`
@@ -46,8 +56,8 @@ type Payment struct {
 // Subscription holds customer-plan subscription related info
 type Subscription struct {
 	// Allowed values are "trialing", "active", "past_due", "canceled", "unpaid".
-	Status string `bson:"status" json:"status"`
-	ID     string `bson:"id" json:"id"`
+	Status SubStatus `bson:"status" json:"status"`
+	ID     string    `bson:"id" json:"id"`
 }
 
 // Customer is the group's customer info from payment provider
@@ -60,10 +70,5 @@ type Customer struct {
 
 // IsSubActive checks if subscription is in valid state for operation
 func (g *Group) IsSubActive() bool {
-	switch g.Payment.Subscription.Status {
-	case PaymentStatusActive, PaymentStatusTrailing:
-		return true
-	default:
-		return false
-	}
+	return g.Payment.Subscription.Status.Active()
 }

--- a/go/src/koding/kites/kloud/stack/team.go
+++ b/go/src/koding/kites/kloud/stack/team.go
@@ -63,10 +63,10 @@ func (k *Kloud) TeamWhoami(r *kite.Request) (interface{}, error) {
 
 	return &WhoamiResponse{
 		Team: &team.Team{
-			Name:         group.Title,
-			Slug:         group.Slug,
-			Privacy:      group.Privacy,
-			Subscription: group.Payment.Subscription.Status,
+			Name:      group.Title,
+			Slug:      group.Slug,
+			Privacy:   group.Privacy,
+			SubStatus: group.Payment.Subscription.Status,
 		},
 	}, nil
 }

--- a/go/src/koding/kites/kloud/team/client.go
+++ b/go/src/koding/kites/kloud/team/client.go
@@ -1,12 +1,14 @@
 package team
 
+import "koding/db/models"
+
 // Team represents a single team.
 type Team struct {
-	Name         string `json:"name"`         // Team name.
-	Slug         string `json:"slug"`         // Team slug.
-	Members      string `json:"members"`      // Number of team members.
-	Privacy      string `json:"privacy"`      // Whether team is public or private.
-	Subscription string `json:"subscription"` // Subscription status.
+	Name      string           `json:"name"`         // Team name.
+	Slug      string           `json:"slug"`         // Team slug.
+	Members   string           `json:"members"`      // Number of team members.
+	Privacy   string           `json:"privacy"`      // Whether team is public or private.
+	SubStatus models.SubStatus `json:"subscription"` // Subscription status.
 }
 
 // Filter is used for filtering team records.

--- a/go/src/koding/kites/kloud/team/mongo.go
+++ b/go/src/koding/kites/kloud/team/mongo.go
@@ -89,11 +89,11 @@ func groups2teams(groups ...*models.Group) []*Team {
 
 		members, _ := group.Counts["members"].(int)
 		teams = append(teams, &Team{
-			Name:         group.Title,
-			Slug:         group.Slug,
-			Members:      strconv.Itoa(members),
-			Privacy:      group.Privacy,
-			Subscription: group.Payment.Subscription.Status,
+			Name:      group.Title,
+			Slug:      group.Slug,
+			Members:   strconv.Itoa(members),
+			Privacy:   group.Privacy,
+			SubStatus: group.Payment.Subscription.Status,
 		})
 	}
 

--- a/go/src/koding/klient/app/klient.go
+++ b/go/src/koding/klient/app/klient.go
@@ -132,8 +132,12 @@ type Klient struct {
 	presence      *presence.Client
 	presenceEvery *onceevery.OnceEvery
 	kloud         *apiutil.LazyKite
+
+	// Team related fields.
+	// TODO(ppknap): move this to separate package.
 	teamMu        sync.Mutex
 	team          *team.Team
+	teamUpdatedAt time.Time
 }
 
 // KlientConfig defines a Klient's config
@@ -461,11 +465,11 @@ func (k *Klient) RegisterMethods() {
 	k.kite.HandleFunc("klient.usage", k.usage.Current)
 
 	// klient os method(s)
-	k.kite.HandleFunc("os.home", kos.Home)
-	k.kite.HandleFunc("os.currentUsername", kos.CurrentUsername)
+	k.handleWithSub("os.home", kos.Home)
+	k.handleWithSub("os.currentUsername", kos.CurrentUsername)
 
 	// Klient Info method(s)
-	k.kite.HandleFunc("klient.info", info.Info)
+	k.handleWithSub("klient.info", info.Info)
 
 	// Collaboration, is used by our Koding.com browser client.
 	k.kite.HandleFunc("klient.disable", control.Disable)
@@ -477,9 +481,9 @@ func (k *Klient) RegisterMethods() {
 	k.addRemoteHandlers()
 
 	// SSH keys
-	k.kite.HandleFunc("sshkeys.list", sshkeys.List)
-	k.kite.HandleFunc("sshkeys.add", sshkeys.Add)
-	k.kite.HandleFunc("sshkeys.delete", sshkeys.Delete)
+	k.handleWithSub("sshkeys.list", sshkeys.List)
+	k.handleWithSub("sshkeys.add", sshkeys.Add)
+	k.handleWithSub("sshkeys.delete", sshkeys.Delete)
 
 	// Storage
 	k.kite.HandleFunc("storage.set", k.storage.SetValue)
@@ -490,20 +494,20 @@ func (k *Klient) RegisterMethods() {
 	k.kite.HandleFunc("log.tail", logfetcher.Tail)
 
 	// Filesystem
-	k.kite.HandleFunc("fs.readDirectory", fs.ReadDirectory)
-	k.kite.HandleFunc("fs.glob", fs.Glob)
-	k.kite.HandleFunc("fs.readFile", fs.ReadFile)
-	k.kite.HandleFunc("fs.writeFile", fs.WriteFile)
-	k.kite.HandleFunc("fs.uniquePath", fs.UniquePath)
-	k.kite.HandleFunc("fs.getInfo", fs.GetInfo)
-	k.kite.HandleFunc("fs.setPermissions", fs.SetPermissions)
-	k.kite.HandleFunc("fs.remove", fs.Remove)
-	k.kite.HandleFunc("fs.rename", fs.Rename)
-	k.kite.HandleFunc("fs.createDirectory", fs.CreateDirectory)
-	k.kite.HandleFunc("fs.move", fs.Move)
-	k.kite.HandleFunc("fs.copy", fs.Copy)
-	k.kite.HandleFunc("fs.getDiskInfo", fs.GetDiskInfo)
-	k.kite.HandleFunc("fs.getPathSize", fs.GetPathSize)
+	k.handleWithSub("fs.readDirectory", fs.ReadDirectory)
+	k.handleWithSub("fs.glob", fs.Glob)
+	k.handleWithSub("fs.readFile", fs.ReadFile)
+	k.handleWithSub("fs.writeFile", fs.WriteFile)
+	k.handleWithSub("fs.uniquePath", fs.UniquePath)
+	k.handleWithSub("fs.getInfo", fs.GetInfo)
+	k.handleWithSub("fs.setPermissions", fs.SetPermissions)
+	k.handleWithSub("fs.remove", fs.Remove)
+	k.handleWithSub("fs.rename", fs.Rename)
+	k.handleWithSub("fs.createDirectory", fs.CreateDirectory)
+	k.handleWithSub("fs.move", fs.Move)
+	k.handleWithSub("fs.copy", fs.Copy)
+	k.handleWithSub("fs.getDiskInfo", fs.GetDiskInfo)
+	k.handleWithSub("fs.getPathSize", fs.GetPathSize)
 
 	// Machine group handlers.
 	k.kite.HandleFunc("machine.create", machinegroup.KiteHandlerCreate(k.machines))
@@ -539,11 +543,11 @@ func (k *Klient) RegisterMethods() {
 	k.kite.HandleFunc("exec", command.Exec)
 
 	// Terminal
-	k.kite.HandleFunc("webterm.getSessions", k.terminal.GetSessions)
-	k.kite.HandleFunc("webterm.connect", k.terminal.Connect)
-	k.kite.HandleFunc("webterm.killSession", k.terminal.KillSession)
-	k.kite.HandleFunc("webterm.killSessions", k.terminal.KillSessions)
-	k.kite.HandleFunc("webterm.rename", k.terminal.RenameSession)
+	k.handleWithSub("webterm.getSessions", k.terminal.GetSessions)
+	k.handleWithSub("webterm.connect", k.terminal.Connect)
+	k.handleWithSub("webterm.killSession", k.terminal.KillSession)
+	k.handleWithSub("webterm.killSessions", k.terminal.KillSessions)
+	k.handleWithSub("webterm.rename", k.terminal.RenameSession)
 
 	// VM -> Client methods
 	ps := client.NewPubSub(k.log)
@@ -578,6 +582,26 @@ func (k *Klient) RegisterMethods() {
 
 		k.log.Info("Start disconnection timer with 1 minute delay.")
 		k.collabCloser.Start()
+	})
+}
+
+// handleWithSub is a middle-ware function that checks team payment status
+// before invoking fn function. It will fail if team is blocked due to unpaid
+// subscription.
+func (k *Klient) handleWithSub(method string, fn kite.HandlerFunc) {
+	k.kite.HandleFunc(method, func(r *kite.Request) (interface{}, error) {
+		team, err := k.cacheTeam()
+		if err != nil {
+			k.log.Error("Cannot find Klient's team: %s", err)
+			return nil, err
+		}
+
+		if !team.IsSubActive() {
+			k.log.Error("Method %q is blocked due to unpaid subscription for %s team.", method, team.Name)
+			return nil, errors.New("method is blocked")
+		}
+
+		return fn(r)
 	})
 }
 
@@ -671,7 +695,7 @@ func (k *Klient) cacheTeam() (*team.Team, error) {
 	k.teamMu.Lock()
 	defer k.teamMu.Unlock()
 
-	if k.team != nil {
+	if k.team != nil && !k.teamUpdatedAt.IsZero() && time.Since(k.teamUpdatedAt) < time.Hour {
 		return k.team, nil
 	}
 
@@ -683,6 +707,7 @@ func (k *Klient) cacheTeam() (*team.Team, error) {
 	k.log.Info("Kite belongs to %q team", team.Name)
 
 	k.team = team
+	k.teamUpdatedAt = time.Now()
 
 	return k.team, nil
 }

--- a/go/src/koding/klient/app/klient.go
+++ b/go/src/koding/klient/app/klient.go
@@ -596,7 +596,7 @@ func (k *Klient) handleWithSub(method string, fn kite.HandlerFunc) {
 			return nil, err
 		}
 
-		if !team.IsSubActive() {
+		if !team.SubStatus.Active() {
 			k.log.Error("Method %q is blocked due to unpaid subscription for %s team.", method, team.Name)
 			return nil, errors.New("method is blocked")
 		}

--- a/go/src/koding/klient/app/klient_unix.go
+++ b/go/src/koding/klient/app/klient_unix.go
@@ -38,7 +38,7 @@ func (k *Klient) handleRemoteFunc(method string, fn kite.HandlerFunc) {
 
 		k.presenceEvery.Do(func() {
 			if err := k.ping(); err != nil {
-				k.log.Error("failed to ping: %s", err)
+				k.log.Error("Failed to ping: %s", err)
 			}
 		})
 

--- a/go/src/koding/klientctl/team.go
+++ b/go/src/koding/klientctl/team.go
@@ -54,7 +54,7 @@ func printTeams(teams []*team.Team) {
 	fmt.Fprintln(w, "NAME\tSLUG\tPRIVACY\tMEMBERS\tSUBSCRIPTION")
 
 	for _, t := range teams {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", t.Name, t.Slug, t.Privacy, t.Members, t.Subscription)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", t.Name, t.Slug, t.Privacy, t.Members, t.SubStatus)
 	}
 }
 

--- a/go/src/koding/klientctl/team_test.go
+++ b/go/src/koding/klientctl/team_test.go
@@ -19,8 +19,8 @@ func TestTeamList(t *testing.T) {
 		"all teams": {
 			nil,
 			[]*team.Team{
-				&team.Team{Name: "teamA", Slug: "teamAS", Privacy: "public", Subscription: "paid"},
-				&team.Team{Name: "teamB", Slug: "teamBS", Privacy: "private", Subscription: "trailing"},
+				&team.Team{Name: "teamA", Slug: "teamAS", Privacy: "public", SubStatus: "paid"},
+				&team.Team{Name: "teamB", Slug: "teamBS", Privacy: "private", SubStatus: "trailing"},
 			},
 		},
 	}

--- a/go/src/socialapi/workers/payment/subscription.go
+++ b/go/src/socialapi/workers/payment/subscription.go
@@ -200,7 +200,7 @@ func syncGroupWithCustomerID(cusID string) error {
 
 	// if subID and subStatus are same, update not needed
 	if group.Payment.Subscription.ID == subID &&
-		group.Payment.Subscription.Status == string(subStatus) {
+		stripe.SubStatus(group.Payment.Subscription.Status) == subStatus {
 		return nil
 	}
 

--- a/go/src/socialapi/workers/payment/webhook.go
+++ b/go/src/socialapi/workers/payment/webhook.go
@@ -325,7 +325,7 @@ func handleInvoiceStateChange(invoice *stripe.Invoice) error {
 	status := group.Payment.Subscription.Status
 
 	// if sub is in cancelled state within 2 months send an event
-	if status == string(SubStatusCanceled) {
+	if stripe.SubStatus(status) == SubStatusCanceled {
 		// if group has been created in last 2 months (1 month trial + 1 month free)
 		totalTrialTime := time.Now().UTC().Add(-time.Hour * 24 * 60)
 		if group.Id.Time().After(totalTrialTime) {
@@ -339,7 +339,7 @@ func handleInvoiceStateChange(invoice *stripe.Invoice) error {
 		group.Slug,
 		"payment_status_changed",
 		map[string]string{
-			"oldStatus": group.Payment.Subscription.Status,
+			"oldStatus": string(group.Payment.Subscription.Status),
 			"newStatus": string(status),
 		},
 	)

--- a/go/src/socialapi/workers/presence/presence.go
+++ b/go/src/socialapi/workers/presence/presence.go
@@ -152,7 +152,7 @@ func getPresenceInfoFromDB(ping *Ping) (*models.PresenceDaily, error) {
 			// Second issue is, when a sub is in non-active state, we should still
 			// collect presence info but we wont be charging users during that period,
 			// because we dont allow them to utilize koding
-			"is_processed": ping.paymentStatus != mongomodels.PaymentStatusActive,
+			"is_processed": ping.paymentStatus != string(mongomodels.SubStatusActive),
 		},
 		Sort: map[string]string{
 			"created_at": "DESC",
@@ -171,7 +171,7 @@ func insertPresenceInfoToDB(ping *Ping) error {
 		GroupName:   ping.GroupName,
 		AccountId:   ping.AccountID,
 		CreatedAt:   ping.CreatedAt,
-		IsProcessed: ping.paymentStatus != mongomodels.PaymentStatusActive,
+		IsProcessed: ping.paymentStatus != string(mongomodels.SubStatusActive),
 	}
 	return p.Create()
 }
@@ -196,12 +196,12 @@ func getGroupPaymentStatusFromCache(groupName string) (string, error) {
 
 	status := group.Payment.Subscription.Status
 	// set defaul payment status
-	if status != mongomodels.PaymentStatusActive {
+	if status != mongomodels.SubStatusActive {
 		status = "invalid"
 	}
 
 	if err := groupCache.Set(groupName, status); err != nil {
 		return "", err
 	}
-	return status, nil
+	return string(status), nil
 }

--- a/go/src/socialapi/workers/presence/presence_test.go
+++ b/go/src/socialapi/workers/presence/presence_test.go
@@ -39,7 +39,7 @@ func TestPresenceDailyOperations(t *testing.T) {
 				pi, err := getPresenceInfoFromDB(&Ping{
 					AccountID:     p2.AccountId,
 					GroupName:     p2.GroupName,
-					paymentStatus: mongomodels.PaymentStatusActive,
+					paymentStatus: string(mongomodels.SubStatusActive),
 				})
 				So(err, ShouldBeNil)
 				So(pi, ShouldNotBeNil)
@@ -51,7 +51,7 @@ func TestPresenceDailyOperations(t *testing.T) {
 				pi2, err := getPresenceInfoFromDB(&Ping{
 					AccountID:     p2.AccountId,
 					GroupName:     "non_existent_group_name",
-					paymentStatus: mongomodels.PaymentStatusActive,
+					paymentStatus: string(mongomodels.SubStatusActive),
 				})
 				So(err, ShouldNotBeNil)
 				So(err, ShouldEqual, bongo.RecordNotFound)
@@ -60,7 +60,7 @@ func TestPresenceDailyOperations(t *testing.T) {
 				pi3, err := getPresenceInfoFromDB(&Ping{
 					AccountID:     rand.Int63(),
 					GroupName:     groupName1,
-					paymentStatus: mongomodels.PaymentStatusActive,
+					paymentStatus: string(mongomodels.SubStatusActive),
 				})
 				So(err, ShouldNotBeNil)
 				So(err, ShouldEqual, bongo.RecordNotFound)
@@ -81,7 +81,7 @@ func TestPresenceDailyVerifyRecord(t *testing.T) {
 					AccountID:     1, // non existing user
 					GroupName:     groupName1,
 					CreatedAt:     today,
-					paymentStatus: mongomodels.PaymentStatusActive,
+					paymentStatus: string(mongomodels.SubStatusActive),
 				}
 				key := getKey(ping, today)
 				_, err := pingCache.Get(key)
@@ -107,7 +107,7 @@ func TestPresenceDailyVerifyRecord(t *testing.T) {
 					AccountID:     2, // non existing user
 					GroupName:     groupName1,
 					CreatedAt:     prev,
-					paymentStatus: mongomodels.PaymentStatusActive,
+					paymentStatus: string(mongomodels.SubStatusActive),
 				}
 				So(insertPresenceInfoToDB(ping), ShouldBeNil)
 
@@ -127,7 +127,7 @@ func TestPresenceDailyVerifyRecord(t *testing.T) {
 					AccountID:     3, // non existing user
 					GroupName:     groupName1,
 					CreatedAt:     today,
-					paymentStatus: mongomodels.PaymentStatusActive,
+					paymentStatus: string(mongomodels.SubStatusActive),
 				}
 				So(insertPresenceInfoToDB(ping), ShouldBeNil)
 
@@ -158,7 +158,7 @@ func TestPresenceDailyPing(t *testing.T) {
 					AccountID:     1, // non existing user
 					GroupName:     groupName1,
 					CreatedAt:     today,
-					paymentStatus: mongomodels.PaymentStatusActive,
+					paymentStatus: string(mongomodels.SubStatusActive),
 				}
 				key := getKey(ping, today)
 				_, err := pingCache.Get(key)


### PR DESCRIPTION
Remote auto-updated clients will refuse callers' request when klient's team is blocked due to unpaid subscription.

Depends on: ~#9870~

| Method   |      Callers      |  Blocked | Command |
|----------|:-------------:|:------:|:-------:|
| `klient.usage` |  kloud | :x: | - |
| `os.home` |    klient   | :white_check_mark: | - | 
| `os.currentUsername` | klient | :white_check_mark: | ssh |
| `klient.info` | klient | :white_check_mark: | list |
| `klient.disable` | browser | :x: | - |
| `klient.share` | kloud/browser/socialapi | :x: | - |
| `klient.unshare` | kloud/browser/socialapi | :x: | - |
| `klient.shared` | browser/socialapi | :x: | - |
| `sshkeys.list` | - | :white_check_mark: | - |
| `sshkeys.add` | klient | :white_check_mark: | ssh |
| `sshkeys.delete` | - | :white_check_mark: | - |
| `storage.set` | browser | :x: | - |
| `storage.get` | browser | :x: | - |
| `storage.delete` | browser | :x: | - |
| `log.tail` | browser | :x: | - |
| `fs.readDirectory` | browser/klient | :white_check_mark: | mount |
| `fs.glob` | browser/klient | :white_check_mark: | mount |
| `fs.readFile` | browser/klient | :white_check_mark: | mount |
| `fs.writeFile` | browser/klient | :white_check_mark: | mount |
| `fs.uniquePath` | browser/klient | :white_check_mark: | mount |
| `fs.getInfo` | browser/klient | :white_check_mark: | mount |
| `fs.setPermissions` | browser/klient | :white_check_mark: | mount |
| `fs.remove` | broser/klient | :white_check_mark: | mount |
| `fs.rename` | browser/klient | :white_check_mark: | mount |
| `fs.createDirectory` | browser/klient | :white_check_mark: | mount |
| `fs.move` | browser/klient | :white_check_mark: | mount |
| `fs.copy` | klient | :white_check_mark: | mount |
| `fs.getDiskInfo` | klient | :white_check_mark: | mount |
| `fs.getPathSize` | klient | :white_check_mark: | mount |
| `vagrant.create` | kloud | :x: | - |
| `vagrant.provider` | kloud | :x: | - |
| `vagrant.list` | kloud | :x: | - |
| `vagrant.up` | kloud | :x: | - |
| `vagrant.halt` | kloud | :x: | - |
| `vagrant.destroy` | kloud | :x: | - |
| `vagrant.status` | kloud | :x: | - |
| `vagrant.version` | kloud | :x: | - |
| `vagrant.listForwardedPorts` | klient | :x: | - |
| `tunnel.info` | kloud | :x: | - |
| `log.upload` | - | :x: | - |
| `webterm.getSessions` | browser | :white_check_mark: | - |
| `webterm.connect`  | browser | :white_check_mark: | - |
| `webterm.killSession` | browser | :white_check_mark: | - |
| `webterm.killSessions` | browser | :white_check_mark: | - |
| `webterm.rename` | browser | :white_check_mark: | - |
| `client.Publish` | KD | :x: | - |
| `client.Subscribe` | browser | :x: | - |
| `client.Unsubscribe` | browser | :x: | - |
## Motivation and Context
Payment handling

## How Has This Been Tested?
Manually

