### PR TITLE
Fix/Reword email instructions for Rainforest test #49632

### DIFF
--- a/tests/spec/rainforest/joinByInvitation_logout_tryToLoginWith_NotAllowedEmail_InvalidPassword.rfml
+++ b/tests/spec/rainforest/joinByInvitation_logout_tryToLoginWith_NotAllowedEmail_InvalidPassword.rfml
@@ -7,7 +7,7 @@
 Click on the 'create a new team' link below the form where it says 'Welcome! Enter your team's Koding domain.'
 Do you see 'Let's sign you up!' form with 'Email Address' and 'Team Name' text fields and a 'NEXT' button?
 
-Enter "rainforest+{{ random.email }}" in the 'Email Address' and "{{ random.last_name }}{{ random.number }}" in 'Team Name' fields and click on 'NEXT' button
+Enter "{{ random.last_name }}{{ random.number }}+{{ random.email }}" in the 'Email Address' and "{{ random.last_name }}{{ random.number }}" in 'Team Name' fields and click on 'NEXT' button
 Do you see 'Your team URL' form with 'Your Team URL' field pre-filled?
 
 Click on 'NEXT' button
@@ -26,7 +26,7 @@ Enter "{{ random.email }}" in the 'Email' field that's highlighted, uncheck the 
 Have you seen 'Invitation is sent to {{ random.email }}' message displayed?
 
 Open a new incognito window by clicking on the 3 dots on the top corner of the browser and selecting 'New Incognito Window' and then go to '{{ random.inbox }}' by pasting the url (using ctrl-v) in the address bar, wait ~1min and refresh the page
-Do you see 'You are invited to join a team on Koding' email in inbox that received a few minutes ago (and, probably, several older emails)?
+Do you see a newly received email with subject 'You are invited to join a team on Koding'? (may take a minute or so to appear)
 
 Click on 'Open Email' for that 'You are invited to join a team on Koding' email
 Do you see 'Hi there, You received this email because {{ random.first_name }}{{ random.number }} would like you to join {{ random.last_name }}{{ random.number }}'s Team on Koding.com' text in the email? Do you see 'ACCEPT INVITE' button?


### PR DESCRIPTION
The usage of `rainforest+random.email` appears to have been causing troubles at Step.3 where it would claim an account already existed with that email, also adjusted wording later on when viewing the random.inbox


This pull request is an attempt at partially fulfilling #9891 and I would like to verify I'm doing what's expected before proceeding to any further changes. I can also be found on Slack as `@bitspill`