### PR TITLE
Removed a premature step of toggling the VM Sharing button

### DIFF
--- a/tests/spec/rainforest/sharedVMs_reject_inviteAgain_accept_checkTerminalActions.rfml
+++ b/tests/spec/rainforest/sharedVMs_reject_inviteAgain_accept_checkTerminalActions.rfml
@@ -11,10 +11,10 @@
 Click to 'REJECT' button
 Did popup disappear? Did 'test_' label disappear along with 'Shared VMs' section in sidebar on the left?
 
-Switch back to first window and move your mouse over 'test' label on left sidebar and click on the circle button appeared next to it. Scroll down until you see 'VM Sharing'. Click on the toggle button next to 'VM Sharing'
+Switch back to first window and move your mouse over 'test' label on left sidebar and click on the circle button appeared next to it. Scroll down until you see 'VM Sharing'. 
 Is the label updated as 'OFF'? Is it turned to gray?
 
-Click to toggle button next to 'VM Sharing' and then enter 'rainforestqa22' in the text box again, hit enter and wait for a few seconds for process to be completed
+Click the toggle button next to 'VM Sharing' and then enter 'rainforestqa22' in the text box again, hit enter and wait for a few seconds for process to be completed
 Is 'rainforestqa22' added below 'Type a username' text box? Is 'This VM has not yet been shared with anyone.' text removed?
 
 Switch to the incognito window and click on 'ACCEPT' button this time


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Needed to remove "Click on the toggle button next to 'VM Sharing'" in one of the steps