### PR TITLE
stack/kloud: enable "team.whoami" method

### DIFF
--- a/go/src/koding/db/mongodb/modelhelper/group.go
+++ b/go/src/koding/db/mongodb/modelhelper/group.go
@@ -105,15 +105,7 @@ func LookupGroup(opts *LookupGroupOptions) (*models.Group, error) {
 	}
 
 	fn := func(c *mgo.Collection) error {
-		find := bson.M{
-			"users": bson.M{
-				"$elemMatch": bson.M{
-					"id": id,
-				},
-			},
-		}
-
-		return c.Find(find).Select(lookupGroupFields).All(&m)
+		return c.Find(bson.M{"users.id": id}).Select(lookupGroupFields).All(&m)
 	}
 
 	if err := Mongo.Run(MachinesColl, fn); err != nil && err != mgo.ErrNotFound {

--- a/go/src/koding/db/mongodb/modelhelper/group.go
+++ b/go/src/koding/db/mongodb/modelhelper/group.go
@@ -116,7 +116,7 @@ func LookupGroup(opts *LookupGroupOptions) (*models.Group, error) {
 	}
 
 	// Look for questString.
-	if qs, err := utils.QueryString(opts.KiteID); err == nil {
+	if qs, err := utils.QueryString(opts.KiteID); err == nil && qs != "" {
 		for i := range m {
 			if len(m[i].Groups) == 0 {
 				continue
@@ -128,14 +128,19 @@ func LookupGroup(opts *LookupGroupOptions) (*models.Group, error) {
 		}
 	}
 
-	if host, err := parseHost(opts.ClientURL); err == nil {
+	if host, err := parseHost(opts.ClientURL); err == nil && host != "" {
 		// Look up for ipAddress.
 		for i := range m {
 			if len(m[i].Groups) == 0 {
 				continue
 			}
 
-			if mHost, err := parseHost(m[i].IPAddress); err == nil && mHost == host {
+			mHost := m[i].IPAddress
+			if host, _, err := net.SplitHostPort(mHost); err == nil {
+				mHost = host
+			}
+
+			if mHost == host {
 				return GetGroupById(m[i].Groups[0].ID.Hex())
 			}
 		}

--- a/go/src/koding/db/mongodb/modelhelper/group.go
+++ b/go/src/koding/db/mongodb/modelhelper/group.go
@@ -99,11 +99,16 @@ func LookupGroup(opts *LookupGroupOptions) (*models.Group, error) {
 		} `bson:"groups"`
 	}
 
+	id, err := GetUserID(opts.Username)
+	if err != nil {
+		return nil, err
+	}
+
 	fn := func(c *mgo.Collection) error {
 		find := bson.M{
 			"users": bson.M{
 				"$elemMatch": bson.M{
-					"username": opts.Username,
+					"id": id,
 				},
 			},
 		}

--- a/go/src/koding/db/mongodb/modelhelper/group.go
+++ b/go/src/koding/db/mongodb/modelhelper/group.go
@@ -2,6 +2,9 @@ package modelhelper
 
 import (
 	"errors"
+	"net"
+	"net/url"
+	"strings"
 	"time"
 
 	"koding/db/models"
@@ -60,33 +63,127 @@ func GetGroupFieldsByIds(ids []string, fields []string) ([]*models.Group, error)
 	return groups, Mongo.Run(GroupsCollectionName, query)
 }
 
+var lookupGroupFields = bson.M{
+	"registerUrl": 1,
+	"queryString": 1,
+	"ipAddress":   1,
+	"groups.id":   1,
+}
+
+type LookupGroupOptions struct {
+	KiteID      string
+	ClientURL   string
+	Environment string
+	Username    string
+}
+
 // GetGroupForKite reverse looks up a team name for the given kiteID
 // by looking up a kiteID among jMachine.queryString fields.
-func GetGroupForKite(kiteID string) (*models.Group, error) {
-	qs, err := utils.QueryString(kiteID)
-	if err != nil {
-		return nil, err
-	}
-
-	var groups struct {
-		Groups []struct {
+//
+// TODO(rjeczalik): This method does client-side filtering,
+// due to lack of indexes on the following fields:
+//
+//   - registerUrl
+//   - queryString
+//   - ipAddress
+//
+// After the indexes are in place, the LookupGroup should
+// be reworked to look up on jMachine.queryString only.
+func LookupGroup(opts *LookupGroupOptions) (*models.Group, error) {
+	var m []struct {
+		RegisterURL string `bson:"registerUrl"`
+		QueryString string `bson:"queryString"`
+		IPAddress   string `bson:"ipAddress"`
+		Groups      []struct {
 			ID bson.ObjectId `bson:"id"`
 		} `bson:"groups"`
 	}
 
 	fn := func(c *mgo.Collection) error {
-		return c.Find(bson.M{"queryString": qs}).Select(bson.M{"groups": 1}).One(&groups)
+		find := bson.M{
+			"users": bson.M{
+				"$elemMatch": bson.M{
+					"username": opts.Username,
+				},
+			},
+		}
+
+		return c.Find(find).Select(lookupGroupFields).All(&m)
 	}
 
-	if err := Mongo.Run(MachinesColl, fn); err != nil {
+	if err := Mongo.Run(MachinesColl, fn); err != nil && err != mgo.ErrNotFound {
 		return nil, err
 	}
 
-	if len(groups.Groups) == 0 {
-		return nil, mgo.ErrNotFound
+	// Look for questString.
+	if qs, err := utils.QueryString(opts.KiteID); err == nil {
+		for i := range m {
+			if len(m[i].Groups) == 0 {
+				continue
+			}
+
+			if m[i].QueryString == qs {
+				return GetGroupById(m[i].Groups[0].ID.Hex())
+			}
+		}
 	}
 
-	return GetGroupById(groups.Groups[0].ID.Hex())
+	if host, err := parseHost(opts.ClientURL); err == nil {
+		// Look up for ipAddress.
+		for i := range m {
+			if len(m[i].Groups) == 0 {
+				continue
+			}
+
+			if mHost, err := parseHost(m[i].IPAddress); err == nil && mHost == host {
+				return GetGroupById(m[i].Groups[0].ID.Hex())
+			}
+		}
+
+		// Look up for registerUrl.
+		for i := range m {
+			if len(m[i].Groups) == 0 {
+				continue
+			}
+
+			if mHost, err := parseHost(m[i].RegisterURL); err == nil && mHost == host {
+				return GetGroupById(m[i].Groups[0].ID.Hex())
+			}
+		}
+	}
+
+	// KD does not have a jMachine document (TODO - #8514), instead
+	// we return a group in a best-effor manner - we look up
+	// the most recently accessed session for the user,
+	// and give the the group attached to it.
+	switch strings.ToLower(opts.Environment) {
+	case "managed", "devmanaged":
+		session, err := GetMostRecentSession(opts.Username)
+		if err != nil {
+			return nil, err
+		}
+
+		return GetGroup(session.GroupName)
+	}
+
+	return nil, mgo.ErrNotFound
+}
+
+func parseHost(s string) (string, error) {
+	if s == "" {
+		return "", errors.New("modelhelper: empty url")
+	}
+
+	u, err := url.Parse(s)
+	if err != nil {
+		return "", err
+	}
+
+	if host, _, err := net.SplitHostPort(u.Host); err == nil {
+		u.Host = host
+	}
+
+	return u.Host, nil
 }
 
 func GetGroup(slugName string) (*models.Group, error) {

--- a/go/src/koding/db/mongodb/modelhelper/group_test.go
+++ b/go/src/koding/db/mongodb/modelhelper/group_test.go
@@ -95,6 +95,16 @@ func TestLookupGroup(t *testing.T) {
 	db := modeltesthelper.NewMongoDB(t)
 	defer db.Close()
 
+	user := &models.User{
+		ObjectId: bson.NewObjectId(),
+		Name:     bson.NewObjectId().Hex(),
+		Email:    bson.NewObjectId().Hex(),
+	}
+
+	if err := modelhelper.CreateUser(user); err != nil {
+		t.Fatalf("CreateUser()=%s", err)
+	}
+
 	groups, err := createGroups(N + 1)
 	if err != nil {
 		t.Fatalf("createGroups()=%s", err)
@@ -108,18 +118,22 @@ func TestLookupGroup(t *testing.T) {
 	for i := range machines {
 		machines[i].Groups = []models.MachineGroup{{Id: groups[i].Id}}
 
-		setGroups := bson.M{
+		update := bson.M{
 			"$set": bson.M{
 				"groups": machines[i].Groups,
+				"users": []*models.MachineUser{{
+					Id:       user.ObjectId,
+					Username: user.Name,
+				}},
 			},
 		}
 
 		if i&2 == 0 {
 			// force to lookup by registerUrl for machines with even index
-			setGroups["$set"].(bson.M)["ipAddress"] = ""
+			update["$set"].(bson.M)["ipAddress"] = ""
 		}
 
-		err := modelhelper.UpdateMachine(machines[i].ObjectId, setGroups)
+		err := modelhelper.UpdateMachine(machines[i].ObjectId, update)
 		if err != nil {
 			t.Fatalf("UpdateMachine()=%s", err)
 		}
@@ -128,7 +142,7 @@ func TestLookupGroup(t *testing.T) {
 	session := &models.Session{
 		Id:        bson.NewObjectId(),
 		GroupName: groups[N].Slug,
-		Username:  "rafal",
+		Username:  user.Name,
 	}
 
 	if err := modelhelper.CreateSession(session); err != nil {
@@ -141,28 +155,28 @@ func TestLookupGroup(t *testing.T) {
 	}{
 		"lookup by queryString": {
 			&modelhelper.LookupGroupOptions{
-				Username: "rafal",
+				Username: user.Name,
 				KiteID:   mustKiteID(machines[0].QueryString),
 			},
 			groups[0].Id,
 		},
 		"lookup by ipAddress": {
 			&modelhelper.LookupGroupOptions{
-				Username:  "rafal",
+				Username:  user.Name,
 				ClientURL: machines[1].RegisterURL,
 			},
 			groups[1].Id,
 		},
 		"lookup by registerUrl": {
 			&modelhelper.LookupGroupOptions{
-				Username:  "rafal",
+				Username:  user.Name,
 				ClientURL: machines[4].RegisterURL,
 			},
 			groups[4].Id,
 		},
 		"lookup by most recent session for KD": {
 			&modelhelper.LookupGroupOptions{
-				Username:    "rafal",
+				Username:    user.Name,
 				Environment: "managed",
 			},
 			groups[N].Id,

--- a/go/src/koding/db/mongodb/modelhelper/group_test.go
+++ b/go/src/koding/db/mongodb/modelhelper/group_test.go
@@ -131,12 +131,29 @@ func TestGetGroupForKite(t *testing.T) {
 		}
 	}
 
-	team, err := modelhelper.GetGroupForKite("64d81792-1691-49b1-b291-54122096b1ec")
-	if err != nil {
-		t.Fatalf("GetGroupForKite()=%s", err)
+	cases := map[string]struct {
+		opts *modelhelper.LookupGroupOptions
+		id   bson.ObjectId
+	}{
+		"lookup by questString": {
+			&modelhelper.LookupGroupOptions{
+				Username: "user",
+				KiteID:   "64d81792-1691-49b1-b291-54122096b1ec",
+			},
+			g.Id,
+		},
 	}
 
-	if team.Id != g.Id {
-		t.Fatalf("got %q, want %q", g.Id.Hex(), team.Id.Hex())
+	for name, cas := range cases {
+		t.Run(name, func(t *testing.T) {
+			team, err := modelhelper.LookupGroup(cas.opts)
+			if err != nil {
+				t.Fatalf("GetGroupForKite()=%s", err)
+			}
+
+			if team.Id != cas.id {
+				t.Fatalf("got %q, want %q", team.Id.Hex(), cas.id.Hex())
+			}
+		})
 	}
 }

--- a/go/src/koding/db/mongodb/modelhelper/session.go
+++ b/go/src/koding/db/mongodb/modelhelper/session.go
@@ -48,6 +48,24 @@ func GetSessionsByUsername(username string) ([]*models.Session, error) {
 	return sessions, nil
 }
 
+func GetMostRecentSession(username string) (*models.Session, error) {
+	var session models.Session
+
+	fn := func(c *mgo.Collection) error {
+		return c.Find(bson.M{"username": username}).Sort("lastAccess").One(&session)
+	}
+
+	if err := Mongo.Run(SessionColl, fn); err != nil {
+		return nil, err
+	}
+
+	if !session.Id.Valid() {
+		return nil, mgo.ErrNotFound
+	}
+
+	return &session, nil
+}
+
 func GetSessionFromToken(token string) (*models.Session, error) {
 	session := new(models.Session)
 

--- a/go/src/koding/db/mongodb/modelhelper/session_test.go
+++ b/go/src/koding/db/mongodb/modelhelper/session_test.go
@@ -58,6 +58,8 @@ func TestSessionUpdateData(t *testing.T) {
 }
 
 func TestGetMostRecentSession(t *testing.T) {
+	db := modeltesthelper.NewMongoDB(t)
+	defer db.Close()
 	g, err := createGroup()
 	if err != nil {
 		t.Fatalf("createGroup()=%s", err)

--- a/go/src/koding/db/mongodb/modelhelper/user.go
+++ b/go/src/koding/db/mongodb/modelhelper/user.go
@@ -52,6 +52,26 @@ func GetUser(username string) (*models.User, error) {
 	return user, nil
 }
 
+var userOnlyID = bson.M{
+	"_id": 1,
+}
+
+func GetUserID(username string) (bson.ObjectId, error) {
+	var id struct {
+		ID bson.ObjectId `bson:"_id"`
+	}
+
+	fn := func(c *mgo.Collection) error {
+		return c.Find(bson.M{"username": username}).Select(userOnlyID).One(&id)
+	}
+
+	if err := Mongo.Run(UserColl, fn); err != nil {
+		return "", err
+	}
+
+	return id.ID, nil
+}
+
 func GetUsersById(ids ...bson.ObjectId) ([]*models.User, error) {
 	var users []*models.User
 	if err := Mongo.Run("jUsers", func(c *mgo.Collection) error {

--- a/go/src/koding/db/mongodb/modelhelper/user_test.go
+++ b/go/src/koding/db/mongodb/modelhelper/user_test.go
@@ -52,6 +52,15 @@ func TestBlockUser(t *testing.T) {
 	if user.BlockedUntil.IsZero() {
 		t.Errorf("User blocked until date is not set")
 	}
+
+	id, err := modelhelper.GetUserID(user.Name)
+	if err != nil {
+		t.Fatalf("GetUserID()=%s", err)
+	}
+
+	if id != user.ObjectId {
+		t.Fatalf("got %q, want %q", id.Hex(), user.ObjectId.Hex())
+	}
 }
 
 func TestRemoveUser(t *testing.T) {

--- a/go/src/koding/kites/kloud/stack/whoami.go
+++ b/go/src/koding/kites/kloud/stack/whoami.go
@@ -1,7 +1,6 @@
 package stack
 
 import (
-	"errors"
 	"koding/db/models"
 	"koding/db/mongodb/modelhelper"
 
@@ -24,13 +23,14 @@ type WhoamiResponse struct {
 
 // TestWhoami is a kite handler for a "team.whoami" kite method.
 func (k *Kloud) TeamWhoami(r *kite.Request) (interface{}, error) {
-	// TODO(rjeczalik): disable until:
-	//
-	//   https://github.com/koding/koding/pull/9870#discussion_r91266706
-	//
-	return nil, errors.New("no team information currently available")
+	opts := &modelhelper.LookupGroupOptions{
+		Username:    r.Username,
+		KiteID:      r.Client.ID,
+		ClientURL:   r.Client.URL,
+		Environment: r.Client.Environment,
+	}
 
-	group, err := modelhelper.GetGroupForKite(r.Client.ID)
+	group, err := modelhelper.LookupGroup(opts)
 	if err != nil {
 		return nil, models.ResError(err, "jGroup")
 	}


### PR DESCRIPTION
Despite the solution described in #9926, I've decided to rework "team.whoami" to lookup group information basing on some heuristics:

- fetch all jMachines for a given user, with only a subset of fields
  - if KiteID is provided, check whether there's one jMachine matching
  - if ClientURL is provided
    - check whether there's one jMachine which host(jMachine.ipAddress) matches host(ClientURL)
    - if none, check whether there's one jMachine which host(jMachine.registerURL) matches host(ClientURL)
  - if none is found and klient is either managed or devmanaged return groupName of last recently accessed session (since KD-originated klients have no jMachine document - #8514 - so we make a best-effort guess)
- return a group for a match 

Addresses: https://github.com/koding/koding/pull/9870#discussion_r91266706

Closes #9926.

[edit]  The team name should still be part of kite.key, but we can tackle this at some later point, to drop the need to call `team.whoami` during klient runtime.
