### PR TITLE
Disable payment requirements on signup for Default Environment

### DIFF
--- a/client/home/lib/homeappview.coffee
+++ b/client/home/lib/homeappview.coffee
@@ -5,6 +5,8 @@ HomeAppAvatarView = require './commons/homeappavatarview'
 HomeTabHandle     = require './commons/hometabhandle'
 isGroupDisabled   = require 'app/util/isGroupDisabled'
 
+isDefaultEnv = -> globals.config.environment is 'default'
+
 module.exports = class HomeAppView extends kd.ModalView
 
   constructor: (options = {}, data) ->
@@ -80,6 +82,9 @@ module.exports = class HomeAppView extends kd.ModalView
       role = if item.role? then item.role else 'admin'
 
       if checkRoles and role not in myRoles
+        continue
+
+      if isDefaultEnv() and item.hideOnDefault
         continue
 
       if isGroupDisabled(group) and not item.showOnDisabled

--- a/client/home/lib/index.coffee
+++ b/client/home/lib/index.coffee
@@ -21,7 +21,7 @@ module.exports = class HomeAppController extends AppController
     { title : 'Stacks', viewClass : HomeStacks, role: 'member' }
     { title : 'My Team', viewClass : HomeMyTeam, role: 'member' }
     { title : 'Team Integrations', viewClass : HomeIntegrations }
-    { title : 'Team Billing', viewClass : HomeTeamBilling, showOnDisabled: yes }
+    { title : 'Team Billing', viewClass : HomeTeamBilling, showOnDisabled: yes, hideOnDefault: yes }
     # { title : 'Payment History', viewClass : HomePaymentHistory }
     { title : 'Koding Utilities', viewClass : HomeUtilities, role: 'member' }
     { title : 'My Account', viewClass : HomeAccount, role: 'member' }

--- a/client/landing/site.landing/coffee/core/utils.coffee
+++ b/client/landing/site.landing/coffee/core/utils.coffee
@@ -245,7 +245,9 @@ module.exports = utils = {
       return _.assign {}, data, { payment: { stripeToken } }
 
     if team = kd.team
-      if token = getPayment()?.token
+      token = getPayment()?.token
+      isDefaultEnv = kd.config.environment is 'default'
+      if not isDefaultEnv and token
         team = attachPayment kd.team, token
       return team
 
@@ -283,10 +285,10 @@ module.exports = utils = {
 
   createTeam: (callbacks = {}) ->
 
-    # this part should never run actually because the signup flow in
-    # TeamAppController takes care of this. But i'll leave this here just in
-    # case.
-    unless token = utils.getPayment()?.token
+    isDefaultEnv = kd.config.environment is 'default'
+    token = utils.getPayment()?.token
+
+    if not isDefaultEnv and not token
       new kd.NotificationView { title : 'You need to enter your credit card!' }
       return kd.singletons.router.handleRoute '/Team/Payment'
 

--- a/client/landing/site.landing/coffee/team/AppController.coffee
+++ b/client/landing/site.landing/coffee/team/AppController.coffee
@@ -11,12 +11,15 @@ FLOW_ROUTES  =
   'register'      : '/Team/Register'
 
 
-CREATION_FLOW = [ 'signup', 'domain', 'payment', 'username' ]
-
+DEFAULT_ENV_FLOW = [ 'signup', 'domain', 'username' ]
+REGULAR_CREATE_FLOW = [ 'signup', 'domain', 'payment', 'username' ]
 
 getFlow = (step) ->
 
-  return CREATION_FLOW if CREATION_FLOW.indexOf(step) > -1
+  flow = if kd.config.environment is 'default'
+  then DEFAULT_ENV_FLOW else REGULAR_CREATE_FLOW
+
+  return flow if flow.indexOf(step) > -1
   return no
 
 

--- a/client/landing/site.landing/coffee/team/forms/teamcreatewithmemberaccountform.coffee
+++ b/client/landing/site.landing/coffee/team/forms/teamcreatewithmemberaccountform.coffee
@@ -13,7 +13,11 @@ module.exports = class TeamCreateWithMemberAccountForm extends TeamJoinWithInvit
 
     @username.input.setValue utils.getTeamData().profile?.nickname
 
-    @backLink = @getButtonLink 'BACK', '/Team/Payment'
+    backRoute = if kd.config.environment is 'default'
+    then '/Team/Domain'
+    else '/Team/Payment'
+
+    @backLink = @getButtonLink 'BACK', backRoute
 
 
   createButtonLinkPartial: -> "Not you? Create with a <a href='#'>fresh account!</a>"

--- a/client/landing/site.landing/coffee/team/forms/teamloginandcreatetabform.coffee
+++ b/client/landing/site.landing/coffee/team/forms/teamloginandcreatetabform.coffee
@@ -14,7 +14,11 @@ module.exports = class TeamLoginAndCreateTabForm extends TeamJoinByLoginForm
 
     super options, data
 
-    @backLink = @getButtonLink 'BACK', '/Team/Payment'
+    backRoute = if kd.config.environment is 'default'
+    then '/Team/Domain'
+    else '/Team/Payment'
+
+    @backLink = @getButtonLink 'BACK', backRoute
 
 
   createButtonLinkPartial: ->

--- a/client/landing/site.landing/coffee/team/forms/teamusernametabform.coffee
+++ b/client/landing/site.landing/coffee/team/forms/teamusernametabform.coffee
@@ -16,7 +16,11 @@ module.exports = class TeamUsernameTabForm extends TeamJoinBySignupForm
 
     super options, data
 
-    @backLink = @getButtonLink 'BACK', '/Team/Payment'
+    backRoute = if kd.config.environment is 'default'
+    then '/Team/Domain'
+    else '/Team/Payment'
+
+    @backLink = @getButtonLink 'BACK', backRoute
 
 
   pistachio: ->

--- a/client/landing/site.landing/coffee/team/tabs/teamdomaintab.coffee
+++ b/client/landing/site.landing/coffee/team/tabs/teamdomaintab.coffee
@@ -36,7 +36,12 @@ module.exports = class TeamDomainTab extends kd.TabPaneView
             # temp putting these empty values here to not break stuff - SY
             utils.storeNewTeamData 'email-domains', { domains : '' }
             utils.storeNewTeamData 'invite', { invitee1 : '', invitee2 : '', invitee3 : '' }
-            kd.singletons.router.handleRoute '/Team/Payment'
+
+            route = if kd.config.environment is 'default'
+            then '/Team/Username'
+            else '/Team/Payment'
+
+            kd.singletons.router.handleRoute route
 
           error   : (error) =>
             @showError error or 'That domain is invalid or taken, please try another one.'


### PR DESCRIPTION
Until this PR we were forcing payment to appear on default environment as well (there were no extra precautions for environments other than `development` and `production`). This PR tries to make sure that open source users of Koding could still continue to use koding with their own installation.

/cc @gokmen 