### PR TITLE
rainforest: fix collaboration_delete_file steps

### DIFF
--- a/tests/spec/rainforest/collaboration_delete_file.rfml
+++ b/tests/spec/rainforest/collaboration_delete_file.rfml
@@ -8,20 +8,20 @@
 - 661370e4-14d7-448d-a664-54d2a1bbdf98
 
 # redirect: false
-Switch the other browser window where you are logged in as 'rainforestqa99' and mouse over user icon at the left of 'END COLLABORATION' button then click on 'Make Presenter'
+Switch the other browser window where you are logged in as 'rainforestqa99' and move your mouse over user the default user avatar on the left of 'END COLLABORATION' button then click on 'Make Presenter'
 Is popup removed from the screen?
 
 Return to the incognito browser window
 Do you see green warning 'ACCESS GRANTED: You can make changes now!'?
 
 Close the warning and click  down arrow icon at the right of /home/rainforestqa99 label in the center part of the page, click 'New file' in the menu (like on screenshot http://snag.gy/nJ2Dd.jpg ) and enter 'file{{random.number}}.txt' file name and press Enter
-Do you see file 'file{{random.number}}.txt' with green icon in the file tree?
+Do you see file 'file{{random.number}}.txt' with a green icon next to it in the file tree?
 
-Click down arrow icon at the right of 'file{{random.number}}.txt' file in the file tree and click 'Delete' in the menu
-Do you see 'Are you sure?' text and red 'Delete' button above the file name?
+Click on the 'file{{random.number}}.txt' file in the file tree, then click on the down arrow icon next to it and select 'Delete' from the menu appeared
+Do you see 'Are you sure?' text and a red 'Delete' button appeared instead of that file?
 
-Click on 'DELETE' button
-Is 'file{{random.number}}.txt' file deleted from file tree?
+Click on 'Delete' button
+Is 'file{{random.number}}.txt' file removed from the file tree?
 
 Return to the other browser window where you are logged in as 'rainforestqa99', close the browser notification if displayed
-Do you see the uploaded file under the filetree? Is 'file{{random.number}}.txt' file removed from file tree?
+Is 'file{{random.number}}.txt' file removed from the file tree?

--- a/tests/spec/rainforest/disableMember_fixPermissions_destroyDisabledUsersVMs.rfml
+++ b/tests/spec/rainforest/disableMember_fixPermissions_destroyDisabledUsersVMs.rfml
@@ -20,7 +20,7 @@ Do you see 'Sign in to {{ random.last_name }}{{ random.number }}' text, 'Your Us
 Enter "rainforestqa22" both in the 'Your Username or Email' and 'Your Password' fields and click on 'SIGN IN' button
 Do you see '{{ random.last_name }}{{ random.number }}' label at the top left corner? Do you see '@rainforestqa22' label below it? Do you see 'STACKS' title and 'Your stacks has not been fully configured yet,' text on left sidebar? Do you see 'You are almost there, rainforestqa22!' title on a pop-up displayed in the center of the page? Do you see 'Your Team Stack is Pending', 'Create a Personal Stack', and 'Install KD' sections? Do you see 'PENDING', 'CREATE' and 'INSTALL' texts next to those sections?
 
-Click on 'Create a Stack for Your Team' section
+Click on 'Create a Personal Stack' section
 Do you see 'Select a Provider' title? Do you see 'amazon web services', 'VAGRANT', 'Google Cloud Platform', 'DigitalOcean', 'Azure', 'Marathon' and 'Softlayer'? Do you see 'CANCEL' and 'CREATE STACK' buttons below?
 
 Click on 'amazon web services' and then click on 'CREATE STACK' button


### PR DESCRIPTION
## Description
fixes the collaboration_delete_file test on rainforest according to the test-run results.

note:also fixes 'create a personal stack' menu item on disableMember_fixPermissions_destroyDisabledUsersVMs test.

related with #9891 