### PR TITLE
rainforest: fix collaboration copied_to_clipboard message

### DIFF
--- a/tests/spec/rainforest/collaboration_endcollaboration.rfml
+++ b/tests/spec/rainforest/collaboration_endcollaboration.rfml
@@ -18,7 +18,7 @@ Click on 'YES' and wait for a few seconds for process to be completed
 Has 'END COLLABORATION' button on the bottom changed to 'START COLLABORATION'? Is 'Camera' icon removed from the bottom status bar?
 
 Return to the incognito window
-Do you see 'Session ended' title pop-up? Do you see 'LEAVE' button?
+Do you see 'Session ended' titled pop-up? Do you see 'LEAVE' button?
 
 Click on 'LEAVE' button
-Is 'aws-instance' item removed from the left module and all panes from that VM closed?
+Are 'SHARED VMS' and aws-instance_' below it removed from the left module and all panes from that VM closed? (They don't have to be removed just now, you can only check if they're not there!)

--- a/tests/spec/rainforest/collaboration_leave_invite_leave_session.rfml
+++ b/tests/spec/rainforest/collaboration_leave_invite_leave_session.rfml
@@ -12,13 +12,13 @@ Click  'LEAVE SESSION' button
 Do you see 'Are you sure?' modal? Do you see 'YES', 'CANCEL' button?
 
 Click on 'YES'
-Are 'aws-instance' item removed from the left module and all panes from that VM closed?
+Are 'aws-instance_' item removed from the left module and all panes from that VM closed?
 
 Switch the other browser window where you are logged in as 'rainforestqa99'
-Do you see the only 'camera' icon at the left of 'END COLLABORATION' button without any other icons/avatars?
+Do you only see an icon for camera on the left of 'END COLLABORATION' button and not any other icons or default user avatars?
 
 Click shortened URL in the bottom status bar
-Do you see 'Copied to clipboard!' popup message?
+Do you see 'Collaboration link is copied to clipboard.' popup message?
 
 Switch the incognito window and paste copied URL in the browser address bar and press enter
 Wait until you see 'SHARED VMS' label in the left module? Do you see 'aws-instance_' item below the 'SHARED VMS' label? Do you see a white popup and two buttons named 'Reject' and 'Accept'?
@@ -33,7 +33,7 @@ Click on 'YES'
 Is 'aws-instance_' under 'Shared VM's section removed from the left module and all panes from that VM closed?
 
 Switch the other browser window where you are logged in as 'rainforestqa99'
-Do you see the only 'camera' icon at the left of 'END COLLABORATION' button without any other icons/avatars?
+Do you only see an icon for camera on the left of 'END COLLABORATION' button and not any other icons or default user avatars?
 
 Click 'END COLLABORATION' button and click 'Yes' on the 'Are you sure?' dialog
 Is 'END COLLABORATION' button changed to 'START COLLABORATION'? Is 'Camera' icon removed from the bottom status bar?

--- a/tests/spec/rainforest/collaboration_reject_accept_invitation.rfml
+++ b/tests/spec/rainforest/collaboration_reject_accept_invitation.rfml
@@ -39,7 +39,7 @@ Click  'START COLLABORATION' button in the bottom right corner
 Do you see 'Starting session' progress bar below the button and after that 'START COLLABORATION' button is converted to 'END COLLABORATION'? Do you see a shortened URL in the bottom status bar (like on screenshot http://snag.gy/dp1Cn.jpg )?
 
 Click shortened URL in the bottom status bar
-Do you see 'Copied to clipboard!' popup message?
+Do you see 'Collaboration link is copied to clipboard.' popup message?
 
 Remember the list of panes opened (terminal, untitled.txt, etc) and select the incognito window and paste copied URL in the browser address bar and press enter
 Do you see 'SHARED VMS' label in the left module on the page? Do you see 'aws-instance' item below the 'SHARED VMS' label? Do you see white popup with 'Reject' and 'Accept' buttons?
@@ -54,7 +54,7 @@ Click 'END COLLABORATION' button and click 'Yes' on the 'Are you sure?' dialog
 Is 'END COLLABORATION' button changed to 'START COLLABORATION'? Is 'Camera' icon removed from the bottom status bar?
 
 Click  'START COLLABORATION' button in the bottom right corner, wait for the 'Starting session' progress bar below the button to finish and click shortened URL in the bottom status bar
-Do you see 'Copied to clipboard!' popup message?
+Do you see 'Collaboration link is copied to clipboard.' popup message?
 
 Return to the incognito browser window and paste copied URL in the browser address bar and press enter
 Do you see 'SHARED VMS' label in the left module on the page? Do you see 'aws-instance' item below the 'SHARED VMS' label? Do you see white popup with 'Reject' and 'Accept' buttons?

--- a/tests/spec/rainforest/collaboration_switch_vms.rfml
+++ b/tests/spec/rainforest/collaboration_switch_vms.rfml
@@ -37,7 +37,7 @@ Click 'START COLLABORATION' button in the bottom right corner
 Do you see 'Starting session' progress bar below the button and after that 'START COLLABORATION' button is converted to 'END COLLABORATION'? Do you see a shortened URL in the bottom status bar (like on screenshot http://snag.gy/dp1Cn.jpg )?
 
 Click shortened URL in the bottom status bar
-Do you see 'Copied to clipboard!' popup message?
+Do you see 'Collaboration link is copied to clipboard.' popup message?
 
 Remember the list of panes opened (terminal, untitled.txt, etc) and select the incognito window and paste copied URL in the browser address bar and press enter
 Do you see 'SHARED VMS' label in the left module on the page? Do you see 'aws-instance' item below the 'SHARED VMS' label? Do you see white popup with 'Reject' and 'Accept' buttons?

--- a/tests/spec/rainforest/collaboration_watchfile_kick_invite_user.rfml
+++ b/tests/spec/rainforest/collaboration_watchfile_kick_invite_user.rfml
@@ -27,7 +27,7 @@ Return to the incognito browser window
 Has 'Session End' dialog not displayed (it shouldn't be displayed)? Is 'LEAVE SESSION' button not visible anymore? Do you see 'Your session has been closed' titled pop-up?
 
 Return to the other browser window, click  'START COLLABORATION' button in the bottom right corner and click on the shortened URL in the bottom status bar
-Do you see 'Copied to clipboard!' popup message?
+Do you see 'Collaboration link is copied to clipboard.' popup message?
 
 Return to the incognito browser window and paste copied URL in the browser address bar and press enter
 Do you see 'SHARED VMS' label in the left module on the page? Do you see 'aws-instance_' item below the 'SHARED VMS' label? Do you see white popup with 'Reject' and 'Accept' buttons?


### PR DESCRIPTION
## Description
fixes the 'copied to clipboard' message as 'Collaboration link is copied to clipboard.' on several collaboration tests

also minor fixes for 'end_collaboration' and 'leave_invite_leave_session' tests

related with #9891 




