### PR TITLE
Show correct amount for free credit on billing dashboard

### DIFF
--- a/client/app/lib/redux/modules/payment/customer.coffee
+++ b/client/app/lib/redux/modules/payment/customer.coffee
@@ -63,12 +63,21 @@ coupon = (state) -> state.customer?.discount?.coupon
 
 email = (state) -> state.customer?.email
 
+freeCredit = (state) ->
+  # negative account balance means user has credits.
+  if state.customer?.account_balance < 0
+  # the amount is in cents, we want dollars.
+  then ((state.customer.account_balance * -1) / 100).toFixed 2
+  # if the balance is greater than 0 that means 0
+  # free credit.
+  else 0
+
 
 module.exports = {
   namespace: withNamespace()
   reducer
 
-  coupon, email
+  coupon, email, freeCredit
 
   load, create, update, remove
   LOAD, CREATE, UPDATE, REMOVE

--- a/client/home/lib/billing/components/subscriptioncontainer.coffee
+++ b/client/home/lib/billing/components/subscriptioncontainer.coffee
@@ -30,12 +30,6 @@ subscriptionTitle = createSelector(
 )
 
 
-freeCredit = createSelector(
-  customer.coupon
-  (coupon) -> if coupon then coupon.amount_off else 0
-)
-
-
 accountUser = createSelector(
   bongo.all('JUser')
   bongo.byId('JAccount', whoami()._id)
@@ -63,7 +57,7 @@ mapStateToProps = (state) ->
     endsAt: info.endsAt(state)
     daysLeft: info.daysLeft(state)
     isTrial: subscription.isTrial(state)
-    freeCredit: freeCredit(state)
+    freeCredit: customer.freeCredit(state)
     # TODO(umut): activate this when we have coupon support.
     isSurveyTaken: yes # !!customer.coupon(state)
     isEmailVerified: isEmailVerified(state)


### PR DESCRIPTION
It is computed from `customer.account_balance` property if it's less than `0`.

![Alt text](https://monosnap.com/file/mThuUMyU0kbK8DE0OQiQ1mU1doHdHD.png)

/cc @cihangir 

Fixes #9944 