### PR TITLE
Ensure credit card form submits smoothly

### DIFF
--- a/client/app/lib/redux/middleware/payment.coffee
+++ b/client/app/lib/redux/middleware/payment.coffee
@@ -8,7 +8,7 @@ module.exports = paymentMiddleware = (service) -> (store) -> (next) -> (action) 
 
   next
     types: types or generateTypes type
-    promise: -> payment(service, { getState: store.getState })
+    promise: -> payment(service, store)
 
 
 generateTypes = (type) -> [

--- a/client/app/lib/redux/modules/payment/constants.coffee
+++ b/client/app/lib/redux/modules/payment/constants.coffee
@@ -17,6 +17,7 @@ module.exports =
     UNKNOWN: 'unknown'
 
   Plan:
+    FREE: 'p_free'
     FREE_FOREVER: 'p_free_forever'
     UP_TO_10_USERS: 'p_up_to_10'
     UP_TO_50_USERS: 'p_up_to_50'

--- a/client/app/lib/redux/modules/payment/creditcard.coffee
+++ b/client/app/lib/redux/modules/payment/creditcard.coffee
@@ -13,6 +13,7 @@ withNamespace = reduxHelper.makeNamespace 'koding', 'payment', 'creditcard'
 
 REMOVE = reduxHelper.expandActionType withNamespace 'REMOVE'
 HAS_CARD = reduxHelper.expandActionType withNamespace 'HAS_CARD'
+AUTHORIZE = reduxHelper.expandActionType withNamespace 'AUTHORIZE'
 
 reducer = (state = null, action) ->
 
@@ -61,6 +62,12 @@ hasCreditCard = ->
     payment: (service) -> service.hasCreditCard()
   }
 
+authorize = ({ source, email }) ->
+  return {
+    types: [ AUTHORIZE.BEGIN, AUTHORIZE.SUCCESS, AUTHORIZE.FAIL ]
+    payment: (service) -> service.authorize { source, email }
+  }
+
 
 creditCard = (state) -> state.creditCard
 
@@ -71,7 +78,7 @@ module.exports = {
 
   creditCard
 
-  remove, hasCreditCard
-  REMOVE, HAS_CARD
+  remove, hasCreditCard, authorize
+  REMOVE, HAS_CARD, AUTHORIZE
 }
 

--- a/client/app/lib/redux/modules/payment/customer.coffee
+++ b/client/app/lib/redux/modules/payment/customer.coffee
@@ -67,7 +67,7 @@ freeCredit = (state) ->
   # negative account balance means user has credits.
   if state.customer?.account_balance < 0
   # the amount is in cents, we want dollars.
-  then ((state.customer.account_balance * -1) / 100).toFixed 2
+  then (state.customer.account_balance * -1) / 100
   # if the balance is greater than 0 that means 0
   # free credit.
   else 0

--- a/client/app/lib/redux/modules/payment/index.coffee
+++ b/client/app/lib/redux/modules/payment/index.coffee
@@ -1,0 +1,113 @@
+Promise = require 'bluebird'
+reduxHelper = require 'app/redux/helper'
+
+# experimental naming convention. r$<moduleName>
+r$customer = require './customer'
+r$subscription = require './subscription'
+r$card = require './creditcard'
+r$stripe = require '../stripe'
+
+{ Plan } = require './constants'
+
+withNamespace = reduxHelper.makeNamespace 'koding', 'payment'
+
+UPDATE_CARD = reduxHelper.expandActionType withNamespace 'UPDATE_CARD'
+
+# @param {object} obj
+# @param {string} field - Field to check existence for
+# @param {object} ensurer - ensurer which should return a Promise
+# @return {Promise} resolves with value, if exist in state; if not resolves result of ensurer.
+ensure = (obj, field, ensurer) ->
+  if value = obj[field]
+  then Promise.resolve(value)
+  else ensurer()
+
+
+# ensureCustomer: ensures payment customer by creating a new one if it doesn't
+# exist.
+#
+# @param {store} Redux Store
+# @return {Promise}
+ensureCustomer = (store) ->
+  ensure store.getState(), 'customer', ->
+    store.dispatch r$customer.create()
+
+
+# ensureSubscription: ensures payment subscription by creating a new
+# subcription with Free Plan for payment customer.
+#
+# NOTE: this is an internal helper, and it naively assumes that there is a
+# customer in the store state. It will throw if there is no customer.
+#
+# @private
+# @param store {object} Redux Store
+# @return {Promise}
+ensureSubscription = (store) ->
+  ensure store.getState(), 'subscription', ->
+    { customer } = store.getState()
+    store.dispatch r$subscription.create(customer.id, Plan.FREE)
+
+
+# createToken: creates a stripe token by dispatching corresponding action.
+#
+# @param store {object} Redux store
+# @param params {object} create token request params.
+# @return {Promise}
+createToken = (store, params) -> store.dispatch r$stripe.createToken params
+
+
+# authorizeCard: authorizes given credit card field values.
+#
+# @param store {object} Redux store
+# @param values {object} credit card data
+# @return {Promise} resolves when authorization is successful
+authorizeCard = (store, values) ->
+
+  # FIXME(umut): after authorization endpoint supports logged in requests
+  return ensureCustomer(store)
+
+  requirements = [
+    ensureCustomer(store)
+    createToken(store, values)
+  ]
+
+  Promise.join requirements..., (customer, token) ->
+    params = { source: { token }, email: customer.email }
+    store.dispatch r$card.authorize(params)
+
+
+# @param store {object} Redux store
+# @param values {object} credit card data
+# @return {Promise} resolves when card is successfully attached to customer.
+attachCard = (store, params) ->
+
+  requirements = [
+    ensureCustomer(store)
+    createToken(store, params)
+  ]
+
+  Promise.join requirements..., (customer, token) ->
+    params = { source: { token, default: yes } }
+    store.dispatch r$customer.update(params)
+
+
+# updateCard: an action creator which will update the payment customer's credit card
+# intelligently.
+#
+# @param values {object} credit card data
+# @return {Promise} resolves when card is successfully attached to customer.
+updateCard = (values) ->
+  return {
+    types: [ UPDATE_CARD.BEGIN, UPDATE_CARD.SUCCESS, UPDATE_CARD.FAIL ]
+    payment: (service, store) ->
+      Promise.resolve()
+        .then -> authorizeCard(store, values)
+        .then -> attachCard(store, values)
+        .then -> ensureSubscription(store)
+  }
+
+
+module.exports = {
+  updateCard
+}
+

--- a/client/app/lib/redux/services/payment.coffee
+++ b/client/app/lib/redux/services/payment.coffee
@@ -70,10 +70,10 @@ exports.authorize = (params = {}) ->
   { source, email } = params
 
   unless source?.token
-    throw new Error "invalid param: source. expected: { token: String }"
+    throw new Error 'invalid param: source. expected: { token: String }'
 
   unless email?
-    throw new Error "invaid param: email. expected: String"
+    throw new Error 'invaid param: email. expected: String'
 
   client.post Endpoints.CreditCardAuth, { source, email }
 

--- a/client/component-lab/CreditCard/CreditCard.coffee
+++ b/client/component-lab/CreditCard/CreditCard.coffee
@@ -59,6 +59,7 @@ CreditCard.propTypes =
     Brand.JCB
     Brand.MAESTRO
     Brand.MASTER_CARD
+    Brand.MASTERCARD
     Brand.AMERICAN_EXPRESS
     Brand.DINERS_CLUB
     Brand.DISCOVER

--- a/client/component-lab/CreditCard/CreditCard.stylus
+++ b/client/component-lab/CreditCard/CreditCard.stylus
@@ -24,6 +24,7 @@
   m-sprite                  app, jcb
 .brand-maestro
   m-sprite                  app, maestro
+.brand-mastercard
 .brand-master-card
   m-sprite                  app, mastercard
 .brand-visa

--- a/client/component-lab/CreditCard/constants.coffee
+++ b/client/component-lab/CreditCard/constants.coffee
@@ -17,6 +17,7 @@ Brand =
   JCB: 'jcb'
   MAESTRO: 'maestro'
   MASTER_CARD: 'master-card'
+  MASTERCARD: 'mastercard'
   AMERICAN_EXPRESS: 'american-express'
   DINERS_CLUB: 'diners-club'
   DISCOVER: 'discover'

--- a/client/component-lab/Input/CreditCardInput.coffee
+++ b/client/component-lab/Input/CreditCardInput.coffee
@@ -45,6 +45,7 @@ CreditCardInput.propTypes =
     Brand.JCB
     Brand.MAESTRO
     Brand.MASTER_CARD
+    Brand.MASTERCARD
     Brand.AMERICAN_EXPRESS
     Brand.DINERS_CLUB
     Brand.DISCOVER

--- a/client/home/lib/billing/components/creditcardcontainer.coffee
+++ b/client/home/lib/billing/components/creditcardcontainer.coffee
@@ -1,16 +1,27 @@
-_ = require 'lodash'
-{ reduxForm, SubmissionError, isDirty, reset: resetForm } = require 'redux-form'
+{ reduxForm, SubmissionError, reset: resetForm } = require 'redux-form'
 { connect } = require 'react-redux'
 
-stripe = require 'app/redux/modules/stripe'
-customer = require 'app/redux/modules/payment/customer'
+{ updateCard } = require 'app/redux/modules/payment'
 
 CreateCreditCardForm = require 'lab/CreateCreditCardForm'
 
 { select, FORM_NAME, mapErrors } = require './helpers'
 
 
+# handleSubmit: redux-form `onSubmit` handler for credit card form.
+# it handles errors in a way that redux-form can make sense.
+#
+# @param {object} values - form values
+# @param {function} dispatch - Redux dispatch function
+# @return {Promise}
+handleSubmit = (values, dispatch) ->
 
+  Promise.resolve()
+    .then -> dispatch(updateCard values)
+    .then -> dispatch(resetForm FORM_NAME)
+    .catch (errors) ->
+      console.error 'errors in card submission', errors
+      throw new SubmissionError mapErrors errors
 
 
 # first we connect reduxForm to ensure
@@ -19,9 +30,11 @@ CreateCreditCardForm = require 'lab/CreateCreditCardForm'
 CreateCreditCardForm = reduxForm(
   form: FORM_NAME
   enableReinitialize: yes
+  onSubmit: handleSubmit
 )(CreateCreditCardForm)
 
-mapStateToProps = (state, props) ->
+
+mapStateToProps = (state) ->
   return {
     isDirty: select.dirty(state)
     # if form is not dirty credit card figure will use this data
@@ -33,9 +46,7 @@ mapStateToProps = (state, props) ->
   }
 
 
-# then we connect our own state mapper.
-# make sure that necessary state values are passed
-# down to the form.
+# then we connect our own state mapper to implement our custom logic.
 CreateCreditCardForm = connect(
   mapStateToProps
   null

--- a/client/home/lib/billing/components/creditcardcontainer.coffee
+++ b/client/home/lib/billing/components/creditcardcontainer.coffee
@@ -7,13 +7,8 @@ customer = require 'app/redux/modules/payment/customer'
 
 CreateCreditCardForm = require 'lab/CreateCreditCardForm'
 
-{ select, FORM_NAME } = require './helpers'
+{ select, FORM_NAME, mapErrors } = require './helpers'
 
-mapErrors = (errors) ->
-  errors.reduce (res, { error }) ->
-    res[error.param] = error.message
-    return res
-  , {}
 
 
 

--- a/client/home/lib/billing/components/creditcardcontainer.coffee
+++ b/client/home/lib/billing/components/creditcardcontainer.coffee
@@ -9,12 +9,14 @@ CreateCreditCardForm = require 'lab/CreateCreditCardForm'
 
 { select, FORM_NAME } = require './helpers'
 
-addCardToCustomer = (values, dispatch) ->
+mapErrors = (errors) ->
+  errors.reduce (res, { error }) ->
+    res[error.param] = error.message
+    return res
+  , {}
 
-  dispatch(stripe.createToken values)
-    .then (token) -> dispatch(customer.update { source: { token } })
-    .then -> dispatch(resetForm(FORM_NAME))
-    .catch (errors) -> throw new SubmissionError mapErrorsToValues errors
+
+
 
 # first we connect reduxForm to ensure
 # form values are stored in store and onSubmit is
@@ -22,7 +24,6 @@ addCardToCustomer = (values, dispatch) ->
 CreateCreditCardForm = reduxForm(
   form: FORM_NAME
   enableReinitialize: yes
-  onSubmit: addCardToCustomer
 )(CreateCreditCardForm)
 
 mapStateToProps = (state, props) ->
@@ -36,11 +37,6 @@ mapStateToProps = (state, props) ->
     formValues: select.values(state)
   }
 
-mapErrorsToValues = (errors) ->
-  errors.reduce (res, { error }) ->
-    res[error.param] = error.message
-    return res
-  , {}
 
 # then we connect our own state mapper.
 # make sure that necessary state values are passed

--- a/client/home/lib/billing/components/helpers.coffee
+++ b/client/home/lib/billing/components/helpers.coffee
@@ -66,8 +66,16 @@ $values = (state) ->
   }
 
 
+mapErrors = (errors) ->
+  errors.reduce (res, { error }) ->
+    res[error.param] = error.message
+    return res
+  , {}
+
+
 module.exports = {
   FORM_NAME
+  mapErrors
   select: {
     dirty: $dirty
     values: $values

--- a/client/home/lib/billing/components/paymentsectioncontainer.coffee
+++ b/client/home/lib/billing/components/paymentsectioncontainer.coffee
@@ -60,9 +60,10 @@ mapDispatchToProps = (dispatch) ->
   return {
     onSuccessModalClose: ->
       dispatch(stripe.resetLastAction())
+      location.reload()
     onInviteMembers: ->
       dispatch(stripe.resetLastAction())
-      kd.singletons.router.handleRoute '/Home/my-team#send-invites'
+      location.replace '/Home/my-team#send-invites'
     onMessageClose: ->
       dispatch(stripe.resetLastAction())
     onResetForm: ->


### PR DESCRIPTION
Right now our payment backend is as stateless as possible, due to the fact that we can't pass around the credit card information. This puts all the conditional resource management into client side. 

Especially because the payment system have changed rapidly in the past several months, we have some teams in which has weird payment states.

- A team created with solo to team migration might not have the subscription, but can have the credit card.
- A team joined to koding after the initial payment release, might have a subscription but not a credit card.
- Or there might be some issues where all of the resources (`Customer`, `Subscription` and `Credit Card`) might be missing. 

All this logic should be handled in the client side because of the problem initially described in this issue.

So this PR fixes by following these changes for when user submits a credit card form:
- **Ensure payment customer**: Before, we were just assuming that a customer will always be present. With this PR, we create a new one if it doesn't exist before try to create a card.
- **Authorize & attach credit card**: Before, no authorization. With this PR, we are adding the same check we are doing (50cent charge request to identify fraud) in signup.
- **Ensure payment subscription**: Before we were assuming that there is a subscription, and we were not taking any action related to that credit card form. With this PR, we check and create a new `FREE` subscription after we attached the credit card to the customer.
- **Reload browser before user taking any action**: Before we were just closing the success modal, without reloading the browser and resulting a limbo state where some parts of the system thinks that team is disabled while some parts are not. With this PR, we make sure to reload the browser before user can take any action. (Success modal actions reloads/redirects the page when any of the buttons are clicked)

/cc @cihangir 

Completes #9956 #9924 