### PR TITLE
Fix Some Release Bugs

### DIFF
--- a/client/app/lib/activity/sidebar/sidebarmachinesharepopup.coffee
+++ b/client/app/lib/activity/sidebar/sidebarmachinesharepopup.coffee
@@ -238,5 +238,5 @@ module.exports = class SidebarMachineSharePopup extends KDModalView
 
   TITLES =
     'shared machine' : 'wants to share their VM with you. <span class="footnote">* Rejecting this will destroy any existing collaboration sessions with this machine.</span>'
-    'collaboration'  : 'wants to collaborate with you on their VM.'
+    'collaboration'  : 'wants to collaborate on with you on their VM.'
     'approved'       : 'Shared with you by'

--- a/client/app/lib/activity/sidebar/sidebarmachinesharepopup.coffee
+++ b/client/app/lib/activity/sidebar/sidebarmachinesharepopup.coffee
@@ -238,5 +238,5 @@ module.exports = class SidebarMachineSharePopup extends KDModalView
 
   TITLES =
     'shared machine' : 'wants to share their VM with you. <span class="footnote">* Rejecting this will destroy any existing collaboration sessions with this machine.</span>'
-    'collaboration'  : 'wants to collaborate on with you on their VM.'
+    'collaboration'  : 'wants to collaborate with you on their VM.'
     'approved'       : 'Shared with you by'

--- a/client/app/lib/flux/environment/actions.coffee
+++ b/client/app/lib/flux/environment/actions.coffee
@@ -19,7 +19,7 @@ requirementsParser = require 'app/util/stacks/requirementsparser'
 generateStackTemplateTitle = require 'app/util/generateStackTemplateTitle'
 Tracker = require 'app/util/tracker'
 $ = require 'jquery'
-
+canCreateStacks = require 'app/util/canCreateStacks'
 _eventsCache = { machine: {}, stack: no }
 
 _bindMachineEvents = (environmentData) ->
@@ -819,6 +819,9 @@ setLabel = (machineUId, label) ->
         resolve newLabel
 
 cloneStackTemplate = (template) ->
+
+  unless canCreateStacks()
+    return new kd.NotificationView { title: 'You are not allowed to create/edit stacks!' }
 
   new kd.NotificationView { title:'Cloning Stack Template' }
 

--- a/client/app/lib/kodinglist/kodinglistview.coffee
+++ b/client/app/lib/kodinglist/kodinglistview.coffee
@@ -25,13 +25,14 @@ module.exports = class KodingListView extends kd.ListView
       content : "<h2>#{description}</h2>"
       buttons :
         cancel      :
+          cssClass  : 'solid medium'
           title     : 'Cancel'
           callback  : ->
             modal.destroy()
             callback { status : no }
         ok          :
           title     : 'Yes'
-          cssClass  : 'solid red medium'
+          cssClass  : 'solid medium'
           callback  : ->
             callback { status : yes, modal }
 

--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -1494,13 +1494,13 @@ module.exports = class ComputeController extends KDController
         buttons :
           cancel      :
             title     : 'Cancel'
-            cssClass  : 'kdbutton solid medium'
+            cssClass  : 'solid medium'
             callback  : ->
               modal.destroy()
               callback { status : no }
           ok          :
             title     : 'Yes'
-            cssClass  : 'kdbutton solid medium'
+            cssClass  : 'solid medium'
             callback  : -> callback { status : yes, modal }
 
       modal.setAttribute 'testpath', 'RemoveStackModal'

--- a/client/app/lib/views/sessionlist/accountsessionlistitem.coffee
+++ b/client/app/lib/views/sessionlist/accountsessionlistitem.coffee
@@ -16,7 +16,7 @@ module.exports = class AccountSessionListItem extends KDListItemView
     listView = @getDelegate()
 
     deleteButtonOptions =
-      title    : 'Terminate'
+      title    : 'Log Out'
       cssClass : 'solid compact delete'
       callback : =>
         listView.emit 'ItemAction',

--- a/client/home/lib/account/homeaccountsecurityview.coffee
+++ b/client/home/lib/account/homeaccountsecurityview.coffee
@@ -51,11 +51,9 @@ module.exports = class HomeAccountSecurityView extends kd.CustomHTMLView
         { key, qrcode } = authInfo
         @_activeKey     = key
 
-        instructionsView = @getInstructionsView()
-        instructionsView.addSubView
         @addSubView @getFormView()
         @enableForm.addSubView @getQrCodeView qrcode
-        @addSubView instructionsView
+        @addSubView @getInstructionsView()
 
 
   getEnabledView: ->
@@ -187,8 +185,6 @@ module.exports = class HomeAccountSecurityView extends kd.CustomHTMLView
           if authInfo
             @_activeKey = authInfo.key
             @imageView.setAttribute 'src', authInfo.qrcode
-
-          kd.utils.defer button.bound 'hideLoader'
 
 
   getLoaderView: ->

--- a/client/home/lib/utilities/components/apiaccess/apitoken.coffee
+++ b/client/home/lib/utilities/components/apiaccess/apitoken.coffee
@@ -27,9 +27,11 @@ module.exports = class ApiToken extends React.Component
       buttons :
         Cancel :
           title : 'Cancel'
+          cssClass  : 'solid medium'
           callback  : -> modal.destroy()
         Yes :
           title : 'Yes'
+          cssClass  : 'solid medium'
           callback  : =>
             apiToken = remote.revive @props.apiToken.toJS()
             apiToken.remove (err) =>

--- a/client/ide/lib/collaborationcontroller.coffee
+++ b/client/ide/lib/collaborationcontroller.coffee
@@ -887,7 +887,7 @@ module.exports = CollaborationController =
 
     modal.container.addSubView new kd.CustomHTMLView
       tagName  : 'p'
-      partial  : "<span class='icon'></span> Joining to collaboration session..."
+      partial  : "<span class='icon'></span> Joining collaboration session..."
       cssClass : 'state-label running'
 
     modal.container.addSubView modal.progressBar = new kd.ProgressBarView { initial: 10 }

--- a/client/ide/lib/styl/ide.styl
+++ b/client/ide/lib/styl/ide.styl
@@ -711,7 +711,7 @@ body.ide .dark .ide-files-tab .kdtabhandle.close-handle .icon
 
     .kdselectbox
       height                24px
-      margin-left           35px
+      margin-left           39px
 
       span
         line-height         20px !important

--- a/client/stack-editor/lib/editor/index.coffee
+++ b/client/stack-editor/lib/editor/index.coffee
@@ -347,14 +347,17 @@ module.exports = class StackEditorView extends kd.View
     @titleTabHandle = new kd.TabHandleView
       cssClass : 'stack-template'
       title : 'Stack Template'
-      click : => @tabView.showPaneByName 'Stack Template'
 
     @titleTabHandle.addSubView @titleActionsWrapper = new kd.CustomHTMLView
       cssClass: 'StackEditorView--header-subHeader'
 
     @titleActionsWrapper.setClass 'readonly' unless @canUpdate
 
-    @titleActionsWrapper.addSubView @inputTitle = new kd.InputView options
+    @titleActionsWrapper.addSubView inputTitleWrapper = new kd.CustomHTMLView
+      cssClass : 'input-title-wrapper'
+      click : => @tabView.showPaneByName 'Stack Template'
+    inputTitleWrapper.addSubView @inputTitle = new kd.InputView options
+
 
     @titleActionsWrapper.addSubView @editName = new CustomLinkView
       cssClass: 'edit-name'

--- a/client/stack-editor/lib/styl/stackeditor.styl
+++ b/client/stack-editor/lib/styl/stackeditor.styl
@@ -744,33 +744,34 @@ $borderColor                = #E3E3E3
     display                 initial
     font-size               12px
 
-  .kdinput.text
+  .input-title-wrapper
     flex                    0 1 auto
-    font-size               15px
-    display                 block
-    size                    auto 16px
-    padding                 0 10px
-    border                  1px solid transparent
-    rounded                 3px
-    color                   #424242
-    bg                      color transparent
     max-width               50%
-    font-weight             400
-    outline                 none
-    shadow                  none
-    pointer-events          none
-    contentBox()
+    .kdinput.text
+      font-size               15px
+      size                    auto 16px
+      display                 block
+      padding                 0 10px
+      color                   #424242
+      bg                      color transparent
+      font-weight             400
+      border                  1px solid transparent
+      rounded                 3px
+      outline                 none
+      shadow                  none
+      pointer-events          none
+      contentBox()
 
-    &:hover
-      border                1px solid transparent
+      &:hover
+        border                1px solid transparent
 
-    &:focus
-      pointer-events        auto
-      padding               6px 10px 5px
-      margin                -6px 0 0
-      outline               inherit
-      bg                    color #FFFFFF
-      border                1px solid $borderColor
+      &:focus
+        pointer-events        auto
+        padding               6px 10px 5px
+        margin                -6px 0 0
+        outline               inherit
+        bg                    color #FFFFFF
+        border                1px solid $borderColor
 
 .StackEditorView--header-subHeader.readonly
   div.buttons


### PR DESCRIPTION
Fixes: #9941, #9945, #9949, #9953, #9979, #9980, #9976 


- Members will not be allowed to clone stack when stack creation is disabled.
- Fix some button styles in `are you sure?` modals
- minor copy changes
- Edit name in stack editor section is clickable when the other tabs active
- Style fix for text box next to `Syntax` option in IDE menu items

![](https://monosnap.com/file/llkS3lFmb3Um4JGM6st5onOEAfB1WC.png)
![](https://monosnap.com/file/3X7MDDP3uxl2JirnnCsRmAo9HgOvzK.png)
![](https://monosnap.com/file/ArZonItpZuaR1JT1mztmKDR3Z7X88E.png)
