### PR TITLE
kites/config: use koding base url

### DIFF
--- a/config/generateKonfig.coffee
+++ b/config/generateKonfig.coffee
@@ -205,20 +205,19 @@ module.exports = (options, credentials) ->
         name           : options.publicLogsS3BucketName
         region         : 'us-east-1'
     endpoints          :
-      ip               : "https://#{options.proxySubdomain}.koding.com/-/ip"
-      ipCheck          : "https://#{options.proxySubdomain}.koding.com/-/ipcheck"
-      kdLatest         : "https://koding-kd.s3.amazonaws.com/#{options.environment}/latest-version.txt"
-      klientLatest     : "https://koding-klient.s3.amazonaws.com/#{options.environment}/latest-version.txt"
-      kloud            : "#{options.publicHostname}/kloud/kite",
-      kontrol          : "#{options.publicHostname}/kontrol/kite",
-      kodingBase       : "#{options.publicHostname}",
-      remoteAPI        :
-        public         : "#{options.customDomain.public}/remote.api"
-        private        : "#{options.customDomain.local}/remote.api"
-      tunnelServer     : "#{options.tunnelUrl}/kite"
-      socialAPI        :
-        public         : "#{options.customDomain.public}/api/social"
-        private        : "#{options.customDomain.local}/api/social"
+      ip               :
+        public         : "https://#{options.proxySubdomain}.koding.com/-/ip"
+      ipCheck          :
+        public         : "https://#{options.proxySubdomain}.koding.com/-/ipcheck"
+      kdLatest         :
+        public         : "https://koding-kd.s3.amazonaws.com/#{options.environment}/latest-version.txt"
+      klientLatest     :
+        public         : "https://koding-klient.s3.amazonaws.com/#{options.environment}/latest-version.txt"
+      kodingBase       :
+        public         : "#{options.publicHostname}"
+        private        : "#{options.customDomain.local}"
+      tunnelServer     :
+        public         : "#{options.tunnelUrl}/kite"
     routes             :
       'dev.koding.com' : '127.0.0.1'
 

--- a/go/src/koding/kites/kloud/credential/store_test.go
+++ b/go/src/koding/kites/kloud/credential/store_test.go
@@ -66,8 +66,8 @@ func TestTeeFetcher(t *testing.T) {
 	p := Creds{}
 
 	s := credential.TeeFetcher{
-		credential.Fetcher: f,
-		credential.Fetcher: p,
+		Fetcher: f,
+		Putter:  p,
 	}
 
 	got := map[string]interface{}{

--- a/go/src/koding/kites/kloud/provider/marathon/stack.go
+++ b/go/src/koding/kites/kloud/provider/marathon/stack.go
@@ -385,9 +385,9 @@ func (s *Stack) injectMetadata(app map[string]interface{}, name string) error {
 
 		konfig := map[string]interface{}{
 			"kiteKey":    kiteKey,
-			"kontrolURL": stack.Konfig.KontrolURL,
-			"kloudURL":   stack.Konfig.KloudURL,
-			"tunnelURL":  stack.Konfig.TunnelURL,
+			"kontrolURL": stack.Konfig.Endpoints.Kontrol().Public.String(),
+			"kloudURL":   stack.Konfig.Endpoints.Kloud().Public.String(),
+			"tunnelURL":  stack.Konfig.Endpoints.Tunnel.Public.String(),
 			"tunnelID":   tunnelID,
 		}
 

--- a/go/src/koding/kites/kloud/provider/marathon/stack_test.go
+++ b/go/src/koding/kites/kloud/provider/marathon/stack_test.go
@@ -21,7 +21,13 @@ import (
 )
 
 func init() {
-	stack.Konfig = &config.Konfig{}
+	stack.Konfig = &config.Konfig{
+		Endpoints: &config.Endpoints{
+			Koding:       config.NewEndpoint(""),
+			Tunnel:       config.NewEndpoint(""),
+			KlientLatest: config.NewEndpoint(""),
+		},
+	}
 }
 
 // stripNondeterministicResources sets the following fields to "...",

--- a/go/src/koding/kites/kloud/userdata/userdata.go
+++ b/go/src/koding/kites/kloud/userdata/userdata.go
@@ -49,7 +49,7 @@ type CloudInitConfig struct {
 	KiteKey string
 
 	LatestKlientURL string // URL of the latest version of the Klient package
-	KontrolURL      string // kontrol kite URL
+	KodingURL       string // koding base URL
 	TunnelURL       string // tunnelserver kite URL
 
 	// DisableEC2Metadata adds a nul route to AWS's metadata service so it
@@ -112,8 +112,14 @@ write_files:
     content: |-
       {
           "konfig": {
-              "kontrolURL": "{{.KontrolURL}}",
-              "tunnelURL": "{{.TunnelURL}}"
+              "endpoints": {
+                  "koding": {
+                      "public": "{{.KodingURL}}"
+                  },
+                  "tunnel": {
+                      "public": "{{.TunnelURL}}"
+                  }
+              }
           }
       }
 
@@ -195,8 +201,12 @@ func (u *Userdata) Create(c *CloudInitConfig) ([]byte, error) {
 
 	c.UserSSHKeys = validatedKeys
 
-	if c.KontrolURL == "" {
-		c.KontrolURL = u.Keycreator.KontrolURL
+	if c.KodingURL == "" {
+		if u, err := url.Parse(u.Keycreator.KontrolURL); err == nil {
+			// TODO(rjeczalik): rework kloud to use koding/kites/config package
+			u.Path = ""
+			c.KodingURL = u.String()
+		}
 	}
 
 	if c.TunnelURL == "" {

--- a/go/src/koding/kites/tunnelproxy/client.go
+++ b/go/src/koding/kites/tunnelproxy/client.go
@@ -92,7 +92,7 @@ func (opts *ClientOptions) tunnelKiteURL() string {
 		return opts.TunnelKiteURL
 	}
 
-	return cfg.Builtin.Endpoints.TunnelServer
+	return cfg.Builtin.Endpoints.TunnelServer.Public.String()
 }
 
 func (opts *ClientOptions) maxRegisterRetry() int {

--- a/go/src/koding/kites/tunnelproxy/server.go
+++ b/go/src/koding/kites/tunnelproxy/server.go
@@ -63,7 +63,7 @@ func (opts *ServerOptions) registerURL() string {
 		return opts.RegisterURL
 	}
 
-	return konfig.Builtin.Endpoints.TunnelServer
+	return konfig.Builtin.Endpoints.TunnelServer.Public.String()
 }
 
 func (opts *ServerOptions) kontrolURL() string {
@@ -71,7 +71,7 @@ func (opts *ServerOptions) kontrolURL() string {
 		return opts.KontrolURL
 	}
 
-	return konfig.Builtin.Endpoints.Kontrol
+	return konfig.Builtin.KontrolPublic().String()
 }
 
 // Server represents tunneling server that handles managing authorization

--- a/go/src/koding/klient/app/klient.go
+++ b/go/src/koding/klient/app/klient.go
@@ -170,19 +170,10 @@ type KlientConfig struct {
 
 	LogBucketRegion   string
 	LogBucketName     string
-	LogKeygenURL      string
 	LogUploadInterval time.Duration
 
 	Metadata     string
 	MetadataFile string
-}
-
-func (conf *KlientConfig) logKeygenURL() string {
-	if conf.LogKeygenURL != "" {
-		return conf.LogKeygenURL
-	}
-
-	return konfig.Konfig.KloudURL
 }
 
 func (conf *KlientConfig) logBucketName() string {
@@ -247,19 +238,30 @@ func NewKlient(conf *KlientConfig) (*Klient, error) {
 	// ensure flags are stored alongside konfig and do not
 	// overwrite konfig here.
 	if conf.KontrolURL != "" {
-		konfig.Konfig.KontrolURL = conf.KontrolURL
+		u, err := url.Parse(conf.KontrolURL)
+		if err != nil {
+			return nil, err
+		}
+		u.Path = ""
+
+		konfig.Konfig.Endpoints.Koding.Public.URL = u
 	}
 
 	if conf.TunnelKiteURL != "" {
-		konfig.Konfig.TunnelURL = conf.TunnelKiteURL
+		u, err := url.Parse(conf.TunnelKiteURL)
+		if err != nil {
+			return nil, err
+		}
+
+		konfig.Konfig.Endpoints.Tunnel.Public.URL = u
 	}
 
 	k := newKite(conf)
 	k.Config.VerifyAudienceFunc = verifyAudience
 
 	if k.Config.KontrolURL == "" || k.Config.KontrolURL == "http://127.0.0.1:3000/kite" ||
-		konfig.Konfig.KontrolURL != konfig.Builtin.KontrolURL {
-		k.Config.KontrolURL = konfig.Konfig.KontrolURL
+		!konfig.Konfig.Endpoints.Kontrol().Equal(konfig.Builtin.Endpoints.Kontrol()) {
+		k.Config.KontrolURL = konfig.Konfig.Endpoints.Kontrol().Public.String()
 	}
 
 	term := terminal.New(k.Log, conf.ScreenrcPath)
@@ -271,7 +273,7 @@ func NewKlient(conf *KlientConfig) (*Klient, error) {
 	}
 
 	up := uploader.New(&uploader.Options{
-		KeygenURL: conf.logKeygenURL(),
+		KeygenURL: konfig.Konfig.Endpoints.Kloud().Public.String(),
 		Kite:      k,
 		Bucket:    conf.logBucketName(),
 		Region:    conf.logBucketRegion(),
@@ -292,7 +294,7 @@ func NewKlient(conf *KlientConfig) (*Klient, error) {
 		Log:           k.Log,
 		Kite:          k,
 		NoProxy:       conf.NoProxy,
-		TunnelKiteURL: konfig.Konfig.TunnelURL,
+		TunnelKiteURL: konfig.Konfig.Endpoints.Tunnel.Public.String(),
 	}
 
 	t, err := tunnel.New(tunOpts)
@@ -327,7 +329,7 @@ func NewKlient(conf *KlientConfig) (*Klient, error) {
 		k.Log.Fatal("Cannot initialize machine group: %s", err)
 	}
 
-	c := k.NewClient(konfig.Konfig.KloudURL)
+	c := k.NewClient(konfig.Konfig.Endpoints.Kloud().Public.String())
 	c.Auth = &kite.Auth{
 		Type: "kiteKey",
 		Key:  k.Config.KiteKey,
@@ -374,7 +376,7 @@ func NewKlient(conf *KlientConfig) (*Klient, error) {
 		},
 		logUploadDelay: 3 * time.Minute,
 		presence: &presence.Client{
-			Endpoint: konfig.Konfig.SocialAPI.Public.WithPath("presence"),
+			Endpoint: konfig.Konfig.Endpoints.Social().Public.WithPath("presence").URL,
 			Client:   restClient,
 		},
 		presenceEvery: onceevery.New(1 * time.Hour),

--- a/go/src/koding/klient/info/publicip/publicip.go
+++ b/go/src/koding/klient/info/publicip/publicip.go
@@ -63,15 +63,11 @@ func (d *director) EndpointPublicIP() string {
 		return "http://echoip.net"
 	}
 
-	return konfig.Konfig.IPURL
+	return konfig.Konfig.Endpoints.IP.Public.String()
 }
 
 func (d *director) EndpointIsReachable(port string) string {
-	if d.fallback {
-		return "http://rjk.io/test/" + port
-	}
-
-	return konfig.Konfig.IPCheckURL + "/" + port
+	return konfig.Konfig.Endpoints.IPCheck.Public.String() + "/" + port
 }
 
 func (d *director) ShouldRetry(err error) bool {

--- a/go/src/koding/klient/main.go
+++ b/go/src/koding/klient/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -57,7 +58,6 @@ var (
 	// Upload log flags
 	flagLogBucketRegion   = flag.String("log-bucket-region", "", "Change bucket region to upload logs")
 	flagLogBucketName     = flag.String("log-bucket-name", "", "Change bucket name to upload logs")
-	flagKeygenURL         = flag.String("log-keygen-url", "", "Change keygen endpoint URL for bucket authorization")
 	flagLogUploadInterval = flag.Duration("log-upload-interval", 90*time.Minute, "Change interval of upload logs")
 
 	// Metadata flags.
@@ -93,7 +93,7 @@ func realMain() int {
 	if *flagRegister {
 		kontrolURL := *flagKontrolURL
 		if kontrolURL == "" {
-			kontrolURL = konfig.Konfig.KontrolURL
+			kontrolURL = konfig.Konfig.Endpoints.Kontrol().Public.String()
 		}
 
 		kiteHome := *flagKiteHome
@@ -101,22 +101,22 @@ func realMain() int {
 			kiteHome = konfig.Konfig.KiteHome()
 		}
 
-		kloudURL := *flagKeygenURL
-		if kloudURL == "" {
-			kloudURL = konfig.Konfig.KloudURL
-		}
-
 		if err := registration.Register(kontrolURL, kiteHome, *flagUsername, *flagToken, debug); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return 1
 		}
 
+		u, err := url.Parse(kontrolURL)
+		if err != nil {
+			log.Fatalf("failed to parse -kontrol-url: %s", err)
+		}
+
 		// Create new konfig.bolt with variables used during registration.
 		kfg := &config.Konfig{
-			KiteKeyFile:        filepath.Join(kiteHome, "kite.key"),
-			KontrolURL:         kontrolURL,
-			TunnelURL:          *flagTunnelName,
-			KloudURL:           kloudURL,
+			KiteKeyFile: filepath.Join(kiteHome, "kite.key"),
+			Endpoints: &config.Endpoints{
+				Koding: config.NewEndpointURL(u),
+			},
 			PublicBucketName:   *flagLogBucketName,
 			PublicBucketRegion: *flagLogBucketRegion,
 		}
@@ -164,7 +164,6 @@ func realMain() int {
 		Autoupdate:        *flagAutoupdate,
 		LogBucketRegion:   *flagLogBucketRegion,
 		LogBucketName:     *flagLogBucketName,
-		LogKeygenURL:      *flagKeygenURL,
 		LogUploadInterval: *flagLogUploadInterval,
 		Metadata:          *flagMetadata,
 		MetadataFile:      *flagMetadataFile,

--- a/go/src/koding/klientctl/auth/register.go
+++ b/go/src/koding/klientctl/auth/register.go
@@ -95,7 +95,7 @@ func RegisterCommand(c *cli.Context, log logging.Logger, _ string) int {
 		return 1
 	}
 
-	host := config.Konfig.KodingBaseURL
+	host := config.Konfig.Endpoints.Koding.Public.String()
 
 	client := httputil.DefaultRestClient(false)
 

--- a/go/src/koding/klientctl/checkupdate.go
+++ b/go/src/koding/klientctl/checkupdate.go
@@ -64,7 +64,7 @@ type CheckUpdate struct {
 func NewCheckUpdate() *CheckUpdate {
 	return &CheckUpdate{
 		LocalVersion:       config.VersionNum(),
-		Location:           config.Konfig.KDLatestURL,
+		Location:           config.Konfig.Endpoints.KDLatest.Public.String(),
 		RandomSeededNumber: rand.Intn(3),
 		ForceCheck:         false,
 	}

--- a/go/src/koding/klientctl/config/config.go
+++ b/go/src/koding/klientctl/config/config.go
@@ -96,7 +96,7 @@ func VersionNum() int {
 }
 
 func S3Klient(version int, env string) string {
-	s3dir := dirURL(Konfig.KlientLatestURL, kd2klient(env))
+	s3dir := dirURL(Konfig.Endpoints.KlientLatest.Public.String(), kd2klient(env))
 
 	// TODO(rjeczalik): klient uses a URL without $GOOS_$GOARCH suffix for
 	// auto-updates. Remove the special case when a redirect is deployed
@@ -110,7 +110,7 @@ func S3Klient(version int, env string) string {
 }
 
 func S3Klientctl(version int, env string) string {
-	return fmt.Sprintf("%s/kd-0.1.%d.%s_%s.gz", dirURL(Konfig.KDLatestURL, env),
+	return fmt.Sprintf("%s/kd-0.1.%d.%s_%s.gz", dirURL(Konfig.Endpoints.KDLatest.Public.String(), env),
 		version, runtime.GOOS, runtime.GOARCH,
 	)
 }

--- a/go/src/koding/klientctl/endpoint/kloud/kloud.go
+++ b/go/src/koding/klientctl/endpoint/kloud/kloud.go
@@ -121,10 +121,7 @@ func (kt *KiteTransport) kite() *kite.Kite {
 	}
 
 	kt.k = kite.New(config.Name, config.KiteVersion)
-	kt.k.Config = config.Konfig.KiteConfig()
-	kt.k.Config.KontrolURL = config.Konfig.KontrolURL
-	kt.k.Config.Environment = config.Environment
-	kt.k.Config.Transport = kitecfg.XHRPolling
+	kt.k.Config = kt.kiteConfig()
 	kt.k.Log = kt.Log
 
 	return kt.k
@@ -136,7 +133,7 @@ func (kt *KiteTransport) kiteConfig() *kitecfg.Config {
 	}
 
 	kt.kCfg = config.Konfig.KiteConfig()
-	kt.kCfg.KontrolURL = config.Konfig.KontrolURL
+	kt.kCfg.KontrolURL = config.Konfig.Endpoints.Kontrol().Public.String()
 	kt.kCfg.Environment = config.Environment
 	kt.kCfg.Transport = kitecfg.XHRPolling
 
@@ -148,7 +145,7 @@ func (kt *KiteTransport) kloud() (*kite.Client, error) {
 		return kt.kKloud, nil
 	}
 
-	kloud := kt.kite().NewClient(config.Konfig.KloudURL)
+	kloud := kt.kite().NewClient(config.Konfig.Endpoints.Kloud().Public.String())
 
 	if err := kloud.DialTimeout(kt.DialTimeout); err != nil {
 		query := &protocol.KontrolQuery{

--- a/go/src/koding/klientctl/endpoint/presence/presence.go
+++ b/go/src/koding/klientctl/endpoint/presence/presence.go
@@ -1,7 +1,6 @@
 package presence
 
 import (
-	"path"
 	"sync"
 
 	"koding/api/presence"
@@ -47,11 +46,8 @@ func (c *Client) init() {
 }
 
 func (c *Client) initClient() {
-	presenceURL := *config.Konfig.SocialAPI.Public.URL
-	presenceURL.Path = path.Join(presenceURL.Path, "presence")
-
 	c.c = &presence.Client{
-		Endpoint: &presenceURL,
+		Endpoint: config.Konfig.Endpoints.Social().Public.WithPath("presence").URL,
 	}
 }
 

--- a/go/src/koding/klientctl/endpoint/remoteapi/remoteapi.go
+++ b/go/src/koding/klientctl/endpoint/remoteapi/remoteapi.go
@@ -1,7 +1,6 @@
 package remoteapi
 
 import (
-	"net/url"
 	"sync"
 
 	"koding/api"
@@ -34,10 +33,7 @@ func (c *Client) init() {
 func (c *Client) initClient() {
 	c.c = &remoteapi.Client{
 		Transport: endpoint.Transport(c.kloud()),
-	}
-
-	if u, err := url.Parse(config.Konfig.RemoteURL); err == nil {
-		c.c.Endpoint = u
+		Endpoint:  config.Konfig.Endpoints.Remote().Public.URL,
 	}
 }
 

--- a/go/src/koding/klientctl/install.go
+++ b/go/src/koding/klientctl/install.go
@@ -204,7 +204,7 @@ func InstallCommandFactory(c *cli.Context, log logging.Logger, _ string) (exit i
 
 	fmt.Println("Downloading...")
 
-	version, err := latestVersion(config.Konfig.KlientLatestURL)
+	version, err := latestVersion(config.Konfig.Endpoints.KlientLatest.Public.String())
 	if err != nil {
 		fmt.Printf(FailedDownloadingKlient)
 		return 1, fmt.Errorf("error getting latest klient version: %s", err)
@@ -299,7 +299,7 @@ func InstallCommandFactory(c *cli.Context, log logging.Logger, _ string) (exit i
 	}
 
 	fmt.Println("Verifying installation...")
-	err = WaitUntilStarted(config.Konfig.KlientURL, CommandAttempts, CommandWaitTime)
+	err = WaitUntilStarted(config.Konfig.Endpoints.Klient.Private.String(), CommandAttempts, CommandWaitTime)
 
 	// After X times, if err != nil we failed to connect to klient.
 	// Inform the user.

--- a/go/src/koding/klientctl/klient/klient.go
+++ b/go/src/koding/klientctl/klient/klient.go
@@ -79,7 +79,7 @@ type KlientOptions struct {
 // NewKlientOptions returns KlientOptions initialized to default values.
 func NewKlientOptions() KlientOptions {
 	return KlientOptions{
-		Address:     config.Konfig.KlientURL,
+		Address:     config.Konfig.Endpoints.Klient.Private.String(),
 		KiteKeyPath: config.Konfig.KiteKeyFile,
 		KiteKey:     config.Konfig.KiteKey,
 		Name:        config.Name,

--- a/go/src/koding/klientctl/restart.go
+++ b/go/src/koding/klientctl/restart.go
@@ -27,7 +27,7 @@ func RestartCommand(c *cli.Context, log logging.Logger, _ string) int {
 
 	fmt.Printf("Restarting the %s, this may take a moment...\n", config.KlientName)
 
-	klientWasRunning := IsKlientRunning(config.Konfig.KlientURL)
+	klientWasRunning := IsKlientRunning(config.Konfig.Endpoints.Klient.Private.String())
 
 	if klientWasRunning {
 		// If klient is running, stop it, and tell the user if we fail
@@ -42,7 +42,7 @@ func RestartCommand(c *cli.Context, log logging.Logger, _ string) int {
 		s.Stop()
 	}
 
-	err = WaitUntilStopped(config.Konfig.KlientURL, CommandAttempts, CommandWaitTime)
+	err = WaitUntilStopped(config.Konfig.Endpoints.Klient.Private.String(), CommandAttempts, CommandWaitTime)
 	if err != nil {
 		log.Error(
 			"Timed out while waiting for Klient to start. attempts:%d, err:%s",

--- a/go/src/koding/klientctl/start.go
+++ b/go/src/koding/klientctl/start.go
@@ -70,7 +70,7 @@ func startKlient(log logging.Logger, s service.Service) error {
 
 	fmt.Println("Starting...")
 
-	err := WaitUntilStarted(config.Konfig.KlientURL, CommandAttempts, CommandWaitTime)
+	err := WaitUntilStarted(config.Konfig.Endpoints.Klient.Private.String(), CommandAttempts, CommandWaitTime)
 	if err != nil {
 		log.Error(
 			"Timed out while waiting for Klient to start. attempts:%d, err:%s",

--- a/go/src/koding/klientctl/status.go
+++ b/go/src/koding/klientctl/status.go
@@ -52,10 +52,10 @@ func NewDefaultHealthChecker(l kodinglogging.Logger) *HealthChecker {
 	return &HealthChecker{
 		Log:                  l.New("HealthChecker"),
 		HTTPClient:           defaultClient,
-		LocalKlientAddress:   config.Konfig.KlientURL,
-		KontrolAddress:       config.Konfig.KontrolURL,
-		InternetCheckAddress: config.Konfig.KlientLatestURL,
-		TunnelKiteAddress:    config.Konfig.TunnelURL,
+		LocalKlientAddress:   config.Konfig.Endpoints.Klient.Private.String(),
+		KontrolAddress:       config.Konfig.Endpoints.Kontrol().Public.String(),
+		InternetCheckAddress: config.Konfig.Endpoints.KlientLatest.Public.String(),
+		TunnelKiteAddress:    config.Konfig.Endpoints.Tunnel.Public.String(),
 	}
 }
 

--- a/go/src/koding/klientctl/stop.go
+++ b/go/src/koding/klientctl/stop.go
@@ -30,7 +30,7 @@ func StopCommand(c *cli.Context, log logging.Logger, _ string) int {
 		return 1
 	}
 
-	err = WaitUntilStopped(config.Konfig.KlientURL, CommandAttempts, CommandWaitTime)
+	err = WaitUntilStopped(config.Konfig.Endpoints.Klient.Private.String(), CommandAttempts, CommandWaitTime)
 	if err != nil {
 		log.Error(
 			"Timed out while waiting for Klient to start. attempts:%d, err:%s",

--- a/go/src/koding/klientctl/update.go
+++ b/go/src/koding/klientctl/update.go
@@ -74,7 +74,7 @@ func UpdateCommand(c *cli.Context, log logging.Logger, _ string) int {
 	if kdVersion == 0 {
 		var err error
 
-		kdVersion, err = latestVersion(config.Konfig.KDLatestURL)
+		kdVersion, err = latestVersion(config.Konfig.Endpoints.KDLatest.Public.String())
 		if err != nil {
 			log.Error("Error fetching klientctl update version. err: %s", err)
 			fmt.Println(FailedCheckingUpdateAvailable)
@@ -85,7 +85,7 @@ func UpdateCommand(c *cli.Context, log logging.Logger, _ string) int {
 	if klientVersion == 0 {
 		var err error
 
-		klientVersion, err = latestVersion(config.Konfig.KlientLatestURL)
+		klientVersion, err = latestVersion(config.Konfig.Endpoints.KlientLatest.Public.String())
 		if err != nil {
 			log.Error("Error fetching klient update version. err: %s", err)
 			fmt.Println(FailedCheckingUpdateAvailable)

--- a/go/src/koding/klientctl/version.go
+++ b/go/src/koding/klientctl/version.go
@@ -13,7 +13,7 @@ import (
 
 // VersionCommand displays version information like Environment or Kite Query ID.
 func VersionCommand(c *cli.Context, log logging.Logger, _ string) int {
-	latest, err := latestVersion(config.Konfig.KDLatestURL)
+	latest, err := latestVersion(config.Konfig.Endpoints.KDLatest.Public.String())
 
 	fmt.Printf("Installed Version: %s\n", getReadableVersion(config.Version))
 


### PR DESCRIPTION
This PR improves kites (kd / klient) configuration to use single endpoint for koding-originated endpoints.

Addresses: https://github.com/koding/koding/pull/9786#discussion_r90436314

Prerequisite for #9643.