### PR TITLE
Leavesessionmodal

### DIFF
--- a/client/app/lib/components/sidebarmachineslistitem/index.coffee
+++ b/client/app/lib/components/sidebarmachineslistitem/index.coffee
@@ -28,7 +28,6 @@ module.exports = class SidebarMachinesListItem extends React.Component
     stack                        : null
     showInSidebar                : yes
     bindWorkspacesTitleClick     : yes
-    activeLeavingSharedMachineId : null
 
 
   getDataBindings: ->
@@ -198,8 +197,8 @@ module.exports = class SidebarMachinesListItem extends React.Component
       sidebarListItem = ReactDOM.findDOMNode @refs.sidebarMachinesListItem
       clientRect      = sidebarListItem.getBoundingClientRect()
       coordinates     =
-        top           : clientRect.top - 15
-        left          : clientRect.width + clientRect.left + 15
+        top           : clientRect.top
+        left          : clientRect.width + clientRect.left
 
       @setState { coordinates: coordinates}
 

--- a/client/app/lib/components/sidebarmachineslistitem/index.coffee
+++ b/client/app/lib/components/sidebarmachineslistitem/index.coffee
@@ -33,6 +33,7 @@ module.exports = class SidebarMachinesListItem extends React.Component
 
   getDataBindings: ->
     activeMachine : EnvironmentFlux.getters.activeMachine
+    activeLeavingMachine : EnvironmentFlux.getters.activeLeavingSharedMachineId
 
 
   constructor: (props) ->
@@ -168,6 +169,7 @@ module.exports = class SidebarMachinesListItem extends React.Component
     return null  if @machine('type') is 'own' or @machine 'hasOldOwner'
     return null  if @state.activeMachine isnt @machine('_id')
     return null  unless @machine 'isApproved'
+    return null  unless @state.activeLeavingMachine
 
     <LeaveSharedMachineWidget
       coordinates={@state.coordinates}

--- a/client/app/lib/flux/environment/stores/activeleavingsharedmachineidstore.coffee
+++ b/client/app/lib/flux/environment/stores/activeleavingsharedmachineidstore.coffee
@@ -12,7 +12,4 @@ module.exports = class ActiveLeavingSharedMachineIdStore extends KodingFluxStore
     @on actions.SET_ACTIVE_LEAVING_SHARED_MACHINE_ID, @setMachineId
 
 
-  setMachineId: (activeWidgetId, { id }) ->
-
-    return null  if activeWidgetId is id
-    return id
+  setMachineId: (activeWidgetId, { id }) -> return id


### PR DESCRIPTION
Fixes: #9579

http://recordit.co/dgNwOKSA5R

Fix activeleavingsharedmachineidstore's setMachineId function then check for activeLeavingMachine to show `leaving session` or `leaving shared vm` modal.
Remove redundant variable.