### PR TITLE
'original stack template has been updated' notification appears for the user that cloned also when he makes the changes himself. 

### DIFF
--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -1045,7 +1045,7 @@ module.exports = class ComputeController extends KDController
     stacks.forEach (stack) =>
       @fetchBaseStackTemplate stack, (err, template) =>
         unless err
-          if stackTemplate.template.sum isnt template.template.sum
+          if stackTemplate.config.clonedSum isnt template.template.sum
             config = stack.config ?= {}
             config.needUpdate = yes
             @updateStackConfig stack, config

--- a/client/stack-editor/lib/index.coffee
+++ b/client/stack-editor/lib/index.coffee
@@ -66,9 +66,9 @@ module.exports = class StackEditorAppController extends AppController
           if originalTemplate
             editor.addClonedFrom originalTemplate
             originalTemplate.on 'update', ->
-              if stackTemplate.template.sum isnt originalTemplate.template.sum
+              if stackTemplate.config.clonedSum isnt originalTemplate.template.sum
                 return editor.addCloneUpdateView originalTemplate
-            if stackTemplate.template.sum isnt originalTemplate.template.sum
+            if stackTemplate.config.clonedSum isnt originalTemplate.template.sum
               editor.addCloneUpdateView originalTemplate
 
     else

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -441,7 +441,8 @@ module.exports = class JStackTemplate extends Module
             # update clonedSum information in the template, if it is exists
             JStackTemplate.one$ client, { _id: originalId }, (err, template) ->
               if template and not err
-                data.config.clonedSum = template.template.sum
+                if template.template.sum is data.template.sum
+                  data.config.clonedSum = template.template.sum
               next()
         (next) =>
           query = { $set: data }

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -435,7 +435,14 @@ module.exports = class JStackTemplate extends Module
 
             data['meta.modifiedAt'] = new Date
 
-            next()
+            originalId = data.config?.clonedFrom
+            return next()  unless originalId
+
+            # update clonedSum information in the template, if it is exists
+            JStackTemplate.one$ client, { _id: originalId }, (err, template) ->
+              if template and not err
+                data.config.clonedSum = template.template.sum
+              next()
         (next) =>
           query = { $set: data }
 


### PR DESCRIPTION
Fixes: #9972

When cloned stack template has update, we need to update its clonedSum info as well.
And while checking update for cloned stack template, we are looking for clonedSum information that we set when we clone the stack template.

http://recordit.co/SlHLMybrXI