### PR TITLE
klientctl: rework klientctl/ssh package and make it business logic agnostic

### DIFF
--- a/go/src/koding/klientctl/ssh/ssh.go
+++ b/go/src/koding/klientctl/ssh/ssh.go
@@ -1,4 +1,3 @@
-// The core logic for the `kd ssh` command.
 package ssh
 
 import (
@@ -6,400 +5,137 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/rand"
-	"net"
 	"os"
-	"os/exec"
 	"os/user"
-	"path"
 	"path/filepath"
 	"strings"
 
-	"koding/kites/tunnelproxy/discover"
-	"koding/klient/remote/req"
-	"koding/klientctl/config"
-	"koding/klientctl/klient"
-	"koding/klientctl/klientctlerrors"
-	"koding/klientctl/list"
-	"koding/klientctl/shortcut"
-	"koding/klientctl/util"
-
-	"github.com/koding/kite/dnode"
-	"github.com/koding/logging"
-
 	"github.com/koding/sshkey"
-
 	"golang.org/x/crypto/ssh"
 )
 
-var (
-	ErrCannotFindUser = errors.New("Cannot find username on remote machine.")
+const (
+	// DefaultKeyDir is the default directory that stores users SSH key pairs.
+	DefaultKeyDir = ".ssh"
 
-	ErrFailedToGetSSHKey = errors.New("Failed to get ssh key.")
-
-	ErrMachineNotValidYet = errors.New("Machine not valid yet.")
-
-	ErrRemoteDialingFailed = errors.New("Dialing remote failed.")
-
-	// Dialing the local klient failed, ie klient is not running or accepting
-	// connections.
-	ErrLocalDialingFailed = errors.New("Local dialing failed.")
-
-	// ErrMachineNotFound is when the requested machine is not found.
-	ErrMachineNotFound = errors.New("Machine not found.")
+	// DefaultKeyName is the default name of the ssh key pair.
+	DefaultKeyName = "kd-ssh-key"
 )
 
-type SSHCommandOpts struct {
-	Ask bool
+var (
+	// ErrPublicKeyNotFound indicates that provided public key does not exist.
+	ErrPublicKeyNotFound = errors.New("public key not found")
+)
 
-	// The Remote SSH Username to connect with.
-	RemoteUsername string
-
-	// Whether to log with debug, and pass debug to Klient.
-	Debug bool
-}
-
-// SSHCommand is the command that lets users ssh into a remote machine.  It
-// manages the creating and storing of authorization keys for ease of use.
-//
-// On first run it generates a new SSH key pair and adds it to the requested
-// machine. On subsequent requests it uses the same key pair, but adds it each
-// time to user machine, since we can't assume if key exists in local, remote
-// machine must also have that key, ie if user has multiple machines, but key
-// was only added to one machine.
-//
-// Before generating a new key, it asks user to confirm or deny.
-//
-// SSH public keys have comment of the form: "koding-<number>", where number is
-// a random integer. Klient requires a non empty comment; by adding a random
-// integer to end of comment this command can be used by multiple computers.
-type SSHCommand struct {
-	*SSHKey
-
-	Log   logging.Logger
-	Debug bool
-
-	// Ask is flag for user interaction, ie should we ask user to generate new
-	// SSH key if it doesn't exist.
-	Ask bool
-
-	// Klient is communication layer between this and local klient. This is
-	// used to add SSH public key to `~/.ssh/authorized_keys` on the remote
-	// machine.
-	Klient interface {
-		RemoteList() (list.KiteInfos, error)
-	}
-}
-
-// NewSSHCommand is the required initializer for SSHCommand.
-func NewSSHCommand(log logging.Logger, opts SSHCommandOpts) (*SSHCommand, error) {
-	usr, err := user.Current()
-	if err != nil {
-		return nil, err
-	}
-
-	klientKite, err := klient.CreateKlientWithDefaultOpts()
-	if err != nil {
-		return nil, err
-	}
-
-	if err := klientKite.Dial(); err != nil {
-		log.New("NewSSHCommand").Error("Dialing local klient failed. err:%s", err)
-		return nil, ErrLocalDialingFailed
-	}
-
-	k := klient.NewKlient(klientKite)
-
-	return &SSHCommand{
-		Klient: k,
-		Log:    log.New("SSHCommand"),
-		Ask:    opts.Ask,
-		Debug:  opts.Debug,
-		SSHKey: &SSHKey{
-			Log:            log.New("SSHKey"),
-			Debug:          opts.Debug,
-			RemoteUsername: opts.RemoteUsername,
-			KeyPath:        path.Join(usr.HomeDir, config.SSHDefaultKeyDir),
-			KeyName:        config.SSHDefaultKeyName,
-			Klient:         k,
-		},
-	}, nil
-}
-
-func (s *SSHCommand) Run(machine string) error {
-	if !s.KeysExist() && s.Ask {
-		util.MustConfirm("'ssh' command needs to create public/private rsa key pair. Continue? [Y|n]")
-	}
-
-	machine, err := shortcut.NewMachineShortcut(s.Klient).GetNameFromShortcut(machine)
-	if err != nil {
-		return err
-	}
-
-	userhost, port, err := s.GetSSHAddr(machine)
-	if err != nil {
-		return err
-	}
-
-	if err := s.PrepareForSSH(machine); err != nil {
-		s.Log.Debug("PrepareForSSH returned err: %s", err)
-
-		if strings.Contains(err.Error(), "user: unknown user") {
-			return ErrCannotFindUser
+// GetKeyPath returns default SSH keys directory for a given user. If user is
+// nil, the current user will be used.
+func GetKeyPath(u *user.User) (path string, err error) {
+	if u == nil {
+		if u, err = user.Current(); err != nil {
+			return "", err
 		}
+	}
 
-		// TODO: We're unable to log the meaningful error returned from klient, so we're
-		// leaking possibly meaningful data here. This will be resolved once SSH gets
-		// updated to the new (final) format. Fix this.
-		if klientctlerrors.IsMachineNotValidYetErr(err) {
-			return ErrMachineNotValidYet
+	path = filepath.Join(u.HomeDir, DefaultKeyDir)
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return "", err
+	}
+
+	return path, nil
+}
+
+// GenerateSaved generates SSH key pair and saves it in provided paths. This
+// function will not replace existing keys if they already exists.
+func GenerateSaved(pubPath, privPath string) (pubKey, privKey string, err error) {
+	keys := map[string]string{
+		"public":  pubPath,
+		"private": privPath,
+	}
+
+	// Check if files exist.
+	for name, keyPath := range keys {
+		switch _, err := os.Stat(keyPath); {
+		case err == nil:
+			return "", "", fmt.Errorf("%s key file %s already exists", name, keyPath)
+		case os.IsNotExist(err):
+		default:
+			return "", "", err
 		}
-
-		if klientctlerrors.IsDialFailedErr(err) {
-			return ErrRemoteDialingFailed
-		}
-
-		return ErrFailedToGetSSHKey
 	}
 
-	args := []string{
-		"-i", s.PrivateKeyPath(),
-		"-o", "ServerAliveInterval=300",
-		"-o", "ServerAliveCountMax=3",
-		"-o", "ConnectTimeout=7",
-		"-o", "ConnectionAttempts=1",
-		userhost,
-	}
-
-	if port != "" {
-		args = append(args, "-p", port)
-	}
-
-	s.Log.Debug("SSHing with command: ssh %s", strings.Join(args, " "))
-	cmd := exec.Command("ssh", args...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	return cmd.Run()
-}
-
-// PrepareForSSH wrappers SSHKey.PrepareForSSH, additionally printing some basic
-// information to the user.
-func (s *SSHCommand) PrepareForSSH(name string) error {
-	if s.KeysExist() {
-		fmt.Printf("Using existing keypair at: %s \n", s.PublicKeyPath())
-	} else {
-		fmt.Printf("Creating new keypair at: %s \n", s.PublicKeyPath())
-	}
-
-	return s.SSHKey.PrepareForSSH(name)
-}
-
-// SSHKey implements methods for dealing with creating a KD local and remote ssh key,
-// and adding it to the remote via klient's remote.sshKeysAdd
-type SSHKey struct {
-	Log   logging.Logger
-	Debug bool
-
-	// The *default* username used.
-	RemoteUsername string
-
-	// KeyPath is the directory that stores the ssh keys pairs. It's defaults
-	// to `.ssh/` in the user's home directory.
-	KeyPath string
-
-	// KeyName is the file name of the SSH key pair. It defaults to `kd-ssh-key`.
-	KeyName string
-
-	// Klient is communication layer between this and local klient. This is
-	// used to add SSH public key to `~/.ssh/authorized_keys` on the remote
-	// machine.
-	Klient interface {
-		RemoteList() (list.KiteInfos, error)
-		RemoteCurrentUsername(req.CurrentUsernameOptions) (string, error)
-		Tell(string, ...interface{}) (*dnode.Partial, error)
-	}
-
-	// Discover is used to resolve SSH address if klient connection is tunneled.
-	Discover discover.Client
-}
-
-// GetSSHAddr returns the username and the hostname of the remove machine to ssh.
-//
-// It assume user exists on the remove machine with the same Koding username.
-// It may also return a custom port number, if other than a default should
-// be used.
-func (s *SSHKey) GetSSHAddr(name string) (userhost, port string, err error) {
-	infos, err := s.Klient.RemoteList()
+	// Generate keys.
+	pubKey, privKey, err = sshkey.Generate()
 	if err != nil {
 		return "", "", err
 	}
 
-	info, ok := infos.FindFromName(name)
+	pubKey += fmt.Sprintf(" koding-%d", rand.Int31())
 
-	if !ok {
-		s.Log.Error("No machine found with specified name: `%s`", name)
-		return "", "", ErrMachineNotFound
+	keys = map[string]string{
+		pubPath:  pubKey,
+		privPath: privKey,
 	}
 
-	remoteUsername, err := s.GetUsername(name)
+	for keyPath, content := range keys {
+		if err := ioutil.WriteFile(keyPath, []byte(content), 0600); err != nil {
+			return "", "", err
+		}
+	}
+
+	return pubKey, privKey, nil
+}
+
+// PublicKey returns a public key stored under the given path. Public key will
+// be validated before this function returns.
+func PublicKey(pubPath string) (pubKey string, err error) {
+	if _, err := os.Stat(pubPath); err != nil {
+		return "", ErrPublicKeyNotFound
+	}
+
+	content, err := ioutil.ReadFile(pubPath)
 	if err != nil {
+		return "", err
+	}
+
+	// Validate key.
+	if _, _, _, _, err = ssh.ParseAuthorizedKey(content); err != nil {
+		return "", err
+	}
+
+	return string(content), nil
+}
+
+// Keypaths generates a public and private keys paths from a given argument. If
+// argument path is a directory, paths will be created from DefaultKeyName.
+// If path point to either private or public key, its name will be used to
+// generate corresponding path.
+func KeyPaths(path string) (pubPath, privPath string, err error) {
+	var isDir bool
+	switch info, err := os.Stat(path); {
+	case os.IsNotExist(err):
+		if err := os.MkdirAll(path, 0700); err != nil {
+			return "", "", err
+		}
+		isDir = true
+	case err != nil:
 		return "", "", err
+	default:
+		isDir = info.IsDir()
 	}
 
-	endpoints, err := s.Discover.Discover(info.IP, "ssh")
-	if err != nil {
-		return fmt.Sprintf("%s@%s", remoteUsername, info.IP), "", nil
+	if isDir {
+		privPath = filepath.Join(path, DefaultKeyName)
+		pubPath = privPath + ".pub"
+		return pubPath, privPath, nil
 	}
 
-	addr := endpoints[0].Addr
-
-	// We prefer local routes to use first, if there's none, we use first
-	// discovered route.
-	if e := endpoints.Filter(discover.ByLocal(true)); len(e) != 0 {
-
-		// All local routes will do, typically there's only one,
-		// we use the first one and ignore the rest.
-		addr = e[0].Addr
-	}
-
-	host, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		host = addr
-	}
-
-	return fmt.Sprintf("%s@%s", remoteUsername, host), port, nil
-}
-
-// GetUsername returns the username of the remote machine.
-func (s *SSHKey) GetUsername(name string) (username string, err error) {
-	if s.RemoteUsername != "" {
-		return s.RemoteUsername, nil
-	}
-
-	// Cache the return value if we have one. Not required, just useful,
-	// no need for repeated queries.
-	defer func() {
-		if err == nil && username != "" {
-			s.RemoteUsername = username
-		}
-	}()
-
-	currentUsernameOpts := req.CurrentUsernameOptions{
-		Debug:       s.Debug,
-		MachineName: name,
-	}
-
-	return s.Klient.RemoteCurrentUsername(currentUsernameOpts)
-}
-
-// GenerateAndSaveKey generates a new SSH key pair and saves it to local.
-func (s *SSHKey) GenerateAndSaveKey() ([]byte, error) {
-	var perms os.FileMode = 0600
-
-	if err := os.MkdirAll(filepath.Dir(s.PrivateKeyPath()), 0700); err != nil {
-		return nil, err
-	}
-
-	publicKey, privateKey, err := sshkey.Generate()
-	if err != nil {
-		return nil, err
-	}
-
-	publicKey += fmt.Sprintf(" koding-%d", rand.Int31())
-
-	// save ssh private key
-	err = ioutil.WriteFile(s.PrivateKeyPath(), []byte(privateKey), perms)
-	if err != nil {
-		return nil, err
-	}
-
-	// save ssh public key
-	err = ioutil.WriteFile(s.PublicKeyPath(), []byte(publicKey), perms)
-	if err != nil {
-		return nil, err
-	}
-
-	return []byte(publicKey), nil
-}
-
-// PublicKeyExists checks if a file exists at the PublicKeyPath
-func (s *SSHKey) PublicKeyExists() bool {
-	if _, err := os.Stat(s.PublicKeyPath()); os.IsNotExist(err) {
-		return false
-	}
-
-	return true
-}
-
-// PrivateKeyExists checks if a file eists at the PrivateKeyPath
-func (s *SSHKey) PrivateKeyExists() bool {
-	if _, err := os.Stat(s.PrivateKeyPath()); os.IsNotExist(err) {
-		return false
-	}
-
-	return true
-}
-
-// PublicKeyPath returns the public key path, based on the private key path
-func (s *SSHKey) PublicKeyPath() string {
-	return fmt.Sprintf("%s.pub", s.PrivateKeyPath())
-}
-
-// PrivateKeyPath returns the private key path, based on the SSHKey.KeyPath and
-// KeyName values.
-func (s *SSHKey) PrivateKeyPath() string {
-	return path.Join(s.KeyPath, s.KeyName)
-}
-
-// KeysExist checks whether both keys exist.
-func (s *SSHKey) KeysExist() bool {
-	return s.PublicKeyExists() && s.PrivateKeyExists()
-}
-
-// PrepareForSSH checks if SSH key pair exists, if not it generates a new one
-// and saves it. It adds the key pair to remote machine each time.
-func (s *SSHKey) PrepareForSSH(name string) error {
-	var (
-		contents []byte
-		err      error
-	)
-
-	if s.KeysExist() {
-		if contents, err = ioutil.ReadFile(s.PublicKeyPath()); err != nil {
-			return err
-		}
-
-		// check if key is valid
-		if _, _, _, _, err = ssh.ParseAuthorizedKey(contents); err != nil {
-			return err
-		}
+	if filepath.Ext(path) == ".pub" {
+		privPath = strings.TrimSuffix(path, ".pub")
+		pubPath = path
 	} else {
-		if contents, err = s.GenerateAndSaveKey(); err != nil {
-			return err
-		}
+		privPath = path
+		pubPath = path + ".pub"
 	}
 
-	username, err := s.GetUsername(name)
-	if err != nil {
-		return err
-	}
-
-	req := req.SSHKeyAdd{
-		Debug:    s.Debug,
-		Name:     name,
-		Username: username,
-		Key:      contents,
-	}
-
-	if _, err = s.Klient.Tell("remote.sshKeysAdd", req); err != nil {
-		s.Log.Debug("Klient's remote.sshKeysAdd method returned err:%s", err)
-
-		// ignore errors about duplicate keys since we're adding on each run
-		if strings.Contains(err.Error(), "cannot add duplicate ssh key") {
-			return nil
-		}
-	}
-
-	return err
+	return pubPath, privPath, nil
 }

--- a/go/src/koding/klientctl/ssh/ssh_test.go
+++ b/go/src/koding/klientctl/ssh/ssh_test.go
@@ -1,0 +1,93 @@
+package ssh
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/koding/sshkey"
+)
+
+func TestSSHGenerateOK(t *testing.T) {
+	dir, err := ioutil.TempDir("", "ssh")
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	pubPath, privPath, err := KeyPaths(dir)
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	pubKey, _, err := GenerateSaved(pubPath, privPath)
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, DefaultKeyName)); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, DefaultKeyName) + ".pub"); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	pk, err := PublicKey(pubPath)
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	if pk != pubKey {
+		t.Fatalf("want public key = %s; got %s", pubKey, pk)
+	}
+}
+
+func TestSSHGenerateCustomName(t *testing.T) {
+	dir, err := ioutil.TempDir("", "ssh")
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	customName := filepath.Join(dir, "custom")
+	pubKey, privKey, err := sshkey.Generate()
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	if err := ioutil.WriteFile(customName, []byte(privKey), 0600); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	if err := ioutil.WriteFile(customName+".pub", []byte(pubKey), 0600); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	pubPath, privPath, err := KeyPaths(customName)
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	if _, _, err := GenerateSaved(pubPath, privPath); err == nil {
+		t.Fatalf("want err != nil; got <nil>")
+	}
+
+	pubPathNonExist, _, err := KeyPaths(dir)
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	if _, err := PublicKey(pubPathNonExist); err == nil {
+		t.Fatalf("want err != nil; got <nil>")
+	}
+
+	pk, err := PublicKey(pubPath)
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	if pk != pubKey {
+		t.Fatalf("want public key = %s; got %s", pubKey, pk)
+	}
+}

--- a/go/src/koding/klientctl/ssh/sshold.go
+++ b/go/src/koding/klientctl/ssh/sshold.go
@@ -1,0 +1,408 @@
+// The core logic for the `kd ssh` command.
+//
+// TODO(ppknap) this logic is deprecated. Remove it once we switch to new
+// machine commands entirely.
+package ssh
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net"
+	"os"
+	"os/exec"
+	"os/user"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"koding/kites/tunnelproxy/discover"
+	"koding/klient/remote/req"
+	"koding/klientctl/config"
+	"koding/klientctl/klient"
+	"koding/klientctl/klientctlerrors"
+	"koding/klientctl/list"
+	"koding/klientctl/shortcut"
+	"koding/klientctl/util"
+
+	"github.com/koding/kite/dnode"
+	"github.com/koding/logging"
+
+	"github.com/koding/sshkey"
+
+	"golang.org/x/crypto/ssh"
+)
+
+var (
+	ErrCannotFindUser = errors.New("Cannot find username on remote machine.")
+
+	ErrFailedToGetSSHKey = errors.New("Failed to get ssh key.")
+
+	ErrMachineNotValidYet = errors.New("Machine not valid yet.")
+
+	ErrRemoteDialingFailed = errors.New("Dialing remote failed.")
+
+	// Dialing the local klient failed, ie klient is not running or accepting
+	// connections.
+	ErrLocalDialingFailed = errors.New("Local dialing failed.")
+
+	// ErrMachineNotFound is when the requested machine is not found.
+	ErrMachineNotFound = errors.New("Machine not found.")
+)
+
+type SSHCommandOpts struct {
+	Ask bool
+
+	// The Remote SSH Username to connect with.
+	RemoteUsername string
+
+	// Whether to log with debug, and pass debug to Klient.
+	Debug bool
+}
+
+// SSHCommand is the command that lets users ssh into a remote machine.  It
+// manages the creating and storing of authorization keys for ease of use.
+//
+// On first run it generates a new SSH key pair and adds it to the requested
+// machine. On subsequent requests it uses the same key pair, but adds it each
+// time to user machine, since we can't assume if key exists in local, remote
+// machine must also have that key, ie if user has multiple machines, but key
+// was only added to one machine.
+//
+// Before generating a new key, it asks user to confirm or deny.
+//
+// SSH public keys have comment of the form: "koding-<number>", where number is
+// a random integer. Klient requires a non empty comment; by adding a random
+// integer to end of comment this command can be used by multiple computers.
+type SSHCommand struct {
+	*SSHKey
+
+	Log   logging.Logger
+	Debug bool
+
+	// Ask is flag for user interaction, ie should we ask user to generate new
+	// SSH key if it doesn't exist.
+	Ask bool
+
+	// Klient is communication layer between this and local klient. This is
+	// used to add SSH public key to `~/.ssh/authorized_keys` on the remote
+	// machine.
+	Klient interface {
+		RemoteList() (list.KiteInfos, error)
+	}
+}
+
+// NewSSHCommand is the required initializer for SSHCommand.
+func NewSSHCommand(log logging.Logger, opts SSHCommandOpts) (*SSHCommand, error) {
+	usr, err := user.Current()
+	if err != nil {
+		return nil, err
+	}
+
+	klientKite, err := klient.CreateKlientWithDefaultOpts()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := klientKite.Dial(); err != nil {
+		log.New("NewSSHCommand").Error("Dialing local klient failed. err:%s", err)
+		return nil, ErrLocalDialingFailed
+	}
+
+	k := klient.NewKlient(klientKite)
+
+	return &SSHCommand{
+		Klient: k,
+		Log:    log.New("SSHCommand"),
+		Ask:    opts.Ask,
+		Debug:  opts.Debug,
+		SSHKey: &SSHKey{
+			Log:            log.New("SSHKey"),
+			Debug:          opts.Debug,
+			RemoteUsername: opts.RemoteUsername,
+			KeyPath:        path.Join(usr.HomeDir, config.SSHDefaultKeyDir),
+			KeyName:        config.SSHDefaultKeyName,
+			Klient:         k,
+		},
+	}, nil
+}
+
+func (s *SSHCommand) Run(machine string) error {
+	if !s.KeysExist() && s.Ask {
+		util.MustConfirm("'ssh' command needs to create public/private rsa key pair. Continue? [Y|n]")
+	}
+
+	machine, err := shortcut.NewMachineShortcut(s.Klient).GetNameFromShortcut(machine)
+	if err != nil {
+		return err
+	}
+
+	userhost, port, err := s.GetSSHAddr(machine)
+	if err != nil {
+		return err
+	}
+
+	if err := s.PrepareForSSH(machine); err != nil {
+		s.Log.Debug("PrepareForSSH returned err: %s", err)
+
+		if strings.Contains(err.Error(), "user: unknown user") {
+			return ErrCannotFindUser
+		}
+
+		// TODO: We're unable to log the meaningful error returned from klient, so we're
+		// leaking possibly meaningful data here. This will be resolved once SSH gets
+		// updated to the new (final) format. Fix this.
+		if klientctlerrors.IsMachineNotValidYetErr(err) {
+			return ErrMachineNotValidYet
+		}
+
+		if klientctlerrors.IsDialFailedErr(err) {
+			return ErrRemoteDialingFailed
+		}
+
+		return ErrFailedToGetSSHKey
+	}
+
+	args := []string{
+		"-i", s.PrivateKeyPath(),
+		"-o", "ServerAliveInterval=300",
+		"-o", "ServerAliveCountMax=3",
+		"-o", "ConnectTimeout=7",
+		"-o", "ConnectionAttempts=1",
+		userhost,
+	}
+
+	if port != "" {
+		args = append(args, "-p", port)
+	}
+
+	s.Log.Debug("SSHing with command: ssh %s", strings.Join(args, " "))
+	cmd := exec.Command("ssh", args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+// PrepareForSSH wrappers SSHKey.PrepareForSSH, additionally printing some basic
+// information to the user.
+func (s *SSHCommand) PrepareForSSH(name string) error {
+	if s.KeysExist() {
+		fmt.Printf("Using existing keypair at: %s \n", s.PublicKeyPath())
+	} else {
+		fmt.Printf("Creating new keypair at: %s \n", s.PublicKeyPath())
+	}
+
+	return s.SSHKey.PrepareForSSH(name)
+}
+
+// SSHKey implements methods for dealing with creating a KD local and remote ssh key,
+// and adding it to the remote via klient's remote.sshKeysAdd
+type SSHKey struct {
+	Log   logging.Logger
+	Debug bool
+
+	// The *default* username used.
+	RemoteUsername string
+
+	// KeyPath is the directory that stores the ssh keys pairs. It's defaults
+	// to `.ssh/` in the user's home directory.
+	KeyPath string
+
+	// KeyName is the file name of the SSH key pair. It defaults to `kd-ssh-key`.
+	KeyName string
+
+	// Klient is communication layer between this and local klient. This is
+	// used to add SSH public key to `~/.ssh/authorized_keys` on the remote
+	// machine.
+	Klient interface {
+		RemoteList() (list.KiteInfos, error)
+		RemoteCurrentUsername(req.CurrentUsernameOptions) (string, error)
+		Tell(string, ...interface{}) (*dnode.Partial, error)
+	}
+
+	// Discover is used to resolve SSH address if klient connection is tunneled.
+	Discover discover.Client
+}
+
+// GetSSHAddr returns the username and the hostname of the remove machine to ssh.
+//
+// It assume user exists on the remove machine with the same Koding username.
+// It may also return a custom port number, if other than a default should
+// be used.
+func (s *SSHKey) GetSSHAddr(name string) (userhost, port string, err error) {
+	infos, err := s.Klient.RemoteList()
+	if err != nil {
+		return "", "", err
+	}
+
+	info, ok := infos.FindFromName(name)
+
+	if !ok {
+		s.Log.Error("No machine found with specified name: `%s`", name)
+		return "", "", ErrMachineNotFound
+	}
+
+	remoteUsername, err := s.GetUsername(name)
+	if err != nil {
+		return "", "", err
+	}
+
+	endpoints, err := s.Discover.Discover(info.IP, "ssh")
+	if err != nil {
+		return fmt.Sprintf("%s@%s", remoteUsername, info.IP), "", nil
+	}
+
+	addr := endpoints[0].Addr
+
+	// We prefer local routes to use first, if there's none, we use first
+	// discovered route.
+	if e := endpoints.Filter(discover.ByLocal(true)); len(e) != 0 {
+
+		// All local routes will do, typically there's only one,
+		// we use the first one and ignore the rest.
+		addr = e[0].Addr
+	}
+
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+
+	return fmt.Sprintf("%s@%s", remoteUsername, host), port, nil
+}
+
+// GetUsername returns the username of the remote machine.
+func (s *SSHKey) GetUsername(name string) (username string, err error) {
+	if s.RemoteUsername != "" {
+		return s.RemoteUsername, nil
+	}
+
+	// Cache the return value if we have one. Not required, just useful,
+	// no need for repeated queries.
+	defer func() {
+		if err == nil && username != "" {
+			s.RemoteUsername = username
+		}
+	}()
+
+	currentUsernameOpts := req.CurrentUsernameOptions{
+		Debug:       s.Debug,
+		MachineName: name,
+	}
+
+	return s.Klient.RemoteCurrentUsername(currentUsernameOpts)
+}
+
+// GenerateAndSaveKey generates a new SSH key pair and saves it to local.
+func (s *SSHKey) GenerateAndSaveKey() ([]byte, error) {
+	var perms os.FileMode = 0600
+
+	if err := os.MkdirAll(filepath.Dir(s.PrivateKeyPath()), 0700); err != nil {
+		return nil, err
+	}
+
+	publicKey, privateKey, err := sshkey.Generate()
+	if err != nil {
+		return nil, err
+	}
+
+	publicKey += fmt.Sprintf(" koding-%d", rand.Int31())
+
+	// save ssh private key
+	err = ioutil.WriteFile(s.PrivateKeyPath(), []byte(privateKey), perms)
+	if err != nil {
+		return nil, err
+	}
+
+	// save ssh public key
+	err = ioutil.WriteFile(s.PublicKeyPath(), []byte(publicKey), perms)
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(publicKey), nil
+}
+
+// PublicKeyExists checks if a file exists at the PublicKeyPath
+func (s *SSHKey) PublicKeyExists() bool {
+	if _, err := os.Stat(s.PublicKeyPath()); os.IsNotExist(err) {
+		return false
+	}
+
+	return true
+}
+
+// PrivateKeyExists checks if a file eists at the PrivateKeyPath
+func (s *SSHKey) PrivateKeyExists() bool {
+	if _, err := os.Stat(s.PrivateKeyPath()); os.IsNotExist(err) {
+		return false
+	}
+
+	return true
+}
+
+// PublicKeyPath returns the public key path, based on the private key path
+func (s *SSHKey) PublicKeyPath() string {
+	return fmt.Sprintf("%s.pub", s.PrivateKeyPath())
+}
+
+// PrivateKeyPath returns the private key path, based on the SSHKey.KeyPath and
+// KeyName values.
+func (s *SSHKey) PrivateKeyPath() string {
+	return path.Join(s.KeyPath, s.KeyName)
+}
+
+// KeysExist checks whether both keys exist.
+func (s *SSHKey) KeysExist() bool {
+	return s.PublicKeyExists() && s.PrivateKeyExists()
+}
+
+// PrepareForSSH checks if SSH key pair exists, if not it generates a new one
+// and saves it. It adds the key pair to remote machine each time.
+func (s *SSHKey) PrepareForSSH(name string) error {
+	var (
+		contents []byte
+		err      error
+	)
+
+	if s.KeysExist() {
+		if contents, err = ioutil.ReadFile(s.PublicKeyPath()); err != nil {
+			return err
+		}
+
+		// check if key is valid
+		if _, _, _, _, err = ssh.ParseAuthorizedKey(contents); err != nil {
+			return err
+		}
+	} else {
+		if contents, err = s.GenerateAndSaveKey(); err != nil {
+			return err
+		}
+	}
+
+	username, err := s.GetUsername(name)
+	if err != nil {
+		return err
+	}
+
+	req := req.SSHKeyAdd{
+		Debug:    s.Debug,
+		Name:     name,
+		Username: username,
+		Key:      contents,
+	}
+
+	if _, err = s.Klient.Tell("remote.sshKeysAdd", req); err != nil {
+		s.Log.Debug("Klient's remote.sshKeysAdd method returned err:%s", err)
+
+		// ignore errors about duplicate keys since we're adding on each run
+		if strings.Contains(err.Error(), "cannot add duplicate ssh key") {
+			return nil
+		}
+	}
+
+	return err
+}


### PR DESCRIPTION
This PR separates SSH-related logic, stored in `klientctl/ssh` package, from klient's business logic part.

Part of #9889

## Description
The old implementation of `klientctl/ssh` package (now in `sshold.go` file) mixes ssh local machine logic with remote klient logic and remote machine discovery. The new one (`ssh.go` && `ssh_test.go`) contains only local SSH related operations (generating keys etc.). Because of this, the package can be moved out of `klientctl` subdirectory(or even to `koding/sshkey` repository) since its logic is not related with `klientctl` anymore.

## Motivation and Context
It was impossible to use(without ugly hacks) existing `kd ssh` logic in `kd machine ssh` 

## How Has This Been Tested?
Unit tests.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

**NOTE**: `sshold.go` should not be reviewed. It's just old `ssh.go` file renamed to `sshold.go`. Git didn't resolve this as file move.

