### PR TITLE
KD: add support for ssh related klient methods.

### DIFF
--- a/go/src/koding/kites/kloud/klient/klient.go
+++ b/go/src/koding/kites/kloud/klient/klient.go
@@ -6,8 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
+
+	"koding/klient/sshkeys"
 
 	"github.com/koding/kite"
 	"github.com/koding/kite/protocol"
@@ -78,17 +81,17 @@ func (k *KlientPool) Get(queryString string) (*Klient, error) {
 			return nil, err
 		}
 
-		k.log.Info("creating new klient connection to %s", queryString)
+		k.log.Info("Creating new klient connection to %s", queryString)
 		k.klients[queryString] = klient
 
 		// remove from the pool if we loose the connection
 		klient.Client.OnDisconnect(func() {
-			k.log.Info("klient %s disconnected. removing from the pool", queryString)
+			k.log.Info("Klient %s disconnected. removing from the pool", queryString)
 			k.Delete(queryString)
 			klient.Close()
 		})
 	} else {
-		k.log.Debug("fetching already connected klient (%s) from pool", queryString)
+		k.log.Debug("Fetching already connected klient (%s) from pool", queryString)
 	}
 
 	return klient, nil
@@ -189,7 +192,7 @@ func NewWithTimeout(k *kite.Kite, queryString string, t time.Duration) (klient *
 
 			return klient, err
 		default:
-			k.Log.Debug("trying to connect to klient: %s", queryString)
+			k.Log.Debug("Trying to connect to klient: %s", queryString)
 
 			if klient, err = ConnectTimeout(k, queryString, DefaultInterval); err == nil {
 				return klient, nil
@@ -297,4 +300,41 @@ func (k *Klient) RemoveUser(username string) error {
 	}
 
 	return fmt.Errorf("wrong response %s", out)
+}
+
+// Username returns remote machine current username.
+func (k *Klient) CurrentUser() (string, error) {
+	resp, err := k.Client.TellWithTimeout("os.currentUsername", k.timeout())
+	if err != nil {
+		return "", err
+	}
+
+	var username string
+	if err := resp.Unmarshal(&username); err != nil {
+		return "", err
+	}
+
+	return username, nil
+}
+
+// SSHAddKeys adds SSH public keys to user's authorized_keys file.
+func (k *Klient) SSHAddKeys(username string, keys ...string) error {
+	addopts := sshkeys.AddOptions{
+		Username: username,
+		Keys:     keys,
+	}
+
+	_, err := k.Client.TellWithTimeout("sshkeys.add", k.timeout(), addopts)
+	if err != nil {
+		// Ignore errors about duplicate keys since we're adding on each run.
+		if strings.Contains(err.Error(), "cannot add duplicate ssh key") {
+			return nil
+		}
+
+		return err
+	}
+
+	// TODO(ppknap): currently sshkeys.add method can return either nil or true
+	// as its response. Add proper support for this.
+	return nil
 }

--- a/go/src/koding/klient/machine/addr.go
+++ b/go/src/koding/klient/machine/addr.go
@@ -3,6 +3,7 @@ package machine
 import (
 	"encoding/json"
 	"errors"
+	"net"
 	"sync"
 	"time"
 )
@@ -26,7 +27,7 @@ type Addr struct {
 }
 
 // String return a string form of stored address.
-func (a *Addr) String() string { return a.Network + " address " + a.Value }
+func (a Addr) String() string { return a.Network + " address " + a.Value }
 
 // AddrBook stores and manages multiple machine addresses. Each machine can
 // can change its end point address over time. This can store all of these
@@ -37,8 +38,45 @@ type AddrBook struct {
 }
 
 // Add adds new address to address book. If provided address already exists, its
-// updated time will be updated.
+// updated time will be updated. Empty addresses will not be added.
+//
+// Moreover, if provided IP address doesn't match IPv4 or IPv6 schema, its
+// network will be changed to `tunnel`. If provided address contains port part
+// and has IP network, there will be two addresses added - one with `ip` network
+// and one with `tcp` network.
 func (ab *AddrBook) Add(a Addr) {
+	var isIP = func(val string) bool {
+		return net.ParseIP(val) != nil // ParseIP returns nil if IP is invalid.
+	}
+
+	if a.Network == "" || a.Value == "" {
+		return
+	}
+
+	if a.Network != "ip" || isIP(a.Value) {
+		ab.add(a)
+		return
+	}
+
+	if host, _, err := net.SplitHostPort(a.Value); err == nil && isIP(host) {
+		ab.add(Addr{
+			Network: "ip",
+			Value:   host,
+		})
+		ab.add(Addr{
+			Network: "tcp",
+			Value:   a.Value,
+		})
+		return
+	}
+
+	ab.add(Addr{
+		Network: "tunnel",
+		Value:   a.Value,
+	})
+}
+
+func (ab *AddrBook) add(a Addr) {
 	ab.mu.Lock()
 	defer ab.mu.Unlock()
 
@@ -52,18 +90,31 @@ func (ab *AddrBook) Add(a Addr) {
 	ab.addrs = append(ab.addrs, a)
 }
 
-// Has reports whether provided address is stored in address book or not.
-func (ab *AddrBook) Has(a Addr) bool {
+// Updated reports when provided address was updated. It returns ErrAddrNotFound
+// when address is not found.
+func (ab *AddrBook) Updated(a Addr) (time.Time, error) {
 	ab.mu.RLock()
 	defer ab.mu.RUnlock()
 
 	for i := range ab.addrs {
 		if ab.addrs[i].Network == a.Network && ab.addrs[i].Value == a.Value {
-			return true
+			return ab.addrs[i].UpdatedAt, nil
 		}
 	}
 
-	return false
+	return time.Time{}, ErrAddrNotFound
+}
+
+// All returns copy of all addresses stored in Address book.
+func (ab *AddrBook) All() (cp []Addr) {
+	ab.mu.RLock()
+	defer ab.mu.RUnlock()
+
+	for i := range ab.addrs {
+		cp = append(cp, ab.addrs[i])
+	}
+
+	return cp
 }
 
 // Latest returns the latest known address for a given network. If no address

--- a/go/src/koding/klient/machine/client.go
+++ b/go/src/koding/klient/machine/client.go
@@ -2,4 +2,9 @@ package machine
 
 // Client describes the operations that can be made on remote machine.
 type Client interface {
+	// CurrentUser returns remote machine current username.
+	CurrentUser() (string, error)
+
+	// SSHAddKeys adds SSH public keys to user's authorized_keys file.
+	SSHAddKeys(string, ...string) error
 }

--- a/go/src/koding/klient/machine/disconnected.go
+++ b/go/src/koding/klient/machine/disconnected.go
@@ -17,6 +17,16 @@ var _ Client = (*DisconnectedClient)(nil)
 // machine and always returns
 type DisconnectedClient struct{}
 
+// CurrentUser always returns ErrDisconnected error.
+func (DisconnectedClient) CurrentUser() (string, error) {
+	return "", ErrDisconnected
+}
+
+// SSHAddKeys always returns ErrDisconnected error.
+func (DisconnectedClient) SSHAddKeys(_ string, _ ...string) error {
+	return ErrDisconnected
+}
+
 var _ ClientBuilder = (*DisconnectedClientBuilder)(nil)
 
 // DisconnectedClientBuilder satisfies ClientBuilder. It produces disconnected

--- a/go/src/koding/klient/machine/dynamic.go
+++ b/go/src/koding/klient/machine/dynamic.go
@@ -141,6 +141,11 @@ func (dc *DynamicClient) Context() context.Context {
 	return dc.ctx
 }
 
+// Addr uses dynamic address function binded to client to obtain addresses.
+func (dc *DynamicClient) Addr(network string) (Addr, error) {
+	return dc.opts.AddrFunc(network)
+}
+
 // Close stops the dynamic client. After this function is called, client is
 // in disconnected state and each contexts returned by it are closed.
 func (dc *DynamicClient) Close() {

--- a/go/src/koding/klient/machine/kite.go
+++ b/go/src/koding/klient/machine/kite.go
@@ -1,0 +1,51 @@
+package machine
+
+import (
+	"context"
+	"time"
+
+	"koding/kites/kloud/klient"
+
+	"github.com/koding/kite"
+)
+
+// KiteBuilder implements ClientBuilder interface. It creates Kite clients that
+// use kite query string as their source address.
+type KiteBuilder struct {
+	pool *klient.KlientPool
+}
+
+// NewKiteBuilder creates a new KiteBuilder instance.
+func NewKiteBuilder(k *kite.Kite) *KiteBuilder {
+	return &KiteBuilder{
+		pool: klient.NewPool(k),
+	}
+}
+
+// Ping uses kite network that stores kite's query string to ping the machine.
+func (kb *KiteBuilder) Ping(dynAddr DynamicAddrFunc) (Status, Addr, error) {
+	addr, err := dynAddr("kite")
+	if err != nil {
+		return Status{}, Addr{}, err
+	}
+
+	if _, err := kb.pool.Get(addr.Value); err != nil {
+		return Status{}, Addr{}, err
+	}
+
+	return Status{
+		State: StateConnected,
+		Since: time.Now(),
+	}, addr, nil
+}
+
+// Build builds new kite client that will connect to machine using provided
+// address.
+func (kb *KiteBuilder) Build(_ context.Context, addr Addr) Client {
+	k, err := kb.pool.Get(addr.Value)
+	if err != nil {
+		return DisconnectedClient{}
+	}
+
+	return k
+}

--- a/go/src/koding/klient/machine/machinegroup/addresses/addresses.go
+++ b/go/src/koding/klient/machine/machinegroup/addresses/addresses.go
@@ -65,7 +65,7 @@ func (a *Addresses) MachineID(addr machine.Addr) (machine.ID, error) {
 	defer a.mu.RUnlock()
 
 	for id, ab := range a.m {
-		if ab.Has(addr) {
+		if _, err := ab.Updated(addr); err != nil {
 			return id, nil
 		}
 	}


### PR DESCRIPTION
This PR adds support for SSH remote connections via `kd machine ssh` subcommand.

Closes: #9889
~Depends on: #10018, #9797~

## How Has This Been Tested?
**NOTE** that `machinegroup.SSH` method is **not** tested. I'm going to implement test client in `machinegrouptest` package which will simulate real behaviour usign loopback devie on localhost.

## Screenshots (if appropriate):

## Types of changes
- [X] New feature (non-breaking change which adds functionality)

