### PR TITLE
Various fixes and improvements for providers and credentials

### DIFF
--- a/client/app/lib/kite/kites/kloud.coffee
+++ b/client/app/lib/kite/kites/kloud.coffee
@@ -7,10 +7,7 @@ globals = require 'globals'
 
 module.exports = class KodingKiteKloudKite extends require('../kodingkite')
 
-  SUPPORTED_PROVIDERS = do ->
-    { providers } = globals.config
-    (Object.keys providers).filter (provider) ->
-      providers[provider].supported
+  SUPPORTED_PROVIDERS = globals.config.providers._getSupportedProviders()
 
   debugEnabled = ->
     kd.singletons.computeController._kloudDebug

--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -37,7 +37,7 @@ require './config'
 module.exports = class ComputeController extends KDController
 
 
-  @providers = globals.config.providers
+  @providers = globals.config.providers._getSupportedProviders()
   @Error     = {
     'TimeoutError', 'KiteError', 'NotSupported'
     Pending: '107', NotVerified: '500'
@@ -161,9 +161,9 @@ module.exports = class ComputeController extends KDController
     if method?
       switch method
         when 'reinit'
-          return NotSupported  if provider in ['aws', 'vagrant']
+          return NotSupported
         when 'createSnapshot'
-          return NotSupported  if provider in ['aws', 'softlayer', 'vagrant']
+          return NotSupported
 
 
 
@@ -1300,11 +1300,10 @@ module.exports = class ComputeController extends KDController
 
   shareCredentials: (credentials, requiredProviders, callback) ->
 
-    for selectedProvider in requiredProviders
-      break  if selectedProvider in ['aws', 'vagrant']
-
+    selectedProvider = null
+    for provider in requiredProviders when provider in @providers
+      selectedProvider = provider
     selectedProvider ?= (Object.keys credentials ? { aws: yes }).first
-    selectedProvider ?= 'aws'
 
     creds = Object.keys credentials
     { groupsController } = kd.singletons

--- a/client/app/lib/providers/config.coffee
+++ b/client/app/lib/providers/config.coffee
@@ -340,3 +340,7 @@ module.exports = globals.config.providers =
                             unwanted results while building your stacks.
                             '''
     credentialFields       : {}
+
+  _getSupportedProviders   : ->
+    (Object.keys this).filter (provider) =>
+      this[provider].supported

--- a/client/app/lib/providers/resourcestatemodal/controllers/credentialscontroller.coffee
+++ b/client/app/lib/providers/resourcestatemodal/controllers/credentialscontroller.coffee
@@ -247,9 +247,12 @@ module.exports = class CredentialsController extends kd.Controller
 
       { requiredProviders } = stack.config
 
-      for provider in requiredProviders
-        break  if provider in ['aws', 'vagrant']
-      provider ?= (Object.keys stack.credentials ? { aws : yes }).first
+      enabledProviders = globals.config.providers._getSupportedProviders()
+      selectedProvider = null
+      for provider in requiredProviders when provider in enabledProviders
+        selectedProvider = provider
+      selectedProvider ?= (Object.keys stack.credentials ? { aws: yes }).first
+      provider = selectedProvider
 
       helpers._loadCredentials { provider }, (err, items) ->
         return callback err  if err

--- a/client/app/lib/providers/resourcestatemodal/views/baseerrorpageview.coffee
+++ b/client/app/lib/providers/resourcestatemodal/views/baseerrorpageview.coffee
@@ -44,7 +44,7 @@ module.exports = class BaseErrorPageView extends JView
   # Defer is required here since onPageDidShow is getting called in
   # the same call stack before it's ready in the DOM and it causes
   # issues in the following call ~ GG
-  onPageDidShow: -> kd.utils.defer ->
+  onPageDidShow: -> kd.utils.defer =>
     # it needs to update container height if it can't be set fixed in css.
     # otherwise, custom scroll doesn't work properly
     container = @getDomElement().find '.main'

--- a/client/app/lib/util/stacks/providersparser.coffee
+++ b/client/app/lib/util/stacks/providersparser.coffee
@@ -17,6 +17,9 @@ module.exports = providersParser = (content) ->
       provider in supportedProviders and
       provider not in ['koding', 'custom']
 
+  if not providers.length or (providers.length is 1 and providers[0] is 'userInput')
+    for provider in supportedProviders
+      providers.push provider  if ///#{provider}\_///g.test content
 
   # Return list of providers
   return providers

--- a/client/app/lib/util/stacks/providersparser.coffee
+++ b/client/app/lib/util/stacks/providersparser.coffee
@@ -10,15 +10,12 @@ module.exports = providersParser = (content) ->
     providers[match[1]] = null
     match = regex.exec content
 
-  knownProviders = globals.config.providers
+  supportedProviders = globals.config.providers._getSupportedProviders()
   providers = (Object.keys providers)
     .filter (provider) ->
-      provider isnt 'koding'
-    .map (provider) ->
-      (Object.keys knownProviders).forEach (_provider) ->
-        if knownProviders[_provider].slug is provider
-          provider = _provider
-      provider
+      provider is 'userInput' or
+      provider in supportedProviders and
+      provider not in ['koding', 'custom']
 
 
   # Return list of providers

--- a/client/app/lib/util/stacks/providersparser.coffee
+++ b/client/app/lib/util/stacks/providersparser.coffee
@@ -2,6 +2,7 @@ globals = require 'globals'
 
 module.exports = providersParser = (content) ->
 
+  content   = content.replace /#.+/igm, ''
   regex     = /\$\{var\.(\w+?)\_/g
   providers = {}
   match     = regex.exec content

--- a/client/app/lib/util/stacks/requirementsparser.coffee
+++ b/client/app/lib/util/stacks/requirementsparser.coffee
@@ -1,5 +1,7 @@
 module.exports = requirementsParser = (content) ->
 
+  content = content.replace /#.+/igm, ''
+
   allowedProps =
     user       : ['username', 'email'] # JUser
     account    : ['profile']           # JAccount

--- a/client/app/lib/util/stacks/requirementsparser.coffee
+++ b/client/app/lib/util/stacks/requirementsparser.coffee
@@ -6,8 +6,9 @@ module.exports = requirementsParser = (content) ->
     user       : ['username', 'email'] # JUser
     account    : ['profile']           # JAccount
     group      : ['title', 'slug']     # JGroup
-    stack      : ['id']                # JComputeStack
-    template   : ['id']                # JStackTemplate
+  # Following injected by Kloud ~ GG
+  # stack      : ['id']                # JComputeStack
+  # template   : ['id']                # JStackTemplate
 
   # Custom variables in Stack Templates
   #

--- a/client/stack-editor/lib/editor/index.coffee
+++ b/client/stack-editor/lib/editor/index.coffee
@@ -50,10 +50,9 @@ module.exports = class StackEditorView extends kd.View
     @stackTemplate = stackTemplate
 
     if stackTemplate
-      unless selectedProvider = stackTemplate.selectedProvider
-        for selectedProvider in stackTemplate.config.requiredProviders when selectedProvider isnt 'koding'
-          break
-      selectedProvider ?= (Object.keys stackTemplate.credentials ? { aws: yes }).first
+      sp = stackTemplate.config.requiredProviders?.filter (provider) ->
+        provider not in ['koding', 'userInput', 'custom']
+      selectedProvider = sp?.first ? (Object.keys stackTemplate.credentials ? { aws: yes }).first
 
     options.selectedProvider = selectedProvider ?= 'aws'
 
@@ -864,9 +863,6 @@ module.exports = class StackEditorView extends kd.View
     @outputView.add 'Parsing template for credential requirements...'
 
     requiredProviders = providersParser templateContent
-
-    if selectedProvider is 'vagrant'
-      requiredProviders.push 'vagrant'
 
     @outputView
       .add 'Following credentials are required:'


### PR DESCRIPTION
## Description
Currently we are not keeping information of which provider is selected for given stack template, we're guessing that information from stack template content. And the way we were doing it was relying on parsing variables with in stack template by using known provider slugs. Since `vagrant` provider doesn't have such information there were no way to understand which provider is using by given stack template. I've updated parsing flow to include `#{provider}_` keys as well. It's not the perfect solution, we need to move all these operations to backend to make things easier and available for `kd` operations as well. I'll make those changes with in new Stack Editor, this one is enough to fix current issues that we've in production right now.

## How Has This Been Tested?
Manually; I've created stacks with/without `userInputs`, `custom variables` with `vagrant`, `digitalocean`, `aws` providers and verified them they are working fine.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] All new and existing tests passed.
