### PR TITLE
kd: improve "config set" subcommand

### DIFF
--- a/go/src/koding/klient/main.go
+++ b/go/src/koding/klient/main.go
@@ -111,6 +111,9 @@ func realMain() int {
 			log.Fatalf("failed to parse -kontrol-url: %s", err)
 		}
 
+		// TODO(rjeczalik): rework client to display KODING_URL instead of KONTROLURL
+		u.Path = ""
+
 		// Create new konfig.bolt with variables used during registration.
 		kfg := &config.Konfig{
 			KiteKeyFile: filepath.Join(kiteHome, "kite.key"),

--- a/go/src/koding/klientctl/config.go
+++ b/go/src/koding/klientctl/config.go
@@ -187,5 +187,9 @@ func setKonfig(cfg *konfig.Konfig, key, value string) error {
 		return err
 	}
 
+	if value == "" {
+		*cfg = konfig.Konfig{}
+	}
+
 	return json.Unmarshal(p, cfg)
 }

--- a/go/src/koding/klientctl/config_test.go
+++ b/go/src/koding/klientctl/config_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -32,4 +33,156 @@ func TestConfigFolder(t *testing.T) {
 			}()
 		})
 	})
+}
+
+func TestSetFlatKeyValue(t *testing.T) {
+	cases := map[string]struct {
+		key   string
+		value string
+		want  map[string]interface{}
+		ok    bool
+	}{
+		"set simple key": {
+			"debug",
+			"true",
+			map[string]interface{}{
+				"endpoints": map[string]interface{}{
+					"koding": map[string]interface{}{
+						"public":  "https://koding.com",
+						"private": "http://127.0.0.1",
+					},
+				},
+				"kdLatest": "http://127.0.0.1/latest-version.txt",
+				"debug":    "true",
+			},
+			true,
+		},
+		"set compound key": {
+			"endpoints.koding.public",
+			"http://rjeczalik.koding.team",
+			map[string]interface{}{
+				"endpoints": map[string]interface{}{
+					"koding": map[string]interface{}{
+						"public":  "http://rjeczalik.koding.team",
+						"private": "http://127.0.0.1",
+					},
+				},
+				"kdLatest": "http://127.0.0.1/latest-version.txt",
+				"debug":    "false",
+			},
+			true,
+		},
+		"overwrite existing key": {
+			"kdLatest",
+			"http://localhost/latest-version.txt",
+			map[string]interface{}{
+				"endpoints": map[string]interface{}{
+					"koding": map[string]interface{}{
+						"public":  "https://koding.com",
+						"private": "http://127.0.0.1",
+					},
+				},
+				"kdLatest": "http://localhost/latest-version.txt",
+				"debug":    "false",
+			},
+			true,
+		},
+		"add new simple key": {
+			"klientLatest",
+			"http://127.0.0.1/latest-version.txt",
+			map[string]interface{}{
+				"endpoints": map[string]interface{}{
+					"koding": map[string]interface{}{
+						"public":  "https://koding.com",
+						"private": "http://127.0.0.1",
+					},
+				},
+				"kdLatest":     "http://127.0.0.1/latest-version.txt",
+				"klientLatest": "http://127.0.0.1/latest-version.txt",
+				"debug":        "false",
+			},
+			true,
+		},
+		"add new compound key": {
+			"endpoints.tunnel.public",
+			"http://t.koding.com",
+			map[string]interface{}{
+				"endpoints": map[string]interface{}{
+					"koding": map[string]interface{}{
+						"public":  "https://koding.com",
+						"private": "http://127.0.0.1",
+					},
+					"tunnel": map[string]interface{}{
+						"public": "http://t.koding.com",
+					},
+				},
+				"kdLatest": "http://127.0.0.1/latest-version.txt",
+				"debug":    "false",
+			},
+			true,
+		},
+		"invalid simple key overwrite": {
+			"debug.invalid.key",
+			"false",
+			nil,
+			false,
+		},
+
+		"unset simple key": {
+			"debug",
+			"",
+			map[string]interface{}{
+				"endpoints": map[string]interface{}{
+					"koding": map[string]interface{}{
+						"public":  "https://koding.com",
+						"private": "http://127.0.0.1",
+					},
+				},
+				"kdLatest": "http://127.0.0.1/latest-version.txt",
+			},
+			true,
+		},
+		"unset compound key": {
+			"endpoints.koding.public",
+			"",
+			map[string]interface{}{
+				"endpoints": map[string]interface{}{
+					"koding": map[string]interface{}{
+						"private": "http://127.0.0.1",
+					},
+				},
+				"kdLatest": "http://127.0.0.1/latest-version.txt",
+				"debug":    "false",
+			},
+			true,
+		},
+	}
+
+	for name, cas := range cases {
+		t.Run(name, func(t *testing.T) {
+			m := map[string]interface{}{
+				"endpoints": map[string]interface{}{
+					"koding": map[string]interface{}{
+						"public":  "https://koding.com",
+						"private": "http://127.0.0.1",
+					},
+				},
+				"kdLatest": "http://127.0.0.1/latest-version.txt",
+				"debug":    "false",
+			}
+
+			err := setFlatKeyValue(m, cas.key, cas.value)
+
+			if !cas.ok {
+				if err == nil {
+					t.Fatal("want err != nil")
+				}
+				return
+			}
+
+			if !reflect.DeepEqual(m, cas.want) {
+				t.Fatalf("got %+v, want %+v", m, cas.want)
+			}
+		})
+	}
 }

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -444,6 +444,10 @@ func run(args []string) {
 							Name:  "defaults",
 							Usage: "Show also default configuration",
 						},
+						cli.BoolFlag{
+							Name:  "json",
+							Usage: "Output in JSON format.",
+						},
 					},
 				}, {
 					Name:   "set",


### PR DESCRIPTION
This PR extends `kd config set` to make it possible to patch configuration objects.

Example:

```
$ kd config show --json
{}
```
```
$ kd config set endpoints.koding.public https://sandbox.koding.com
```
```
$ kd config show --json
{
	"endpoints": {
		"koding": {
			"public": "https://sandbox.koding.com"
		}
	}
}

```

Blocker: #10003