### PR TITLE
KD: add support for ID and SSH methods to machine group

### DIFF
--- a/go/src/koding/klient/app/klient.go
+++ b/go/src/koding/klient/app/klient.go
@@ -508,7 +508,7 @@ func (k *Klient) RegisterMethods() {
 	k.kite.HandleFunc("fs.getPathSize", fs.GetPathSize)
 
 	// Machine group handlers.
-	k.kite.HandleFunc("machine.create", machinegroup.KiteCreateHandler(k.machines))
+	k.kite.HandleFunc("machine.create", machinegroup.KiteHandlerCreate(k.machines))
 
 	// Vagrant
 	k.kite.HandleFunc("vagrant.create", k.vagrant.Create)

--- a/go/src/koding/klient/machine/machinegroup/addresses/addresses.go
+++ b/go/src/koding/klient/machine/machinegroup/addresses/addresses.go
@@ -2,6 +2,7 @@ package addresses
 
 import (
 	"sync"
+	"time"
 
 	"koding/klient/machine"
 )
@@ -58,16 +59,26 @@ func (a *Addresses) Latest(id machine.ID, network string) (machine.Addr, error) 
 }
 
 // MachineID checks if there is a machine ID that is binded to provided address
-// If yes, the machine ID is returned. machine.ErrMachineNotFound is returned
-// if there is no machine that has provided address.
+// If yes, the machine ID is returned. If there are more machines with the same
+// address, machine with the newest address will be provided. ErrMachineNotFound
+// is returned if there is no machine that has provided address.
 func (a *Addresses) MachineID(addr machine.Addr) (machine.ID, error) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 
+	var (
+		ret     machine.ID
+		updated time.Time
+	)
+
 	for id, ab := range a.m {
-		if _, err := ab.Updated(addr); err == nil {
-			return id, nil
+		if u, err := ab.Updated(addr); err == nil && u.After(updated) {
+			ret, updated = id, u
 		}
+	}
+
+	if ret != "" {
+		return ret, nil
 	}
 
 	return "", machine.ErrMachineNotFound

--- a/go/src/koding/klient/machine/machinegroup/addresses/addresses_test.go
+++ b/go/src/koding/klient/machine/machinegroup/addresses/addresses_test.go
@@ -83,3 +83,54 @@ func TestAddressesMachineID(t *testing.T) {
 		})
 	}
 }
+
+func TestAddressesMachineIDDuplicated(t *testing.T) {
+	makeAddr := func(updatedAt time.Time) machine.Addr {
+		return machine.Addr{
+			Network:   "ip",
+			Value:     "52.254.159.36",
+			UpdatedAt: updatedAt,
+		}
+	}
+
+	machines := []struct {
+		ID   machine.ID
+		Addr machine.Addr
+	}{
+		{
+			ID:   "ID_1",
+			Addr: makeAddr(time.Date(2010, time.May, 1, 0, 0, 0, 0, time.UTC)),
+		},
+		{
+			ID:   "ID_2",
+			Addr: makeAddr(time.Date(2012, time.May, 1, 0, 0, 0, 0, time.UTC)),
+		},
+		{
+			ID:   "ID_3",
+			Addr: makeAddr(time.Date(2011, time.May, 1, 0, 0, 0, 0, time.UTC)),
+		},
+	}
+
+	addrs := addresses.New()
+	machineIDs := make(map[machine.ID]struct{})
+
+	for i, machine := range machines {
+		machineIDs[machine.ID] = struct{}{}
+		if err := addrs.Add(machine.ID, machine.Addr); err != nil {
+			t.Fatalf("want err = nil; got %v (i:%v)", err, i)
+		}
+	}
+
+	if len(machineIDs) != len(addrs.Registered()) {
+		t.Fatal("want %d machines; got %d", len(machineIDs), len(addrs.Registered()))
+	}
+
+	id, err := addrs.MachineID(makeAddr(time.Time{}))
+	if err != nil {
+		t.Errorf("want err = nil; got %v", err)
+	}
+
+	if wantID := machine.ID("ID_2"); wantID != id {
+		t.Errorf("want machine ID = %v; got %v", wantID, id)
+	}
+}

--- a/go/src/koding/klient/machine/machinegroup/aliases/aliases.go
+++ b/go/src/koding/klient/machine/machinegroup/aliases/aliases.go
@@ -4,9 +4,15 @@ import (
 	"math/rand"
 	"strconv"
 	"sync"
+	"time"
 
 	"koding/klient/machine"
 )
+
+func init() {
+	// initialize pseudo random number generator.
+	rand.Seed(time.Now().UnixNano())
+}
 
 // colors defines the available colors for aliases. The first letter of each
 // color name must be unique across the slice.

--- a/go/src/koding/klient/machine/machinegroup/create.go
+++ b/go/src/koding/klient/machine/machinegroup/create.go
@@ -1,6 +1,8 @@
 package machinegroup
 
 import (
+	"errors"
+
 	"koding/klient/machine"
 )
 
@@ -24,6 +26,10 @@ type CreateResponse struct {
 // Create updates internal state of machine group. It gets the current
 // information about user machines so it can add new ones to group.
 func (g *Group) Create(req *CreateRequest) (*CreateResponse, error) {
+	if req == nil {
+		return nil, errors.New("invalid nil request")
+	}
+
 	res := &CreateResponse{
 		Statuses: make(map[machine.ID]machine.Status),
 		Aliases:  make(map[machine.ID]string),

--- a/go/src/koding/klient/machine/machinegroup/create_test.go
+++ b/go/src/koding/klient/machine/machinegroup/create_test.go
@@ -9,7 +9,7 @@ import (
 	"koding/klient/machine/machinetest"
 )
 
-func TestClients(t *testing.T) {
+func TestCreate(t *testing.T) {
 	var (
 		builder = machinetest.NewNilBuilder()
 

--- a/go/src/koding/klient/machine/machinegroup/id.go
+++ b/go/src/koding/klient/machine/machinegroup/id.go
@@ -1,0 +1,47 @@
+package machinegroup
+
+import (
+	"errors"
+
+	"koding/klient/machine"
+)
+
+// IDRequest defines machine group ID request.
+type IDRequest struct {
+	// Identifier is a string that identifiers remote machine.
+	Identifier string `json:"identifier"`
+}
+
+// IDResponse defines machine group ID response.
+type IDResponse struct {
+	// ID is a unique identifier for the remote machine.
+	ID machine.ID `json:"id"`
+}
+
+// ID gets machine ID from provided identifier. This method looks up machine
+// aliases and machine IP addresses. Supported identifiers are:
+//  - machine full ID string.
+//  - machine alias.
+//  - machine IP address.
+func (g *Group) ID(req *IDRequest) (*IDResponse, error) {
+	if req == nil {
+		return nil, errors.New("invalid nil request")
+	}
+
+	// If machine ID or machine alias, Aliases will have it.
+	if id, err := g.alias.MachineID(req.Identifier); err == nil {
+		return &IDResponse{ID: id}, nil
+	}
+
+	// Look up for machine IP. This have races, since machine can be added or
+	// deleted in the meantime.
+	if id, err := g.address.MachineID(machine.Addr{
+		Network: "ip",
+		Value:   req.Identifier,
+	}); err == nil {
+		return &IDResponse{ID: id}, nil
+	}
+
+	g.log.Error("Cannot find machine with identifier: %s", req.Identifier)
+	return nil, machine.ErrMachineNotFound
+}

--- a/go/src/koding/klient/machine/machinegroup/id_test.go
+++ b/go/src/koding/klient/machine/machinegroup/id_test.go
@@ -1,0 +1,97 @@
+package machinegroup
+
+import (
+	"testing"
+	"time"
+
+	"koding/klient/machine"
+	"koding/klient/machine/machinetest"
+)
+
+func TestID(t *testing.T) {
+	var (
+		idA = machine.ID("servA")
+		idB = machine.ID("servB")
+
+		ipA = machine.Addr{Network: "ip", Value: "52.24.123.32", UpdatedAt: time.Now()}
+		ipB = machine.Addr{Network: "ip", Value: "10.0.1.16", UpdatedAt: time.Now()}
+	)
+
+	g, err := New(testOptions(machinetest.NewNilBuilder()))
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	defer g.Close()
+
+	req := &CreateRequest{
+		Addresses: map[machine.ID][]machine.Addr{
+			idA: {ipA},
+			idB: {ipB},
+		},
+	}
+
+	res, err := g.Create(req)
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	tests := map[string]struct {
+		Identifier string
+		ID         machine.ID
+		Found      bool
+	}{
+		"by ID": {
+			Identifier: string(idA),
+			ID:         idA,
+			Found:      true,
+		},
+		"by alias": {
+			Identifier: res.Aliases[idB],
+			ID:         idB,
+			Found:      true,
+		},
+		"by IP": {
+			Identifier: ipA.Value,
+			ID:         idA,
+			Found:      true,
+		},
+		"not found alias": {
+			Identifier: "unknown_alias",
+			ID:         "",
+			Found:      false,
+		},
+		"not found IP": {
+			Identifier: "127.0.0.12",
+			ID:         "",
+			Found:      false,
+		},
+		"not found TCP": {
+			Identifier: ipB.Value + ":8080",
+			ID:         "",
+			Found:      false,
+		},
+	}
+
+	for name, test := range tests {
+		test := test // capture range variable.
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			req := &IDRequest{
+				Identifier: test.Identifier,
+			}
+
+			res, err := g.ID(req)
+			if (err == nil) != test.Found {
+				t.Fatalf("want (err == nil) = %t; got err: %v", test.Found, err)
+			}
+
+			if !test.Found {
+				return
+			}
+
+			if res.ID != test.ID {
+				t.Fatalf("want ID = %v; got %v", test.ID, res.ID)
+			}
+		})
+	}
+}

--- a/go/src/koding/klient/machine/machinegroup/kite.go
+++ b/go/src/koding/klient/machine/machinegroup/kite.go
@@ -4,9 +4,9 @@ import (
 	"github.com/koding/kite"
 )
 
-// KiteCreateHandler creates a kite handler function that, when called, invokes
-// machine group create method.
-func KiteCreateHandler(g *Group) kite.HandlerFunc {
+// KiteHandlerCreate creates a kite handler function that, when called, invokes
+// machine group Create method.
+func KiteHandlerCreate(g *Group) kite.HandlerFunc {
 	return func(r *kite.Request) (interface{}, error) {
 		req := &CreateRequest{}
 
@@ -17,6 +17,56 @@ func KiteCreateHandler(g *Group) kite.HandlerFunc {
 		}
 
 		res, err := g.Create(req)
+		if err != nil {
+			// TODO(ppknap): create errors file similar to kloud/stack/errors.
+			return nil, &kite.Error{
+				Type:    "machinesError",
+				Message: err.Error(),
+			}
+		}
+
+		return res, nil
+	}
+}
+
+// KiteHandlerID creates a kite handler function that, when called, invokes
+// machine group ID method.
+func KiteHandlerID(g *Group) kite.HandlerFunc {
+	return func(r *kite.Request) (interface{}, error) {
+		req := &IDRequest{}
+
+		if r.Args != nil {
+			if err := r.Args.One().Unmarshal(req); err != nil {
+				return nil, err
+			}
+		}
+
+		res, err := g.ID(req)
+		if err != nil {
+			// TODO(ppknap): create errors file similar to kloud/stack/errors.
+			return nil, &kite.Error{
+				Type:    "machinesError",
+				Message: err.Error(),
+			}
+		}
+
+		return res, nil
+	}
+}
+
+// KiteHandlerSSH creates a kite handler function that, when called, invokes
+// machine group SSH method.
+func KiteHandlerSSH(g *Group) kite.HandlerFunc {
+	return func(r *kite.Request) (interface{}, error) {
+		req := &SSHRequest{}
+
+		if r.Args != nil {
+			if err := r.Args.One().Unmarshal(req); err != nil {
+				return nil, err
+			}
+		}
+
+		res, err := g.SSH(req)
 		if err != nil {
 			// TODO(ppknap): create errors file similar to kloud/stack/errors.
 			return nil, &kite.Error{

--- a/go/src/koding/klient/machine/machinegroup/machinegroup.go
+++ b/go/src/koding/klient/machine/machinegroup/machinegroup.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	"koding/kites/tunnelproxy/discover"
 	"koding/klient/machine"
 	"koding/klient/machine/machinegroup/addresses"
 	"koding/klient/machine/machinegroup/aliases"
@@ -15,6 +16,10 @@ import (
 
 // GroupOpts are the options used to configure machine group.
 type GroupOpts struct {
+	// Discover is used to resolve address if klient connection is tunneled. If
+	// nil, default discover client will be used.
+	Discover *discover.Client
+
 	// Storage defines the storage where machine group can save its state. If
 	// nil, no storage will be used.
 	Storage storage.ValueInterface
@@ -59,6 +64,8 @@ type Group struct {
 	client  *clients.Clients
 	address addresses.Addresser
 	alias   aliases.Aliaser
+
+	discover *discover.Client
 }
 
 // New creates a new Group object.
@@ -74,6 +81,13 @@ func New(opts *GroupOpts) (*Group, error) {
 		g.log = opts.Log.New("machines")
 	} else {
 		g.log = machine.DefaultLogger.New("machines")
+	}
+
+	// Use default discover client when not set.
+	if opts.Discover != nil {
+		g.discover = opts.Discover
+	} else {
+		g.discover = discover.NewClient()
 	}
 
 	// Create dynamic clients.

--- a/go/src/koding/klient/machine/machinegroup/ssh.go
+++ b/go/src/koding/klient/machine/machinegroup/ssh.go
@@ -1,0 +1,113 @@
+package machinegroup
+
+import (
+	"errors"
+	"net"
+	"strconv"
+
+	"koding/kites/tunnelproxy/discover"
+	"koding/klient/machine"
+)
+
+// SSHInfoRequest defines machine group ssh info request.
+type SSHRequest struct {
+	// ID is a unique identifier for the remote machine.
+	ID machine.ID `json:"id"`
+
+	// Username defines the remote machine user name. This field is optional, if
+	// not set, the current remote user will be used instead.
+	Username string `json:"username"`
+
+	// PublicKey contains local machine public key content which is meant to be
+	// added to remote machine authorized_keys file. This field is optional, if
+	// not set, no keys will be added.
+	PublicKey string `json:"public_key"`
+}
+
+// SSHInfoResponse defines machine group ssh info response.
+type SSHResponse struct {
+	// Username defines the remote machine user name.
+	Username string `json:"username"`
+
+	// Host is the remote machine host used for SSH connections.
+	Host string `json:"host"`
+
+	// Port defines remote machine SSH listening port.
+	Port int `json:"port"`
+}
+
+// Create updates internal state of machine group. It gets the current
+// information about user machines so it can add new ones to group.
+func (g *Group) SSH(req *SSHRequest) (*SSHResponse, error) {
+	if req == nil {
+		return nil, errors.New("invalid nil request")
+	}
+
+	c, err := g.client.Client(req.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Use provided username or ask remote machine to return it.
+	username := req.Username
+	if username == "" {
+		if username, err = c.CurrentUser(); err != nil {
+			return nil, err
+		}
+	}
+
+	// Add pubic key to remote machine authorized keys.
+	if req.PublicKey != "" {
+		if err := c.SSHAddKeys(username, req.PublicKey); err != nil {
+			return nil, err
+		}
+	}
+
+	// Check for tunneled connections.
+	addr, err := g.address.Latest(req.ID, "tunnel")
+	if err != nil {
+		// There are no tunnel addresses. Get latest IP.
+		if addr, err = g.address.Latest(req.ID, "ip"); err != nil {
+			return nil, err
+		}
+
+		return &SSHResponse{
+			Username: username,
+			Host:     addr.Value,
+		}, nil
+	}
+
+	// Discover tunnel SSH address.
+	endpoints, err := g.discover.Discover(addr.Value, "ssh")
+	if err != nil {
+		return &SSHResponse{
+			Username: username,
+			Host:     addr.Value,
+		}, nil
+	}
+
+	tuneladdr := endpoints[0].Addr
+	// We prefer local routes to use first, if there's none, we use first
+	// discovered route.
+	if e := endpoints.Filter(discover.ByLocal(true)); len(e) != 0 {
+		// All local routes will do, typically there's only one,
+		// we use the first one and ignore the rest.
+		tuneladdr = e[0].Addr
+	}
+
+	host, port, err := net.SplitHostPort(tuneladdr)
+	if err != nil {
+		host, port = tuneladdr, "0"
+	}
+
+	n, err := strconv.Atoi(port)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SSHResponse{
+		Username: username,
+		Host:     host,
+		Port:     n,
+	}, nil
+}


### PR DESCRIPTION
This PR adds support for SSH remote connections via kd machine ssh subcommand.

Closes: #9889
Depends on: ~#10018, #9797, #10019~