### PR TITLE
broker: fix nil pointer dereference

### DIFF
--- a/go/src/vendor/github.com/koding/broker/subscriber.go
+++ b/go/src/vendor/github.com/koding/broker/subscriber.go
@@ -140,9 +140,9 @@ func (l *Consumer) Close() error {
 	}
 
 	return fmt.Errorf(
-		"err while closing consumer connections ConsumerErr: %s, MaintenanceErr: %s",
-		err.Error(),
-		err2.Error(),
+		"err while closing consumer connections ConsumerErr: %v, MaintenanceErr: %v",
+		err,
+		err2,
 	)
 }
 


### PR DESCRIPTION
This is a fix for nil pointer dereference panic i noticed in logs:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x642f91]
goroutine 1 [running]:
panic(0x98c9e0, 0xc42000c0a0)
	/usr/local/go/src/runtime/panic.go:500 +0x1a1
vendor/github.com/koding/broker.(*Consumer).Close(0xc4200e55f0, 0xcda400, 0xd02f00)
	/var/app/current/go/src/vendor/github.com/koding/broker/subscriber.go:145 +0x151
vendor/github.com/koding/broker.(*Broker).Close(0xc420097ec0, 0x0, 0x0)
	/var/app/current/go/src/vendor/github.com/koding/broker/broker.go:150 +0x32b
vendor/github.com/koding/bongo.(*Bongo).Close(0xc42022c1e0, 0xc4200e2050, 0xc4202e9cd8)
	/var/app/current/go/src/vendor/github.com/koding/bongo/bongo.go:63 +0x32
vendor/github.com/koding/runner.(*Runner).Close(0xc420097d40, 0xc420075d18, 0xc41fff5f09)
	/var/app/current/go/src/vendor/github.com/koding/runner/runner.go:197 +0x41
```

I would update original package, if I had write access to it:

```
ERROR: Permission to koding/broker.git denied to ppknap.
fatal: Could not read from remote repository.
```

