### PR TITLE
klient: add set operations on machines

### DIFF
--- a/go/src/koding/klient/machine/machinegroup/addresses/addresses.go
+++ b/go/src/koding/klient/machine/machinegroup/addresses/addresses.go
@@ -65,7 +65,7 @@ func (a *Addresses) MachineID(addr machine.Addr) (machine.ID, error) {
 	defer a.mu.RUnlock()
 
 	for id, ab := range a.m {
-		if _, err := ab.Updated(addr); err != nil {
+		if _, err := ab.Updated(addr); err == nil {
 			return id, nil
 		}
 	}

--- a/go/src/koding/klient/machine/machinegroup/idset/idset.go
+++ b/go/src/koding/klient/machine/machinegroup/idset/idset.go
@@ -1,0 +1,66 @@
+package idset
+
+import (
+	"koding/klient/machine"
+)
+
+// Union returns a set of all elements in A and B sets.
+func Union(a, b []machine.ID) []machine.ID {
+	aset := make(map[machine.ID]struct{})
+	for i := range a {
+		aset[a[i]] = struct{}{}
+	}
+
+	res := make([]machine.ID, len(a))
+	copy(res, a)
+
+	for i := range b {
+		if _, ok := aset[b[i]]; !ok {
+			res = append(res, b[i])
+		}
+	}
+
+	return res
+}
+
+// Intersection returns a set that contains all elements of A that also belong
+// to B, but no other elements.
+func Intersection(a, b []machine.ID) []machine.ID {
+	aset := make(map[machine.ID]bool)
+	for i := range a {
+		aset[a[i]] = true
+	}
+
+	res := make([]machine.ID, 0, len(a))
+	for i := range b {
+		if aset[b[i]] {
+			res = append(res, b[i])
+		}
+	}
+
+	return res
+}
+
+// Diff returns a relative complement of B in A. This means that the result
+// contains elements present in A but not in B.
+func Diff(a, b []machine.ID) []machine.ID {
+	aset := make(map[machine.ID]struct{})
+	for i := range a {
+		aset[a[i]] = struct{}{}
+	}
+
+	for i := range b {
+		if _, ok := aset[b[i]]; ok {
+			delete(aset, b[i])
+		}
+	}
+
+	res := make([]machine.ID, 0, len(a))
+	for i := range a {
+		if _, ok := aset[a[i]]; ok {
+			res = append(res, a[i])
+		}
+	}
+
+	return res
+}

--- a/go/src/koding/klient/machine/machinegroup/idset/idset_test.go
+++ b/go/src/koding/klient/machine/machinegroup/idset/idset_test.go
@@ -2,7 +2,6 @@ package idset
 
 import (
 	"reflect"
-	"strings"
 	"testing"
 
 	"koding/klient/machine"
@@ -13,34 +12,34 @@ func TestUnion(t *testing.T) {
 		A, B, Expected []machine.ID
 	}{
 		"simple union": {
-			A:        genIDs("x1, x2, x3, x4"),
-			B:        genIDs("x3, x4, x5"),
-			Expected: genIDs("x1, x2, x3, x4, x5"),
+			A:        []machine.ID{"x1", "x2", "x3", "x4"},
+			B:        []machine.ID{"x3", "x4", "x5"},
+			Expected: []machine.ID{"x1", "x2", "x3", "x4", "x5"},
 		},
 		"empty A": {
-			A:        genIDs(""),
-			B:        genIDs("x1, x2, x3"),
-			Expected: genIDs("x1, x2, x3"),
+			A:        []machine.ID{},
+			B:        []machine.ID{"x1", "x2", "x3"},
+			Expected: []machine.ID{"x1", "x2", "x3"},
 		},
 		"empty B": {
-			A:        genIDs("x1, x2, x3"),
-			B:        genIDs(""),
-			Expected: genIDs("x1, x2, x3"),
+			A:        []machine.ID{"x1", "x2", "x3"},
+			B:        []machine.ID{},
+			Expected: []machine.ID{"x1", "x2", "x3"},
 		},
 		"union of zero slices": {
-			A:        genIDs(""),
-			B:        genIDs(""),
-			Expected: genIDs(""),
+			A:        []machine.ID{},
+			B:        []machine.ID{},
+			Expected: []machine.ID{},
 		},
 		"unordered elements": {
-			A:        genIDs("x5, x4, x3, x2, x1"),
-			B:        genIDs("x3, x4, x6, x5"),
-			Expected: genIDs("x5, x4, x3, x2, x1, x6"),
+			A:        []machine.ID{"x5", "x4", "x3", "x2", "x1"},
+			B:        []machine.ID{"x3", "x4", "x6", "x5"},
+			Expected: []machine.ID{"x5", "x4", "x3", "x2", "x1", "x6"},
 		},
 		"duplicated elements": {
-			A:        genIDs("x5, x3, x3, x3, x1"),
-			B:        genIDs("x3, x4"),
-			Expected: genIDs("x5, x3, x3, x3, x1, x4"),
+			A:        []machine.ID{"x5", "x3", "x3", "x3", "x1"},
+			B:        []machine.ID{"x3", "x4"},
+			Expected: []machine.ID{"x5", "x3", "x3", "x3", "x1", "x4"},
 		},
 	}
 
@@ -59,34 +58,34 @@ func TestIntersection(t *testing.T) {
 		A, B, Expected []machine.ID
 	}{
 		"simple intersection": {
-			A:        genIDs("x1, x2, x3, x4"),
-			B:        genIDs("x3, x4, x5"),
-			Expected: genIDs("x3, x4"),
+			A:        []machine.ID{"x1", "x2", "x3", "x4"},
+			B:        []machine.ID{"x3", "x4", "x5"},
+			Expected: []machine.ID{"x3", "x4"},
 		},
 		"empty A": {
-			A:        genIDs(""),
-			B:        genIDs("x1, x2, x3"),
-			Expected: genIDs(""),
+			A:        []machine.ID{},
+			B:        []machine.ID{"x1", "x2", "x3"},
+			Expected: []machine.ID{},
 		},
 		"empty B": {
-			A:        genIDs("x1, x2, x3"),
-			B:        genIDs(""),
-			Expected: genIDs(""),
+			A:        []machine.ID{"x1", "x2", "x3"},
+			B:        []machine.ID{},
+			Expected: []machine.ID{},
 		},
 		"intersection to zero slice": {
-			A:        genIDs("x1, x2, x3"),
-			B:        genIDs("x4, x5, x6"),
-			Expected: genIDs(""),
+			A:        []machine.ID{"x1", "x2", "x3"},
+			B:        []machine.ID{"x4", "x5", "x6"},
+			Expected: []machine.ID{},
 		},
 		"unordered elements": {
-			A:        genIDs("x5, x4, x3, x2, x1"),
-			B:        genIDs("x3, x4, x6, x5"),
-			Expected: genIDs("x3, x4, x5"),
+			A:        []machine.ID{"x5", "x4", "x3", "x2", "x1"},
+			B:        []machine.ID{"x3", "x4", "x6", "x5"},
+			Expected: []machine.ID{"x3", "x4", "x5"},
 		},
 		"duplicated elements": {
-			A:        genIDs("x5, x3, x3, x3, x1"),
-			B:        genIDs("x3, x4"),
-			Expected: genIDs("x3"),
+			A:        []machine.ID{"x5", "x3", "x3", "x3", "x1"},
+			B:        []machine.ID{"x3", "x4"},
+			Expected: []machine.ID{"x3"},
 		},
 	}
 
@@ -105,34 +104,34 @@ func TestDiff(t *testing.T) {
 		A, B, Expected []machine.ID
 	}{
 		"simple diff": {
-			A:        genIDs("x1, x2, x3, x4"),
-			B:        genIDs("x3, x4, x5"),
-			Expected: genIDs("x1, x2"),
+			A:        []machine.ID{"x1", "x2", "x3", "x4"},
+			B:        []machine.ID{"x3", "x4", "x5"},
+			Expected: []machine.ID{"x1", "x2"},
 		},
 		"empty A": {
-			A:        genIDs(""),
-			B:        genIDs("x1, x2, x3"),
-			Expected: genIDs(""),
+			A:        []machine.ID{},
+			B:        []machine.ID{"x1", "x2", "x3"},
+			Expected: []machine.ID{},
 		},
 		"empty B": {
-			A:        genIDs("x1, x2, x3"),
-			B:        genIDs(""),
-			Expected: genIDs("x1, x2, x3"),
+			A:        []machine.ID{"x1", "x2", "x3"},
+			B:        []machine.ID{},
+			Expected: []machine.ID{"x1", "x2", "x3"},
 		},
 		"diff to zero slice": {
-			A:        genIDs("x1, x2, x3"),
-			B:        genIDs("x1, x2, x3, x4"),
-			Expected: genIDs(""),
+			A:        []machine.ID{"x1", "x2", "x3"},
+			B:        []machine.ID{"x1", "x2", "x3", "x4"},
+			Expected: []machine.ID{},
 		},
 		"unordered elements": {
-			A:        genIDs("x5, x4, x3, x2, x1"),
-			B:        genIDs("x3, x4, x5"),
-			Expected: genIDs("x2, x1"),
+			A:        []machine.ID{"x5", "x4", "x3", "x2", "x1"},
+			B:        []machine.ID{"x3", "x4", "x5"},
+			Expected: []machine.ID{"x2", "x1"},
 		},
 		"duplicated elements": {
-			A:        genIDs("x5, x3, x3, x3, x1"),
-			B:        genIDs("x3, x4"),
-			Expected: genIDs("x5, x1"),
+			A:        []machine.ID{"x5", "x3", "x3", "x3", "x1"},
+			B:        []machine.ID{"x3", "x4"},
+			Expected: []machine.ID{"x5", "x1"},
 		},
 	}
 
@@ -144,16 +143,4 @@ func TestDiff(t *testing.T) {
 			}
 		})
 	}
-}
-
-func genIDs(ids string) (res []machine.ID) {
-	if ids == "" {
-		return []machine.ID{}
-	}
-
-	for _, id := range strings.Split(ids, ",") {
-		res = append(res, machine.ID(strings.TrimSpace(id)))
-	}
-
-	return res
 }

--- a/go/src/koding/klient/machine/machinegroup/idset/idset_test.go
+++ b/go/src/koding/klient/machine/machinegroup/idset/idset_test.go
@@ -1,0 +1,159 @@
+package idset
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"koding/klient/machine"
+)
+
+func TestUnion(t *testing.T) {
+	tests := map[string]struct {
+		A, B, Expected []machine.ID
+	}{
+		"simple union": {
+			A:        genIDs("x1, x2, x3, x4"),
+			B:        genIDs("x3, x4, x5"),
+			Expected: genIDs("x1, x2, x3, x4, x5"),
+		},
+		"empty A": {
+			A:        genIDs(""),
+			B:        genIDs("x1, x2, x3"),
+			Expected: genIDs("x1, x2, x3"),
+		},
+		"empty B": {
+			A:        genIDs("x1, x2, x3"),
+			B:        genIDs(""),
+			Expected: genIDs("x1, x2, x3"),
+		},
+		"union of zero slices": {
+			A:        genIDs(""),
+			B:        genIDs(""),
+			Expected: genIDs(""),
+		},
+		"unordered elements": {
+			A:        genIDs("x5, x4, x3, x2, x1"),
+			B:        genIDs("x3, x4, x6, x5"),
+			Expected: genIDs("x5, x4, x3, x2, x1, x6"),
+		},
+		"duplicated elements": {
+			A:        genIDs("x5, x3, x3, x3, x1"),
+			B:        genIDs("x3, x4"),
+			Expected: genIDs("x5, x3, x3, x3, x1, x4"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			res := Union(test.A, test.B)
+			if !reflect.DeepEqual(res, test.Expected) {
+				t.Errorf("want result set = %v; got %v", test.Expected, res)
+			}
+		})
+	}
+}
+
+func TestIntersection(t *testing.T) {
+	tests := map[string]struct {
+		A, B, Expected []machine.ID
+	}{
+		"simple intersection": {
+			A:        genIDs("x1, x2, x3, x4"),
+			B:        genIDs("x3, x4, x5"),
+			Expected: genIDs("x3, x4"),
+		},
+		"empty A": {
+			A:        genIDs(""),
+			B:        genIDs("x1, x2, x3"),
+			Expected: genIDs(""),
+		},
+		"empty B": {
+			A:        genIDs("x1, x2, x3"),
+			B:        genIDs(""),
+			Expected: genIDs(""),
+		},
+		"intersection to zero slice": {
+			A:        genIDs("x1, x2, x3"),
+			B:        genIDs("x4, x5, x6"),
+			Expected: genIDs(""),
+		},
+		"unordered elements": {
+			A:        genIDs("x5, x4, x3, x2, x1"),
+			B:        genIDs("x3, x4, x6, x5"),
+			Expected: genIDs("x3, x4, x5"),
+		},
+		"duplicated elements": {
+			A:        genIDs("x5, x3, x3, x3, x1"),
+			B:        genIDs("x3, x4"),
+			Expected: genIDs("x3"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			res := Intersection(test.A, test.B)
+			if !reflect.DeepEqual(res, test.Expected) {
+				t.Errorf("want result set = %v; got %v", test.Expected, res)
+			}
+		})
+	}
+}
+
+func TestDiff(t *testing.T) {
+	tests := map[string]struct {
+		A, B, Expected []machine.ID
+	}{
+		"simple diff": {
+			A:        genIDs("x1, x2, x3, x4"),
+			B:        genIDs("x3, x4, x5"),
+			Expected: genIDs("x1, x2"),
+		},
+		"empty A": {
+			A:        genIDs(""),
+			B:        genIDs("x1, x2, x3"),
+			Expected: genIDs(""),
+		},
+		"empty B": {
+			A:        genIDs("x1, x2, x3"),
+			B:        genIDs(""),
+			Expected: genIDs("x1, x2, x3"),
+		},
+		"diff to zero slice": {
+			A:        genIDs("x1, x2, x3"),
+			B:        genIDs("x1, x2, x3, x4"),
+			Expected: genIDs(""),
+		},
+		"unordered elements": {
+			A:        genIDs("x5, x4, x3, x2, x1"),
+			B:        genIDs("x3, x4, x5"),
+			Expected: genIDs("x2, x1"),
+		},
+		"duplicated elements": {
+			A:        genIDs("x5, x3, x3, x3, x1"),
+			B:        genIDs("x3, x4"),
+			Expected: genIDs("x5, x1"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			res := Diff(test.A, test.B)
+			if !reflect.DeepEqual(res, test.Expected) {
+				t.Errorf("want result set = %v; got %v", test.Expected, res)
+			}
+		})
+	}
+}
+
+func genIDs(ids string) (res []machine.ID) {
+	if ids == "" {
+		return []machine.ID{}
+	}
+
+	for _, id := range strings.Split(ids, ",") {
+		res = append(res, machine.ID(strings.TrimSpace(id)))
+	}
+
+	return res
+}


### PR DESCRIPTION
This PR adds package with basic operations on machine sets.

## Motivation and Context
Needed for `machine mount` subcommand. 

## How Has This Been Tested?
Unit tests.

## Screenshots (if appropriate):

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

