### PR TITLE
klient: restore stored state on klient initialization

### DIFF
--- a/go/src/koding/klient/machine/disconnected.go
+++ b/go/src/koding/klient/machine/disconnected.go
@@ -11,22 +11,6 @@ var (
 	ErrDisconnected = errors.New("machine disconnected")
 )
 
-var _ Client = (*DisconnectedClient)(nil)
-
-// DisconnectedClient satisfies Client interface. It indicates disconnected
-// machine and always returns
-type DisconnectedClient struct{}
-
-// CurrentUser always returns ErrDisconnected error.
-func (DisconnectedClient) CurrentUser() (string, error) {
-	return "", ErrDisconnected
-}
-
-// SSHAddKeys always returns ErrDisconnected error.
-func (DisconnectedClient) SSHAddKeys(_ string, _ ...string) error {
-	return ErrDisconnected
-}
-
 var _ ClientBuilder = (*DisconnectedClientBuilder)(nil)
 
 // DisconnectedClientBuilder satisfies ClientBuilder. It produces disconnected
@@ -42,4 +26,20 @@ func (DisconnectedClientBuilder) Ping(_ DynamicAddrFunc) (Status, Addr, error) {
 // Build always returns disconnected client.
 func (DisconnectedClientBuilder) Build(_ context.Context, _ Addr) Client {
 	return DisconnectedClient{}
+}
+
+var _ Client = (*DisconnectedClient)(nil)
+
+// DisconnectedClient satisfies Client interface. It indicates disconnected
+// machine and always returns
+type DisconnectedClient struct{}
+
+// CurrentUser always returns ErrDisconnected error.
+func (DisconnectedClient) CurrentUser() (string, error) {
+	return "", ErrDisconnected
+}
+
+// SSHAddKeys always returns ErrDisconnected error.
+func (DisconnectedClient) SSHAddKeys(_ string, _ ...string) error {
+	return ErrDisconnected
 }

--- a/go/src/koding/klient/machine/machine.go
+++ b/go/src/koding/klient/machine/machine.go
@@ -2,6 +2,7 @@ package machine
 
 import (
 	"errors"
+	"strings"
 
 	"koding/klient/config"
 
@@ -19,3 +20,16 @@ var DefaultLogger = logging.NewCustom("machine", config.Konfig.Debug)
 
 // ID is a unique identifier of the machine.
 type ID string
+
+// IDSlice represents a set of machine IDs.
+type IDSlice []ID
+
+// String implements fmt.Stringer interface. It pretty prints machine IDs.
+func (ids IDSlice) String() string {
+	strs := make([]string, len(ids))
+	for i := range ids {
+		strs[i] = string(ids[i])
+	}
+
+	return strings.Join(strs, ", ")
+}

--- a/go/src/koding/klient/machine/machinegroup/addresses/addresser.go
+++ b/go/src/koding/klient/machine/machinegroup/addresses/addresser.go
@@ -19,5 +19,5 @@ type Addresser interface {
 	MachineID(machine.Addr) (machine.ID, error)
 
 	// Registered returns all machines that are managed by addresser.
-	Registered() []machine.ID
+	Registered() machine.IDSlice
 }

--- a/go/src/koding/klient/machine/machinegroup/addresses/addresses.go
+++ b/go/src/koding/klient/machine/machinegroup/addresses/addresses.go
@@ -74,11 +74,11 @@ func (a *Addresses) MachineID(addr machine.Addr) (machine.ID, error) {
 }
 
 // Registered returns all machines that are stored in this object.
-func (a *Addresses) Registered() []machine.ID {
+func (a *Addresses) Registered() machine.IDSlice {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 
-	registered := make([]machine.ID, 0, len(a.m))
+	registered := make(machine.IDSlice, 0, len(a.m))
 	for id := range a.m {
 		registered = append(registered, id)
 	}

--- a/go/src/koding/klient/machine/machinegroup/addresses/cached.go
+++ b/go/src/koding/klient/machine/machinegroup/addresses/cached.go
@@ -25,7 +25,7 @@ func NewCached(st storage.ValueInterface) (*Cached, error) {
 		addresses: New(),
 	}
 
-	if err := c.st.GetValue(storageKey, &c.addresses.m); err != nil {
+	if err := c.st.GetValue(storageKey, &c.addresses.m); err != nil && err != storage.ErrKeyNotFound {
 		return nil, err
 	}
 
@@ -70,6 +70,6 @@ func (c *Cached) MachineID(addr machine.Addr) (machine.ID, error) {
 }
 
 // Registered returns all machines that are stored in this object.
-func (c *Cached) Registered() []machine.ID {
+func (c *Cached) Registered() machine.IDSlice {
 	return c.addresses.Registered()
 }

--- a/go/src/koding/klient/machine/machinegroup/aliases/aliaser.go
+++ b/go/src/koding/klient/machine/machinegroup/aliases/aliaser.go
@@ -17,5 +17,5 @@ type Aliaser interface {
 	MachineID(string) (machine.ID, error)
 
 	// Registered returns all machines that are managed by aliaser.
-	Registered() []machine.ID
+	Registered() machine.IDSlice
 }

--- a/go/src/koding/klient/machine/machinegroup/aliases/aliases.go
+++ b/go/src/koding/klient/machine/machinegroup/aliases/aliases.go
@@ -131,11 +131,11 @@ func (a *Aliases) MachineID(alias string) (machine.ID, error) {
 }
 
 // Registered returns all machines that are stored in this object.
-func (a *Aliases) Registered() []machine.ID {
+func (a *Aliases) Registered() machine.IDSlice {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 
-	registered := make([]machine.ID, 0, len(a.m))
+	registered := make(machine.IDSlice, 0, len(a.m))
 	for id := range a.m {
 		registered = append(registered, id)
 	}

--- a/go/src/koding/klient/machine/machinegroup/aliases/cached.go
+++ b/go/src/koding/klient/machine/machinegroup/aliases/cached.go
@@ -25,7 +25,7 @@ func NewCached(st storage.ValueInterface) (*Cached, error) {
 		aliases: New(),
 	}
 
-	if err := c.st.GetValue(storageKey, &c.aliases.m); err != nil {
+	if err := c.st.GetValue(storageKey, &c.aliases.m); err != nil && err != storage.ErrKeyNotFound {
 		return nil, err
 	}
 
@@ -83,6 +83,6 @@ func (c *Cached) MachineID(alias string) (machine.ID, error) {
 }
 
 // Registered returns all machines that are stored in this object.
-func (c *Cached) Registered() []machine.ID {
+func (c *Cached) Registered() machine.IDSlice {
 	return c.aliases.Registered()
 }

--- a/go/src/koding/klient/machine/machinegroup/clients/clients.go
+++ b/go/src/koding/klient/machine/machinegroup/clients/clients.go
@@ -184,11 +184,11 @@ func (c *Clients) Context(id machine.ID) (context.Context, error) {
 }
 
 // Registered returns all machines that are stored in this object.
-func (c *Clients) Registered() []machine.ID {
+func (c *Clients) Registered() machine.IDSlice {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	registered := make([]machine.ID, 0, len(c.m))
+	registered := make(machine.IDSlice, 0, len(c.m))
 	for id := range c.m {
 		registered = append(registered, id)
 	}

--- a/go/src/koding/klient/machine/machinegroup/create.go
+++ b/go/src/koding/klient/machine/machinegroup/create.go
@@ -66,10 +66,3 @@ func (g *Group) Create(req *CreateRequest) (*CreateResponse, error) {
 
 	return res, nil
 }
-
-// dynamicAddr creates dynamic address functor for the given machine.
-func (g *Group) dynamicAddr(id machine.ID) machine.DynamicAddrFunc {
-	return func(network string) (machine.Addr, error) {
-		return g.address.Latest(id, network)
-	}
-}

--- a/go/src/koding/klient/machine/machinegroup/idset/idset.go
+++ b/go/src/koding/klient/machine/machinegroup/idset/idset.go
@@ -5,13 +5,13 @@ import (
 )
 
 // Union returns a set of all elements in A and B sets.
-func Union(a, b []machine.ID) []machine.ID {
+func Union(a, b machine.IDSlice) machine.IDSlice {
 	aset := make(map[machine.ID]struct{})
 	for i := range a {
 		aset[a[i]] = struct{}{}
 	}
 
-	res := make([]machine.ID, len(a))
+	res := make(machine.IDSlice, len(a))
 	copy(res, a)
 
 	for i := range b {
@@ -25,13 +25,13 @@ func Union(a, b []machine.ID) []machine.ID {
 
 // Intersection returns a set that contains all elements of A that also belong
 // to B, but no other elements.
-func Intersection(a, b []machine.ID) []machine.ID {
+func Intersection(a, b machine.IDSlice) machine.IDSlice {
 	aset := make(map[machine.ID]bool)
 	for i := range a {
 		aset[a[i]] = true
 	}
 
-	res := make([]machine.ID, 0, len(a))
+	res := make(machine.IDSlice, 0, len(a))
 	for i := range b {
 		if aset[b[i]] {
 			res = append(res, b[i])
@@ -43,7 +43,7 @@ func Intersection(a, b []machine.ID) []machine.ID {
 
 // Diff returns a relative complement of B in A. This means that the result
 // contains elements present in A but not in B.
-func Diff(a, b []machine.ID) []machine.ID {
+func Diff(a, b machine.IDSlice) machine.IDSlice {
 	aset := make(map[machine.ID]struct{})
 	for i := range a {
 		aset[a[i]] = struct{}{}
@@ -55,7 +55,7 @@ func Diff(a, b []machine.ID) []machine.ID {
 		}
 	}
 
-	res := make([]machine.ID, 0, len(a))
+	res := make(machine.IDSlice, 0, len(a))
 	for i := range a {
 		if _, ok := aset[a[i]]; ok {
 			res = append(res, a[i])

--- a/go/src/koding/klient/machine/machinegroup/idset/idset_test.go
+++ b/go/src/koding/klient/machine/machinegroup/idset/idset_test.go
@@ -9,37 +9,37 @@ import (
 
 func TestUnion(t *testing.T) {
 	tests := map[string]struct {
-		A, B, Expected []machine.ID
+		A, B, Expected machine.IDSlice
 	}{
 		"simple union": {
-			A:        []machine.ID{"x1", "x2", "x3", "x4"},
-			B:        []machine.ID{"x3", "x4", "x5"},
-			Expected: []machine.ID{"x1", "x2", "x3", "x4", "x5"},
+			A:        machine.IDSlice{"x1", "x2", "x3", "x4"},
+			B:        machine.IDSlice{"x3", "x4", "x5"},
+			Expected: machine.IDSlice{"x1", "x2", "x3", "x4", "x5"},
 		},
 		"empty A": {
-			A:        []machine.ID{},
-			B:        []machine.ID{"x1", "x2", "x3"},
-			Expected: []machine.ID{"x1", "x2", "x3"},
+			A:        machine.IDSlice{},
+			B:        machine.IDSlice{"x1", "x2", "x3"},
+			Expected: machine.IDSlice{"x1", "x2", "x3"},
 		},
 		"empty B": {
-			A:        []machine.ID{"x1", "x2", "x3"},
-			B:        []machine.ID{},
-			Expected: []machine.ID{"x1", "x2", "x3"},
+			A:        machine.IDSlice{"x1", "x2", "x3"},
+			B:        machine.IDSlice{},
+			Expected: machine.IDSlice{"x1", "x2", "x3"},
 		},
 		"union of zero slices": {
-			A:        []machine.ID{},
-			B:        []machine.ID{},
-			Expected: []machine.ID{},
+			A:        machine.IDSlice{},
+			B:        machine.IDSlice{},
+			Expected: machine.IDSlice{},
 		},
 		"unordered elements": {
-			A:        []machine.ID{"x5", "x4", "x3", "x2", "x1"},
-			B:        []machine.ID{"x3", "x4", "x6", "x5"},
-			Expected: []machine.ID{"x5", "x4", "x3", "x2", "x1", "x6"},
+			A:        machine.IDSlice{"x5", "x4", "x3", "x2", "x1"},
+			B:        machine.IDSlice{"x3", "x4", "x6", "x5"},
+			Expected: machine.IDSlice{"x5", "x4", "x3", "x2", "x1", "x6"},
 		},
 		"duplicated elements": {
-			A:        []machine.ID{"x5", "x3", "x3", "x3", "x1"},
-			B:        []machine.ID{"x3", "x4"},
-			Expected: []machine.ID{"x5", "x3", "x3", "x3", "x1", "x4"},
+			A:        machine.IDSlice{"x5", "x3", "x3", "x3", "x1"},
+			B:        machine.IDSlice{"x3", "x4"},
+			Expected: machine.IDSlice{"x5", "x3", "x3", "x3", "x1", "x4"},
 		},
 	}
 
@@ -55,37 +55,37 @@ func TestUnion(t *testing.T) {
 
 func TestIntersection(t *testing.T) {
 	tests := map[string]struct {
-		A, B, Expected []machine.ID
+		A, B, Expected machine.IDSlice
 	}{
 		"simple intersection": {
-			A:        []machine.ID{"x1", "x2", "x3", "x4"},
-			B:        []machine.ID{"x3", "x4", "x5"},
-			Expected: []machine.ID{"x3", "x4"},
+			A:        machine.IDSlice{"x1", "x2", "x3", "x4"},
+			B:        machine.IDSlice{"x3", "x4", "x5"},
+			Expected: machine.IDSlice{"x3", "x4"},
 		},
 		"empty A": {
-			A:        []machine.ID{},
-			B:        []machine.ID{"x1", "x2", "x3"},
-			Expected: []machine.ID{},
+			A:        machine.IDSlice{},
+			B:        machine.IDSlice{"x1", "x2", "x3"},
+			Expected: machine.IDSlice{},
 		},
 		"empty B": {
-			A:        []machine.ID{"x1", "x2", "x3"},
-			B:        []machine.ID{},
-			Expected: []machine.ID{},
+			A:        machine.IDSlice{"x1", "x2", "x3"},
+			B:        machine.IDSlice{},
+			Expected: machine.IDSlice{},
 		},
 		"intersection to zero slice": {
-			A:        []machine.ID{"x1", "x2", "x3"},
-			B:        []machine.ID{"x4", "x5", "x6"},
-			Expected: []machine.ID{},
+			A:        machine.IDSlice{"x1", "x2", "x3"},
+			B:        machine.IDSlice{"x4", "x5", "x6"},
+			Expected: machine.IDSlice{},
 		},
 		"unordered elements": {
-			A:        []machine.ID{"x5", "x4", "x3", "x2", "x1"},
-			B:        []machine.ID{"x3", "x4", "x6", "x5"},
-			Expected: []machine.ID{"x3", "x4", "x5"},
+			A:        machine.IDSlice{"x5", "x4", "x3", "x2", "x1"},
+			B:        machine.IDSlice{"x3", "x4", "x6", "x5"},
+			Expected: machine.IDSlice{"x3", "x4", "x5"},
 		},
 		"duplicated elements": {
-			A:        []machine.ID{"x5", "x3", "x3", "x3", "x1"},
-			B:        []machine.ID{"x3", "x4"},
-			Expected: []machine.ID{"x3"},
+			A:        machine.IDSlice{"x5", "x3", "x3", "x3", "x1"},
+			B:        machine.IDSlice{"x3", "x4"},
+			Expected: machine.IDSlice{"x3"},
 		},
 	}
 
@@ -101,37 +101,37 @@ func TestIntersection(t *testing.T) {
 
 func TestDiff(t *testing.T) {
 	tests := map[string]struct {
-		A, B, Expected []machine.ID
+		A, B, Expected machine.IDSlice
 	}{
 		"simple diff": {
-			A:        []machine.ID{"x1", "x2", "x3", "x4"},
-			B:        []machine.ID{"x3", "x4", "x5"},
-			Expected: []machine.ID{"x1", "x2"},
+			A:        machine.IDSlice{"x1", "x2", "x3", "x4"},
+			B:        machine.IDSlice{"x3", "x4", "x5"},
+			Expected: machine.IDSlice{"x1", "x2"},
 		},
 		"empty A": {
-			A:        []machine.ID{},
-			B:        []machine.ID{"x1", "x2", "x3"},
-			Expected: []machine.ID{},
+			A:        machine.IDSlice{},
+			B:        machine.IDSlice{"x1", "x2", "x3"},
+			Expected: machine.IDSlice{},
 		},
 		"empty B": {
-			A:        []machine.ID{"x1", "x2", "x3"},
-			B:        []machine.ID{},
-			Expected: []machine.ID{"x1", "x2", "x3"},
+			A:        machine.IDSlice{"x1", "x2", "x3"},
+			B:        machine.IDSlice{},
+			Expected: machine.IDSlice{"x1", "x2", "x3"},
 		},
 		"diff to zero slice": {
-			A:        []machine.ID{"x1", "x2", "x3"},
-			B:        []machine.ID{"x1", "x2", "x3", "x4"},
-			Expected: []machine.ID{},
+			A:        machine.IDSlice{"x1", "x2", "x3"},
+			B:        machine.IDSlice{"x1", "x2", "x3", "x4"},
+			Expected: machine.IDSlice{},
 		},
 		"unordered elements": {
-			A:        []machine.ID{"x5", "x4", "x3", "x2", "x1"},
-			B:        []machine.ID{"x3", "x4", "x5"},
-			Expected: []machine.ID{"x2", "x1"},
+			A:        machine.IDSlice{"x5", "x4", "x3", "x2", "x1"},
+			B:        machine.IDSlice{"x3", "x4", "x5"},
+			Expected: machine.IDSlice{"x2", "x1"},
 		},
 		"duplicated elements": {
-			A:        []machine.ID{"x5", "x3", "x3", "x3", "x1"},
-			B:        []machine.ID{"x3", "x4"},
-			Expected: []machine.ID{"x5", "x1"},
+			A:        machine.IDSlice{"x5", "x3", "x3", "x3", "x1"},
+			B:        machine.IDSlice{"x3", "x4"},
+			Expected: machine.IDSlice{"x5", "x1"},
 		},
 	}
 

--- a/go/src/koding/klient/machine/machinegroup/machinegroup.go
+++ b/go/src/koding/klient/machine/machinegroup/machinegroup.go
@@ -8,6 +8,7 @@ import (
 	"koding/klient/machine/machinegroup/addresses"
 	"koding/klient/machine/machinegroup/aliases"
 	"koding/klient/machine/machinegroup/clients"
+	"koding/klient/machine/machinegroup/idset"
 	"koding/klient/storage"
 
 	"github.com/koding/logging"
@@ -110,10 +111,53 @@ func New(opts *GroupOpts) (*Group, error) {
 		g.alias = alias
 	}
 
+	// Start memory workers.
+	g.bootstrap()
+
 	return g, nil
 }
 
 // Close closes Group's underlying clients.
 func (g *Group) Close() {
 	g.client.Close()
+}
+
+// bootstrap initializes machine group workers and checks loaded data for
+// consistency.
+func (g *Group) bootstrap() {
+	var (
+		aliasIDs   = g.alias.Registered()
+		addressIDs = g.address.Registered()
+	)
+
+	// Report and generate missing aliases.
+	if noAliases := idset.Diff(addressIDs, aliasIDs); len(noAliases) != 0 {
+		g.log.Warning("Missing aliases for %v, regenerating...", noAliases)
+
+		for _, id := range noAliases {
+			alias, err := g.alias.Create(id)
+			if err != nil {
+				g.log.Error("Cannot create alias for %s: %s", id, err)
+			}
+
+			g.log.Info("Created alias for %s, %s", id, alias)
+		}
+	}
+
+	// Start clients for stored IDs.
+	for _, id := range addressIDs {
+		if err := g.client.Create(id, g.dynamicAddr(id)); err != nil {
+			g.log.Error("Cannot create client for %s: %s", id, err)
+		}
+	}
+
+	n := len(idset.Union(aliasIDs, addressIDs))
+	g.log.Info("Detected %d machines, started %d clients.", n, len(g.client.Registered()))
+}
+
+// dynamicAddr creates dynamic address functor for the given machine.
+func (g *Group) dynamicAddr(id machine.ID) machine.DynamicAddrFunc {
+	return func(network string) (machine.Addr, error) {
+		return g.address.Latest(id, network)
+	}
 }

--- a/go/src/koding/klient/machine/machinegroup/machinegroup_test.go
+++ b/go/src/koding/klient/machine/machinegroup/machinegroup_test.go
@@ -1,16 +1,139 @@
 package machinegroup
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
 	"time"
 
 	"koding/klient/machine"
+	"koding/klient/machine/machinegroup/addresses"
+	"koding/klient/machine/machinegroup/aliases"
+	"koding/klient/machine/machinetest"
+	"koding/klient/storage"
+
+	"github.com/boltdb/bolt"
 )
+
+func TestMachineGroupFreshStart(t *testing.T) {
+	st, stop, err := testBoltStorage()
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	defer stop()
+
+	builder := machinetest.NewNilBuilder()
+	g, err := New(testOptionsStorage(builder, st))
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	defer g.Close()
+
+	// Nothing should be added to addresses storage.
+	address, err := addresses.NewCached(st)
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	if len(address.Registered()) != 0 {
+		t.Errorf("want no registered machines; got %v", address.Registered())
+	}
+
+	// Nothing should be added to aliases storage.
+	alias, err := aliases.NewCached(st)
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	if len(alias.Registered()) != 0 {
+		t.Errorf("want no registered machines; got %v", alias.Registered())
+	}
+}
+
+func TestMachineGroupNoAliases(t *testing.T) {
+	st, stop, err := testBoltStorage()
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	defer stop()
+
+	// Add initial address.
+	id := machine.ID("servA")
+	address, err := addresses.NewCached(st)
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	if err := address.Add(id, machinetest.TurnOnAddr()); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	if len(address.Registered()) != 1 {
+		t.Errorf("want one registered machine; got %v", address.Registered())
+	}
+
+	builder := machinetest.NewNilBuilder()
+	g, err := New(testOptionsStorage(builder, st))
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	defer g.Close()
+
+	// Machine group should add alias for missing ID.
+	alias, err := aliases.NewCached(st)
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	if len(alias.Registered()) != 1 {
+		t.Errorf("want one registered machine; got %v", address.Registered())
+	}
+
+	// Dynamic client should be started.
+	if err := builder.WaitForBuild(time.Second); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	if builder.BuildsCount() != 1 {
+		t.Errorf("want dynamic builds number = 1; got %d", builder.BuildsCount())
+	}
+}
 
 // testOptions returns default Group options used for testing purposes.
 func testOptions(b machine.ClientBuilder) *GroupOpts {
+	return testOptionsStorage(b, nil)
+}
+
+// testOptionsStorage returns default Group options used for testing purposes.
+// This function allows to specify custom storage.
+func testOptionsStorage(b machine.ClientBuilder, st storage.ValueInterface) *GroupOpts {
 	return &GroupOpts{
+		Storage:         st,
 		Builder:         b,
 		DynAddrInterval: 10 * time.Millisecond,
 		PingInterval:    50 * time.Millisecond,
 	}
+}
+
+// testBoltStorage creates a temporary bolt database. In order to clean
+// resources, stop function must be run at the end of each test.
+func testBoltStorage() (st storage.ValueInterface, stop func(), err error) {
+	testpath, err := ioutil.TempDir("", "machinegroup")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	db, err := bolt.Open(filepath.Join(testpath, "test.db"), 0600, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	stop = func() {
+		db.Close()
+		os.RemoveAll(testpath)
+	}
+
+	bstorage, err := storage.NewBoltStorageBucket(db, []byte("klient"))
+	if err != nil {
+		stop()
+		return nil, nil, err
+	}
+
+	return &storage.EncodingStorage{
+		Interface: bstorage,
+	}, stop, nil
 }

--- a/go/src/koding/klient/machine/status.go
+++ b/go/src/koding/klient/machine/status.go
@@ -63,7 +63,7 @@ func (s *Status) String() string {
 		toks = append(toks, "reason: "+s.Reason)
 	}
 
-	if !s.Since.IsZero() {
+	if s.Since.IsZero() {
 		toks = append(toks, "since: <unknown>")
 	} else {
 		toks = append(toks, "since: "+s.Since.Format(time.RFC822))


### PR DESCRIPTION
This PR allow to restore klient state after restart/reinitialization.

## Motivation and Context
Until now, `machine list` started clients, they must be started without this command to make `machine mount` work correctly.

~Depends on: #10054~

## How Has This Been Tested?
Unit tests.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
