### PR TITLE
klient: update machine group internal state after machine list command

### DIFF
--- a/go/src/koding/klient/machine/dynamic_test.go
+++ b/go/src/koding/klient/machine/dynamic_test.go
@@ -14,7 +14,7 @@ import (
 func TestDynamicClientOnOff(t *testing.T) {
 	var (
 		serv    = &machinetest.Server{}
-		builder = machinetest.NewNilBuilder()
+		builder = machinetest.NewClientBuilder(nil)
 	)
 
 	dc, err := machine.NewDynamicClient(machinetest.DynamicClientOpts(serv, builder))
@@ -56,7 +56,7 @@ func TestDynamicClientOnOff(t *testing.T) {
 func TestDynamicClientContext(t *testing.T) {
 	var (
 		serv    = &machinetest.Server{}
-		builder = machinetest.NewNilBuilder()
+		builder = machinetest.NewClientBuilder(nil)
 	)
 
 	dc, err := machine.NewDynamicClient(machinetest.DynamicClientOpts(serv, builder))

--- a/go/src/koding/klient/machine/machinegroup/clients/clients_test.go
+++ b/go/src/koding/klient/machine/machinegroup/clients/clients_test.go
@@ -22,7 +22,7 @@ func testOptions(b machine.ClientBuilder) *clients.ClientsOpts {
 
 func TestClients(t *testing.T) {
 	var (
-		builder = machinetest.NewNilBuilder()
+		builder = machinetest.NewClientBuilder(nil)
 
 		idA = machine.ID("servA")
 		idB = machine.ID("servB")

--- a/go/src/koding/klient/machine/machinegroup/create.go
+++ b/go/src/koding/klient/machine/machinegroup/create.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"koding/klient/machine"
+	"koding/klient/machine/machinegroup/idset"
 )
 
 // CreateRequest defines machine group create request.
@@ -61,7 +62,9 @@ func (g *Group) Create(req *CreateRequest) (*CreateResponse, error) {
 	}
 
 	// Get machine statuses.
+	ids := make(machine.IDSlice, 0, len(req.Addresses))
 	for id := range req.Addresses {
+		ids = append(ids, id)
 		stat, err := g.client.Status(id)
 		if err != nil {
 			g.log.Critical("Status for %s is not available: %s", id, err)
@@ -70,5 +73,46 @@ func (g *Group) Create(req *CreateRequest) (*CreateResponse, error) {
 		res.Statuses[id] = stat
 	}
 
+	// Update and clean up stale machines. No need to block here.
+	go g.balance(ids)
+
 	return res, nil
+}
+
+// balance ensures that stale clients and other resources will be closed and
+// removed.
+func (g *Group) balance(ids machine.IDSlice) {
+	var (
+		regAlias   = g.alias.Registered()
+		regAddress = g.address.Registered()
+		regClient  = g.client.Registered()
+	)
+
+	union := idset.Union(idset.Union(regAlias, regAddress), regClient)
+
+	for _, id := range idset.Diff(union, ids) {
+		var errored = false
+
+		// Drop machine alias.
+		if err := g.alias.Drop(id); err != nil {
+			errored = true
+			g.log.Warning("Alias of machine %s cannot be removed: %v", id, err)
+		}
+
+		// Drop machine client.
+		if err := g.client.Drop(id); err != nil {
+			errored = true
+			g.log.Warning("Client for machine %s cannot be deleted: %v", id, err)
+		}
+
+		// Drop all machine addresses.
+		if err := g.address.Drop(id); err != nil {
+			errored = true
+			g.log.Warning("Addresses of %s machine cannot be removed: %v", id, err)
+		}
+
+		if !errored {
+			g.log.Info("Machine with ID: %s was removed.", id)
+		}
+	}
 }

--- a/go/src/koding/klient/machine/machinegroup/create_test.go
+++ b/go/src/koding/klient/machine/machinegroup/create_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestCreate(t *testing.T) {
 	var (
-		builder = machinetest.NewNilBuilder()
+		builder = machinetest.NewClientBuilder(nil)
 
 		idA = machine.ID("servA")
 		idB = machine.ID("servB")
@@ -79,5 +79,43 @@ func TestCreate(t *testing.T) {
 	}
 	if !reflect.DeepEqual(statuses, res.Statuses) {
 		t.Fatalf("want statuses = %#v; got %#v", statuses, res.Statuses)
+	}
+}
+
+func TestCreateBalance(t *testing.T) {
+	var (
+		client  = machinetest.NewClient()
+		builder = machinetest.NewClientBuilder(client)
+		id      = machine.ID("serv")
+	)
+
+	g, err := New(testOptions(builder))
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	defer g.Close()
+
+	req := &CreateRequest{
+		Addresses: map[machine.ID][]machine.Addr{
+			id: {machinetest.TurnOffAddr()},
+		},
+	}
+
+	if _, err := g.Create(req); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	if err := builder.WaitForBuild(time.Second); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	// Create with empty addresses should remove previously added machine.
+	if _, err := g.Create(&CreateRequest{}); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	// Client context should be closed.
+	if err := machinetest.WaitForContextClose(client.Context(), time.Second); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
 	}
 }

--- a/go/src/koding/klient/machine/machinegroup/id_test.go
+++ b/go/src/koding/klient/machine/machinegroup/id_test.go
@@ -17,7 +17,7 @@ func TestID(t *testing.T) {
 		ipB = machine.Addr{Network: "ip", Value: "10.0.1.16", UpdatedAt: time.Now()}
 	)
 
-	g, err := New(testOptions(machinetest.NewNilBuilder()))
+	g, err := New(testOptions(machinetest.NewClientBuilder(nil)))
 	if err != nil {
 		t.Fatalf("want err = nil; got %v", err)
 	}

--- a/go/src/koding/klient/machine/machinegroup/machinegroup_test.go
+++ b/go/src/koding/klient/machine/machinegroup/machinegroup_test.go
@@ -23,7 +23,7 @@ func TestMachineGroupFreshStart(t *testing.T) {
 	}
 	defer stop()
 
-	builder := machinetest.NewNilBuilder()
+	builder := machinetest.NewClientBuilder(nil)
 	g, err := New(testOptionsStorage(builder, st))
 	if err != nil {
 		t.Fatalf("want err = nil; got %v", err)
@@ -69,7 +69,7 @@ func TestMachineGroupNoAliases(t *testing.T) {
 		t.Errorf("want one registered machine; got %v", address.Registered())
 	}
 
-	builder := machinetest.NewNilBuilder()
+	builder := machinetest.NewClientBuilder(nil)
 	g, err := New(testOptionsStorage(builder, st))
 	if err != nil {
 		t.Fatalf("want err = nil; got %v", err)

--- a/go/src/koding/klient/machine/machinetest/client.go
+++ b/go/src/koding/klient/machine/machinetest/client.go
@@ -1,0 +1,40 @@
+package machinetest
+
+import (
+	"context"
+	"sync"
+
+	"koding/klient/machine"
+)
+
+// Client satisfies machine.Client interface. It mimics real client and should
+// be used for testing purposes.
+type Client struct {
+	machine.DisconnectedClient
+
+	mu  sync.Mutex
+	ctx context.Context
+}
+
+// NewClient create a new Client instance with background context.
+func NewClient() *Client {
+	return &Client{
+		ctx: context.Background(),
+	}
+}
+
+// SetContext sets provided context to test client.
+func (c *Client) SetContext(ctx context.Context) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.ctx = ctx
+}
+
+// Context returns test client context.
+func (c *Client) Context() context.Context {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.ctx
+}


### PR DESCRIPTION
This PR closes clients and does clean ups for machines not present in Kloud.

## Description
Depends on: ~#10055~

## Motivation and Context
We don't want to maintain state of non existing machines.

## How Has This Been Tested?
Unit tests.

## Screenshots (if appropriate):

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
