### PR TITLE
config: make serviceHost configurable

### DIFF
--- a/config/main.default.coffee
+++ b/config/main.default.coffee
@@ -14,7 +14,7 @@ Configuration = (options = {}) ->
     port: '8090'
 
   options.boot2dockerbox or= if os.type() is "Darwin" then "192.168.59.103" else "localhost"
-  options.serviceHost = options.boot2dockerbox
+  options.serviceHost or= options.boot2dockerbox
   options.publicPort or= "8090"
   options.hostname or= "dev.koding.com"
   options.protocol or= "http:"

--- a/config/main.dev.coffee
+++ b/config/main.dev.coffee
@@ -14,7 +14,7 @@ Configuration = (options = {}) ->
     port: '8090'
 
   options.boot2dockerbox or= if os.type() is "Darwin" then "192.168.59.103" else "localhost"
-  options.serviceHost = options.boot2dockerbox
+  options.serviceHost or= options.boot2dockerbox
   options.publicPort or= "8090"
   options.hostname or= "dev.koding.com"
   options.protocol or= "http:"

--- a/config/main.sandbox.coffee
+++ b/config/main.sandbox.coffee
@@ -13,7 +13,7 @@ Configuration = (options = {}) ->
     main: 'sandbox.koding.com'
     port: '80'
 
-  options.serviceHost = "10.0.0.23"
+  options.serviceHost or= "10.0.0.23"
   options.publicPort = "80"
   options.hostname = "sandbox.koding.com#{if options.publicPort is "80" then "" else ":"+options.publicPort}"
   options.protocol = "https:"


### PR DESCRIPTION
Since "serviceHost" was not configurable we were not able to change the docker's ip when we re-create the machine. Sometimes docker-machine & boot2docker gives different ips.  