### PR TITLE
wercker: enable klient machine tests

### DIFF
--- a/scripts/test-klient.sh
+++ b/scripts/test-klient.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-# TODO: missing -race support: https://koding.atlassian.net/browse/TMS-2158
+# TODO: missing -race support: https://github.com/koding/koding/issues/9128
 
 go test -v koding/klient/client     \
 	       koding/klient/fs         \
@@ -10,3 +10,5 @@ go test -v koding/klient/client     \
 		   koding/klient/logfetcher \
 		   koding/klient/sshkeys    \
 		   koding/klient/storage
+
+go test -v --race koding/klient/machine/...


### PR DESCRIPTION
This PR enable klient machine tests in CI.

This adds (on my machine):
```
ok  	koding/klient/machine	1.298s
ok  	koding/klient/machine/machinegroup	1.033s
ok  	koding/klient/machine/machinegroup/addresses	1.045s
ok  	koding/klient/machine/machinegroup/aliases	1.431s
ok  	koding/klient/machine/machinegroup/clients	1.029s
ok  	koding/klient/machine/machinegroup/idset	1.027s
?   	koding/klient/machine/machinetest	[no test files]

real	0m14.499s
user	0m37.347s
sys	0m1.867s
```

## Motivation and Context
Test everything.

