### PR TITLE
klient: add fallback to corrupted/inconsistent data in database

### DIFF
--- a/go/src/koding/klient/machine/machinegroup/addresses/cached.go
+++ b/go/src/koding/klient/machine/machinegroup/addresses/cached.go
@@ -29,6 +29,13 @@ func NewCached(st storage.ValueInterface) (*Cached, error) {
 		return nil, err
 	}
 
+	// Drop inconsistent data.
+	for id, ab := range c.addresses.m {
+		if ab == nil {
+			delete(c.addresses.m, id)
+		}
+	}
+
 	return c, nil
 }
 

--- a/go/src/koding/klient/machine/machinegroup/aliases/cached.go
+++ b/go/src/koding/klient/machine/machinegroup/aliases/cached.go
@@ -29,6 +29,13 @@ func NewCached(st storage.ValueInterface) (*Cached, error) {
 		return nil, err
 	}
 
+	// Drop inconsistent data.
+	for id, alias := range c.aliases.m {
+		if alias == "" {
+			delete(c.aliases.m, id)
+		}
+	}
+
 	return c, nil
 }
 

--- a/go/src/koding/klient/machine/machinegroup/idset/idset.go
+++ b/go/src/koding/klient/machine/machinegroup/idset/idset.go
@@ -26,14 +26,14 @@ func Union(a, b machine.IDSlice) machine.IDSlice {
 // Intersection returns a set that contains all elements of A that also belong
 // to B, but no other elements.
 func Intersection(a, b machine.IDSlice) machine.IDSlice {
-	aset := make(map[machine.ID]bool)
+	aset := make(map[machine.ID]struct{})
 	for i := range a {
-		aset[a[i]] = true
+		aset[a[i]] = struct{}{}
 	}
 
 	res := make(machine.IDSlice, 0, len(a))
 	for i := range b {
-		if aset[b[i]] {
+		if _, ok := aset[b[i]]; ok {
 			res = append(res, b[i])
 		}
 	}


### PR DESCRIPTION
This PR fixes #10076 

I was not able to reproduce the issue even when I used Rafal's `klient.bolt` file. When he reads the file, there is one entry with null value, however I don't see it when I read the same file on my machine.

I will just skip the entry if such will be found, the logic will remove them(or add if present) from db after `machine list` command.