### PR TITLE
kites/config: use http scheme for private endpoints

### DIFF
--- a/config/generateKonfig.coffee
+++ b/config/generateKonfig.coffee
@@ -136,6 +136,7 @@ module.exports = (options, credentials) ->
     keygenBucket: credentials.kloud.keygenBucket
 
     address: "http://localhost:#{kloudPort}/kite"
+    noSneaker: false
 
     kontrolUrl: kontrol.url
     kodingUrl:  "#{options.customDomain.public}"

--- a/config/main.default.coffee
+++ b/config/main.default.coffee
@@ -87,7 +87,7 @@ Configuration = (options = {}) ->
   KONFIG.client.runtimeOptions = require('./generateRuntimeConfig')(KONFIG, credentials, options)
 
   # Disable Sneaker for kloud.
-  KONFIG.kloud.credentialEndPoint = ''
+  KONFIG.kloud.noSneaker = true
 
   options.requirementCommands = [
     "$KONFIG_PROJECTROOT/scripts/generate-kite-keys.sh"

--- a/go/src/koding/kites/config/config.go
+++ b/go/src/koding/kites/config/config.go
@@ -142,6 +142,7 @@ func NewEndpoint(u string) *Endpoint {
 // The u argument is expected to be non-nil.
 func NewEndpointURL(u *url.URL) *Endpoint {
 	uPriv := *u
+	uPriv.Scheme = "http"
 	uPriv.Host = "127.0.0.1"
 
 	if _, port, err := net.SplitHostPort(u.Host); err == nil {

--- a/go/src/koding/kites/kloud/kloud/kloud.go
+++ b/go/src/koding/kites/kloud/kloud/kloud.go
@@ -135,6 +135,7 @@ type Config struct {
 	TerraformerSecretKey string
 
 	KodingURL *config.URL // Koding base URL
+	NoSneaker bool        // use Mongo for reading credentials, instead of /social/credential endpoint
 }
 
 // New gives new, registered kloud kite.
@@ -180,9 +181,14 @@ func New(conf *Config) (*Kloud, error) {
 	storeOpts := &credential.Options{
 		MongoDB: sess.DB,
 		Log:     sess.Log.New("stackcred"),
-		CredURL: e.Social().WithPath("/credential").Private.URL,
 		Client:  restClient,
 	}
+
+	if !conf.NoSneaker {
+		storeOpts.CredURL = e.Social().WithPath("/credential").Private.URL
+	}
+
+	sess.Log.Debug("storeOpts: %+v", storeOpts)
 
 	userPrivateKey, userPublicKey := userMachinesKeys(conf.UserPublicKey, conf.UserPrivateKey)
 


### PR DESCRIPTION
This PR fixes the following error in dev / sandbox environment:

```
bundle.js:125 Verify failed: KiteError {message: "the "jCredentialData" resource was not found: [6f3…81ca68ee] credentials not found (error code: 900)", name: "KiteError", type: "kloudError", code: "900", isOperational: true}
```

/cc @usirin @andrewjcasal 