### PR TITLE
klient: remove nondeterministic check from client tests

### DIFF
--- a/go/src/koding/klient/machine/dynamic_test.go
+++ b/go/src/koding/klient/machine/dynamic_test.go
@@ -48,9 +48,6 @@ func TestDynamicClientOnOff(t *testing.T) {
 	if n := builder.BuildsCount(); n != 2 {
 		t.Fatalf("want builds count = 2; got %d", n)
 	}
-	if status := dc.Status(); status.State != machine.StateOffline {
-		t.Fatalf("want state = %s; got %s", machine.StateOffline, status.State)
-	}
 }
 
 func TestDynamicClientContext(t *testing.T) {

--- a/go/src/koding/klient/machine/dynamic_test.go
+++ b/go/src/koding/klient/machine/dynamic_test.go
@@ -41,12 +41,19 @@ func TestDynamicClientOnOff(t *testing.T) {
 	}
 
 	// Stop server.
+	ctx := dc.Context()
 	serv.TurnOff()
 	if err := builder.WaitForBuild(time.Second); err != nil {
 		t.Fatalf("want err = nil; got %v", err)
 	}
 	if n := builder.BuildsCount(); n != 2 {
 		t.Fatalf("want builds count = 2; got %d", n)
+	}
+	if err := machinetest.WaitForContextClose(ctx, time.Second); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	if status := dc.Status(); status.State != machine.StateOffline {
+		t.Fatalf("want state = %s; got %s", machine.StateOffline, status.State)
 	}
 }
 

--- a/go/src/koding/klient/machine/dynamic_test.go
+++ b/go/src/koding/klient/machine/dynamic_test.go
@@ -62,8 +62,9 @@ func TestDynamicClientContext(t *testing.T) {
 	}
 	defer dc.Close()
 
+	ctx := dc.Context()
 	serv.TurnOn()
-	if err := builder.WaitForBuild(time.Second); err != nil {
+	if err := machinetest.WaitForContextClose(ctx, time.Second); err != nil {
 		t.Fatalf("want err = nil; got %v", err)
 	}
 
@@ -85,11 +86,12 @@ func TestDynamicClientContext(t *testing.T) {
 		t.Fatalf("want err = nil; got %v", err)
 	}
 
+	ctx = dc.Context()
 	serv.TurnOff()
 	for i := 0; i < ContextWorkers; i++ {
 		g.Go(func() error {
 			select {
-			case <-dc.Context().Done():
+			case <-ctx.Done():
 				return nil
 			case <-time.After(time.Second):
 				return errors.New("timed out")


### PR DESCRIPTION
This PR removes nondeterministic check which can result in false negative tests. See [comment](https://github.com/koding/koding/pull/10101#issuecomment-268965682)

## Description
Following test waits for `Build` method then, it checks  `dc.stat` member which is set **after** Build method. This is done on separate goroutine thus, we cannot see `dc.stat` value just by checking `Build` method.

```go
c := dc.opts.Builder.Build(ctx, a)

// Update current address.
*addr = a

dc.mu.Lock()
if dc.cancel != nil {
	dc.cancel()
}
dc.c, dc.stat, dc.ctx, dc.cancel = c, stat, ctx, cancel
dc.mu.Unlock()
```

## Motivation and Context
False negative test results.
