### PR TITLE
more explicit, non-dev error messaging.

### DIFF
--- a/go/src/koding/kites/kloud/provider/aws/aws.go
+++ b/go/src/koding/kites/kloud/provider/aws/aws.go
@@ -202,10 +202,10 @@ func (meta *Cred) Valid() error {
 		return errors.New("aws: secret key is empty")
 	}
 	if !reAccessKey.MatchString(meta.AccessKey) {
-		return errors.New("aws: access key is ill-formed")
+		return errors.New("aws: access key is invalid")
 	}
 	if !reSecretKey.MatchString(meta.SecretKey) {
-		return errors.New("aws: secret key is ill-formed")
+		return errors.New("aws: secret key is invalid")
 	}
 	return nil
 }

--- a/go/src/koding/kites/kloud/provider/google/google.go
+++ b/go/src/koding/kites/kloud/provider/google/google.go
@@ -91,7 +91,7 @@ func (c *Cred) Valid() error {
 	}{}
 
 	if err := json.Unmarshal([]byte(c.Credentials), &acckey); err != nil {
-		return fmt.Errorf("credentials are ill-formed: %s", err)
+		return fmt.Errorf("credentials are invalid: %s", err)
 	}
 
 	if acckey.Typ != "service_account" {

--- a/go/src/koding/klient/tunnel/vbox.go
+++ b/go/src/koding/klient/tunnel/vbox.go
@@ -191,7 +191,7 @@ func (t *Tunnel) buildServices() map[string]*tunnelproxy.Tunnel {
 
 	_, kitePort, err := parseHostPort(t.opts.LocalAddr)
 	if err != nil {
-		t.opts.Log.Error("ill-formed local address: %s", err)
+		t.opts.Log.Error("invalid local address: %s", err)
 
 		return nil
 	}


### PR DESCRIPTION
customer facing messages should conform to https://en.wikipedia.org/wiki/Basic_English as much as possible due to international nature of our product.
