### PR TITLE
kd: add password login for "auth login" command

### DIFF
--- a/go/src/koding/kites/config/config.go
+++ b/go/src/koding/kites/config/config.go
@@ -201,7 +201,7 @@ type Config struct {
 		KlientLatest *Endpoint `json:"klientLatest" required:"true"`
 		KodingBase   *Endpoint `json:"kodingBase" required:"true"`
 		TunnelServer *Endpoint `json:"tunnelServer" required:"true"`
-	}
+	} `json:"endpoints"`
 	Routes map[string]string `json:"routes"`
 }
 

--- a/go/src/koding/kites/config/konfig.go
+++ b/go/src/koding/kites/config/konfig.go
@@ -172,10 +172,6 @@ func (k *Konfig) buildKiteConfig() *konfig.Config {
 		}
 	}
 
-	if cfg, err := konfig.Get(); err == nil {
-		return cfg
-	}
-
 	return konfig.New()
 }
 

--- a/go/src/koding/kites/config/konfig.go
+++ b/go/src/koding/kites/config/konfig.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/boltdb/bolt"
@@ -115,7 +116,20 @@ func (k *Konfig) Valid() error {
 }
 
 func (k *Konfig) ID() string {
-	hash := sha1.Sum([]byte(k.KodingPublic().String()))
+	return ID(k.KodingPublic().String())
+}
+
+func ID(kodingURL string) string {
+	if kodingURL == "" {
+		return ""
+	}
+	if u, err := url.Parse(kodingURL); err == nil {
+		// Since id is input sensitive we clean the path so "example.com/koding"
+		// "example.com/koding/" are effecitvely the same urls.
+		u.Path = strings.TrimRight(path.Clean(u.Path), "/")
+		kodingURL = u.String()
+	}
+	hash := sha1.Sum([]byte(kodingURL))
 	return hex.EncodeToString(hash[:4])
 }
 

--- a/go/src/koding/kites/kloud/kloud/kloud.go
+++ b/go/src/koding/kites/kloud/kloud/kloud.go
@@ -427,7 +427,10 @@ func newEndpoints(cfg *Config) *config.Endpoints {
 	}
 
 	if cfg.TunnelURL != "" {
-		e.Tunnel = config.NewEndpoint(cfg.TunnelURL)
+		if u, err := url.Parse(cfg.TunnelURL); err == nil {
+			u.Path = "/kite"
+			e.Tunnel = config.NewEndpoint(u.String())
+		}
 	}
 
 	return e

--- a/go/src/koding/kites/kloud/kloud/kloud.go
+++ b/go/src/koding/kites/kloud/kloud/kloud.go
@@ -242,6 +242,7 @@ func New(conf *Config) (*Kloud, error) {
 	}
 
 	kloud.Stack.Endpoints = e
+	kloud.Stack.Userdata = sess.Userdata
 	kloud.Stack.DescribeFunc = provider.Desc
 	kloud.Stack.CredClient = credential.NewClient(storeOpts)
 	kloud.Stack.MachineClient = machine.NewClient(machine.NewMongoDatabase())
@@ -314,6 +315,7 @@ func New(conf *Config) (*Kloud, error) {
 
 	// Authorization handling.
 	k.HandleFunc("auth.login", kloud.Stack.AuthLogin)
+	k.HandleFunc("auth.passwordLogin", kloud.Stack.AuthPasswordLogin).DisableAuthentication()
 
 	// Configuration handling.
 	k.HandleFunc("config.metadata", kloud.Stack.ConfigMetadata)

--- a/go/src/koding/kites/kloud/stack/auth.go
+++ b/go/src/koding/kites/kloud/stack/auth.go
@@ -75,7 +75,7 @@ func (req *PasswordLoginRequest) Valid() error {
 type PasswordLoginResponse struct {
 	LoginResponse
 
-	KiteKey string `json:"kiteKey"`
+	KiteKey string `json:"kiteKey,omitempty"`
 }
 
 // AuthLogin creates a jSession for the given username and team.

--- a/go/src/koding/kites/kloud/stack/auth.go
+++ b/go/src/koding/kites/kloud/stack/auth.go
@@ -1,12 +1,14 @@
 package stack
 
 import (
+	"errors"
+
 	"koding/db/models"
 	"koding/db/mongodb/modelhelper"
 
-	mgo "gopkg.in/mgo.v2"
-
 	"github.com/koding/kite"
+	uuid "github.com/satori/go.uuid"
+	mgo "gopkg.in/mgo.v2"
 )
 
 // LoginRequest represents a request model for "auth.login"
@@ -20,6 +22,15 @@ type LoginRequest struct {
 
 	// Metadata whether
 	Metadata bool `json:"metadata,omitempty"`
+}
+
+var _ Validator = (*LoginRequest)(nil)
+
+func (req *LoginRequest) Valid() error {
+	if req.GroupName == "" {
+		req.GroupName = models.KDIOGroupName
+	}
+	return nil
 }
 
 // LoginResponse represents a response model for "auth.login"
@@ -42,6 +53,31 @@ type LoginResponse struct {
 	Metadata *Metadata `json:"metadata,omitempty"`
 }
 
+type PasswordLoginRequest struct {
+	LoginRequest
+
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+var _ Validator = (*PasswordLoginRequest)(nil)
+
+func (req *PasswordLoginRequest) Valid() error {
+	if req.Username == "" {
+		return errors.New("invalid empty username")
+	}
+	if req.Password == "" {
+		return errors.New("invalid empty password")
+	}
+	return req.LoginRequest.Valid()
+}
+
+type PasswordLoginResponse struct {
+	LoginResponse
+
+	KiteKey string `json:"kiteKey"`
+}
+
 // AuthLogin creates a jSession for the given username and team.
 //
 // If a session already exists, the method is a nop and returns
@@ -52,12 +88,17 @@ type LoginResponse struct {
 func (k *Kloud) AuthLogin(r *kite.Request) (interface{}, error) {
 	k.Log.Debug("AuthLogin called by %q with %q", r.Username, r.Args.Raw)
 
-	req, err := getLoginReq(r)
-	if err != nil {
+	var req LoginRequest
+
+	if err := getReq(r, &req); err != nil {
 		return nil, err
 	}
 
-	ses, err := modelhelper.UserLogin(r.Username, req.GroupName)
+	return k.authLogin(r.Username, &req)
+}
+
+func (k *Kloud) authLogin(username string, req *LoginRequest) (*LoginResponse, error) {
+	ses, err := modelhelper.UserLogin(username, req.GroupName)
 	switch err {
 	case nil:
 	case mgo.ErrNotFound:
@@ -65,19 +106,19 @@ func (k *Kloud) AuthLogin(r *kite.Request) (interface{}, error) {
 	case modelhelper.ErrNotParticipant:
 		return nil, NewError(ErrNotAuthorized)
 	default:
-		k.Log.Debug("Got generic error for UserLogin, username: %q, err: %q, args: %q", r.Username, err.Error(), r.Args.Raw)
+		k.Log.Debug("Got generic error for UserLogin, username: %q, err: %q", username, err)
 		return nil, NewError(ErrInternalServer)
 	}
 
-	if err := k.PresenceClient.Ping(r.Username, req.GroupName); err != nil {
+	if err := k.PresenceClient.Ping(username, req.GroupName); err != nil {
 		// we dont need to block user login if there is something wrong with socialapi.
-		k.Log.Error("Ping failed with %q for user %q", err.Error(), r.Username)
+		k.Log.Error("ping for user %q failed: %s", username, err)
 	}
 
 	resp := &LoginResponse{
 		ClientID:  ses.ClientId,
 		GroupName: req.GroupName,
-		Username:  r.Username,
+		Username:  username,
 	}
 
 	if req.Metadata {
@@ -89,19 +130,45 @@ func (k *Kloud) AuthLogin(r *kite.Request) (interface{}, error) {
 	return resp, nil
 }
 
-func getLoginReq(r *kite.Request) (*LoginRequest, error) {
+func (k *Kloud) AuthPasswordLogin(r *kite.Request) (interface{}, error) {
+	var req PasswordLoginRequest
+
+	if err := getReq(r, &req); err != nil {
+		return nil, err
+	}
+
+	if _, err := modelhelper.CheckAndGetUser(req.Username, req.Password); err != nil {
+		return nil, errors.New("username and/or password does not match")
+	}
+
+	resp, err := k.authLogin(req.Username, &req.LoginRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	kiteKey, err := k.Userdata.Keycreator.Create(req.Username, uuid.NewV4().String())
+	if err != nil {
+		return nil, err
+	}
+
+	return &PasswordLoginResponse{
+		LoginResponse: *resp,
+		KiteKey:       kiteKey,
+	}, nil
+}
+
+func getReq(r *kite.Request, req interface{}) error {
 	if r.Args == nil {
-		return nil, NewError(ErrNoArguments)
+		return NewError(ErrNoArguments)
 	}
 
-	var req LoginRequest
-	if err := r.Args.One().Unmarshal(&req); err != nil {
-		return nil, NewError(ErrBadRequest)
+	if err := r.Args.One().Unmarshal(req); err != nil {
+		return NewError(ErrBadRequest)
 	}
 
-	if req.GroupName == "" {
-		req.GroupName = models.KDIOGroupName
+	if v, ok := req.(Validator); ok {
+		return v.Valid()
 	}
 
-	return &req, nil
+	return nil
 }

--- a/go/src/koding/kites/kloud/stack/kloud.go
+++ b/go/src/koding/kites/kloud/stack/kloud.go
@@ -17,6 +17,7 @@ import (
 	"koding/kites/kloud/pkg/dnsclient"
 	"koding/kites/kloud/pkg/idlock"
 	"koding/kites/kloud/team"
+	"koding/kites/kloud/userdata"
 	"koding/remoteapi"
 	presence "socialapi/workers/presence/client"
 
@@ -75,6 +76,9 @@ type Kloud struct {
 
 	// Endpoints represents Koding endpoints configuration.
 	Endpoints *config.Endpoints
+
+	// Userdata is used to generate new kite.keys.
+	Userdata *userdata.Userdata
 
 	// DescribeFunc is used to obtain provider types description.
 	//

--- a/go/src/koding/klientctl/auth.go
+++ b/go/src/koding/klientctl/auth.go
@@ -2,53 +2,118 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
+	"net/url"
 	"os"
 
+	"koding/kites/config"
+	"koding/kites/config/configstore"
 	"koding/kites/kloud/stack"
 	"koding/klientctl/endpoint/auth"
 	"koding/klientctl/endpoint/kloud"
 	"koding/klientctl/endpoint/team"
+	"koding/klientctl/helper"
 
 	"github.com/codegangsta/cli"
 	"github.com/koding/logging"
 )
 
 func AuthLogin(c *cli.Context, log logging.Logger, _ string) (int, error) {
+	kodingURL, err := url.Parse(c.String("koding"))
+	if err != nil {
+		return 1, fmt.Errorf("%q is not a valid URL value: %s\n", c.String("koding"), err)
+	}
+
+	k, existing := configstore.List()[config.ID(kodingURL.String())]
+	if !existing {
+		k = &config.Konfig{
+			Endpoints: &config.Endpoints{
+				Koding: config.NewEndpointURL(kodingURL),
+			},
+		}
+	}
+
+	if err := configstore.Use(k); err != nil {
+		return 1, err
+	}
+
+	// We create here a kloud client instead of using kloud.DefaultClient
+	// in order to handle first-time login attempts where configuration
+	// for kloud does not yet exist.
+	kloudClient := &kloud.Client{
+		Transport: &kloud.KiteTransport{
+			Konfig: k,
+			Log:    log,
+		},
+	}
+
+	authClient := &auth.Client{
+		Kloud: kloudClient,
+	}
+
+	teamClient := &team.Client{
+		Kloud: kloudClient,
+	}
+
 	// If we already own a valid kite.key, it means we were already
 	// authenticated and we just call kloud using kite.key authentication.
-	err := kloud.DefaultClient.Transport.(stack.Validator).Valid()
+	err = kloudClient.Transport.(stack.Validator).Valid()
 
 	log.Debug("auth: transport test: %s", err)
+
+	var session *auth.Session
 
 	if err == nil {
 		opts := &auth.LoginOptions{
 			Team: c.String("team"),
 		}
 
-		session, err := auth.Login(opts)
+		session, err = authClient.Login(opts)
+	} else {
+		user, err := helper.Ask("Username [%s]: ", config.CurrentUser.Username)
 		if err != nil {
-			return 1, fmt.Errorf("error logging into your Koding account: %v", err)
+			return 1, err
 		}
 
-		team.Use(&team.Team{Name: session.Team})
-
-		if c.Bool("json") {
-			enc := json.NewEncoder(os.Stdout)
-			enc.SetIndent("", "\t")
-			enc.Encode(session)
-		} else {
-			fmt.Fprintf(os.Stderr, "Successfully logged in to %q team.\n", session.Team)
+		if user == "" {
+			user = config.CurrentUser.Username
 		}
 
-		return 0, nil
+		pass, err := helper.AskSecret("Password [***]: ")
+		if err != nil {
+			return 1, err
+		}
+
+		opts := &auth.LoginOptions{
+			Team:     c.String("team"),
+			Username: user,
+			Password: pass,
+		}
+
+		session, err = authClient.Login(opts)
 	}
 
-	// If we do not have a valid kite.key, we authenticate with user/pass.
-	// TODO(rjeczalik): implement user/pass authentication
+	if err != nil {
+		return 1, fmt.Errorf("error logging into your Koding account: %v", err)
+	}
 
-	fmt.Fprintln(os.Stderr, "Unable to log into your Koding account. Please try again at some later time.")
+	if session.KiteKey != "" {
+		k.KiteKey = session.KiteKey
 
-	return 1, errors.New("user/pass: not implemented")
+		if err := configstore.Use(k); err != nil {
+			return 1, err
+		}
+	}
+
+	teamClient.Use(&team.Team{Name: session.Team})
+
+	if c.Bool("json") {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "\t")
+		enc.Encode(session)
+	} else {
+		fmt.Fprintf(os.Stderr, "Successfully logged in to %q team.\n", session.Team)
+	}
+
+	return 0, nil
 }

--- a/go/src/koding/klientctl/auth.go
+++ b/go/src/koding/klientctl/auth.go
@@ -19,7 +19,7 @@ import (
 )
 
 func AuthLogin(c *cli.Context, log logging.Logger, _ string) (int, error) {
-	kodingURL, err := url.Parse(c.String("koding"))
+	kodingURL, err := url.Parse(c.String("baseurl"))
 	if err != nil {
 		return 1, fmt.Errorf("%q is not a valid URL value: %s\n", c.String("koding"), err)
 	}

--- a/go/src/koding/klientctl/auth.go
+++ b/go/src/koding/klientctl/auth.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	"koding/kites/kloud/stack"
 	"koding/klientctl/endpoint/auth"
 	"koding/klientctl/endpoint/kloud"
 	"koding/klientctl/endpoint/team"
@@ -17,7 +18,7 @@ import (
 func AuthLogin(c *cli.Context, log logging.Logger, _ string) (int, error) {
 	// If we already own a valid kite.key, it means we were already
 	// authenticated and we just call kloud using kite.key authentication.
-	err := kloud.DefaultClient.Transport.Valid()
+	err := kloud.DefaultClient.Transport.(stack.Validator).Valid()
 
 	log.Debug("auth: transport test: %s", err)
 

--- a/go/src/koding/klientctl/auth.go
+++ b/go/src/koding/klientctl/auth.go
@@ -18,6 +18,10 @@ import (
 	"github.com/koding/logging"
 )
 
+var testKloudHook = nop
+
+func nop(*kloud.Client) {}
+
 func AuthLogin(c *cli.Context, log logging.Logger, _ string) (int, error) {
 	kodingURL, err := url.Parse(c.String("baseurl"))
 	if err != nil {
@@ -46,6 +50,8 @@ func AuthLogin(c *cli.Context, log logging.Logger, _ string) (int, error) {
 			Log:    log,
 		},
 	}
+
+	testKloudHook(kloudClient)
 
 	authClient := &auth.Client{
 		Kloud: kloudClient,

--- a/go/src/koding/klientctl/auth.go
+++ b/go/src/koding/klientctl/auth.go
@@ -61,19 +61,11 @@ func AuthLogin(c *cli.Context, log logging.Logger, _ string) (int, error) {
 
 	log.Debug("auth: transport test: %s", err)
 
-	var resp *stack.PasswordLoginResponse
+	opts := &auth.LoginOptions{
+		Team: c.String("team"),
+	}
 
-	if err == nil {
-		opts := &auth.LoginOptions{
-			Team: c.String("team"),
-		}
-
-		resp, err = authClient.Login(opts)
-	} else {
-		opts := &auth.LoginOptions{
-			Team: c.String("team"),
-		}
-
+	if err != nil {
 		opts.Username, err = helper.Ask("Username [%s]: ", config.CurrentUser.Username)
 		if err != nil {
 			return 1, err
@@ -92,10 +84,9 @@ func AuthLogin(c *cli.Context, log logging.Logger, _ string) (int, error) {
 				break
 			}
 		}
-
-		resp, err = authClient.Login(opts)
 	}
 
+	resp, err := authClient.Login(opts)
 	if err != nil {
 		return 1, fmt.Errorf("error logging into your Koding account: %v", err)
 	}
@@ -116,7 +107,7 @@ func AuthLogin(c *cli.Context, log logging.Logger, _ string) (int, error) {
 		enc.SetIndent("", "\t")
 		enc.Encode(resp)
 	} else {
-		fmt.Fprintf(os.Stderr, "Successfully logged in to %q team.\n", resp.GroupName)
+		fmt.Fprintf(os.Stdout, "Successfully logged in to %q team.\n", resp.GroupName)
 	}
 
 	return 0, nil

--- a/go/src/koding/klientctl/auth/register.go
+++ b/go/src/koding/klientctl/auth/register.go
@@ -119,16 +119,13 @@ func RegisterCommand(c *cli.Context, log logging.Logger, _ string) int {
 	// team cannot be empty (because of required while registering)
 	// otherwise it return error while registering user
 	// store groupName or slug as "team" inside the cache
-	teamname := c.String("team")
-	session := endpointauth.Session{
+	session := &endpointauth.Session{
 		ClientID: clientID,
-		Team:     teamname,
+		Team:     r.Slug,
 	}
+
 	// Set clientId and teamname into the kd.bolt
-	if err := endpointauth.DefaultClient.SetSession(teamname, session); err != nil {
-		log.Error("error while caching team")
-		return 1
-	}
+	endpointauth.Use(session)
 
 	return 0
 }

--- a/go/src/koding/klientctl/auth_test.go
+++ b/go/src/koding/klientctl/auth_test.go
@@ -8,34 +8,36 @@ import (
 	"testing"
 
 	"koding/kites/kloud/stack"
-	"koding/klientctl/endpoint/auth"
 	"koding/klientctl/endpoint/team"
 )
 
 func TestAuthLogin(t *testing.T) {
 	cases := map[string]struct {
-		team    *team.Team
-		session *auth.Session
+		team *team.Team
+		resp *stack.LoginResponse
 	}{
 		"foobar team": {
 			&team.Team{Name: "foobar"},
-			&auth.Session{
-				Team:     "foobar",
-				ClientID: "abcd-efgh-ijk-lmn",
+			&stack.LoginResponse{
+				GroupName: "foobar",
+				Username:  "user",
+				ClientID:  "abcd-efgh-ijk-lmn",
 			},
 		},
 		"barbaz team": {
 			&team.Team{Name: "barbaz"},
-			&auth.Session{
-				Team:     "barbaz",
-				ClientID: "abcd-efgh-ijk-lmn",
+			&stack.LoginResponse{
+				GroupName: "barbaz",
+				Username:  "user",
+				ClientID:  "abcd-efgh-ijk-lmn",
 			},
 		},
 		"hebele team": {
 			&team.Team{Name: "hebele"},
-			&auth.Session{
-				Team:     "hebele",
-				ClientID: "abcd-efgh-ijk-lmn",
+			&stack.LoginResponse{
+				GroupName: "hebele",
+				Username:  "user",
+				ClientID:  "abcd-efgh-ijk-lmn",
 			},
 		},
 	}
@@ -50,10 +52,7 @@ func TestAuthLogin(t *testing.T) {
 			}
 
 			cmd.FT.Add("kite.print", nil)
-			cmd.FT.Add("auth.login", &stack.LoginResponse{
-				GroupName: cas.session.Team,
-				ClientID:  cas.session.ClientID,
-			})
+			cmd.FT.Add("auth.login", cas.resp)
 
 			err := cmd.Run("auth", "login",
 				"--team", cas.team.Name,
@@ -64,14 +63,14 @@ func TestAuthLogin(t *testing.T) {
 				t.Fatalf("Run()=%s", err)
 			}
 
-			var got auth.Session
+			var got stack.LoginResponse
 
 			if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
 				t.Fatalf("Unmarshal()=%s", err)
 			}
 
-			if !reflect.DeepEqual(&got, cas.session) {
-				t.Fatalf("got %#v, want %#v", &got, cas.session)
+			if !reflect.DeepEqual(&got, cas.resp) {
+				t.Fatalf("got %#v, want %#v", &got, cas.resp)
 			}
 
 			buf.Reset()

--- a/go/src/koding/klientctl/deploy.sh
+++ b/go/src/koding/klientctl/deploy.sh
@@ -35,6 +35,12 @@ echo "# uploading files to s3://${BUCKET}/${CHANNEL}/"
 s3cp "kd-0.1.${VERSION}.linux_amd64.gz" "s3://${BUCKET}/${CHANNEL}/"
 s3cp "kd-0.1.${VERSION}.darwin_amd64.gz" "s3://${BUCKET}/${CHANNEL}/"
 
+s3rm "s3://${BUCKET}/${CHANNEL}/kd.linux_amd64.gz"
+s3cp "s3://${BUCKET}/${CHANNEL}/kd-0.1.${VERSION}.linux_amd64.gz" "s3://${BUCKET}/${CHANNEL}/kd.linux_amd64.gz"
+
+s3rm "s3://${BUCKET}/${CHANNEL}/kd.darwin_amd64.gz"
+s3cp "s3://${BUCKET}/${CHANNEL}/kd-0.1.${VERSION}.darwin_amd64.gz" "s3://${BUCKET}/${CHANNEL}/kd.darwin_amd64.gz"
+
 cp -f go/src/koding/klientctl/install-kd.sh install-kd.sh
 sed -i "" -e "s|\%RELEASE_CHANNEL\%|${CHANNEL}|g" install-kd.sh
 s3rm "s3://${BUCKET}/${CHANNEL}/install-kd.sh"

--- a/go/src/koding/klientctl/endpoint/auth/auth.go
+++ b/go/src/koding/klientctl/endpoint/auth/auth.go
@@ -91,7 +91,7 @@ func (c *Client) SetSession(team string, s Session) error {
 	return nil
 }
 
-func (c *Client) GetSession(team string) *Session {
+func (c *Client) Session(team string) *Session {
 	c.init()
 
 	v, ok := c.sessions[team]

--- a/go/src/koding/klientctl/endpoint/machine/list.go
+++ b/go/src/koding/klientctl/endpoint/machine/list.go
@@ -31,7 +31,6 @@ func List(options *ListOptions) ([]*Info, error) {
 
 	// Get info from kloud.
 	if err := kloud.Call("machine.list", &listReq, &listRes); err != nil {
-		fmt.Fprintln(os.Stderr, "Error communicating with Koding:", err)
 		return nil, err
 	}
 

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -107,11 +107,7 @@ func run(args []string) {
 		os.Exit(10)
 	}
 
-	kloud.DefaultClient.Log = log
-	if kt, ok := kloud.DefaultClient.Transport.(*kloud.KiteTransport); ok {
-		kt.Log = log
-	}
-
+	kloud.DefaultLog = log
 	defer ctlcli.Close()
 
 	// TODO(leeola): deprecate this default, instead passing it as a dependency
@@ -424,7 +420,12 @@ func run(args []string) {
 							},
 							cli.StringFlag{
 								Name:  "team, t",
-								Usage: "Specify a koding.com team to log in. Leaving empty logs in to kd.io by default.",
+								Usage: "Specify a Koding team to log in. Leaving empty logs in to kd.io by default.",
+							},
+							cli.StringFlag{
+								Name:  "koding",
+								Usage: "Specify a Koding endpoint to log in.",
+								Value: config.Konfig.Endpoints.Koding.Public.String(),
 							},
 						},
 					},

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -108,6 +108,7 @@ func run(args []string) {
 	}
 
 	kloud.DefaultLog = log
+	testKloudHook(kloud.DefaultClient)
 	defer ctlcli.Close()
 
 	// TODO(leeola): deprecate this default, instead passing it as a dependency

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -423,7 +423,7 @@ func run(args []string) {
 								Usage: "Specify a Koding team to log in. Leaving empty logs in to kd.io by default.",
 							},
 							cli.StringFlag{
-								Name:  "koding",
+								Name:  "baseurl",
 								Usage: "Specify a Koding endpoint to log in.",
 								Value: config.Konfig.Endpoints.Koding.Public.String(),
 							},

--- a/go/src/koding/klientctl/main_test.go
+++ b/go/src/koding/klientctl/main_test.go
@@ -34,7 +34,13 @@ func TestMainHelper(t *testing.T) {
 	}
 
 	if ft := NewFakeTransport(os.Getenv("TEST_MAIN_HELPER_FAKETRANSPORT")); ft != nil {
-		kloud.DefaultClient.Transport = ft
+		testKloudHook = func(client *kloud.Client) {
+			client.Transport = ft
+		}
+
+		defer func() {
+			testKloudHook = nop
+		}()
 	}
 
 	run(append(os.Args[:1], args...))


### PR DESCRIPTION
This PR implements password login for kd.

It makes it possible to login with just kd binary to a Koding account, without the need of magic link:

```
$ wget https://s3.amazonaws.com/koding-kd/development/kd.darwin_amd64.gz
$ gunzip -c kd.darwin_amd64.gz > ~/bin/kd
$ chmod +x ~/bin/kd
```
```
$ kd auth login --team foobar --baseurl http://rjeczalik.koding.team
Username [rjeczalik]: 
Password [***]: 
Successfully logged in to "foobar" team.
```

`--team`: Currently dev environment has no default group created (and new users are not its members be default) - https://github.com/koding/koding/issues/9827 (cc @usirin) - that's why it requires explicit team name for development environment.

`--baseurl`: Logs in to a particular Koding deployment using single kd binary, so it's possible e.g. to work with production and sandbox environment. If not provided logs in to:

- `https://sandbox.koding.com` for development kd
- `https://koding.com` for production kd

Next step is to migrate install-kd.sh to koding/klientctl - it will be a base for reworked `kd daemon install` that also installs dependencies. First run of `kd auth login` will detect that kd was not yet installed (no deps + no kd daemon service running) and will offer a user a way to install it right away.

Depends on: ~#10127~ ~#10111~