### PR TITLE
	landing: fix lint error

### DIFF
--- a/client/landing/site.landing/coffee/team/forms/stripepaymenttabform.coffee
+++ b/client/landing/site.landing/coffee/team/forms/stripepaymenttabform.coffee
@@ -75,7 +75,7 @@ module.exports = class StripePaymentTabForm extends LoginViewInlineForm
     @whyTip = new kd.CustomHTMLView
       cssClass : 'TeamsModal-ccwarning'
       partial : '''<strong>We ask your credit card purely for verification purposes.</strong>
-                   Your credit card will be charged 50 cents for authentication, and it will be 
+                   Your credit card will be charged 50 cents for authentication, and it will be
                    automatically refunded within 1-7 days. You will receive an email to confirm
                    before your trial ends.
                    '''


### PR DESCRIPTION
Current master fails with:

```
$ scripts/wercker/run-command scripts/lint-coffeescript.sh
Linting client directory
  ✗ scripts/../client/landing/site.landing/coffee/team/forms/stripepaymenttabform.coffee
     ✗ #78: Line ends with trailing whitespace.
```