### PR TITLE
klient/mount: abstract mount types

### DIFF
--- a/go/src/koding/klient/machine/mount/mount.go
+++ b/go/src/koding/klient/machine/mount/mount.go
@@ -1,0 +1,10 @@
+package mount
+
+// ID is a unique identifier of the mount.
+type ID string
+
+// Mount stores information about a single local to remote machine mount.
+type Mount struct {
+	Path  string `json:"path"`  // Mount point.
+	RPath string `json:"rpath"` // Remote directory path.
+}

--- a/go/src/koding/klient/machine/mount/mount.go
+++ b/go/src/koding/klient/machine/mount/mount.go
@@ -5,6 +5,6 @@ type ID string
 
 // Mount stores information about a single local to remote machine mount.
 type Mount struct {
-	Path  string `json:"path"`  // Mount point.
-	RPath string `json:"rpath"` // Remote directory path.
+	Path       string `json:"path"`       // Mount point.
+	RemotePath string `json:"remotePath"` // Remote directory path.
 }


### PR DESCRIPTION
This PR adds `mount` abstract types.

Depends on: -

## Description
This is an index-based machine mount architecture. It is intended to solve all(known) performance and stability problems with current implementation. It will allow for:

 - multiple mounts per remote machine.
 - two-way synchronization using FUSE for fast local->remote synchronization and Poller for remote->local->remote sync.
 - FUSE logic is loosely coupled - it is possible to easily replace/extend it if we want to support different VFS(may be useful for Windows support).
 - "lazy" mounts - in order to create complete FS on local machine, we only need to fetch remote index. Other files can be downloaded when requested by Kernel.
 - Context based synchronization - all sync processes will be stopped if remote machine is unreachable.
 - Star network mounts - local machines A & B can mount directory from machine C and changes made by A will be seen by machine B(not in real time).
 - etc.

## Architecture
![image](https://cloud.githubusercontent.com/assets/5021246/21513385/f7771780-ccb7-11e6-96e9-5a1ff8861641.png)

- **Mount** - abstract representation of single mount.
- Local/remote **Index** - index of files stored in mounted directory.
- **Mounts** - storage of mounts per machine.

- **Sync** - type responsible for syncing remote and local indexes.
- **Syncer** - interface responsible for transferring files between local and remote machine.
- **RSync** - RSync process used for syncing files.

- **Notifier** - interface responsible for creating index changes.
- **FUSE** - real time FS notification system based on FUSE.
- **Poller** - periodically checks remote and local index in order to keep them synced.


## How Has This Been Tested?
Only data structures - nothing to test.

## Screenshots (if appropriate):
none

## Types of changes
- [x] New feature (non-breaking change which adds functionality)