### PR TITLE
Update trial decision mechanism

### DIFF
--- a/client/app/lib/redux/modules/payment/subscription.coffee
+++ b/client/app/lib/redux/modules/payment/subscription.coffee
@@ -84,17 +84,10 @@ makePlanAmount = (userCount) ->
 plan = (state) -> state.subscription?.plan
 
 
-isTrialing = (state) -> state.subscription?.status is 'trialing'
+isTrial = (state) -> state.subscription?.status is 'trialing'
 
 
 hasNoCard = (state) -> not state.creditCard
-
-
-isTrial = createSelector(
-  isTrialing
-  hasNoCard
-  (trialing, noCard) -> noCard and trialing
-)
 
 
 endsAt = (state) ->
@@ -136,5 +129,3 @@ module.exports = {
   # Selectors
   plan, isTrial, endsAt, pricePerSeat, trialDays, daysLeft
 }
-
-

--- a/client/component-lab/SubscriptionHeader/SubscriptionHeader.coffee
+++ b/client/component-lab/SubscriptionHeader/SubscriptionHeader.coffee
@@ -61,7 +61,9 @@ module.exports = class SubscriptionHeader extends Component
 
   renderNextBillingAmount: ->
 
-    { nextBillingAmount } = @props
+    { nextBillingAmount, isTrial } = @props
+
+    return null  if isTrial
 
     <Col xs={4} className={textStyles.right}>
       <Label size="small" type="info">
@@ -96,4 +98,3 @@ SubscriptionHeader.defaultProps =
   nextBillingAmount: 0
   isTrial: no
   endsAt: Date.now()
-

--- a/client/component-lab/TrialChargeInfo/TrialChargeInfo.coffee
+++ b/client/component-lab/TrialChargeInfo/TrialChargeInfo.coffee
@@ -1,53 +1,19 @@
 kd = require 'kd'
 { PropTypes } = React = require 'react'
-generateClassName = require 'classnames'
 pluralize = require 'pluralize'
-{ Grid, Row, Col } = require 'react-flexbox-grid'
-dateDiffInDays = require 'app/util/dateDiffInDays'
+{ Row, Col } = require 'react-flexbox-grid'
 formatNumber = require 'app/util/formatNumber'
 
-classes = require './TrialChargeInfo.stylus'
 textStyles = require 'lab/Text/Text.stylus'
 
 Box = require 'lab/Box'
 Label = require 'lab/Text/Label'
 
-ExpirationMessage = ({ daysLeft }) ->
-
-  daysLeft ?= 100
-
-  title = if daysLeft >= 0
-  then "Your trial period is about to expire"
-  else "Your trial period has expired"
-
-  <Row>
-    <Col xs={12}>
-      <Label size="small" type="danger">
-        <strong>{title}</strong>
-      </Label>
-    </Col>
-    <Col xs={12}>
-      <Label size="small" type="info">
-        Please add a credit card below to continue to use Koding. You will be
-        charged based on your team size. If you have free credit,  it will be
-        deducted from your bill after you enter a credit card. Click below for
-        pricing details.
-      </Label>
-    </Col>
-  </Row>
-
 
 TrialChargeInfo = ({ teamSize, pricePerSeat, daysLeft }) ->
 
-  isDanger = daysLeft < 4
-
-  <Box border={1} type={if isDanger then 'danger' else 'secondary'}>
+  <Box border={1} type='secondary'>
     <Row>
-      {if daysLeft < 4
-        <Col xs={12} className={classes['expiration']}>
-          <ExpirationMessage daysLeft={daysLeft} />
-        </Col>
-      }
       <Col xs={5}>
         <Label size="small">
           Team Size: <strong>{pluralize 'Developer', teamSize, yes}</strong>
@@ -72,4 +38,3 @@ TrialChargeInfo.defaultProps =
   pricePerSeat: 49.977777777777776
 
 module.exports = TrialChargeInfo
-


### PR DESCRIPTION
We were deciding if a team is in trial via checking if the subscription status is `trialing` **AND** if they have no credit card on file. This PR changes this behavior as each team should have a credit card already.

Before
=====
![image](https://cloud.githubusercontent.com/assets/1783869/21518429/3fc1294e-cc9b-11e6-83b7-05e814459068.png)

After
====
![image](https://cloud.githubusercontent.com/assets/1783869/21518434/46086376-cc9b-11e6-99d0-3f20a49de032.png)

