### PR TITLE
kloud: preserve private endpoint

### DIFF
--- a/config/generateKonfig.coffee
+++ b/config/generateKonfig.coffee
@@ -209,7 +209,7 @@ module.exports = (options, credentials) ->
       klientLatest     :
         public         : "https://koding-klient.s3.amazonaws.com/#{options.environment}/latest-version.txt"
       kodingBase       :
-        public         : "#{options.publicHostname}"
+        public         : "#{options.customDomain.public}"
         private        : "#{options.customDomain.local}"
       tunnelServer     :
         public         : "#{options.tunnelUrl}/kite"

--- a/go/src/koding/kites/kloud/kloud/kloud.go
+++ b/go/src/koding/kites/kloud/kloud/kloud.go
@@ -421,7 +421,7 @@ func newEndpoints(cfg *Config) *config.Endpoints {
 	e := config.NewKonfig(&config.Environments{Env: cfg.Environment}).Endpoints
 
 	if cfg.KodingURL != nil {
-		e.Koding = config.NewEndpointURL(cfg.KodingURL.URL)
+		e.Koding.Public = cfg.KodingURL
 	}
 
 	if cfg.TunnelURL != "" {


### PR DESCRIPTION
Do not overwrite private endpoint, which was read from the built-in configuration.

This fixes scenario, where public endpoint (notably kontrol) is
configured behind a tunnel with a mapped port. Like:

```
./configure --host=koding-hakankaradis.oud.cc:4480 --hostname=koding-hakankaradis.oud.cc --config dev
```

/cc @hakankaradis @gokmen 