### PR TITLE
kloud: kd machine list - add support for managed machines.

### DIFF
--- a/go/src/koding/db/models/machine.go
+++ b/go/src/koding/db/models/machine.go
@@ -38,25 +38,25 @@ type MachineGeneratedFrom struct {
 }
 
 type Machine struct {
-	ObjectId      bson.ObjectId        `bson:"_id" json:"_id"`
-	Uid           string               `bson:"uid" json:"uid"`
-	QueryString   string               `bson:"queryString,omitempty" json:"queryString"`
-	IpAddress     string               `bson:"ipAddress" json:"ipAddress"`
-	RegisterURL   string               `bson:"registerUrl" json:"registerUrl"`
-	Domain        string               `bson:"domain" json:"domain"`
-	Provider      string               `bson:"provider" json:"provider"`
-	Label         string               `bson:"label" json:"label"`
-	Slug          string               `bson:"slug" json:"slug"`
-	Provisoners   []bson.ObjectId      `bson:"provisoners" json:"provisoners"`
-	Credential    string               `bson:"credential" json:"credential"`
-	Users         []MachineUser        `bson:"users" json:"users"`
-	Groups        []MachineGroup       `bson:"groups" json:"groups"`
-	CreatedAt     time.Time            `bson:"createdAt" json:"createdAt" `
-	Status        MachineStatus        `bson:"status" json:"status"`
-	Meta          bson.M               `bson:"meta" json:"meta"`
-	Assignee      MachineAssignee      `bson:"assignee" json:"assignee"`
-	UserDeleted   bool                 `bson:"userDeleted" json:"userDeleted"`
-	GeneratedFrom MachineGeneratedFrom `bson:"generatedFrom,omitempty" json:"generatedFrom,omitempty"`
+	ObjectId      bson.ObjectId         `bson:"_id" json:"_id"`
+	Uid           string                `bson:"uid" json:"uid"`
+	QueryString   string                `bson:"queryString,omitempty" json:"queryString"`
+	IpAddress     string                `bson:"ipAddress" json:"ipAddress"`
+	RegisterURL   string                `bson:"registerUrl" json:"registerUrl"`
+	Domain        string                `bson:"domain" json:"domain"`
+	Provider      string                `bson:"provider" json:"provider"`
+	Label         string                `bson:"label" json:"label"`
+	Slug          string                `bson:"slug" json:"slug"`
+	Provisoners   []bson.ObjectId       `bson:"provisoners" json:"provisoners"`
+	Credential    string                `bson:"credential" json:"credential"`
+	Users         []MachineUser         `bson:"users" json:"users"`
+	Groups        []MachineGroup        `bson:"groups" json:"groups"`
+	CreatedAt     time.Time             `bson:"createdAt" json:"createdAt" `
+	Status        MachineStatus         `bson:"status" json:"status"`
+	Meta          bson.M                `bson:"meta" json:"meta"`
+	Assignee      MachineAssignee       `bson:"assignee" json:"assignee"`
+	UserDeleted   bool                  `bson:"userDeleted" json:"userDeleted"`
+	GeneratedFrom *MachineGeneratedFrom `bson:"generatedFrom,omitempty" json:"generatedFrom,omitempty"`
 }
 
 // Owner returns the owner of a machine

--- a/go/src/koding/kites/kloud/machine/mongo.go
+++ b/go/src/koding/kites/kloud/machine/mongo.go
@@ -107,19 +107,10 @@ func (m *MongoDatabase) Machines(f *Filter) ([]*Machine, error) {
 		groupTitles[st.Id] = [2]string{st.Group, st.Title}
 	}
 
-	var team, stack string
 	machines := make([]*Machine, len(machinesDB))
 	for i, mdb := range machinesDB {
-		team, stack = "", ""
-		if mdb.GeneratedFrom != nil {
-			team = groupTitles[mdb.GeneratedFrom.TemplateId][0]
-			stack = groupTitles[mdb.GeneratedFrom.TemplateId][1]
-		}
-
 		machines[i] = &Machine{
 			ID:          mdb.ObjectId.Hex(),
-			Team:        team,
-			Stack:       stack,
 			Provider:    mdb.Provider,
 			Label:       mdb.Label,
 			IP:          hostOnly(mdb.IpAddress),
@@ -132,6 +123,11 @@ func (m *MongoDatabase) Machines(f *Filter) ([]*Machine, error) {
 				ModifiedAt: mdb.Status.ModifiedAt,
 			},
 			Users: filterUsers(mdb.Users, f),
+		}
+
+		if mdb.GeneratedFrom != nil {
+			machines[i].Team = groupTitles[mdb.GeneratedFrom.TemplateId][0]
+			machines[i].Stack = groupTitles[mdb.GeneratedFrom.TemplateId][1]
 		}
 	}
 

--- a/go/src/koding/kites/kloud/machine/mongo_test.go
+++ b/go/src/koding/kites/kloud/machine/mongo_test.go
@@ -62,7 +62,7 @@ func prepareMongoMachines() error {
 				State:  "running",
 				Reason: "because it can",
 			},
-			GeneratedFrom: models.MachineGeneratedFrom{
+			GeneratedFrom: &models.MachineGeneratedFrom{
 				TemplateId: boberStack,
 			},
 		},
@@ -87,7 +87,7 @@ func prepareMongoMachines() error {
 					Username: blaster,
 				},
 			},
-			GeneratedFrom: models.MachineGeneratedFrom{
+			GeneratedFrom: &models.MachineGeneratedFrom{
 				TemplateId: boberStack,
 			},
 		},
@@ -111,7 +111,7 @@ func prepareMongoMachines() error {
 					Username: blaster,
 				},
 			},
-			GeneratedFrom: models.MachineGeneratedFrom{
+			GeneratedFrom: &models.MachineGeneratedFrom{
 				TemplateId: johnStack,
 			},
 		},
@@ -126,7 +126,7 @@ func prepareMongoMachines() error {
 					Username: blaster,
 				},
 			},
-			GeneratedFrom: models.MachineGeneratedFrom{
+			GeneratedFrom: &models.MachineGeneratedFrom{
 				TemplateId: blasterStack,
 			},
 		},

--- a/go/src/koding/klient/machine/dynamic_test.go
+++ b/go/src/koding/klient/machine/dynamic_test.go
@@ -29,6 +29,7 @@ func TestDynamicClientOnOff(t *testing.T) {
 	}
 
 	// Server starts responding.
+	ctx := dc.Context()
 	serv.TurnOn()
 	if err := builder.WaitForBuild(time.Second); err != nil {
 		t.Fatalf("want err = nil; got %v", err)
@@ -36,12 +37,15 @@ func TestDynamicClientOnOff(t *testing.T) {
 	if n := builder.BuildsCount(); n != 1 {
 		t.Fatalf("want builds count = 1; got %d", n)
 	}
+	if err := machinetest.WaitForContextClose(ctx, time.Second); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
 	if status := dc.Status(); status.State != machine.StateOnline {
 		t.Fatalf("want state = %s; got %s", machine.StateOnline, status.State)
 	}
 
 	// Stop server.
-	ctx := dc.Context()
+	ctx = dc.Context()
 	serv.TurnOff()
 	if err := builder.WaitForBuild(time.Second); err != nil {
 		t.Fatalf("want err = nil; got %v", err)


### PR DESCRIPTION
Machine.GeneratedFrom field is `null` for managed machines. This causes `kd machine ls` fail for them, since we try to bson-unmarshal nil pointer to non-pointer field:

```sh
$ kd machine ls
Error communicating with Koding: ObjectIDs must be exactly 12 bytes long (got 0) (329309e5469ed4b2)
error executing "list" command: ObjectIDs must be exactly 12 bytes long (got 0) (329309e5469ed4b2)
```

After the fix:
```sh
kd machine ls
ID                        ALIAS         TEAM  STACK                     PROVIDER  LABEL             OWNER  AGE     IP                                         STATUS
584ffc262586bbae18308d44  olive_raisin  ssh   Alakazam Aws Stack        aws       aws-instance             15d5h   35.156.209.39                              online (15d5h)
584ffd312586bbae18308d4b  fuchsia_kiwi  ssh   Aerodactyl Vagrant Stack  vagrant   vagrant-instance         15d5h   upsvfffe9f69.pawel.1d543013.dev.koding.me  offline (7d23h: Machine is marked as Stopped)
58640b4f569ccef36b598315  black_banana  -     -                         managed   archpk                   18m56s  c1feb3e08536.pawel.1d543013.dev.koding.me  <unknown> (-)
```

This PR also fixes false negative race condition in machine dynamic client tests.

## Motivation and Context
Bug fix in db/models

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

