### PR TITLE
kites/config: copy builtin endpoint values

### DIFF
--- a/go/src/koding/kites/config/config.go
+++ b/go/src/koding/kites/config/config.go
@@ -104,6 +104,28 @@ func (u *URL) WithPath(paths ...string) *URL {
 	return &URL{URL: &ur}
 }
 
+// Copy returns a copy of the u.
+func (u *URL) Copy() *URL {
+	if u.IsNil() {
+		return nil
+	}
+
+	uCopy := *u.URL
+	if u.URL.User != nil {
+		userCopy := *u.URL.User
+		uCopy.User = &userCopy
+	}
+
+	return &URL{
+		URL: &uCopy,
+	}
+}
+
+// IsNil returns true if either u or the underlying url is nil.
+func (u *URL) IsNil() bool {
+	return u == nil || u.URL == nil
+}
+
 // Endpoint represents a single endpoint.
 type Endpoint struct {
 	Public  *URL `json:"public,omitempty"`
@@ -186,6 +208,22 @@ func (e *Endpoint) WithPath(path string) *Endpoint {
 	}
 
 	return ePath
+}
+
+// Copy returns a copy of the e.
+func (e *Endpoint) Copy() *Endpoint {
+	if e.IsNil() {
+		return nil
+	}
+	return &Endpoint{
+		Public:  e.Public.Copy(),
+		Private: e.Private.Copy(),
+	}
+}
+
+// IsNil returns true if either e or both of the public and private urls are nil.
+func (e *Endpoint) IsNil() bool {
+	return e == nil || (e.Public.IsNil() && e.Private.IsNil())
 }
 
 // Config stores all static configuration data generated during ./configure phase.

--- a/go/src/koding/kites/config/config_test.go
+++ b/go/src/koding/kites/config/config_test.go
@@ -2,7 +2,11 @@ package config
 
 import (
 	"fmt"
+	"net/url"
+	"reflect"
 	"testing"
+
+	"koding/tools/utils"
 )
 
 func TestReplaceEnv(t *testing.T) {
@@ -198,5 +202,92 @@ func TestEndpointEqual(t *testing.T) {
 				t.Fatalf("got %t, want %t", ok, cas.ok)
 			}
 		})
+	}
+}
+
+func TestURLCopy(t *testing.T) {
+	cases := map[string]*URL{
+		"nil url":            nil,
+		"nil underlying url": {URL: nil},
+		"simple url":         {URL: &url.URL{Scheme: "http", Host: "example.com"}},
+		"url with user":      {URL: &url.URL{Scheme: "http", Host: "example.com", User: url.UserPassword("user", "pass")}},
+	}
+
+	for name, u := range cases {
+		t.Run(name, func(t *testing.T) {
+			uCopy := u.Copy()
+
+			if u.IsNil() {
+				if uCopy != nil {
+					t.Errorf("want uCopy to be nil; got %#v", uCopy)
+				}
+
+				return
+			}
+
+			modifyURL(uCopy)
+
+			if reflect.DeepEqual(uCopy, u) {
+				t.Errorf("want %#v != %#v", uCopy, u)
+			}
+		})
+	}
+}
+
+func modifyURL(u *URL) {
+	if u.IsNil() {
+		return
+	}
+
+	u.URL.Host = utils.RandomString()
+
+	if u.URL.User != nil {
+		u.URL.User = url.UserPassword(utils.RandomString(), "")
+	}
+}
+
+func TestEndpointCopy(t *testing.T) {
+	url := &URL{URL: &url.URL{Scheme: "http", Host: "example.com", User: url.UserPassword("user", "pass")}}
+
+	cases := map[string]*Endpoint{
+		"nil endpoint":          nil,
+		"nil underlying urls":   {Private: nil, Public: nil},
+		"private-only endpoint": {Private: url},
+		"public-only endpoint":  {Public: url},
+		"endpoint":              {Private: url, Public: url},
+	}
+
+	for name, e := range cases {
+		t.Run(name, func(t *testing.T) {
+			eCopy := e.Copy()
+
+			if e.IsNil() {
+				if eCopy != nil {
+					t.Errorf("want eCopy to be nil; got %#v", eCopy)
+				}
+
+				return
+			}
+
+			modifyEndpoint(eCopy)
+
+			if reflect.DeepEqual(eCopy, e) {
+				t.Errorf("want %#v != %#v", eCopy, e)
+			}
+		})
+	}
+}
+
+func modifyEndpoint(e *Endpoint) {
+	if e.IsNil() {
+		return
+	}
+
+	if !e.Public.IsNil() {
+		modifyURL(e.Public)
+	}
+
+	if !e.Private.IsNil() {
+		modifyURL(e.Private)
 	}
 }

--- a/go/src/koding/kites/config/konfig.go
+++ b/go/src/koding/kites/config/konfig.go
@@ -232,10 +232,10 @@ func NewKonfig(e *Environments) *Konfig {
 	return &Konfig{
 		Environment: e.Env,
 		Endpoints: &Endpoints{
-			Koding:       Builtin.Endpoints.KodingBase,
-			Tunnel:       Builtin.Endpoints.TunnelServer,
-			IP:           Builtin.Endpoints.IP,
-			IPCheck:      Builtin.Endpoints.IPCheck,
+			Koding:       Builtin.Endpoints.KodingBase.Copy(),
+			Tunnel:       Builtin.Endpoints.TunnelServer.Copy(),
+			IP:           Builtin.Endpoints.IP.Copy(),
+			IPCheck:      Builtin.Endpoints.IPCheck.Copy(),
 			KlientLatest: ReplaceEnv(Builtin.Endpoints.KlientLatest, e.klientEnv()),
 			KDLatest:     ReplaceEnv(Builtin.Endpoints.KDLatest, RmManaged(e.kdEnv())),
 			Klient: &Endpoint{


### PR DESCRIPTION
This PR adds defensive copying to protect config.Builtin from unintentional writes.