### PR TITLE
Machine mount index cache

### DIFF
--- a/go/src/koding/klient/machine/mount/index/cache.go
+++ b/go/src/koding/klient/machine/mount/index/cache.go
@@ -1,0 +1,172 @@
+package index
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const tempIndexDirPrefix = "koding_index_"
+
+// GetCachedIndex returns index that describes the current directory state. This
+// function stores the resulting index in temporary file in order to not
+// recompute it each time when the index is requested.
+func GetCachedIndex(root string) (*Index, error) {
+	var cs ChangeSlice
+
+	// Load or create index.
+	idx, path, err := getCachedIndex(root)
+	if err != nil {
+		// Generate new index.
+		if idx, err = NewIndexFiles(root); err != nil {
+			return nil, err
+		}
+	} else {
+		// Update loaded index.
+		cs = idx.Compare(root)
+		idx.Apply(root, cs)
+	}
+
+	// If index changed or was generated, save it.
+	if path == "" || len(cs) != 0 {
+		if path == "" {
+			if path, err = createTempPath(root); err != nil {
+				return nil, err
+			}
+		}
+
+		if err = cacheIndex(idx, path); err != nil {
+			return nil, err
+		}
+	}
+
+	return idx, nil
+}
+
+// HeadCachedIndex gets cached index or creates a new one and returns the number
+// and the overall size of stored files.
+func HeadCachedIndex(root string) (count int, diskSize int64, err error) {
+	idx, err := GetCachedIndex(root)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return idx.Count(-1), idx.DiskSize(-1), nil
+}
+
+// getCachedIndex looks up for index stored in one of temporary directories.
+// If provided index is found, it will be loaded to memory and returned.
+func getCachedIndex(root string) (idx *Index, path string, err error) {
+	name := hashSHA1(root)
+	// Find index in temporary directories.
+	for _, tempdir := range indexTempDirs(-1) {
+		path = filepath.Join(tempdir, name)
+		if _, err = os.Stat(path); err == nil {
+			break
+		}
+	}
+
+	if path == "" || err != nil {
+		return nil, "", errors.New("index file not found")
+	}
+
+	// Read index content.
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, "", err
+	}
+	defer f.Close()
+
+	idx = NewIndex()
+	if err = json.NewDecoder(f).Decode(idx); err != nil {
+		return nil, "", err
+	}
+
+	return idx, path, nil
+}
+
+// cacheIndex atomically saves the provided index under a given path. If the
+// path is empty, this function will create or use existing index temporary
+// directory.
+func cacheIndex(idx *Index, path string) (err error) {
+	dir, name := filepath.Split(path)
+	f, err := ioutil.TempFile(dir, name+"_")
+	if err != nil {
+		return err
+	}
+
+	if err := json.NewEncoder(f).Encode(idx); err == nil {
+		err = f.Sync()
+	}
+
+	if cerr := f.Close(); cerr != nil && err == nil {
+		err = cerr
+	}
+
+	if err == nil {
+		err = os.Rename(f.Name(), path)
+	}
+
+	if err != nil {
+		os.Remove(f.Name())
+	}
+
+	return err
+}
+
+// createTempPath creates a valid path to index file.
+func createTempPath(root string) (path string, err error) {
+	if dirs := indexTempDirs(1); len(dirs) > 0 {
+		path = dirs[0]
+	} else {
+		if path, err = ioutil.TempDir("", tempIndexDirPrefix); err != nil {
+			return "", err
+		}
+	}
+
+	return filepath.Join(path, hashSHA1(root)), nil
+}
+
+// indexTempDirs reads all directory names that could be created by index cache.
+func indexTempDirs(n int) []string {
+	d, err := os.Open(os.TempDir())
+	if err != nil {
+		return nil
+	}
+	defer d.Close()
+
+	if n <= 0 {
+		n = -1
+	}
+
+	var dirs []string
+	for len(dirs) != n {
+		// Limit the number of read directories.
+		names, err := d.Readdirnames(100)
+
+		for i := range names {
+			if strings.HasPrefix(names[i], tempIndexDirPrefix) {
+				dirs = append(dirs, filepath.Join(os.TempDir(), names[i]))
+			}
+		}
+
+		if err != nil {
+			break
+		}
+	}
+
+	return dirs
+}
+
+// hashSHA1 converts a string to hex representation of its SHA-1 checksum.
+func hashSHA1(val string) string {
+	h := sha1.New()
+	io.WriteString(h, val)
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/go/src/koding/klient/machine/mount/index/cache.go
+++ b/go/src/koding/klient/machine/mount/index/cache.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -166,7 +165,6 @@ func indexTempDirs(n int) []string {
 
 // hashSHA1 converts a string to hex representation of its SHA-1 checksum.
 func hashSHA1(val string) string {
-	h := sha1.New()
-	io.WriteString(h, val)
-	return hex.EncodeToString(h.Sum(nil))
+	h := sha1.Sum([]byte(val))
+	return hex.EncodeToString(h[:])
 }

--- a/go/src/koding/klient/machine/mount/index/cache_test.go
+++ b/go/src/koding/klient/machine/mount/index/cache_test.go
@@ -1,0 +1,140 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCachedIndexCreate(t *testing.T) {
+	if err := cleanTempDirs(); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	defer cleanTempDirs()
+
+	root, clean, err := generateTree()
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	defer clean()
+
+	idx, err := GetCachedIndex(root)
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	// Check index integrity.
+	count, diskSize, err := HeadCachedIndex(root)
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	if count != idx.Count(-1) {
+		t.Errorf("want %d entries, got %d", idx.Count(-1), count)
+	}
+	if diskSize != idx.DiskSize(-1) {
+		t.Errorf("want size = %d bytes, got %d", idx.DiskSize(-1), diskSize)
+	}
+
+	// Cache should reuse existing index.
+	dirnames, idxs, err := tmpDirInfo()
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	if l := len(dirnames); l != 1 {
+		t.Errorf("want 1 temp directory; got %d", l)
+	}
+	if l := len(idxs); l != 1 {
+		t.Errorf("want 1 index file; got %d", l)
+	}
+}
+
+func TestCahcedIndexUpdated(t *testing.T) {
+	if err := cleanTempDirs(); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	defer cleanTempDirs()
+
+	root, clean, err := generateTree()
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	defer clean()
+
+	idx, err := GetCachedIndex(root)
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	if err := writeFile("new_file.txt", 1024)(root); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	// Should update and return new index.
+	idx2, err := GetCachedIndex(root)
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	if count := idx.Count(-1) + 1; count != idx2.Count(-1) {
+		t.Errorf("want %d entries; got %d", count, idx2.Count(-1))
+	}
+	if diskSize := idx.DiskSize(-1) + 1024; diskSize > idx2.DiskSize(-1) {
+		t.Errorf("want at least %d B of disk size; got %d B", diskSize, idx2.DiskSize(-1))
+	}
+
+	// Cache should reuse existing index.
+	dirnames, idxs, err := tmpDirInfo()
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	if l := len(dirnames); l != 1 {
+		t.Errorf("want 1 temp directory; got %d", l)
+	}
+	if l := len(idxs); l != 1 {
+		t.Errorf("want 1 index file; got %d", l)
+	}
+}
+
+func cleanTempDirs() error {
+	dirnames, _, err := tmpDirInfo()
+	if err != nil {
+		return err
+	}
+
+	for _, dirname := range dirnames {
+		if e := os.RemoveAll(dirname); e != nil && err == nil {
+			err = e
+		}
+	}
+
+	return err
+}
+
+func tmpDirInfo() (dirnames, idxs []string, err error) {
+	walkFn := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+
+		dir, file := filepath.Split(path)
+		if info.IsDir() && strings.HasPrefix(file, tempIndexDirPrefix) {
+			dirnames = append(dirnames, path)
+		}
+
+		if strings.HasPrefix(filepath.Base(dir), tempIndexDirPrefix) {
+			if filepath.Join(os.TempDir(), filepath.Base(dir), file) != path {
+				return nil
+			}
+
+			idxs = append(idxs, path)
+		}
+
+		return nil
+	}
+
+	if err := filepath.Walk(os.TempDir(), walkFn); err != nil {
+		return nil, nil, err
+	}
+
+	return dirnames, idxs, nil
+}

--- a/go/src/koding/klient/machine/mount/index/cache_test.go
+++ b/go/src/koding/klient/machine/mount/index/cache_test.go
@@ -29,11 +29,11 @@ func TestCachedIndexCreate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("want err = nil; got %v", err)
 	}
-	if count != idx.Count(-1) {
-		t.Errorf("want %d entries, got %d", idx.Count(-1), count)
+	if n := idx.Count(-1); count != n {
+		t.Errorf("want %d entries, got %d", n, count)
 	}
-	if diskSize != idx.DiskSize(-1) {
-		t.Errorf("want size = %d bytes, got %d", idx.DiskSize(-1), diskSize)
+	if n := idx.DiskSize(-1); diskSize != n {
+		t.Errorf("want size = %d bytes, got %d", n, diskSize)
 	}
 
 	// Cache should reuse existing index.
@@ -75,11 +75,11 @@ func TestCahcedIndexUpdated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("want err = nil; got %v", err)
 	}
-	if count := idx.Count(-1) + 1; count != idx2.Count(-1) {
-		t.Errorf("want %d entries; got %d", count, idx2.Count(-1))
+	if count, n := idx.Count(-1)+1, idx2.Count(-1); count != n {
+		t.Errorf("want %d entries; got %d", count, n)
 	}
-	if diskSize := idx.DiskSize(-1) + 1024; diskSize > idx2.DiskSize(-1) {
-		t.Errorf("want at least %d B of disk size; got %d B", diskSize, idx2.DiskSize(-1))
+	if diskSize, n := idx.DiskSize(-1)+1024, idx2.DiskSize(-1); diskSize > n {
+		t.Errorf("want at least %d B of disk size; got %d B", diskSize, n)
 	}
 
 	// Cache should reuse existing index.

--- a/go/src/koding/klient/machine/mount/index/index.go
+++ b/go/src/koding/klient/machine/mount/index/index.go
@@ -12,6 +12,9 @@ import (
 	"github.com/djherbis/times"
 )
 
+// Version stores current version of index.
+const Version = 1
+
 // Entry represents a single file registered to index.
 type Entry struct {
 	Name  string      `json:"name"`  // The relative name of the file.

--- a/go/src/koding/klient/machine/mount/index/index_test.go
+++ b/go/src/koding/klient/machine/mount/index/index_test.go
@@ -140,6 +140,9 @@ func TestIndex(t *testing.T) {
 				t.Fatalf("want err = nil; got %v", err)
 			}
 
+			// Synchronize underlying file-system.
+			Sync()
+
 			cs := idx.Compare(root)
 			sort.Sort(cs)
 			if len(cs) != len(test.Changes) {
@@ -256,6 +259,8 @@ func generateTree() (root string, clean func(), err error) {
 
 func addDir(file string) func(string) error {
 	return func(root string) error {
+		defer Sync()
+
 		dir := filepath.Join(root, filepath.FromSlash(file))
 		if filepath.Ext(dir) != "" {
 			dir = filepath.Dir(dir)
@@ -267,6 +272,8 @@ func addDir(file string) func(string) error {
 
 func writeFile(file string, size int64) func(string) error {
 	return func(root string) error {
+		defer Sync()
+
 		if filepath.Ext(file) == "" {
 			return nil
 		}
@@ -284,22 +291,29 @@ func writeFile(file string, size int64) func(string) error {
 
 func rmAllFile(file string) func(string) error {
 	return func(root string) error {
+		defer Sync()
+
 		return os.RemoveAll(filepath.Join(root, filepath.FromSlash(file)))
 	}
 }
 
 func mvFile(oldpath, newpath string) func(string) error {
 	return func(root string) error {
+		defer Sync()
+
 		var (
 			oldpath = filepath.Join(root, filepath.FromSlash(oldpath))
 			newpath = filepath.Join(root, filepath.FromSlash(newpath))
 		)
+
 		return os.Rename(oldpath, newpath)
 	}
 }
 
 func chmodFile(file string, mode os.FileMode) func(string) error {
 	return func(root string) error {
+		defer Sync()
+
 		return os.Chmod(filepath.Join(root, filepath.FromSlash(file)), mode)
 	}
 }

--- a/go/src/koding/klient/machine/mount/index/index_unix_test.go
+++ b/go/src/koding/klient/machine/mount/index/index_unix_test.go
@@ -1,0 +1,12 @@
+// +build !windows
+
+package index
+
+import "syscall"
+
+// Sync causes all buffered modifications to file metadata and data to be
+// written to the underlying file systems. This function must be called in order
+// to not receive false negative test results.
+func Sync() {
+	syscall.Sync()
+}

--- a/go/src/koding/klient/machine/mount/index/index_windows_test.go
+++ b/go/src/koding/klient/machine/mount/index/index_windows_test.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package index
+
+// Sync is a no-op on Windows. This file is here only to make windows builds
+// work.
+func Sync() {}

--- a/go/src/koding/klient/machine/mount/mount.go
+++ b/go/src/koding/klient/machine/mount/mount.go
@@ -23,6 +23,13 @@ func MakeID() ID {
 	return ID(uuid.NewV4().String())
 }
 
+// IDSlice stores multiple mount IDs.
+type IDSlice []ID
+
+func (ids IDSlice) Len() int           { return len(ids) }
+func (ids IDSlice) Swap(i, j int)      { ids[i], ids[j] = ids[j], ids[i] }
+func (ids IDSlice) Less(i, j int) bool { return ids[i] < ids[j] }
+
 // Mount stores information about a single local to remote machine mount.
 type Mount struct {
 	Path       string `json:"path"`       // Mount point.
@@ -97,7 +104,7 @@ func (mb *MountBook) Path(path string) (ID, error) {
 // remote directory to different local paths. This function returns
 // ErrMountNotFound if neither of stored mounts uses the given path. Provided
 // path must be in its absolute and cleaned representation.
-func (mb *MountBook) RemotePath(path string) (ids []ID, err error) {
+func (mb *MountBook) RemotePath(path string) (ids IDSlice, err error) {
 	if !filepath.IsAbs(path) {
 		return nil, fmt.Errorf("path %q is not absolute", path)
 	}

--- a/go/src/koding/klient/machine/mount/mount_test.go
+++ b/go/src/koding/klient/machine/mount/mount_test.go
@@ -3,6 +3,7 @@ package mount
 import (
 	"encoding/json"
 	"reflect"
+	"sort"
 	"testing"
 )
 
@@ -32,19 +33,19 @@ func TestMountBook(t *testing.T) {
 		Path          string
 		PathID        ID
 		RemotePath    string
-		RemotePathIDs []ID
+		RemotePathIDs IDSlice
 	}{
 		"paths from mount A": {
 			Path:          "/home/koding/a",
 			PathID:        idA,
 			RemotePath:    "/home/koding/remote/a",
-			RemotePathIDs: []ID{idA},
+			RemotePathIDs: IDSlice{idA},
 		},
 		"shared remote path": {
 			Path:          "/home/koding/b",
 			PathID:        idB,
 			RemotePath:    "/home/koding/remote/shared",
-			RemotePathIDs: []ID{idB, idC},
+			RemotePathIDs: IDSlice{idB, idC},
 		},
 		"unknown paths": {
 			Path:          "/home/koding/unknown",
@@ -63,7 +64,7 @@ func TestMountBook(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-
+			sort.Sort(test.RemotePathIDs)
 			id, err := mb.Path(test.Path)
 			if test.PathID == "" && err == nil {
 				t.Errorf("want err != nil, got nil")
@@ -76,6 +77,7 @@ func TestMountBook(t *testing.T) {
 			}
 
 			ids, err := mb.RemotePath(test.RemotePath)
+			sort.Sort(ids)
 			if test.RemotePathIDs == nil && err == nil {
 				t.Errorf("want err != nil, got nil")
 			}


### PR DESCRIPTION
Cache is used to retrieve mounted directory index without recomputing it each time. 

Depends on: ~#10134~

**Code coverage**: 84.6% of statements.

## Description
This is an index-based machine mount architecture. It is intended to solve all(known) performance and stability problems with current implementation. It will allow for:

 - multiple mounts per remote machine.
 - two-way synchronization using FUSE for fast local->remote synchronization and Poller for remote->local->remote sync.
 - FUSE logic is loosely coupled - it is possible to easily replace/extend it if we want to support different VFS(may be useful for Windows support).
 - "lazy" mounts - in order to create complete FS on local machine, we only need to fetch remote index. Other files can be downloaded when requested by Kernel.
 - Context based synchronization - all sync processes will be stopped if remote machine is unreachable.
 - Star network mounts - local machines A & B can mount directory from machine C and changes made by A will be seen by machine B(not in real time).
 - etc.

## Architecture
![image](https://cloud.githubusercontent.com/assets/5021246/21575756/163a2894-cf18-11e6-945c-4dff23576561.png)


- **Mount** - abstract representation of single mount.
- Local/remote **Index** - index of files stored in mounted directory.
- **Mounts** - storage of mounts per machine.

- **Sync** - type responsible for syncing remote and local indexes.
- **Syncer** - interface responsible for transferring files between local and remote machine.
- **RSync** - RSync process used for syncing files.

- **Notifier** - interface responsible for creating index changes.
- **FUSE** - real time FS notification system based on FUSE.
- **Poller** - periodically checks remote and local index in order to keep them synced.


## How Has This Been Tested?
Unit tests.

## Screenshots (if appropriate):
none

## Types of changes
- [x] New feature (non-breaking change which adds functionality)