### PR TITLE
Member-role change menu doesn't disappear after selecting make member/admin options.

### DIFF
--- a/client/app/lib/components/buttonwithmenu/index.coffee
+++ b/client/app/lib/components/buttonwithmenu/index.coffee
@@ -13,7 +13,6 @@ module.exports = class ButtonWithMenu extends React.Component
 
   @defaultProps =
     items: []
-    isMenuOpen: no
     listClass:''
     menuClassName:''
 
@@ -30,7 +29,6 @@ module.exports = class ButtonWithMenu extends React.Component
   listDidMount: (_list) ->
 
     button = ReactDOM.findDOMNode @refs.button
-    return @setState isMenuOpen: no  unless button
     list = ReactDOM.findDOMNode _list
     buttonRect = button.getBoundingClientRect()
 

--- a/client/app/lib/components/buttonwithmenu/index.coffee
+++ b/client/app/lib/components/buttonwithmenu/index.coffee
@@ -17,10 +17,18 @@ module.exports = class ButtonWithMenu extends React.Component
     menuClassName:''
 
 
+  constructor: (props) ->
+
+    super props
+
+    @state = { isMenuOpen : null }
+
+
   renderListMenu: ->
 
     onClick = (item) => (event) =>
       item.onClick event
+      @setState { isMenuOpen: false }
 
     @props.items.map (item) ->
       <li onClick={onClick item} key={item.key}>{item.title}</li>

--- a/client/app/lib/components/buttonwithmenu/index.coffee
+++ b/client/app/lib/components/buttonwithmenu/index.coffee
@@ -47,8 +47,9 @@ module.exports = class ButtonWithMenu extends React.Component
   render: ->
 
     button = <button ref='button'></button>
+
     <div className="ButtonWithMenuWrapper">
-      <Portal openByClickOn={button} closeOnOutsideClick closeOnEsc>
+      <Portal openByClickOn={button} closeOnOutsideClick closeOnEsc isOpened={@state.isMenuOpen}>
         <div className={@props.menuClassName}>
           <ul ref={@bound 'listDidMount'} className={kd.utils.curry "ButtonWithMenuItemsList", @props.listClass}>
             {@renderListMenu()}

--- a/client/home/lib/myteam/components/hometeamteammates/member.coffee
+++ b/client/home/lib/myteam/components/hometeamteammates/member.coffee
@@ -11,22 +11,6 @@ module.exports = class Member extends React.Component
 
     super props
 
-    @state =
-      isMenuOpen: no
-
-
-  onClickMemberRole: (role, event) ->
-
-    kd.utils.stopDOMEvent event
-    @setState { isMenuOpen: yes }
-
-
-  componentWillReceiveProps: (nextProps) ->
-
-    { isMenuOpen } = nextProps
-
-    @setState { isMenuOpen }
-
 
   getMenuItems: (role) ->
 
@@ -91,30 +75,29 @@ module.exports = class Member extends React.Component
         items={@getMenuItems role}
         admins={@props.admins}
         canEdit={canEdit}
-        onClick={@onClickMemberRole.bind(this, role)}
-        isMenuOpen={@state.isMenuOpen}
         member={@props.member} />
     </div>
 
 
-MemberRoleWithDropDownMenu = ({ canEdit, role, onClick, items, isMenuOpen, admins, member }) ->
+MemberRoleWithDropDownMenu = ({ canEdit, role, items, admins, member }) ->
 
   showButtonWithMenu = role is 'owner' and admins.size is 0
-
   unless canEdit and not showButtonWithMenu
     <div className='dropdown'>
       <MemberRole role={role} canEdit={canEdit}  />
-      {<ButtonWithMenu menuClassName='menu-class' items={items} isMenuOpen={isMenuOpen} />  if member.get('inviterId') is whoami()._id}
+      {<ButtonWithMenu menuClassName='menu-class' items={items} />  if member.get('inviterId') is whoami()._id}
     </div>
   else
-    <div className='dropdown' onClick={onClick}>
+    <div className='dropdown'>
       <MemberRole role={role} canEdit={canEdit} showPointer={yes} />
-      <ButtonWithMenu menuClassName='menu-class' items={items} isMenuOpen={isMenuOpen} />
+      <ButtonWithMenu menuClassName='menu-class' items={items} />
     </div>
+
 
 Badge = ({ role }) ->
   role = 'member'  unless role
   <div className={"badge #{role}"} title={role}></div>
+
 
 NickName = ({ nickname }) ->
 
@@ -122,9 +105,11 @@ NickName = ({ nickname }) ->
   then <span className='nickname'>@{nickname}</span>
   else <i></i>
 
+
 Email = ({ email }) ->
 
   <span className='email-js email' title={email}>{email}</span>
+
 
 AvatarView = ({ member, role }) ->
 


### PR DESCRIPTION
The member roles list portal wasn't disappeared  After changing member role form Dashboar/My Team/Teammates section.

React-Portal V3:
We are handling opening portal with `openByClickOn` prop. but it doesn't enough to close the portal. 
We added another prop to close portal that is `isOpened`. This props will be deprecated in React-Portal V4, we should be aware of that when we upgrade the `react-portal` package.

In old version of react-portal we were using isMenuOpened props, but now we don't need to handle opening and closing modal in other components.

In the buttonwithmenu/index.coffee
When user click one of list item, we are setting `isOpened` prop to `false` to close the portal 


## Motivation and Context
fixes: #10067 

## Screenshots (if appropriate):
http://recordit.co/gH1TI1BNHF

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
