### PR TITLE
Name of the file isn't updated on editor's header when you rename the file from the file tree.

### DIFF
--- a/client/finder/lib/filetree/controllers/nfindertreecontroller.coffee
+++ b/client/finder/lib/filetree/controllers/nfindertreecontroller.coffee
@@ -300,10 +300,8 @@ module.exports = class NFinderTreeController extends JTreeViewController
 
       nodeData.rename newValue, (err) =>
         if err then @notify null, null, err
-        @emit 'NodeRenamed', nodeData, newValue
         Tracker.track Tracker.FILETREE_RENAME_FILE_FOLDER
 
-      # @setKeyView()
       @beingEdited = null
 
   createFile: (nodeView, type = 'file') ->

--- a/client/finder/lib/filetree/controllers/nfindertreecontroller.coffee
+++ b/client/finder/lib/filetree/controllers/nfindertreecontroller.coffee
@@ -300,6 +300,8 @@ module.exports = class NFinderTreeController extends JTreeViewController
 
       nodeData.rename newValue, (err) =>
         if err then @notify null, null, err
+
+        nodeData.emit 'FilePathChanged', newValue
         Tracker.track Tracker.FILETREE_RENAME_FILE_FOLDER
 
       @beingEdited = null

--- a/client/ide/lib/finder/idefindertreecontroller.coffee
+++ b/client/ide/lib/finder/idefindertreecontroller.coffee
@@ -7,25 +7,6 @@ IDEHelpers = require '../idehelpers'
 module.exports = class IDEFinderTreeController extends NFinderTreeController
 
 
-  constructor: (options, data) ->
-
-    super options, data
-
-    @on 'NodeRenamed',  (node, newName) ->
-      return if node.options.type is 'file'
-
-      IDEHelpers.updateWorkspace node, node.parentPath + '/' + newName
-
-    @on 'NodesRemoved',  (nodes) ->
-      IDEHelpers.updateWorkspace node.getData() for node in nodes
-
-
-    @on 'NodesMoved',  (nodes, target) ->
-      for node in nodes
-        sourceItem = node.getData()
-        IDEHelpers.updateWorkspace sourceItem, target.path + '/' + sourceItem.name
-
-
   cmCreateWorkspace: (node) -> @createWorkspace node
 
 

--- a/client/ide/lib/views/tabview/ideview.coffee
+++ b/client/ide/lib/views/tabview/ideview.coffee
@@ -98,7 +98,6 @@ module.exports = class IDEView extends IDEWorkspaceTabView
           tabHandle.on 'RenamingRequested', (newTitle) =>
             pane.view.file.rename newTitle, (err) =>
               if err then @notify null, null, err
-              @emit 'NodeRenamed', pane.view.file, newTitle
 
               pane.view.file.emit 'FilePathChanged', newTitle
           tabHandle.makeEditable()


### PR DESCRIPTION
## Description
Emit FilePathChanged from file when file is renamed from file tree

## Motivation and Context
Fixes: #10058 

## Screenshots (if appropriate):
http://recordit.co/5reQMBoWcj

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
