### PR TITLE
Extra padding on top of each stack and teammates section on dashboard 

### DIFF
--- a/client/home/lib/styl/homestacks.styl
+++ b/client/home/lib/styl/homestacks.styl
@@ -67,6 +67,11 @@ $borderColor                = rgba(151, 151, 151, .52)
 .ListView-section.HomeAppViewStackSection
   .ListView-row
     borderizeListItems      25px, 1px solid $borderColor
+  .ListView-row
+    padding-top             0px !important
+  .ListView-row ~ .ListView-row
+    padding-top             25px !important
+
 
 .HomeAppView--scroller.stacks
 

--- a/client/home/lib/styl/hometeammates.styl
+++ b/client/home/lib/styl/hometeammates.styl
@@ -36,25 +36,14 @@ hometeammates.styl
         left                4px
         r-sprite            app badge_icon_admin
 
-
-  &:first-of-type
-    .avatarview
-      top                   4px
-      overflow              visible
-
-    .dropdown
-      top                   10px
-
   .avatarview
     height                  40px
-    abs                     24px 0 0 0px
     &.default
       r-sprite              home user_default
 
   .details
     line-height             24px
     margin-left             57px
-
 
   p
     dInline()
@@ -84,7 +73,6 @@ hometeammates.styl
 
 
   .dropdown
-    abs                     30px 2px 0 0
 
     .role
       display               inline-block
@@ -109,4 +97,18 @@ hometeammates.styl
         borderBox()
 
 
+.HomeApp-Teammate--ListItem
+  padding-top               0px !important
+  .avatarview
+    abs                     4px 0 0 0px
+    overflow                visible
 
+  .dropdown
+    abs                     20px 2px 0 0
+
+.HomeApp-Teammate--ListItem ~ .HomeApp-Teammate--ListItem
+  padding-top               20px !important
+  .avatarview
+    top                     24px
+  .dropdown
+    top                     30px


### PR DESCRIPTION
Even we have this code for `borderizeListItems`
https://github.com/koding/koding/blob/master/client/app/styl/commons/appfn.styl#L340
with the description of `:first-of-type` that represents the first element among siblings of its element type. But the first element's of the list `padding-top` wasn't set correctly. 
Strangely, it is working for some other components...

My first solution was adding a style for this class to generalize the solution https://github.com/koding/koding/blob/master/client/app/lib/components/list/index.coffee#L136
That cause other styling problems in other components because of some custom implementation.

So I had to customize the all elements in list but first.
Not sure that it is a correct solution.
![](https://monosnap.com/file/S6JtVdfVWzEdhwbdmav165D9KiWsmL.png)
![](https://monosnap.com/file/jut6C9uMYaIUTSuPyQDTOh3p4g9ywE.png)

Fixes #10203