### PR TITLE
Add mount storage group that manages all kd mounts.

### DIFF
--- a/go/src/koding/klient/machine/machinegroup/mounts/cached.go
+++ b/go/src/koding/klient/machine/machinegroup/mounts/cached.go
@@ -1,0 +1,105 @@
+package mounts
+
+import (
+	"sync"
+
+	"koding/klient/machine"
+	"koding/klient/machine/mount"
+	"koding/klient/storage"
+)
+
+// storageKey is a database key used to store mounts.
+const storageKey = "mounts"
+
+// Cached is a Mounts object with additional storage layer.
+type Cached struct {
+	mu sync.Mutex
+	st storage.ValueInterface
+
+	mounts *Mounts
+}
+
+// NewCached creates a new Cached object backed by provided storage.
+func NewCached(st storage.ValueInterface) (*Cached, error) {
+	c := &Cached{
+		st:     st,
+		mounts: New(),
+	}
+
+	if err := c.st.GetValue(storageKey, &c.mounts.m); err != nil && err != storage.ErrKeyNotFound {
+		return nil, err
+	}
+
+	// Drop inconsistent data.
+	for id, mb := range c.mounts.m {
+		if mb == nil {
+			delete(c.mounts.m, id)
+		}
+	}
+
+	return c, nil
+}
+
+// Add adds provided mount to a given machine and updates the cache.
+func (c *Cached) Add(id machine.ID, mountID mount.ID, m mount.Mount) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.mounts.Add(id, mountID, m); err != nil {
+		return err
+	}
+
+	return c.st.SetValue(storageKey, c.mounts.all())
+}
+
+// Remove removes a given mount from cache ad updates it.
+func (c *Cached) Remove(mountID mount.ID) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.mounts.Remove(mountID); err != nil {
+		return err
+	}
+
+	return c.st.SetValue(storageKey, c.mounts.all())
+}
+
+// Drop removes all mounts which are binded to provided machine ID and
+// updates the cache.
+func (c *Cached) Drop(id machine.ID) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.mounts.Drop(id); err != nil {
+		return err
+	}
+
+	return c.st.SetValue(storageKey, c.mounts.all())
+}
+
+// Path returns mount ID which mount's local path is equal to provided
+// argument.
+func (c *Cached) Path(path string) (mount.ID, error) {
+	return c.mounts.Path(path)
+}
+
+// RemotePath returns all mount IDs which RemotePath field matches provided
+// argument.
+func (c *Cached) RemotePath(path string) (mount.IDSlice, error) {
+	return c.mounts.RemotePath(path)
+}
+
+// MachineID gets machine ID based on provided mount ID.
+func (c *Cached) MachineID(mountID mount.ID) (machine.ID, error) {
+	return c.mounts.MachineID(mountID)
+}
+
+// All returns a copy of all mounts connected with a given machine.
+func (c *Cached) All(id machine.ID) (map[mount.ID]mount.Mount, error) {
+	return c.mounts.All(id)
+}
+
+// Registered returns all machines that are managed by mounter.
+func (c *Cached) Registered() machine.IDSlice {
+	return c.mounts.Registered()
+}

--- a/go/src/koding/klient/machine/machinegroup/mounts/mounter.go
+++ b/go/src/koding/klient/machine/machinegroup/mounts/mounter.go
@@ -1,0 +1,35 @@
+package mounts
+
+import (
+	"koding/klient/machine"
+	"koding/klient/machine/mount"
+)
+
+// Mounter is an interface used to manage machines' mounts.
+type Mounter interface {
+	// Add adds provided mount to a given machine.
+	Add(machine.ID, mount.ID, mount.Mount) error
+
+	// Remove removes a given mount from cache.
+	Remove(mount.ID) error
+
+	// Drop removes all mounts which are binded to provided machine ID.
+	Drop(machine.ID) error
+
+	// Path returns mount ID which mount's local path is equal to provided
+	// argument.
+	Path(string) (mount.ID, error)
+
+	// RemotePath returns all mount IDs which RemotePath field matches provided
+	// argument.
+	RemotePath(string) (mount.IDSlice, error)
+
+	// MachineID gets machine ID based on provided mount ID.
+	MachineID(mount.ID) (machine.ID, error)
+
+	// All returns a copy of all mounts connected with a given machine.
+	All(machine.ID) (map[mount.ID]mount.Mount, error)
+
+	// Registered returns all machines that are managed by mounter.
+	Registered() machine.IDSlice
+}

--- a/go/src/koding/klient/machine/machinegroup/mounts/mounts.go
+++ b/go/src/koding/klient/machine/machinegroup/mounts/mounts.go
@@ -1,0 +1,169 @@
+package mounts
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+
+	"koding/klient/machine"
+	"koding/klient/machine/mount"
+)
+
+// Mounts store mounts of all machines in the group.
+type Mounts struct {
+	mu sync.RWMutex
+	m  map[machine.ID]*mount.MountBook
+}
+
+// New creates an empty Mounts object.
+func New() *Mounts {
+	return &Mounts{
+		m: make(map[machine.ID]*mount.MountBook),
+	}
+}
+
+// Add adds provided mount to a given machine.
+func (ms *Mounts) Add(id machine.ID, mountID mount.ID, m mount.Mount) error {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+
+	mb, ok := ms.m[id]
+	if !ok {
+		mb = mount.NewMountBook()
+	}
+
+	mb.Add(mountID, m)
+	ms.m[id] = mb
+
+	return nil
+}
+
+// Remove removes a given mount from the cache.
+func (ms *Mounts) Remove(mountID mount.ID) error {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+
+	for id, mb := range ms.m {
+		all := mb.All()
+		switch _, ok := all[mountID]; {
+		case ok && len(all) == 1:
+			// Drop the entire mount book.
+			delete(ms.m, id)
+			return nil
+		case ok:
+			mb.Remove(mountID)
+			return nil
+		}
+	}
+
+	return nil
+}
+
+// Drop removes all mounts which are binded to provided machine ID.
+func (ms *Mounts) Drop(id machine.ID) error {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	delete(ms.m, id)
+
+	return nil
+}
+
+// Path returns mount ID which mount's local path is equal to provided
+// argument.
+func (ms *Mounts) Path(path string) (mount.ID, error) {
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("path %q is not absolute", path)
+	}
+
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+
+	for _, mb := range ms.m {
+		if mountID, err := mb.Path(path); err == nil {
+			return mountID, nil
+		}
+	}
+
+	return "", mount.ErrMountNotFound
+}
+
+// RemotePath returns all mount IDs which RemotePath field matches provided
+// argument. Path must be absolute and cleaned. mount.ErrMountNotFound is
+// returned if there is no mount with provided ID.
+func (ms *Mounts) RemotePath(path string) (ids mount.IDSlice, err error) {
+	if !filepath.IsAbs(path) {
+		return nil, fmt.Errorf("path %q is not absolute", path)
+	}
+
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+
+	for _, mb := range ms.m {
+		if mids, err := mb.RemotePath(path); err == nil {
+			ids = append(ids, mids...)
+		}
+	}
+
+	if len(ids) == 0 {
+		return nil, mount.ErrMountNotFound
+	}
+
+	return ids, nil
+}
+
+// MachineID gets machine ID based on provided mount ID. mount.ErrMountNotFound
+// is returned if there is no mount with provided ID.
+func (ms *Mounts) MachineID(mountID mount.ID) (machine.ID, error) {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+
+	for id, mb := range ms.m {
+		for storedID := range mb.All() {
+			if mountID == storedID {
+				return id, nil
+			}
+		}
+	}
+
+	return "", mount.ErrMountNotFound
+}
+
+// All returns a copy of all mounts connected with a given machine.
+func (ms *Mounts) All(id machine.ID) (map[mount.ID]mount.Mount, error) {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+
+	if mb, ok := ms.m[id]; ok {
+		return mb.All(), nil
+	}
+
+	return nil, machine.ErrMachineNotFound
+}
+
+// Registered returns all machines that are managed by mounts object.
+func (ms *Mounts) Registered() machine.IDSlice {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+
+	registered := make(machine.IDSlice, 0, len(ms.m))
+	for id := range ms.m {
+		registered = append(registered, id)
+	}
+
+	return registered
+}
+
+// all returns all stored mounts.
+func (ms *Mounts) all() map[machine.ID]*mount.MountBook {
+	all := make(map[machine.ID]*mount.MountBook)
+
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+	for id, mb := range ms.m {
+		// It is save to return pointer here since mount book's internal
+		// fields are synchronized internally.
+		all[id] = mb
+	}
+
+	return all
+}

--- a/go/src/koding/klient/machine/machinegroup/mounts/mounts_test.go
+++ b/go/src/koding/klient/machine/machinegroup/mounts/mounts_test.go
@@ -1,0 +1,220 @@
+package mounts
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"koding/klient/machine"
+	"koding/klient/machine/mount"
+)
+
+func TestMountsPath(t *testing.T) {
+	tests := map[string]struct {
+		Path    string
+		MountID mount.ID
+		Valid   bool
+	}{
+		"valid mount from A machine": {
+			Path:    "/home/koding/b",
+			MountID: "mountAB",
+			Valid:   true,
+		},
+		"valid mount from B machine": {
+			Path:    "/home/koding/d",
+			MountID: "mountBA",
+			Valid:   true,
+		},
+		"non absolute path": {
+			Path:    "../.",
+			MountID: "",
+			Valid:   false,
+		},
+		"unknown path": {
+			Path:    "/home/koding/unknown",
+			MountID: "",
+			Valid:   false,
+		},
+	}
+
+	ms, err := mountsObject()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mountID, err := ms.Path(test.Path)
+			if (err == nil) != test.Valid {
+				t.Fatalf("want err == nil => %t; got err %v", test.Valid, err)
+			}
+
+			if err == nil && test.MountID != mountID {
+				t.Fatalf("want mount ID = %s; got %s", test.MountID, mountID)
+			}
+		})
+	}
+}
+
+func TestMountsRemotePath(t *testing.T) {
+	tests := map[string]struct {
+		RemotePath string
+		MountIDs   mount.IDSlice
+		Valid      bool
+	}{
+		"remote from A machine": {
+			RemotePath: "/home/koding/remote/c",
+			MountIDs:   mount.IDSlice{"mountAC"},
+			Valid:      true,
+		},
+		"remote from A and B machines": {
+			RemotePath: "/home/koding/remote/a",
+			MountIDs:   mount.IDSlice{"mountAA", "mountBA"},
+			Valid:      true,
+		},
+		"non absolute path": {
+			RemotePath: "../.",
+			MountIDs:   nil,
+			Valid:      false,
+		},
+		"unknown path": {
+			RemotePath: "/home/koding/unknown",
+			MountIDs:   nil,
+			Valid:      false,
+		},
+	}
+
+	ms, err := mountsObject()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mountIDs, err := ms.RemotePath(test.RemotePath)
+			sort.Sort(mountIDs)
+			if (err == nil) != test.Valid {
+				t.Fatalf("want err == nil => %t; got err %v", test.Valid, err)
+			}
+
+			if err == nil && !reflect.DeepEqual(mountIDs, test.MountIDs) {
+				t.Fatalf("want mount ID = %v; got %v", test.MountIDs, mountIDs)
+			}
+		})
+	}
+}
+
+func TestMountsMachineID(t *testing.T) {
+	tests := map[string]struct {
+		MountID mount.ID
+		ID      machine.ID
+		Valid   bool
+	}{
+		"machine A mount": {
+			MountID: "mountAC",
+			ID:      "machineA",
+			Valid:   true,
+		},
+		"machine B mount": {
+			MountID: "mountBA",
+			ID:      "machineB",
+			Valid:   true,
+		},
+		"unknown mount ID": {
+			MountID: "unknown",
+			ID:      "",
+			Valid:   false,
+		},
+	}
+
+	ms, err := mountsObject()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			id, err := ms.MachineID(test.MountID)
+			if (err == nil) != test.Valid {
+				t.Fatalf("want err == nil => %t; got err %v", test.Valid, err)
+			}
+
+			if err == nil && test.ID != id {
+				t.Fatalf("want machine ID = %s; got %s", test.ID, id)
+			}
+		})
+	}
+}
+
+func TestMountsRemove(t *testing.T) {
+	ms, err := mountsObject()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ms.Remove("mountAA"); err != nil {
+		t.Errorf("want err = nil; got %v", err)
+	}
+	all, err := ms.All("machineA")
+	if err != nil {
+		t.Errorf("want err = nil; got %v", err)
+	}
+	if l := len(all); l != 2 {
+		t.Errorf("want 2 mounts in machine A; got %d", l)
+	}
+
+	if err := ms.Remove("mountBA"); err != nil {
+		t.Errorf("want err = nil; got %v", err)
+	}
+	if _, err := ms.All("machineB"); err == nil {
+		t.Errorf("want err != nil; got nil")
+	}
+}
+
+func mountsObject() (*Mounts, error) {
+	var data = []struct {
+		ID      machine.ID
+		MountID mount.ID
+		Mount   mount.Mount
+	}{
+		{
+			ID:      "machineA",
+			MountID: "mountAA",
+			Mount: mount.Mount{
+				Path:       "/home/koding/a",
+				RemotePath: "/home/koding/remote/a",
+			},
+		}, {
+			ID:      "machineA",
+			MountID: "mountAB",
+			Mount: mount.Mount{
+				Path:       "/home/koding/b",
+				RemotePath: "/home/koding/remote/b",
+			},
+		}, {
+			ID:      "machineA",
+			MountID: "mountAC",
+			Mount: mount.Mount{
+				Path:       "/home/koding/c",
+				RemotePath: "/home/koding/remote/c",
+			},
+		}, {
+			ID:      "machineB",
+			MountID: "mountBA",
+			Mount: mount.Mount{
+				Path:       "/home/koding/d",
+				RemotePath: "/home/koding/remote/a",
+			},
+		},
+	}
+
+	ms := New()
+	for i, d := range data {
+		if err := ms.Add(d.ID, d.MountID, d.Mount); err != nil {
+			return nil, fmt.Errorf("want err = nil; got %v (i:%d)", err, i)
+		}
+	}
+
+	return ms, nil
+}


### PR DESCRIPTION
Mounts provided persistent storage between kd restarts.

Depends on: ~#10206~

**Code coverage**: 52.2% of statements

## Description
This is an index-based machine mount architecture. It is intended to solve all(known) performance and stability problems with current implementation. It will allow for:

 - multiple mounts per remote machine.
 - two-way synchronization using FUSE for fast local->remote synchronization and Poller for remote->local->remote sync.
 - FUSE logic is loosely coupled - it is possible to easily replace/extend it if we want to support different VFS(may be useful for Windows support).
 - "lazy" mounts - in order to create complete FS on local machine, we only need to fetch remote index. Other files can be downloaded when requested by Kernel.
 - Context based synchronization - all sync processes will be stopped if remote machine is unreachable.
 - Star network mounts - local machines A & B can mount directory from machine C and changes made by A will be seen by machine B(not in real time).
 - etc.

## Architecture
![image](https://cloud.githubusercontent.com/assets/5021246/21663606/93053c02-d2e1-11e6-9104-2a7749ca7552.png)

- **Mount** - abstract representation of single mount.
- **Mount Book** - group of mounts.
- Local/remote **Index** - index of files stored in mounted directory.
- **Mounts** - storage of mounts per machine.

- **Sync** - type responsible for syncing remote and local indexes.
- **Syncer** - interface responsible for transferring files between local and remote machine.
- **RSync** - RSync process used for syncing files.

- **Notifier** - interface responsible for creating index changes.
- **FUSE** - real time FS notification system based on FUSE.
- **Poller** - periodically checks remote and local index in order to keep them synced.


## How Has This Been Tested?
Unit tests.

## Screenshots (if appropriate):
none

## Types of changes
- [x] New feature (non-breaking change which adds functionality)