### PR TITLE
scripts/api-generator: improvements for method parameters

### DIFF
--- a/scripts/api-generator.coffee
+++ b/scripts/api-generator.coffee
@@ -154,7 +154,7 @@ generateMethodPaths = (model, definitions, paths, docs) ->
   methods = model.getSharedMethods()
 
   schema = if definitions[name]
-  then { $ref: "#/definitions/#{name}" }
+  then { allOf: [ { $ref: "#/definitions/#{name}" }, { $ref: '#/definitions/DefaultResponse' } ] }
   else { $ref: '#/definitions/DefaultResponse' }
 
   for method, signatures of methods.statik

--- a/scripts/api-generator.coffee
+++ b/scripts/api-generator.coffee
@@ -194,7 +194,7 @@ generateMethodPaths = (model, definitions, paths, docs) ->
 
   for method, signatures of methods.instance
 
-    parameters = [ { $ref: '#/parameters/instanceParam' } ]
+    parameters = [ { $ref: '#/parameters/instanceParam' }, { $ref: '#/parameters/bodyParam' } ]
     response = { description: 'OK', schema }
     if returns = docs[name]['instance'][method]?.returns
       if Object.keys(returns).length and swagger.definitions[returns.type]

--- a/scripts/api-generator.coffee
+++ b/scripts/api-generator.coffee
@@ -43,11 +43,6 @@ swagger =
           example: 'KodingError'
     DefaultSelector:
       type: 'object'
-      properties:
-        _id:
-          type: 'string'
-          description: 'Mongo Object ID'
-          example: '582c21d43bf248161538450b'
     DefaultResponse:
       type: 'object'
       properties:

--- a/website/swagger.json
+++ b/website/swagger.json
@@ -244,14 +244,7 @@
       }
     },
     "DefaultSelector": {
-      "type": "object",
-      "properties": {
-        "_id": {
-          "type": "string",
-          "description": "Mongo Object ID",
-          "example": "582c21d43bf248161538450b"
-        }
-      }
+      "type": "object"
     },
     "DefaultResponse": {
       "type": "object",

--- a/website/swagger.json
+++ b/website/swagger.json
@@ -1851,6 +1851,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -1875,6 +1878,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -1899,6 +1905,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -1923,6 +1932,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -1947,6 +1959,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -1971,6 +1986,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -1995,6 +2013,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2019,6 +2040,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2043,6 +2067,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2067,6 +2094,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2091,6 +2121,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2115,6 +2148,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2139,6 +2175,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2163,6 +2202,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2187,6 +2229,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2211,6 +2256,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2235,6 +2283,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2259,6 +2310,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2283,6 +2337,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2307,6 +2364,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2331,6 +2391,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2355,6 +2418,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2379,6 +2445,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2403,6 +2472,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2427,6 +2499,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2451,6 +2526,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2475,6 +2553,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2499,6 +2580,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2523,6 +2607,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2547,6 +2634,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2571,6 +2661,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2595,6 +2688,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2619,6 +2715,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2643,6 +2742,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2693,6 +2795,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -2807,6 +2912,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -3266,6 +3374,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -3290,6 +3401,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -3314,6 +3428,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -3338,6 +3455,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -3362,6 +3482,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -3386,6 +3509,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -3410,6 +3536,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -3494,6 +3623,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -3518,6 +3650,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -3542,6 +3677,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -3566,6 +3704,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -3590,6 +3731,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -3614,6 +3758,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -3638,6 +3785,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -3662,6 +3812,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -3776,6 +3929,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -3800,6 +3956,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -3824,6 +3983,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -3908,6 +4070,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -4042,6 +4207,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -4066,6 +4234,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -4090,6 +4261,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -4114,6 +4288,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -4138,6 +4315,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -4162,6 +4342,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -4186,6 +4369,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -4270,6 +4456,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -4294,6 +4483,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -4464,6 +4656,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -4488,6 +4683,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -4512,6 +4710,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -4536,6 +4737,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -4560,6 +4764,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5004,6 +5211,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5028,6 +5238,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5052,6 +5265,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5076,6 +5292,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           },
           {
             "in": "body",
@@ -5115,6 +5334,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5139,6 +5361,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5163,6 +5388,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5187,6 +5415,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5211,6 +5442,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5235,6 +5469,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5259,6 +5496,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5283,6 +5523,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5307,6 +5550,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5331,6 +5577,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5355,6 +5604,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5379,6 +5631,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5403,6 +5658,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5427,6 +5685,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5451,6 +5712,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5475,6 +5739,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5499,6 +5766,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5523,6 +5793,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5547,6 +5820,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5571,6 +5847,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5595,6 +5874,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5619,6 +5901,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5643,6 +5928,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5667,6 +5955,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5691,6 +5982,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5715,6 +6009,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5739,6 +6036,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5763,6 +6063,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5787,6 +6090,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5811,6 +6117,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5835,6 +6144,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -5859,6 +6171,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -6063,6 +6378,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -6087,6 +6405,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -6407,6 +6728,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -6431,6 +6755,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -6815,6 +7142,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -6839,6 +7169,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -6915,6 +7248,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -8555,6 +8891,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -8579,6 +8918,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -8603,6 +8945,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -8627,6 +8972,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -8651,6 +8999,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -8675,6 +9026,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -8699,6 +9053,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -9169,6 +9526,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -9193,6 +9553,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -9217,6 +9580,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -9241,6 +9607,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -9265,6 +9634,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -9289,6 +9661,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -9313,6 +9688,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -9337,6 +9715,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -9361,6 +9742,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -9385,6 +9769,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -9409,6 +9796,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -9523,6 +9913,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {
@@ -10247,6 +10640,9 @@
         "parameters": [
           {
             "$ref": "#/parameters/instanceParam"
+          },
+          {
+            "$ref": "#/parameters/bodyParam"
           }
         ],
         "responses": {

--- a/website/swagger.json
+++ b/website/swagger.json
@@ -1860,7 +1860,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -1887,7 +1894,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -1914,7 +1928,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -1941,7 +1962,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -1968,7 +1996,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -1995,7 +2030,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2022,7 +2064,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2049,7 +2098,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2076,7 +2132,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2103,7 +2166,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2130,7 +2200,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2157,7 +2234,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2184,7 +2268,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2211,7 +2302,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2238,7 +2336,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2265,7 +2370,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2292,7 +2404,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2319,7 +2438,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2346,7 +2472,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2373,7 +2506,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2400,7 +2540,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2427,7 +2574,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2454,7 +2608,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2481,7 +2642,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2508,7 +2676,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2535,7 +2710,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2562,7 +2744,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2589,7 +2778,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2616,7 +2812,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2643,7 +2846,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2670,7 +2880,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2697,7 +2914,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2724,7 +2948,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2751,7 +2982,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JAccount"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JAccount"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2804,7 +3042,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JApiToken"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JApiToken"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -2921,7 +3166,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JCombinedAppStorage"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JCombinedAppStorage"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -3383,7 +3635,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JCredential"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JCredential"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -3410,7 +3669,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JCredential"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JCredential"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -3437,7 +3703,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JCredential"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JCredential"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -3464,7 +3737,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JCredential"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JCredential"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -3491,7 +3771,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JCredential"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JCredential"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -3518,7 +3805,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JCredential"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JCredential"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -3545,7 +3839,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JCredential"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JCredential"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -3632,7 +3933,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JMachine"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JMachine"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -3659,7 +3967,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JMachine"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JMachine"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -3686,7 +4001,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JMachine"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JMachine"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -3713,7 +4035,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JMachine"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JMachine"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -3740,7 +4069,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JMachine"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JMachine"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -3767,7 +4103,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JMachine"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JMachine"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -3794,7 +4137,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JMachine"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JMachine"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -3821,7 +4171,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JMachine"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JMachine"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -3938,7 +4295,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JProvisioner"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JProvisioner"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -3965,7 +4329,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JProvisioner"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JProvisioner"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -3992,7 +4363,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JProvisioner"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JProvisioner"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -4079,7 +4457,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JSnapshot"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JSnapshot"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -4216,7 +4601,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JStackTemplate"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JStackTemplate"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -4243,7 +4635,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JStackTemplate"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JStackTemplate"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -4270,7 +4669,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JStackTemplate"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JStackTemplate"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -4297,7 +4703,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JStackTemplate"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JStackTemplate"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -4324,7 +4737,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JStackTemplate"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JStackTemplate"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -4351,7 +4771,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JStackTemplate"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JStackTemplate"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -4378,7 +4805,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JStackTemplate"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JStackTemplate"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -4465,7 +4899,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JCustomPartials"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JCustomPartials"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -4492,7 +4933,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JCustomPartials"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JCustomPartials"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -4665,7 +5113,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JProposedDomain"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JProposedDomain"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -4692,7 +5147,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JProposedDomain"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JProposedDomain"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -4719,7 +5181,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JProposedDomain"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JProposedDomain"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -4746,7 +5215,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JProposedDomain"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JProposedDomain"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -4773,7 +5249,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JProposedDomain"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JProposedDomain"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5220,7 +5703,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5247,7 +5737,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5274,7 +5771,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5343,7 +5847,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5370,7 +5881,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5397,7 +5915,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5424,7 +5949,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5451,7 +5983,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5478,7 +6017,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5505,7 +6051,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5532,7 +6085,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5559,7 +6119,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5586,7 +6153,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5613,7 +6187,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5640,7 +6221,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5667,7 +6255,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5694,7 +6289,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5721,7 +6323,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5748,7 +6357,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5775,7 +6391,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5802,7 +6425,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5829,7 +6459,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5856,7 +6493,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5883,7 +6527,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5910,7 +6561,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5937,7 +6595,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5964,7 +6629,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -5991,7 +6663,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -6018,7 +6697,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -6045,7 +6731,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -6072,7 +6765,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -6099,7 +6799,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -6126,7 +6833,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -6153,7 +6867,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -6180,7 +6901,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JGroup"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JGroup"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -6387,7 +7115,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JInvitation"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JInvitation"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -6414,7 +7149,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JInvitation"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JInvitation"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -6737,7 +7479,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JProxyFilter"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JProxyFilter"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -6764,7 +7513,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JProxyFilter"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JProxyFilter"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -7151,7 +7907,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JRewardCampaign"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JRewardCampaign"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -7178,7 +7941,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JRewardCampaign"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JRewardCampaign"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -7257,7 +8027,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JSession"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JSession"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -8900,7 +9677,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JComputeStack"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JComputeStack"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -8927,7 +9711,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JComputeStack"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JComputeStack"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -8954,7 +9745,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JComputeStack"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JComputeStack"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -8981,7 +9779,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JComputeStack"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JComputeStack"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -9008,7 +9813,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JComputeStack"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JComputeStack"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -9035,7 +9847,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JComputeStack"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JComputeStack"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -9062,7 +9881,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JComputeStack"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JComputeStack"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -9535,7 +10361,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JTag"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JTag"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -9562,7 +10395,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JTag"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JTag"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -9589,7 +10429,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JTag"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JTag"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -9616,7 +10463,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JTag"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JTag"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -9643,7 +10497,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JTag"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JTag"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -9670,7 +10531,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JTag"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JTag"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -9697,7 +10565,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JTag"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JTag"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -9724,7 +10599,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JTag"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JTag"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -9751,7 +10633,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JTag"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JTag"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -9778,7 +10667,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JTag"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JTag"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -9805,7 +10701,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JTag"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JTag"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -9922,7 +10825,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JTeamInvitation"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JTeamInvitation"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }
@@ -10649,7 +11559,14 @@
           "200": {
             "description": "OK",
             "schema": {
-              "$ref": "#/definitions/JWorkspace"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/JWorkspace"
+                },
+                {
+                  "$ref": "#/definitions/DefaultResponse"
+                }
+              ]
             }
           }
         }

--- a/workers/social/lib/social/models/computeproviders/computeprovider.coffee
+++ b/workers/social/lib/social/models/computeproviders/computeprovider.coffee
@@ -110,6 +110,8 @@ module.exports = class ComputeProvider extends Base
   #
   # @option options [String] provider provider slug
   #
+  # @return {JMachine} created JMachine instance
+  #
   # @example api
   #
   #   {

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -168,10 +168,10 @@ module.exports = class JStackTemplate extends Module
   #   data object describes new JStackTemplate
   #
   # @option data [String] template template's content as stringified JSON
-  #
   # @option data [String] title template's title
-  #
   # @option data [Object] credentials template's credentials
+  #
+  # @return {JStackTemplate} created JStackTemplate instance
   #
   # @example api
   #


### PR DESCRIPTION
A number of improvements for swagger.json:

- scripts/api-generator: make DefaultSelector a generic object

Setting properties of DefaultSelector to single field ("_id") makes
the DefaultSelector to be just a struct with single field, which is
useless in majority of cases.

- scripts/api-generator: make it possible to send payload for update methods

This PR adds generic bodyParam definition for each instance methods, so
it's possible to set a body for e.g. JStackTemplate.update request,
which currently is not possible.