### PR TITLE
rainforest: collaboration_switch_vms add embedded data info

### DIFF
--- a/tests/spec/rainforest/collaboration_switch_vms.rfml
+++ b/tests/spec/rainforest/collaboration_switch_vms.rfml
@@ -3,6 +3,7 @@
 # start_uri: /
 # tags: automated
 
+# ide_switch_vms is embedded
 - a8cdb653-6e46-4e0f-885a-e921684a22f7
 
 # redirect: false


### PR DESCRIPTION
Added lack of information about the embedded test

/cc: @diclee 

This lack of information causes a problem while parsing the rfml files.