### PR TITLE
klient/mount: add remote index kite handlers

### DIFF
--- a/go/src/koding/klient/app/klient.go
+++ b/go/src/koding/klient/app/klient.go
@@ -35,6 +35,7 @@ import (
 	"koding/klient/logfetcher"
 	"koding/klient/machine"
 	"koding/klient/machine/machinegroup"
+	"koding/klient/machine/mount/index"
 	kos "koding/klient/os"
 	"koding/klient/remote"
 	"koding/klient/sshkeys"
@@ -515,6 +516,10 @@ func (k *Klient) RegisterMethods() {
 	k.kite.HandleFunc("machine.create", machinegroup.KiteHandlerCreate(k.machines))
 	k.kite.HandleFunc("machine.id", machinegroup.KiteHandlerID(k.machines))
 	k.kite.HandleFunc("machine.ssh", machinegroup.KiteHandlerSSH(k.machines))
+
+	// Machine mount index handlers.
+	k.handleWithSub("machine.mount.index.head", index.KiteHandlerHead())
+	k.handleWithSub("machine.mount.index.get", index.KiteHandlerGet())
 
 	// Vagrant
 	k.kite.HandleFunc("vagrant.create", k.vagrant.Create)

--- a/go/src/koding/klient/machine/mount/index/handler.go
+++ b/go/src/koding/klient/machine/mount/index/handler.go
@@ -1,0 +1,92 @@
+package index
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Request defines cached index operations that are requested from
+// client to remote machine.
+type Request struct {
+	Path string `json:"remotePath"` // Path to the folder we want to mount.
+}
+
+// HeadResponse contains the basic info about requested index.
+type HeadResponse struct {
+	AbsPath  string `json:"absPath"`  // Absolute representation of requested path.
+	Count    int    `json:"count"`    // Number of all files stored in index.
+	DiskSize int64  `json:"diskSize"` // The byte size of all files stored in index.
+}
+
+// Head gives the basic information about requested directory index.
+func Head(req *Request) (*HeadResponse, error) {
+	if req == nil {
+		return nil, errors.New("invalid empty request")
+	}
+
+	absPath, err := preparePath(req.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	count, diskSize, err := (&Cached{}).HeadCachedIndex(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("remote path index error: %s", err)
+	}
+
+	return &HeadResponse{
+		AbsPath:  absPath,
+		Count:    count,
+		DiskSize: diskSize,
+	}, nil
+}
+
+// GetResponse stores the index of requested directory.
+type GetResponse struct {
+	Index *Index `json:"index"`
+}
+
+// Get gets the complete index of requested directory.
+func Get(req *Request) (*GetResponse, error) {
+	if req == nil {
+		return nil, errors.New("invalid empty request")
+	}
+
+	absPath, err := preparePath(req.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	idx, err := (&Cached{}).GetCachedIndex(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("remote path index error: %s", err)
+	}
+
+	return &GetResponse{
+		Index: idx,
+	}, nil
+}
+
+// preparePath performs basic checks and makes a given path usable for local
+// file system.
+func preparePath(path string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("remote path format is invalid: %s", err)
+	}
+
+	info, err := os.Stat(absPath)
+	if os.IsNotExist(err) {
+		return "", errors.New("remote path does not exist")
+	} else if err != nil {
+		return "", fmt.Errorf("cannot stat remote path: %s", err)
+	}
+
+	if !info.IsDir() {
+		return "", errors.New("remote path is not a directory")
+	}
+
+	return absPath, nil
+}

--- a/go/src/koding/klient/machine/mount/index/kite.go
+++ b/go/src/koding/klient/machine/mount/index/kite.go
@@ -1,0 +1,55 @@
+package index
+
+import (
+	"github.com/koding/kite"
+)
+
+// KiteHandlerHead creates a kite handler function that, when called, invokes
+// index package Head method.
+func KiteHandlerHead() kite.HandlerFunc {
+	return func(r *kite.Request) (interface{}, error) {
+		req := &Request{}
+
+		if r.Args != nil {
+			if err := r.Args.One().Unmarshal(req); err != nil {
+				return nil, err
+			}
+		}
+
+		res, err := Head(req)
+		if err != nil {
+			// TODO(ppknap): create errors file similar to kloud/stack/errors.
+			return nil, &kite.Error{
+				Type:    "indexError",
+				Message: err.Error(),
+			}
+		}
+
+		return res, nil
+	}
+}
+
+// KiteHandlerGet creates a kite handler function that, when called, invokes
+// index package Get method.
+func KiteHandlerGet() kite.HandlerFunc {
+	return func(r *kite.Request) (interface{}, error) {
+		req := &Request{}
+
+		if r.Args != nil {
+			if err := r.Args.One().Unmarshal(req); err != nil {
+				return nil, err
+			}
+		}
+
+		res, err := Get(req)
+		if err != nil {
+			// TODO(ppknap): create errors file similar to kloud/stack/errors.
+			return nil, &kite.Error{
+				Type:    "indexError",
+				Message: err.Error(),
+			}
+		}
+
+		return res, nil
+	}
+}


### PR DESCRIPTION
This PR adds kite handlers to client so the local klient can call remote one when it wants remote index data.

Depends on: #10188

## Motivation and Context
local -> remote machine sync

## How Has This Been Tested?
No test written - these are only handlers to already tested functions + simple path validation.

