### PR TITLE
kd: add stack subcommand

### DIFF
--- a/go/src/koding/kites/config/konfig.go
+++ b/go/src/koding/kites/config/konfig.go
@@ -172,6 +172,10 @@ func (k *Konfig) buildKiteConfig() *konfig.Config {
 		}
 	}
 
+	if cfg, err := konfig.Get(); err == nil {
+		return cfg
+	}
+
 	return konfig.New()
 }
 

--- a/go/src/koding/kites/kloud/kloud/kloud.go
+++ b/go/src/koding/kites/kloud/kloud/kloud.go
@@ -239,6 +239,11 @@ func New(conf *Config) (*Kloud, error) {
 	transport := &api.Transport{
 		RoundTripper: storeOpts.Client.Transport,
 		AuthFunc:     api.NewCache(authFn).Auth,
+		Debug:        conf.DebugMode,
+	}
+
+	if conf.DebugMode {
+		transport.Log = sess.Log
 	}
 
 	kloud.Stack.Endpoints = e

--- a/go/src/koding/kites/kloud/stack/credential.go
+++ b/go/src/koding/kites/kloud/stack/credential.go
@@ -237,6 +237,22 @@ func (c *CredentialListResponse) Provider(identifier string) string {
 	return ""
 }
 
+// Provider gives a provider name for the given identifier.
+//
+// If no credential with the given identifier is found,
+// an empty string is returned.
+func (c *CredentialListResponse) Provider(identifier string) string {
+	for provider, credentials := range c.Credentials {
+		for _, credential := range credentials {
+			if credential.Identifier == identifier {
+				return provider
+			}
+		}
+	}
+
+	return ""
+}
+
 // CredentialAddRequest represents a request
 // value for "credential.add" kloud method.
 type CredentialAddRequest struct {

--- a/go/src/koding/kites/kloud/stack/credential.go
+++ b/go/src/koding/kites/kloud/stack/credential.go
@@ -237,22 +237,6 @@ func (c *CredentialListResponse) Provider(identifier string) string {
 	return ""
 }
 
-// Provider gives a provider name for the given identifier.
-//
-// If no credential with the given identifier is found,
-// an empty string is returned.
-func (c *CredentialListResponse) Provider(identifier string) string {
-	for provider, credentials := range c.Credentials {
-		for _, credential := range credentials {
-			if credential.Identifier == identifier {
-				return provider
-			}
-		}
-	}
-
-	return ""
-}
-
 // CredentialAddRequest represents a request
 // value for "credential.add" kloud method.
 type CredentialAddRequest struct {

--- a/go/src/koding/klientctl/auth.go
+++ b/go/src/koding/klientctl/auth.go
@@ -115,7 +115,7 @@ func AuthLogin(c *cli.Context, log logging.Logger, _ string) (int, error) {
 		enc.SetIndent("", "\t")
 		enc.Encode(resp)
 	} else {
-		fmt.Fprintf(os.Stdout, "Successfully logged in to the following team: %s.\n", resp.GroupName)
+		fmt.Fprintln(os.Stdout, "Successfully logged in to the following team:", resp.GroupName)
 	}
 
 	return 0, nil

--- a/go/src/koding/klientctl/auth.go
+++ b/go/src/koding/klientctl/auth.go
@@ -92,6 +92,8 @@ func AuthLogin(c *cli.Context, log logging.Logger, _ string) (int, error) {
 		}
 	}
 
+	fmt.Fprintln(os.Stderr, "Logging to", kodingURL, "...")
+
 	resp, err := authClient.Login(opts)
 	if err != nil {
 		return 1, fmt.Errorf("error logging into your Koding account: %v", err)
@@ -113,7 +115,7 @@ func AuthLogin(c *cli.Context, log logging.Logger, _ string) (int, error) {
 		enc.SetIndent("", "\t")
 		enc.Encode(resp)
 	} else {
-		fmt.Fprintf(os.Stdout, "Successfully logged in to %q team.\n", resp.GroupName)
+		fmt.Fprintf(os.Stdout, "Successfully logged in to the following team: %s.\n", resp.GroupName)
 	}
 
 	return 0, nil

--- a/go/src/koding/klientctl/config.go
+++ b/go/src/koding/klientctl/config.go
@@ -189,13 +189,27 @@ func printKonfigs(konfigs []*konfig.Konfig) {
 	}
 }
 
+// ignoredFields are not displayed on "kd config show"
+// as they are either for internal purpose or are
+// deprecated ones.
+var ignoredFields = []string{
+	"kiteKey",
+	"kiteKeyFile",
+	"kontrolURL", // deprecated
+	"tunnelURL",  // deprecated
+	"environment",
+	"publicBucketName",
+	"publicBucketRegion",
+	"tunnelID",
+}
+
 func printKonfig(konfig *konfig.Konfig) {
 	w := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
 	defer w.Flush()
 
 	fmt.Fprintln(w, "KEY\tVALUE")
 
-	obj := b.Build(konfig, "kiteKey", "kontrolURL", "tunnelURL")
+	obj := b.Build(konfig, ignoredFields...)
 
 	for _, key := range obj.Keys() {
 		value := obj[key]

--- a/go/src/koding/klientctl/credential.go
+++ b/go/src/koding/klientctl/credential.go
@@ -12,6 +12,7 @@ import (
 	"koding/kites/config"
 	"koding/kites/kloud/stack"
 	"koding/klientctl/endpoint/credential"
+	"koding/klientctl/endpoint/team"
 	"koding/klientctl/helper"
 
 	"github.com/codegangsta/cli"
@@ -147,9 +148,13 @@ func AskCredentialCreate(c *cli.Context) (*credential.CreateOptions, error) {
 
 	// TODO(rjeczalik): remove when support for generic team is implemented
 	if opts.Team == "" {
-		opts.Team, err = helper.Ask("Team name []: ")
+		opts.Team, err = helper.Ask("Team name [%s]: ", team.Used().Name)
 		if err != nil {
 			return nil, err
+		}
+
+		if opts.Team == "" {
+			opts.Team = team.Used().Name
 		}
 	}
 

--- a/go/src/koding/klientctl/credential.go
+++ b/go/src/koding/klientctl/credential.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -252,14 +253,37 @@ func CredentialDescribe(c *cli.Context, log logging.Logger, _ string) (int, erro
 	return 0, nil
 }
 
+func CredentialUse(c *cli.Context, _ logging.Logger, _ string) (int, error) {
+	if c.NArg() != 1 {
+		cli.ShowCommandHelp(c, "use")
+		return 1, errors.New("missing argument")
+	}
+
+	arg := c.Args().Get(0)
+
+	if err := credential.Use(arg); err != nil {
+		return 1, errors.New("error changing default credential: " + err.Error())
+	}
+
+	return 0, nil
+}
+
 func printCreds(creds []stack.CredentialItem) {
 	w := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
 	defer w.Flush()
 
-	fmt.Fprintln(w, "ID\tTITLE\tTEAM\tPROVIDER")
+	used := credential.Used()
+
+	fmt.Fprintln(w, "ID\tTITLE\tTEAM\tPROVIDER\tUSED")
 
 	for _, cred := range creds {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", cred.Identifier, cred.Title, cred.Team, cred.Provider)
+		isused := "-"
+
+		if ident, ok := used[cred.Provider]; ok && cred.Identifier == ident {
+			isused = "default"
+		}
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", cred.Identifier, cred.Title, cred.Team, cred.Provider, isused)
 	}
 }
 

--- a/go/src/koding/klientctl/ctlcli/ctlcli.go
+++ b/go/src/koding/klientctl/ctlcli/ctlcli.go
@@ -16,6 +16,12 @@ import (
 
 var closers []io.Closer
 
+// ExitFunc is called upon command exit, it sets exit code.
+//
+// It is overwritten during testing, as calling os.Exit
+// prevents saving coverage profile.
+var ExitFunc = os.Exit
+
 // CloseOnExit is a hack to close program-lifetime-bound resources,
 // like log file or BoltDB database.
 func CloseOnExit(c io.Closer) {
@@ -87,7 +93,7 @@ func ExitAction(f ExitingCommand, log logging.Logger, cmdName string) func(*cli.
 	return func(c *cli.Context) {
 		exit := f(c, log, cmdName)
 		Close()
-		os.Exit(exit)
+		ExitFunc(exit)
 	}
 }
 
@@ -102,7 +108,7 @@ func ExitErrAction(f ExitingErrCommand, log logging.Logger, cmdName string) func
 		}
 
 		Close()
-		os.Exit(exit)
+		ExitFunc(exit)
 	}
 }
 
@@ -124,7 +130,7 @@ func FactoryAction(factory CommandFactory, log logging.Logger, cmdName string) f
 		}
 
 		Close()
-		os.Exit(exit)
+		ExitFunc(exit)
 	}
 }
 

--- a/go/src/koding/klientctl/endpoint/credential/credential.go
+++ b/go/src/koding/klientctl/endpoint/credential/credential.go
@@ -54,7 +54,7 @@ type Client struct {
 func (c *Client) List(opts *ListOptions) (stack.Credentials, error) {
 	c.init()
 
-	var req *stack.CredentialListRequest
+	var req = &stack.CredentialListRequest{}
 	var resp stack.CredentialListResponse
 
 	if opts != nil {

--- a/go/src/koding/klientctl/endpoint/credential/credential.go
+++ b/go/src/koding/klientctl/endpoint/credential/credential.go
@@ -10,16 +10,13 @@ import (
 	"koding/klientctl/endpoint/kloud"
 )
 
-// DefaultClient
 var DefaultClient = &Client{}
 
-// ListOptions
 type ListOptions struct {
 	Team     string
 	Provider string
 }
 
-// CreateOptions
 type CreateOptions struct {
 	Team     string
 	Provider string
@@ -40,7 +37,6 @@ func (opts *CreateOptions) Valid() error {
 	return nil
 }
 
-// Client
 type Client struct {
 	Kloud *kloud.Client
 
@@ -50,7 +46,6 @@ type Client struct {
 	describe map[string]*stack.Description
 }
 
-// List
 func (c *Client) List(opts *ListOptions) (stack.Credentials, error) {
 	c.init()
 
@@ -73,7 +68,6 @@ func (c *Client) List(opts *ListOptions) (stack.Credentials, error) {
 	return resp.Credentials, nil
 }
 
-// Create
 func (c *Client) Create(opts *CreateOptions) (*stack.CredentialItem, error) {
 	c.init()
 
@@ -94,6 +88,13 @@ func (c *Client) Create(opts *CreateOptions) (*stack.CredentialItem, error) {
 		return nil, err
 	}
 
+	c.cached[opts.Provider] = append(c.cached[opts.Provider], stack.CredentialItem{
+		Identifier: resp.Identifier,
+		Title:      resp.Title,
+		Team:       opts.Team,
+		Provider:   opts.Provider,
+	})
+
 	return &stack.CredentialItem{
 		Title:      resp.Title,
 		Team:       req.Team,
@@ -101,7 +102,6 @@ func (c *Client) Create(opts *CreateOptions) (*stack.CredentialItem, error) {
 	}, nil
 }
 
-// Use
 func (c *Client) Use(identifier string) error {
 	c.init()
 
@@ -115,14 +115,12 @@ func (c *Client) Use(identifier string) error {
 	return nil
 }
 
-// User
 func (c *Client) Used() map[string]string {
 	c.init()
 
 	return c.used
 }
 
-// Provider
 func (c *Client) Provider(identifier string) (provider string, err error) {
 	c.init()
 
@@ -159,7 +157,6 @@ func (c *Client) Describe() (stack.Descriptions, error) {
 	return c.describe, nil
 }
 
-// Close
 func (c *Client) Close() (err error) {
 	if len(c.cached) != 0 {
 		err = c.kloud().Cache().SetValue("credential", c.cached)

--- a/go/src/koding/klientctl/endpoint/kloud/kloud.go
+++ b/go/src/koding/klientctl/endpoint/kloud/kloud.go
@@ -127,7 +127,7 @@ func (kt *KiteTransport) kite() *kite.Kite {
 
 	kt.k = kite.New(config.Name, config.KiteVersion)
 	kt.k.Config = kt.kiteConfig()
-	kt.k.Log = kt.Log
+	kt.k.Log = kt.log()
 
 	return kt.k
 }

--- a/go/src/koding/klientctl/endpoint/stack/export_test.go
+++ b/go/src/koding/klientctl/endpoint/stack/export_test.go
@@ -1,3 +1,4 @@
 package stack
 
-func FixHCL(v interface{}) { fixHCL(v) }
+func FixHCL(v interface{})              { fixHCL(v) }
+func FixYAML(v interface{}) interface{} { return fixYAML(v) }

--- a/go/src/koding/klientctl/endpoint/stack/stack.go
+++ b/go/src/koding/klientctl/endpoint/stack/stack.go
@@ -1,6 +1,7 @@
 package stack
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -130,7 +131,7 @@ func (c *Client) jsonReencode(data []byte) ([]byte, error) {
 	var ymlv interface{}
 
 	if err := yaml.Unmarshal(data, &ymlv); err == nil {
-		return json.Marshal(fixYAML(ymlv))
+		return jsonMarshal(fixYAML(ymlv))
 	}
 
 	var hclv interface{}
@@ -138,7 +139,7 @@ func (c *Client) jsonReencode(data []byte) ([]byte, error) {
 	if err := hcl.Unmarshal(data, &hclv); err == nil {
 		fixHCL(hclv)
 
-		return json.Marshal(hclv)
+		return jsonMarshal(hclv)
 	}
 
 	return nil, errors.New("unknown encoding")
@@ -167,6 +168,19 @@ func (c *Client) readProviders(data []byte) ([]string, error) {
 // Create
 func Create(opts *CreateOptions) (*stack.ImportResponse, error) {
 	return DefaultClient.Create(opts)
+}
+
+func jsonMarshal(v interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
 }
 
 // fixYAML is a best-effort of fixing representation of

--- a/go/src/koding/klientctl/endpoint/stack/stack.go
+++ b/go/src/koding/klientctl/endpoint/stack/stack.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"sort"
 
 	"koding/kites/kloud/stack"
@@ -48,9 +47,7 @@ func (c *Client) Create(opts *CreateOptions) (*stack.ImportResponse, error) {
 		return nil, err
 	}
 
-	log.Println("BEFORE RE-ENCODE")
 	data, err := c.jsonReencode(opts.Template)
-	log.Println("AFTER RE-ENCODE")
 	if err != nil {
 		return nil, fmt.Errorf("stack: template encoding error: %s", err)
 	}

--- a/go/src/koding/klientctl/endpoint/stack/stack.go
+++ b/go/src/koding/klientctl/endpoint/stack/stack.go
@@ -9,6 +9,7 @@ import (
 	"koding/kites/kloud/stack"
 	"koding/klientctl/endpoint/credential"
 	"koding/klientctl/endpoint/kloud"
+	"koding/klientctl/endpoint/team"
 
 	"github.com/hashicorp/hcl"
 	yaml "gopkg.in/yaml.v2"
@@ -69,6 +70,10 @@ func (c *Client) Create(opts *CreateOptions) (*stack.ImportResponse, error) {
 		Team:        opts.Team,
 		Title:       opts.Title,
 		Credentials: make(map[string][]string),
+	}
+
+	if req.Team == "" {
+		req.Team = team.Used().Name
 	}
 
 	var resp stack.ImportResponse

--- a/go/src/koding/klientctl/endpoint/stack/stack_test.go
+++ b/go/src/koding/klientctl/endpoint/stack/stack_test.go
@@ -6,70 +6,15 @@ import (
 	"testing"
 
 	"koding/klientctl/endpoint/stack"
+	"koding/klientctl/endpoint/stack/stackfixture"
 
 	"github.com/hashicorp/hcl"
 )
 
-var awsStackHCL = []byte(`provider "aws" {
-	access_key = "${var.aws_access_key}"
-	secret_key = "${var.aws_secret_key}"
-}
-
-resource "aws_instance" "example-instance" {
-	instance_type = "t2.nano"
-	ami = ""
-	tags {
-		Name = "${var.koding_user_username}-${var.koding_group_slug}"
-	}
-	user_data = "echo \"hello world!\" >> /helloworld.txt"
-}`)
-
-var awsStackJSON = []byte(`{
-	"provider": {
-		"aws": {
-			"access_key": "${var.aws_access_key}",
-			"secret_key": "${var.aws_secret_key}"
-		}
-	},
-	"resource": {
-		"aws_instance": {
-			"example-instance": {
-				"instance_type": "t2.nano",
-				"ami": "",
-				"tags": {
-					"Name": "${var.koding_user_username}-${var.koding_group_slug}"
-				},
-				"user_data": "echo \"hello world!\" >> /helloworld.txt"
-			}
-		}
-	}
-}`)
-
-var awsStack = map[string]interface{}{
-	"provider": map[string]interface{}{
-		"aws": map[string]interface{}{
-			"access_key": "${var.aws_access_key}",
-			"secret_key": "${var.aws_secret_key}",
-		},
-	},
-	"resource": map[string]interface{}{
-		"aws_instance": map[string]interface{}{
-			"example-instance": map[string]interface{}{
-				"instance_type": "t2.nano",
-				"ami":           "",
-				"tags": map[string]interface{}{
-					"Name": "${var.koding_user_username}-${var.koding_group_slug}",
-				},
-				"user_data": "echo \"hello world!\" >> /helloworld.txt",
-			},
-		},
-	},
-}
-
 func TestFixHCL(t *testing.T) {
 	var vHCL interface{}
 
-	if err := hcl.Unmarshal(awsStackHCL, &vHCL); err != nil {
+	if err := hcl.Unmarshal(stackfixture.StackHCL, &vHCL); err != nil {
 		t.Fatalf("hcl.Unmarshal()=%s", err)
 	}
 
@@ -77,19 +22,19 @@ func TestFixHCL(t *testing.T) {
 		t.Logf("original (vHCL):\n%s", mustJSON(vHCL))
 	}
 
-	if reflect.DeepEqual(vHCL, awsStack) {
+	if reflect.DeepEqual(vHCL, stackfixture.Stack) {
 		t.Fatal("expected HCL-encoded stack to not unmarshal cleanly")
 	}
 
 	stack.FixHCL(vHCL)
 
-	if !reflect.DeepEqual(vHCL, awsStack) {
-		t.Fatalf("got %+v, want %+v", vHCL, awsStack)
+	if !reflect.DeepEqual(vHCL, stackfixture.Stack) {
+		t.Fatalf("got %+v, want %+v", vHCL, stackfixture.Stack)
 	}
 
 	var vJSON interface{}
 
-	if err := json.Unmarshal(awsStackJSON, &vJSON); err != nil {
+	if err := json.Unmarshal(stackfixture.StackJSON, &vJSON); err != nil {
 		t.Fatalf("json.Unmarshal()=%s", err)
 	}
 

--- a/go/src/koding/klientctl/endpoint/stack/stack_test.go
+++ b/go/src/koding/klientctl/endpoint/stack/stack_test.go
@@ -102,6 +102,64 @@ func TestFixHCL(t *testing.T) {
 	}
 }
 
+func TestFixYAML(t *testing.T) {
+	cases := map[string]struct {
+		yaml interface{}
+		want interface{}
+	}{
+		"fix map": {
+			map[interface{}]interface{}{
+				"abc": 1,
+			},
+			map[string]interface{}{
+				"abc": 1,
+			},
+		},
+		"fix slice of maps": {
+			[]interface{}{
+				"abc",
+				map[interface{}]interface{}{
+					"abc": 1,
+				},
+				1,
+			},
+			[]interface{}{
+				"abc",
+				map[string]interface{}{
+					"abc": 1,
+				},
+				1,
+			},
+		},
+		"fix nested maps": {
+			map[interface{}]interface{}{
+				"abc": map[interface{}]interface{}{
+					"abc": map[interface{}]interface{}{
+						"abc": 1,
+					},
+				},
+			},
+			map[string]interface{}{
+				"abc": map[string]interface{}{
+					"abc": map[string]interface{}{
+						"abc": 1,
+					},
+				},
+			},
+		},
+	}
+
+	for name, cas := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := stack.FixYAML(cas.yaml)
+
+			if !reflect.DeepEqual(got, cas.want) {
+				t.Fatalf("got %#v, want %#v", got, cas.want)
+			}
+		})
+	}
+}
+
 func mustJSON(v interface{}) []byte {
 	p, err := json.MarshalIndent(v, "", "\t")
 	if err != nil {

--- a/go/src/koding/klientctl/endpoint/stack/stackfixture/stackfixture.go
+++ b/go/src/koding/klientctl/endpoint/stack/stackfixture/stackfixture.go
@@ -1,0 +1,70 @@
+package stackfixture
+
+var StackHCL = []byte(`provider "aws" {
+	access_key = "${var.aws_access_key}"
+	secret_key = "${var.aws_secret_key}"
+}
+
+resource "aws_instance" "example-instance" {
+	instance_type = "t2.nano"
+	ami = ""
+	tags {
+		Name = "${var.koding_user_username}-${var.koding_group_slug}"
+	}
+	user_data = "echo \"hello world!\" >> /helloworld.txt"
+}`)
+
+var StackJSON = []byte(`{
+	"provider": {
+		"aws": {
+			"access_key": "${var.aws_access_key}",
+			"secret_key": "${var.aws_secret_key}"
+		}
+	},
+	"resource": {
+		"aws_instance": {
+			"example-instance": {
+				"instance_type": "t2.nano",
+				"ami": "",
+				"tags": {
+					"Name": "${var.koding_user_username}-${var.koding_group_slug}"
+				},
+				"user_data": "echo \"hello world!\" >> /helloworld.txt"
+			}
+		}
+	}
+}`)
+
+var StackYAML = []byte(`provider:
+  aws:
+    access_key: "${var.aws_access_key}"
+    secret_key: "${var.aws_secret_key}"
+resource:
+  aws_instance:
+    example-instance:
+      instance_type: t2.nano
+      ami: ''
+      tags:
+        Name: "${var.koding_user_username}-${var.koding_group_slug}"
+      user_data: echo "hello world!" >> /helloworld.txt`)
+
+var Stack = map[string]interface{}{
+	"provider": map[string]interface{}{
+		"aws": map[string]interface{}{
+			"access_key": "${var.aws_access_key}",
+			"secret_key": "${var.aws_secret_key}",
+		},
+	},
+	"resource": map[string]interface{}{
+		"aws_instance": map[string]interface{}{
+			"example-instance": map[string]interface{}{
+				"instance_type": "t2.nano",
+				"ami":           "",
+				"tags": map[string]interface{}{
+					"Name": "${var.koding_user_username}-${var.koding_group_slug}",
+				},
+				"user_data": "echo \"hello world!\" >> /helloworld.txt",
+			},
+		},
+	},
+}

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -595,7 +595,7 @@ func run(args []string) {
 						},
 						cli.StringFlag{
 							Name:  "file, f",
-							Value: "",
+							Value: "kd.yml",
 							Usage: "Read stack template from a file.",
 						},
 						cli.BoolFlag{

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -531,6 +531,10 @@ func run(args []string) {
 						},
 					},
 				}, {
+					Name:   "use",
+					Usage:  "Change default credential per provider.",
+					Action: ctlcli.ExitErrAction(CredentialUse, log, "use"),
+				}, {
 					Name:   "describe",
 					Usage:  "Describe credential documents.",
 					Action: ctlcli.ExitErrAction(CredentialDescribe, log, "describe"),

--- a/go/src/koding/klientctl/stack.go
+++ b/go/src/koding/klientctl/stack.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -41,6 +42,14 @@ func StackCreate(c *cli.Context, log logging.Logger, _ string) (int, error) {
 	resp, err := stack.Create(opts)
 	if err != nil {
 		return 1, errors.New("error creating stack: " + err.Error())
+	}
+
+	if c.Bool("json") {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "\t")
+		enc.Encode(res)
+
+		return 0, nil
 	}
 
 	fmt.Fprintf(os.Stderr, "Creatad %q stack with %s ID.\n", resp.Title, resp.StackID)

--- a/go/src/koding/klientctl/stack.go
+++ b/go/src/koding/klientctl/stack.go
@@ -30,7 +30,7 @@ func StackCreate(c *cli.Context, log logging.Logger, _ string) (int, error) {
 		return 1, errors.New("error reading template file: " + err.Error())
 	}
 
-	fmt.Println("Creating stack... ")
+	fmt.Fprintln(os.Stderr, "Creating stack... ")
 
 	opts := &stack.CreateOptions{
 		Team:        c.String("team"),
@@ -47,7 +47,7 @@ func StackCreate(c *cli.Context, log logging.Logger, _ string) (int, error) {
 	if c.Bool("json") {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "\t")
-		enc.Encode(res)
+		enc.Encode(resp)
 
 		return 0, nil
 	}

--- a/go/src/koding/klientctl/stack.go
+++ b/go/src/koding/klientctl/stack.go
@@ -18,9 +18,7 @@ func StackCreate(c *cli.Context, log logging.Logger, _ string) (int, error) {
 
 	switch file := c.String("file"); file {
 	case "":
-		// TODO(rjeczalik): remove once interactive mode is implemented
-		fmt.Fprintln(os.Stderr, "No credential file was provided.")
-		return 1, errors.New("no credential file was provided")
+		return 1, errors.New("no template file was provided")
 	case "-":
 		p, err = ioutil.ReadAll(os.Stdin)
 	default:
@@ -28,8 +26,7 @@ func StackCreate(c *cli.Context, log logging.Logger, _ string) (int, error) {
 	}
 
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error reading credential file: ", err)
-		return 1, err
+		return 1, errors.New("error reading template file: " + err.Error())
 	}
 
 	fmt.Println("Creating stack... ")
@@ -43,8 +40,7 @@ func StackCreate(c *cli.Context, log logging.Logger, _ string) (int, error) {
 
 	resp, err := stack.Create(opts)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error creating stack:", err)
-		return 1, err
+		return 1, errors.New("error creating stack: " + err.Error())
 	}
 
 	fmt.Fprintf(os.Stderr, "Creatad %q stack with %s ID.\n", resp.Title, resp.StackID)

--- a/go/src/koding/klientctl/stack_test.go
+++ b/go/src/koding/klientctl/stack_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+
+	"koding/kites/kloud/provider/aws"
+	"koding/kites/kloud/stack"
+	"koding/klientctl/endpoint/stack/stackfixture"
+)
+
+func TestStackCreate(t *testing.T) {
+	cases := map[string]struct {
+		tmpl []byte
+		cred string
+		resp *stack.ImportResponse
+	}{
+		"a yaml template": {
+			stackfixture.StackYAML,
+			"587265a0bbc81e01cd2f849b",
+			&stack.ImportResponse{
+				TemplateID: "5870035a50368f142b105e9f",
+				StackID:    "587003e6d90a2a0a2bc4f385",
+				Title:      "TestStackCreate credential",
+			},
+		},
+		"a json template": {
+			stackfixture.StackJSON,
+			"587265adbbc81e01cd2f849c",
+			&stack.ImportResponse{
+				TemplateID: "5870035a50368f142b105ea4",
+				StackID:    "53925a609b76835748c0c4fd",
+				Title:      "TestStackCreate credential",
+			},
+		},
+		"a hcl template": {
+			stackfixture.StackHCL,
+			"587265b7bbc81e01cd2f849d",
+			&stack.ImportResponse{
+				TemplateID: "587003e6d90a2a0a2bc4f384",
+				StackID:    "587003b2d90a2a0a2bc4f380",
+				Title:      "TestStackCreate credential",
+			},
+		},
+	}
+
+	for name, cas := range cases {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+
+			cmd := &MainCmd{
+				Stdin:  bytes.NewReader(cas.tmpl),
+				Stderr: os.Stderr,
+				Stdout: &buf,
+			}
+			defer cmd.Close()
+
+			cmd.FT.Add("import", cas.resp)
+
+			if err := addCredential(cmd, cas.cred); err != nil {
+				t.Fatalf("addCredential()=%s", err)
+			}
+
+			err := cmd.Run("stack", "create",
+				"--file", "-",
+				"--json",
+			)
+
+			if err != nil {
+				t.Fatalf("Run()=%s", err)
+			}
+
+			var got stack.ImportResponse
+
+			if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+				t.Fatalf("Unmarshal()=%s", err)
+			}
+
+			if !reflect.DeepEqual(&got, cas.resp) {
+				t.Fatalf("got %#v, want %#v", &got, cas.resp)
+			}
+		})
+	}
+}
+
+func addCredential(cmd *MainCmd, identifier string) error {
+	c := cmd.New()
+
+	p, err := json.Marshal(&aws.Cred{
+		AccessKey: "***",
+		SecretKey: "***",
+		Region:    "us-east-1",
+	})
+	if err != nil {
+		return err
+	}
+
+	c.Stdin = bytes.NewReader(p)
+	c.Stderr = os.Stderr
+	c.Stdout = os.Stderr
+
+	c.FT.Add("credential.add", &stack.CredentialItem{
+		Identifier: identifier,
+		Title:      "TestStackCreate credential",
+		Team:       "foobar",
+	})
+
+	return nonil(
+		c.Run("credential", "create",
+			"--provider", "aws",
+			"--team", "foobar",
+			"--file", "-",
+		),
+		c.Run("credential", "use", identifier),
+	)
+}

--- a/go/src/koding/klientctl/team.go
+++ b/go/src/koding/klientctl/team.go
@@ -71,7 +71,7 @@ func TeamShow(c *cli.Context, log logging.Logger, _ string) (int, error) {
 		enc.SetIndent("", "\t")
 		enc.Encode(t)
 	} else {
-		fmt.Fprintf(os.Stderr, "You are currently logged in to a %q team.", t.Name)
+		fmt.Fprintln(os.Stderr, "You are currently logged in to the following team:", t.Name)
 	}
 
 	return 0, nil


### PR DESCRIPTION
This PR adds `stack` subcommand.

I'm going to give a rough overview of existing kd commands workflow, in order to get feedback and improve things when necessary.

### Login workflow

In order to create a stack user needs to be logged in into Koding and have a verified credential.

### Logging to Koding / kd.io

In order to log in to kd.io one needs to:

```
$ kd auth login
```

Currently logging in to kd.io does not work in dev environments, as there's no kd-io team created by default, use `--team` switch to log in to your team instead.

For the first time kd will ask for username / password in order to obtain kite.key from kontrol. Once kite.key is saved, consecutive `kd auth login --team x` commands will proceed without asking for password. 

In order to login to your dev koding use `--baseurl` flag:

```
$ kd auth login --baseurl http://rjeczalik.koding.team --team foobar
Logging to http://rjeczalik.koding.team ...
Successfully logged in to the following team: foobar
```

If you need to switch between kodings during development, use `kd config list` to list them:

```
$ kd config list
ID        KODING URL
10bc5796  https://sandbox.koding.com
1d1f3321  http://dev.koding.com:8090
79154da7  https://koding.com
824f84b3  http://rjeczalik.koding.team
```

And `kd config use` or `kd auth login --baseurl` to make the switch:

```
$ kd config use 824f84b3
Switched to http://rjeczalik.koding.team.

Please run "sudo kd restart" for the new configuration to take effect.
```

A todo here could be to add some aliasing support, so it's possible to `kd config use production`, `kd config use rjeczalik` etc.

### Stack workflow

In order to create a stack, user needs to have a valid credential. In order to list credentials, do:

```
$ kd credential list
ID                                TITLE                                              TEAM  PROVIDER  USED
5320460345e6b0ce20c8c64ff8afa777  kdev                                                     aws       -
aa5705ac2f689d6ecd05ccf5dd696e41  khaled                                                   aws       -
f41f95a5553614c9a9df1c490141218d  khaled2                                                  aws       -
8aa8da8016ae0e5a125d41e6ba2dacd1  khaled-test                                              aws       -
06e4df2e93c6ed47b49fecac20099c01  khaled3                                                  aws       -
35c9e3f8d948e3f31bc2f434483943b9  af                                                       aws       -
8e0bb69117abbd6f73f17b79895f4a63  asdasdasd                                                aws       -
58695fb7b8966365413d4cf0          rjeczalik 2017-01-01 19:59:51.521225533 +0000 UTC        aws       -
58696068b8966365413d4cf3          rjeczalik 2017-01-01 20:02:48.006556361 +0000 UTC        aws       -
586960b0b8966365413d4cf6          rjeczalik 2017-01-01 20:04:00.067389374 +0000 UTC        aws       default
6642a8525ef16a3d20d75bc824cad669  dev                                                      marathon  default
b5c4da7a77199924d3e4852d0acccb0d  rafal                                                    vagrant   default
```

It is possible to set a default credential for each of the provider with `kd credential use`. Default credential is the one that is used by stack creation when no explicit credential was provided. When no explicit credential was provided and no default credential is set, `kd stack create` command will fail.

The simplest way to create a stack is to:

```
$ kd stack create
```

This command will use `kd.yml` from the current working directory and create a stack template out of it, create a stack with default credential and build it. The command returns as soon as the stack starts to build. A todo is a `--wait` flag, that will make the command not return until the stack finishes building.

The command also accepts `--file` flag, being either custom path to a template file or `-` - which makes it read the template content from stdin. The file can be either a json, yaml or hcl.

A todo is to use existing stack template with `--template, -t` flag, like:

```
$ kd stack create --template rjeczalik/stack 
```

This will be introduced after `kd template` command is implemented.