### PR TITLE
Incorrect message displayed on sidebar when you have stacks but you've removed all of them from sidebar.

### DIFF
--- a/client/app/lib/components/sidebar/index.coffee
+++ b/client/app/lib/components/sidebar/index.coffee
@@ -41,6 +41,8 @@ module.exports = class Sidebar extends React.Component
     return {
       stacks                       : SidebarFlux.getters.sidebarStacks
       drafts                       : SidebarFlux.getters.sidebarDrafts
+      teamStackTemplates           : EnvironmentFlux.getters.teamStackTemplates
+      privateStackTemplates        : EnvironmentFlux.getters.privateStackTemplates
       sharedMachines               : EnvironmentFlux.getters.sharedMachines
       collaborationMachines        : EnvironmentFlux.getters.collaborationMachines
       sharedMachineListItems       : EnvironmentFlux.getters.sharedMachineListItems
@@ -252,7 +254,9 @@ module.exports = class Sidebar extends React.Component
     else if @state.isLoading
       <div/>
     else
-      <SidebarNoStacks />
+      <SidebarNoStacks
+        teamStacks={@state.teamStackTemplates.size}
+        privateStacks={@state.privateStackTemplates.size} />
 
 
   renderDifferentStackResources: ->

--- a/client/app/lib/components/sidebarstacksection/sidebarnostacks.coffee
+++ b/client/app/lib/components/sidebarstacksection/sidebarnostacks.coffee
@@ -7,7 +7,14 @@ isAdmin = require 'app/util/isAdmin'
 module.exports = class SidebarNoStacks extends React.Component
 
   renderMessage: ->
-    if canCreateStacks()
+
+    { teamStacks, privateStacks } = @props
+
+    if teamStacks or privateStacks
+      <p>
+        Open your dashboard and add your stacks to sidebar to continue
+      </p>
+    else if canCreateStacks()
       <p>
         Your stacks has not been
         fully configured yet, please


### PR DESCRIPTION
Even user has private or team stack but they are removed from sidebar, we were showing wrong message to user.

## Description
Check availability of team or private stack templates before showing `no stack` message.
`SidebarNoStacks` class will get `teamStacks` and `privateStacks` options as boolean
If one of them exists, we will show
`Open your dashboard and add your stacks to sidebar to continue` message
@sinan wdyt about the message?


## Motivation and Context
Fixes: #10231 


## Screenshots (if appropriate):
![](https://monosnap.com/file/xttc8l6cm7tFtUMBmlkE2esnKpzY6U.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
