### PR TITLE
IDE: Syntax-Selector, Text in the select-box is not aligned correctly (vertically)

### DIFF
--- a/client/ide/lib/styl/ide.styl
+++ b/client/ide/lib/styl/ide.styl
@@ -718,6 +718,9 @@ body.ide .dark .ide-files-tab .kdtabhandle.close-handle .icon
         height              20px !important
         padding             0
 
+      span.title
+        padding-top         2px
+
       .arrows
         r-sprite            'finder', 'expanded'
         top                 2px


### PR DESCRIPTION
Syntax-selector, vertical alignment fix
![](https://monosnap.com/file/lRLPD5ARx2uEUYiqMgx8qKhl33B3PK.png)
Fixes: #9979 