### PR TITLE
Fix text and X alignment, add ESC functionality

### DIFF
--- a/client/app/lib/components/contentModal/index.coffee
+++ b/client/app/lib/components/contentModal/index.coffee
@@ -26,6 +26,8 @@ module.exports = class ContentModal extends kd.ModalView
     @createBody()
     @createFooter()
 
+  keyup: (e) ->
+    @cancel() if e.which is 27
 
   createHeader: ->
 

--- a/client/app/lib/components/contentModal/index.coffee
+++ b/client/app/lib/components/contentModal/index.coffee
@@ -26,6 +26,7 @@ module.exports = class ContentModal extends kd.ModalView
     @createBody()
     @createFooter()
 
+  # commented function in kd.ModalView class
   keyup: (e) ->
     @cancel() if e.which is 27
 

--- a/client/app/lib/components/contentModal/styl/contentModal.styl
+++ b/client/app/lib/components/contentModal/styl/contentModal.styl
@@ -36,9 +36,12 @@ contentModal.styl
 
     .kdmodal-inner .close-icon
       r-sprite              app content_modal_close_icon
-      top                   24px
-      right                 24px
-      background-position   0 !important
+      width                 23px
+      height                24px
+      top                   19px
+      right                 19px
+      background-position   center !important
+      background-repeat     no-repeat
 
     &.formline.button-field
       button.kdbutton
@@ -120,7 +123,7 @@ contentModal.styl
         color               #727272
         font-size           22px
         font-weight         300
-        line-height         60px
+        line-height         65px
         display             inline-block
         letter-spacing      0px
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- "Do you want to save your changes?" vertical alignment
- Press ESC to close out of the modal
- 5px padding around the X to make easier to close modal

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Displaying title text alignment to be vertical
![image](https://cloud.githubusercontent.com/assets/1885776/21780801/c9c82bd6-d661-11e6-998b-03c92c4bf2a2.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
