### PR TITLE
'stack template is shared with team' notification appears for the already shared template when it's updated.

### DIFF
--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -368,11 +368,14 @@ module.exports = class JStackTemplate extends Module
       { group } = client.r
       query = { $set: { accessLevel } }
       id = @getId()
+      currentAccessLevel = @getAt 'accessLevel'
 
       @update query, (err) =>
 
         return callback err  if err
         return  unless group.slug
+
+        return callback null, this  if currentAccessLevel is accessLevel
 
         JGroup = require '../group'
         JGroup.one { slug : group.slug }, (err, group_) =>


### PR DESCRIPTION
## Description
Do not notify the group with `SharedStackTemplateAccessLevel` event if the accessLevel of stack template didn't change

## Motivation and Context
Fixes: #10142 

## Screenshots (if appropriate):
http://recordit.co/7fE3vNlwHA

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

