### PR TITLE
Promises: Return missing values to keep promise chains safe

### DIFF
--- a/client/app/lib/kite/kites/klient.coffee
+++ b/client/app/lib/kite/kites/klient.coffee
@@ -199,6 +199,7 @@ module.exports = class KodingKiteKlientKite extends require('../kodingkite')
             locked = no
             consume()
             resolve res
+            return res
 
           .catch (err) ->
             locked = no

--- a/client/app/lib/kite/kodingkite.coffee
+++ b/client/app/lib/kite/kodingkite.coffee
@@ -106,6 +106,8 @@ module.exports = class KodingKite extends kd.Object
 
             )
 
+            return args
+
           .catch (err) =>
 
             KiteLogger.failed name, rpcMethod, err

--- a/client/app/lib/providers/computestatechecker.coffee
+++ b/client/app/lib/providers/computestatechecker.coffee
@@ -103,6 +103,8 @@ module.exports = class ComputeStateChecker extends KDObject
           kd.info "csc: machine (#{machineId}) state changed: ", response.State
           computeController.triggerReviveFor machineId
 
+        return response
+
       .timeout globals.COMPUTECONTROLLER_TIMEOUT
 
       .catch (err) ->

--- a/client/ide/lib/index.coffee
+++ b/client/ide/lib/index.coffee
@@ -1868,14 +1868,20 @@ module.exports = class IDEAppController extends AppController
 
       .then (data) =>
 
-        return callback data  if data
+        if data
+          callback data
+          return data
 
         # Backward compatibility plug
-        return callback null  unless @mountedMachine.isMine()
+        unless @mountedMachine.isMine()
+          callback null
+          return null
 
         fetch()
           .then callback
           .catch handleError
+
+        return data
 
       .catch handleError
 


### PR DESCRIPTION
Fixes warnings on client side related with http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it