### PR TITLE
stacktemplate: setAccess, Fix callback when there is no group.slug data

### DIFF
--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -373,9 +373,9 @@ module.exports = class JStackTemplate extends Module
       @update query, (err) =>
 
         return callback err  if err
-        return  unless group.slug
 
-        return callback null, this  if currentAccessLevel is accessLevel
+        if currentAccessLevel is accessLevel or not group.slug
+          return callback null, this
 
         JGroup = require '../group'
         JGroup.one { slug : group.slug }, (err, group_) =>


### PR DESCRIPTION
Minor update in setAccess function of stack template
Return correct callback when there is not group.slug data provided