### PR TITLE
StackTemplate: slug support, create with defaults

### DIFF
--- a/client/app/lib/util/getPokemonName.coffee
+++ b/client/app/lib/util/getPokemonName.coffee
@@ -27,4 +27,4 @@ pokemons = [
   'Dragonair', 'Dragonite', 'Mewtwo', 'Mew'
 ]
 
-module.exports = -> _.sample pokemons
+module.exports = -> sample pokemons

--- a/client/new-stack-editor/lib/index.coffee
+++ b/client/new-stack-editor/lib/index.coffee
@@ -49,6 +49,10 @@ module.exports = class StackEditorAppController extends AppController
 
   openEditor: (templateId, reset = no) ->
 
+    unless templateId
+      do @openStackWizard
+      return
+
     @fetchStackTemplate templateId, (err, template) =>
       return showErrorNotification err  if err
       @stackEditor.setTemplateData template, reset
@@ -63,6 +67,8 @@ module.exports = class StackEditorAppController extends AppController
 
 
   reloadEditor: (templateId) ->
+
+    return  unless @templates[templateId]
 
     delete @templates[templateId]
     @openEditor templateId, reset = yes

--- a/client/new-stack-editor/lib/views/toolbar.coffee
+++ b/client/new-stack-editor/lib/views/toolbar.coffee
@@ -10,7 +10,7 @@ module.exports = class Toolbar extends JView
   constructor: (options = {}, data) ->
 
     options.cssClass = kd.utils.curry 'toolbar', options.cssClass
-    data ?= { title: 'Loading...' }
+    data ?= { title: '' }
 
     super options, data
 

--- a/website/swagger.json
+++ b/website/swagger.json
@@ -610,6 +610,7 @@
       "type": "object",
       "required": [
         "title",
+        "slug",
         "originId",
         "group"
       ],
@@ -626,6 +627,10 @@
         "title": {
           "type": "string",
           "description": "Title of this stack template"
+        },
+        "slug": {
+          "type": "string",
+          "description": "Unique slug of stack template"
         },
         "description": {
           "type": "string",

--- a/workers/migrations/0015-create_default_indexes.js
+++ b/workers/migrations/0015-create_default_indexes.js
@@ -78,15 +78,6 @@ var indexes = {
       "_id": 1
     },
     "ns": "koding.jStackTemplates"
-  }, {
-    "name": "groupName_originId_slug",
-    "key": {
-      "slug": 1,
-      "group": 1,
-      "originId": 1
-    },
-    "ns": "koding.jStackTemplates",
-    "unique": true
   }],
   "jSecretNames": [{
     "name": "_id_",

--- a/workers/migrations/0015-create_default_indexes.js
+++ b/workers/migrations/0015-create_default_indexes.js
@@ -78,6 +78,15 @@ var indexes = {
       "_id": 1
     },
     "ns": "koding.jStackTemplates"
+  }, {
+    "name": "groupName_originId_slug",
+    "key": {
+      "slug": 1,
+      "group": 1,
+      "originId": 1
+    },
+    "ns": "koding.jStackTemplates",
+    "unique": true
   }],
   "jSecretNames": [{
     "name": "_id_",

--- a/workers/migrations/0025-stacktemplate-index.js
+++ b/workers/migrations/0025-stacktemplate-index.js
@@ -1,0 +1,20 @@
+
+var mongodb = require('mongodb');
+
+exports.up = function(db, next){
+  var index = {
+    "name": "groupName_originId_slug",
+    "key": {
+      "slug": 1,
+      "group": 1,
+      "originId": 1
+    },
+    "ns": "koding.jStackTemplates",
+    "unique": true
+  }
+  db.ensureIndex("jStackTemplates", index.key, index, next);
+};
+
+exports.down = function(db, next){
+  next();
+};

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -234,7 +234,9 @@ module.exports = class JStackTemplate extends Module
 
       ComputeProvider = require './computeprovider'
       ComputeProvider.validateTemplateContent \
-        data.template, limitConfig, (err) -> callback err, replacements
+        data.template, limitConfig, (err) ->
+          return callback err  if err
+          callback null, replacements
 
 
   generateTemplateTitle = (provider) ->

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -188,6 +188,10 @@ module.exports = class JStackTemplate extends Module
     slug = _title = if index? then "#{title} #{index}" else title
     slug = slugify slug
 
+    if index >= 20
+      return callback new KodingError \
+        'Too many occurrences, please provide a different title'
+
     JStackTemplate.count { originId, group, slug }, (err, count) ->
       return callback err  if err?
 

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -179,6 +179,14 @@ module.exports = class JStackTemplate extends Module
     ComputeProvider.validateTemplateContent template, limitConfig, callback
 
 
+  generateTemplateTitle = (provider) ->
+
+    { capitalize } = require 'lodash'
+    getPokemonName = clientRequire 'app/lib/util/getPokemonName'
+
+    return "#{getPokemonName()} #{capitalize provider} Stack"
+
+
   # creates a JStackTemplate with requested content
   #
   # @param {Object} data
@@ -223,7 +231,6 @@ module.exports = class JStackTemplate extends Module
         stackTemplate = new JStackTemplate
           originId    : delegate.getId()
           group       : client.context.group
-          title       : data.title
           config      : data.config      ? {}
           description : data.description ? ''
           machines    : data.machines    ? []
@@ -234,6 +241,9 @@ module.exports = class JStackTemplate extends Module
 
         stackTemplate.config = updateConfigForTemplate \
           stackTemplate.config, stackTemplate.template.rawContent
+
+        stackTemplate.title = data.title ? \
+          generateTemplateTitle stackTemplate.config.requiredProviders[0]
 
         stackTemplate.save (err) ->
           if err

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -7,6 +7,7 @@ clientRequire            = require '../../clientrequire'
 
 module.exports = class JStackTemplate extends Module
 
+  { slugify }  = require '../../traits/slugifiable'
   { permit }   = require '../group/permissionset'
   Validators   = require '../group/validators'
   { revive, checkTemplateUsage } = require './computeutils'
@@ -82,6 +83,11 @@ module.exports = class JStackTemplate extends Module
         type          : String
         required      : yes
         _description  : 'Title of this stack template'
+
+      slug            :
+        type          : String
+        required      : yes
+        _description  : 'Unique slug of stack template'
 
       description     :
         type          : String
@@ -214,8 +220,8 @@ module.exports = class JStackTemplate extends Module
 
     success: revive
 
-      shouldReviveClient   : yes
-      shouldReviveProvider : no
+      shouldReviveClient    : yes
+      shouldReviveProvider  : no
       shouldFetchGroupLimit : yes
 
     , (client, data, callback) ->
@@ -245,6 +251,8 @@ module.exports = class JStackTemplate extends Module
 
         stackTemplate.title = data.title ? \
           generateTemplateTitle stackTemplate.config.requiredProviders[0]
+
+        stackTemplate.slug = slugify data.slug ? stackTemplate.title
 
         stackTemplate.save (err) ->
           if err

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -38,6 +38,13 @@ module.exports = class JStackTemplate extends Module
       'check own stack usage'     : ['member']
       'check stack usage'         : []
 
+    # we need a compound index here
+    # since bongo is not supporting them
+    # we need to manually define following:
+    #
+    #   - originId, group, slug (unique)
+    #
+
     sharedMethods     :
 
       static          :

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -316,6 +316,10 @@ module.exports = class JStackTemplate extends Module
       unless typeof selector is 'object'
         return callback new KodingError 'Invalid query'
 
+      # By default return stack templates that requester owns
+      if (Object.keys selector).length is 0
+        selector = { originId: delegate.getId() }
+
       selector.$and ?= []
       selector.$and.push
         $or : [

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -166,9 +166,13 @@ module.exports = class JStackTemplate extends Module
     return config
 
 
-  validateTemplate = (template, group, callback) ->
+  validateTemplate = (templateData, group, callback) ->
 
-    limitConfig = helpers.getLimitConfig group
+    unless templateData
+      return callback new KodingError 'Template data is required!'
+
+    { template } = templateData
+    limitConfig  = helpers.getLimitConfig group
     return callback null  unless limitConfig.limit # No limit, no pain.
 
     ComputeProvider = require './computeprovider'
@@ -210,15 +214,7 @@ module.exports = class JStackTemplate extends Module
       { group }    = client.r # we have revived JGroup and JUser here ~ GG
       { delegate } = client.connection
 
-      # TODO(rjeczalik): move app/util/getPokemonName.coffee here
-      # and refactor JStackTemplate.create to not require title;
-      # if title is missing or empty, generate pokemon name as
-      # it's done currently on client side; this way we do not
-      # need to reimplement pokemon naming in kloud as well.
-      unless data?.title
-        return callback new KodingError 'Title required.'
-
-      validateTemplate data.template, group, (err) ->
+     validateTemplate data, group, (err) ->
         return callback err  if err
 
         if data.config?

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -160,6 +160,7 @@ module.exports = class JStackTemplate extends Module
     providersParser    = clientRequire 'app/lib/util/stacks/providersparser'
     requirementsParser = clientRequire 'app/lib/util/stacks/requirementsparser'
 
+    config.groupStack       ?= no
     config.requiredData      = requirementsParser template
     config.requiredProviders = providersParser template, supportedProviders
 

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -275,12 +275,17 @@ module.exports = class JStackTemplate extends Module
 
       { group }    = client.r # we have revived JGroup and JUser here ~ GG
       { delegate } = client.connection
+      originId     = delegate.getId()
+      options      = { group, originId }
 
-      validateTemplateData data, group, (err, replacements) ->
+      if not data.template or not data.rawContent
+        return callback new KodingError 'Template content is required!'
+
+      validateTemplateData data, options, (err, replacements) ->
         return callback err  if err
 
         stackTemplate = new JStackTemplate
-          originId    : delegate.getId()
+          originId    : originId
           group       : client.context.group
           description : data.description ? ''
           machines    : data.machines    ? []

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.test.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.test.coffee
@@ -65,6 +65,23 @@ runTests = -> describe 'workers.social.models.computeproviders.stacktemplate', -
             expect(template.title.split(' ')[1])  .to.be.equal 'Aws'
             done()
 
+      it 'should generate config automatically from template content', (done) ->
+
+        withConvertedUser ({ client }) ->
+
+          stackTemplateData = generateStackTemplateData client
+          delete stackTemplateData.config
+
+          StackTemplate.create client, stackTemplateData, (err, template) ->
+            expect(err?.message)                      .not.exist
+            expect(template.config)                   .to.exist
+            expect(template.config.groupStack)        .to.be.equal no
+            expect(template.config.requiredData)      .to.be.deep.equal {
+              user: [ 'username' ], group: [ 'slug' ]
+            }
+            expect(template.config.requiredProviders) .to.be.deep.equal ['aws']
+            done()
+
 
   describe '#some$()', ->
 

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.test.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.test.coffee
@@ -44,7 +44,7 @@ runTests = -> describe 'workers.social.models.computeproviders.stacktemplate', -
             expect(err?.message)              .not.exist
             expect(template.title)            .to.be.equal stackTemplateData.title
             expect(template.slug)             .to.be.equal slugify stackTemplateData.title
-            expect(template.config)           .to.be.deep.equal stackTemplateData.config
+            expect(template.config)           .to.exist
             expect(template.credentials)      .to.be.equal stackTemplateData.credentials
             expect(template.machines.length)  .to.be.equal stackTemplateData.machines.length
             expect(template.accessLevel)      .to.be.equal stackTemplateData.accessLevel

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.test.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.test.coffee
@@ -295,8 +295,9 @@ runTests = -> describe 'workers.social.models.computeproviders.stacktemplate', -
 
             (next) ->
               config = { verified: yes }
-              stackTemplate.update$ client, { config }, (err) ->
+              stackTemplate.update$ client, { config }, (err, template) ->
                 expect(err).to.not.exist
+                expect(template.config.verified).to.be.equal yes
                 next()
 
             (next) ->

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.test.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.test.coffee
@@ -52,6 +52,19 @@ runTests = -> describe 'workers.social.models.computeproviders.stacktemplate', -
             expect(template.template.sum)     .to.exist
             done()
 
+      it 'should generate a title if title is not provided', (done) ->
+
+        withConvertedUser ({ client }) ->
+
+          stackTemplateData = generateStackTemplateData client
+          delete stackTemplateData.title
+
+          StackTemplate.create client, stackTemplateData, (err, template) ->
+            expect(err?.message)                  .not.exist
+            expect(template.title)                .to.exist
+            expect(template.title.split(' ')[1])  .to.be.equal 'Aws'
+            done()
+
 
   describe '#some$()', ->
 

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.test.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.test.coffee
@@ -13,6 +13,7 @@ StackTemplate   = require './stacktemplate'
   withConvertedUserAndStackTemplate } = require \
   '../../../../testhelper/models/computeproviders/stacktemplatehelper'
 
+{ slugify } = require '../../traits/slugifiable'
 
 # this function will be called once before running any test
 beforeTests = -> before (done) ->
@@ -42,6 +43,7 @@ runTests = -> describe 'workers.social.models.computeproviders.stacktemplate', -
           StackTemplate.create client, stackTemplateData, (err, template) ->
             expect(err?.message)              .not.exist
             expect(template.title)            .to.be.equal stackTemplateData.title
+            expect(template.slug)             .to.be.equal slugify stackTemplateData.title
             expect(template.config)           .to.be.deep.equal stackTemplateData.config
             expect(template.credentials)      .to.be.equal stackTemplateData.credentials
             expect(template.machines.length)  .to.be.equal stackTemplateData.machines.length
@@ -52,17 +54,20 @@ runTests = -> describe 'workers.social.models.computeproviders.stacktemplate', -
             expect(template.template.sum)     .to.exist
             done()
 
-      it 'should generate a title if title is not provided', (done) ->
+      it 'should generate a title/slug if not provided', (done) ->
 
         withConvertedUser ({ client }) ->
 
           stackTemplateData = generateStackTemplateData client
+
+          delete stackTemplateData.slug
           delete stackTemplateData.title
 
           StackTemplate.create client, stackTemplateData, (err, template) ->
             expect(err?.message)                  .not.exist
             expect(template.title)                .to.exist
             expect(template.title.split(' ')[1])  .to.be.equal 'Aws'
+            expect(template.slug)                 .to.be.equal slugify template.title
             done()
 
       it 'should generate config automatically from template content', (done) ->

--- a/workers/social/testhelper/models/computeproviders/stacktemplatehelper.coffee
+++ b/workers/social/testhelper/models/computeproviders/stacktemplatehelper.coffee
@@ -62,9 +62,11 @@ generateStackTemplateData = (client, data) ->
   '''
 
 
+  title = generateRandomString()
   stackTemplate =
     group           : client.context.group
-    title           : generateRandomString()
+    title           : title
+    slug            : title
     config          : {}
     originId        : delegate.getId()
     machines        : []


### PR DESCRIPTION
- [x] `slug` field needs to be created with unique index on `group`, `originId` and `slug`
- [x] `slug` should be created automatically from `title` if not provided
- [x] `title` should be auto generated like in client side if not provided
- [x] all required fields of `config` should be auto generated if not provided
- [x] `slug` should automatically provide incremental alternatives (`foo, foo-1, foo-2` and so on)

fixes: #10269 
rel: https://github.com/koding/koding/pull/9488/files#diff-888f0565303232623f005f3516ced158
