### PR TITLE
kd/klientctl: remove unused Members field from team

### DIFF
--- a/go/src/koding/kites/kloud/team/client.go
+++ b/go/src/koding/kites/kloud/team/client.go
@@ -6,7 +6,6 @@ import "koding/db/models"
 type Team struct {
 	Name      string           `json:"name"`         // Team name.
 	Slug      string           `json:"slug"`         // Team slug.
-	Members   string           `json:"members"`      // Number of team members.
 	Privacy   string           `json:"privacy"`      // Whether team is public or private.
 	SubStatus models.SubStatus `json:"subscription"` // Subscription status.
 }

--- a/go/src/koding/klientctl/team.go
+++ b/go/src/koding/klientctl/team.go
@@ -51,10 +51,10 @@ func printTeams(teams []*team.Team) {
 	w := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
 	defer w.Flush()
 
-	fmt.Fprintln(w, "NAME\tSLUG\tPRIVACY\tMEMBERS\tSUBSCRIPTION")
+	fmt.Fprintln(w, "NAME\tSLUG\tPRIVACY\tSUBSCRIPTION")
 
 	for _, t := range teams {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", t.Name, t.Slug, t.Privacy, t.Members, t.SubStatus)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", t.Name, t.Slug, t.Privacy, t.SubStatus)
 	}
 }
 


### PR DESCRIPTION
This field is no longer valid and is always set to 0.
