### PR TITLE
vendor: update jacobsa/fuse

### DIFF
--- a/go/src/glide.lock
+++ b/go/src/glide.lock
@@ -486,7 +486,7 @@ imports:
   - models
   - pkg/escape
 - name: github.com/jacobsa/fuse
-  version: 3b8b4e55df5483817cd361a28d0a830d5acd962b
+  version: dc1be2d5b8abc34991a649f7499f9f673e36bb46
   subpackages:
   - fuseops
   - fuseutil

--- a/go/src/vendor/github.com/jacobsa/fuse/.travis.yml
+++ b/go/src/vendor/github.com/jacobsa/fuse/.travis.yml
@@ -4,7 +4,7 @@
 language: go
 
 go:
-  - 1.4.2
+  - 1.7.4
   - tip
 
 # Use the virtualized Trusty beta Travis is running in order to get support for

--- a/go/src/vendor/github.com/jacobsa/fuse/connection.go
+++ b/go/src/vendor/github.com/jacobsa/fuse/connection.go
@@ -55,7 +55,8 @@ var contextKey interface{} = contextKeyType(0)
 // Reading a page at a time is a drag. Ask for a larger size.
 const maxReadahead = 1 << 20
 
-// A connection to the fuse kernel process.
+// Connection represents a connection to the fuse kernel process. It is used to
+// receive and reply to requests from the kernel.
 type Connection struct {
 	cfg         MountConfig
 	debugLogger *log.Logger
@@ -115,7 +116,7 @@ func newConnection(
 	return
 }
 
-// Do the work necessary to cause the mount process to complete.
+// Init performs the work necessary to cause the mount process to complete.
 func (c *Connection) Init() (err error) {
 	// Read the init op.
 	ctx, op, err := c.ReadOp()
@@ -360,9 +361,9 @@ func (c *Connection) writeMessage(msg []byte) (err error) {
 	return
 }
 
-// Read the next op from the kernel process, returning the op and a context
-// that should be used for work related to the op. Return io.EOF if the kernel
-// has closed the connection.
+// ReadOp consumes the next op from the kernel process, returning the op and a
+// context that should be used for work related to the op. It returns io.EOF if
+// the kernel has closed the connection.
 //
 // If err != nil, the user is responsible for later calling c.Reply with the
 // returned context.
@@ -443,8 +444,8 @@ func (c *Connection) shouldLogError(
 	return true
 }
 
-// Reply to an op previously read using ReadOp, with the supplied error (or nil
-// if successful). The context must be the context returned by ReadOp.
+// Reply replies to an op previously read using ReadOp, with the supplied error
+// (or nil if successful). The context must be the context returned by ReadOp.
 //
 // LOCKS_EXCLUDED(c.mu)
 func (c *Connection) Reply(ctx context.Context, opErr error) {

--- a/go/src/vendor/github.com/jacobsa/fuse/fuseops/simple_types.go
+++ b/go/src/vendor/github.com/jacobsa/fuse/fuseops/simple_types.go
@@ -22,18 +22,19 @@ import (
 	"github.com/jacobsa/fuse/internal/fusekernel"
 )
 
-// A 64-bit number used to uniquely identify a file or directory in the file
-// system. File systems may mint inode IDs with any value except for
+// InodeID is a 64-bit number used to uniquely identify a file or directory in
+// the file system. File systems may mint inode IDs with any value except for
 // RootInodeID.
 //
 // This corresponds to struct inode::i_no in the VFS layer.
 // (Cf. http://goo.gl/tvYyQt)
 type InodeID uint64
 
-// A distinguished inode ID that identifies the root of the file system, e.g.
-// in an OpenDirOp or LookUpInodeOp. Unlike all other inode IDs, which are
-// minted by the file system, the FUSE VFS layer may send a request for this ID
-// without the file system ever having referenced it in a previous response.
+// RootInodeID is a distinguished inode ID that identifies the root of the file
+// system, e.g. in an OpenDirOp or LookUpInodeOp. Unlike all other inode IDs,
+// which are minted by the file system, the FUSE VFS layer may send a request
+// for this ID without the file system ever having referenced it in a previous
+// response.
 const RootInodeID = 1
 
 func init() {
@@ -55,8 +56,8 @@ func init() {
 	}
 }
 
-// Attributes for a file or directory inode. Corresponds to struct inode (cf.
-// http://goo.gl/tvYyQt).
+// InodeAttributes contains attributes for a file or directory inode. It
+// corresponds to struct inode (cf. http://goo.gl/tvYyQt).
 type InodeAttributes struct {
 	Size uint64
 
@@ -107,9 +108,10 @@ func (a *InodeAttributes) DebugString() string {
 		a.Gid)
 }
 
-// A generation number for an inode. Irrelevant for file systems that won't be
-// exported over NFS. For those that will and that reuse inode IDs when they
-// become free, the generation number must change when an ID is reused.
+// GenerationNumber represents a generation of an inode. It is irrelevant for
+// file systems that won't be exported over NFS. For those that will and that
+// reuse inode IDs when they become free, the generation number must change
+// when an ID is reused.
 //
 // This corresponds to struct inode::i_generation in the VFS layer.
 // (Cf. http://goo.gl/tvYyQt)
@@ -124,20 +126,20 @@ func (a *InodeAttributes) DebugString() string {
 //
 type GenerationNumber uint64
 
-// An opaque 64-bit number used to identify a particular open handle to a file
-// or directory.
+// HandleID is an opaque 64-bit number used to identify a particular open
+// handle to a file or directory.
 //
 // This corresponds to fuse_file_info::fh.
 type HandleID uint64
 
-// An offset into an open directory handle. This is opaque to FUSE, and can be
-// used for whatever purpose the file system desires. See notes on
-// ReadDirOp.Offset for details.
+// DirOffset is an offset into an open directory handle. This is opaque to
+// FUSE, and can be used for whatever purpose the file system desires. See
+// notes on ReadDirOp.Offset for details.
 type DirOffset uint64
 
-// Information about a child inode within its parent directory. Shared by
-// LookUpInodeOp, MkDirOp, CreateFileOp, etc. Consumed by the kernel in order
-// to set up a dcache entry.
+// ChildInodeEntry contains information about a child inode within its parent
+// directory. It is shared by LookUpInodeOp, MkDirOp, CreateFileOp, etc, and is
+// consumed by the kernel in order to set up a dcache entry.
 type ChildInodeEntry struct {
 	// The ID of the child inode. The file system must ensure that the returned
 	// inode ID remains valid until a later ForgetInodeOp.

--- a/go/src/vendor/github.com/jacobsa/fuse/internal/buffer/out_message.go
+++ b/go/src/vendor/github.com/jacobsa/fuse/internal/buffer/out_message.go
@@ -23,14 +23,9 @@ import (
 	"github.com/jacobsa/fuse/internal/fusekernel"
 )
 
-const outHeaderSize = unsafe.Sizeof(fusekernel.OutHeader{})
-
-// OutMessage structs begin life with Len() == OutMessageInitialSize.
-const OutMessageInitialSize = outHeaderSize
-
-// We size out messages to be large enough to hold a header for the response
-// plus the largest read that may come in.
-const outMessageSize = outHeaderSize + MaxReadSize
+// OutMessageHeaderSize is the size of the leading header in every
+// properly-constructed OutMessage. Reset brings the message back to this size.
+const OutMessageHeaderSize = int(unsafe.Sizeof(fusekernel.OutHeader{}))
 
 // OutMessage provides a mechanism for constructing a single contiguous fuse
 // message from multiple segments, where the first segment is always a
@@ -38,72 +33,95 @@ const outMessageSize = outHeaderSize + MaxReadSize
 //
 // Must be initialized with Reset.
 type OutMessage struct {
-	offset  uintptr
-	storage [outMessageSize]byte
+	// The offset into payload to which we're currently writing.
+	payloadOffset int
+
+	header  fusekernel.OutHeader
+	payload [MaxReadSize]byte
 }
 
-// Make sure alignment works out correctly, at least for the header.
+// Make sure that the header and payload are contiguous.
 func init() {
-	a := unsafe.Alignof(OutMessage{})
-	o := unsafe.Offsetof(OutMessage{}.storage)
-	e := unsafe.Alignof(fusekernel.OutHeader{})
+	a := unsafe.Offsetof(OutMessage{}.header) + uintptr(OutMessageHeaderSize)
+	b := unsafe.Offsetof(OutMessage{}.payload)
 
-	if a%e != 0 || o%e != 0 {
-		log.Panicf("Bad alignment or offset: %d, %d, need %d", a, o, e)
+	if a != b {
+		log.Panicf(
+			"header ends at offset %d, but payload starts at offset %d",
+			a, b)
 	}
 }
 
-// Reset the message so that it is ready to be used again. Afterward, the
-// contents are solely a zeroed header.
+// Reset resets m so that it's ready to be used again. Afterward, the contents
+// are solely a zeroed fusekernel.OutHeader struct.
 func (m *OutMessage) Reset() {
-	m.offset = OutMessageInitialSize
-	memclr(unsafe.Pointer(&m.storage), OutMessageInitialSize)
+	// Ideally we'd like to write:
+	//
+	//     m.payloadOffset = 0
+	//     m.header = fusekernel.OutHeader{}
+	//
+	// But Go 1.8 beta 2 generates bad code for this
+	// (https://golang.org/issue/18370). Encourage it to generate the same code
+	// as Go 1.7.4 did.
+	if unsafe.Offsetof(m.payload) != 24 {
+		panic("unexpected OutMessage layout")
+	}
+
+	a := (*[3]uint64)(unsafe.Pointer(m))
+	a[0] = 0
+	a[1] = 0
+	a[2] = 0
 }
 
-// Return a pointer to the header at the start of the message.
-func (b *OutMessage) OutHeader() (h *fusekernel.OutHeader) {
-	h = (*fusekernel.OutHeader)(unsafe.Pointer(&b.storage))
-	return
+// OutHeader returns a pointer to the header at the start of the message.
+func (m *OutMessage) OutHeader() *fusekernel.OutHeader {
+	return &m.header
 }
 
-// Grow the buffer by the supplied number of bytes, returning a pointer to the
-// start of the new segment, which is zeroed. If there is no space left, return
-// the nil pointer.
-func (b *OutMessage) Grow(size uintptr) (p unsafe.Pointer) {
-	p = b.GrowNoZero(size)
+// Grow grows m's buffer by the given number of bytes, returning a pointer to
+// the start of the new segment, which is guaranteed to be zeroed. If there is
+// insufficient space, it returns nil.
+func (m *OutMessage) Grow(n int) (p unsafe.Pointer) {
+	p = m.GrowNoZero(n)
 	if p != nil {
-		memclr(p, size)
+		memclr(p, uintptr(n))
 	}
 
 	return
 }
 
-// Equivalent to Grow, except the new segment is not zeroed. Use with caution!
-func (b *OutMessage) GrowNoZero(size uintptr) (p unsafe.Pointer) {
-	if outMessageSize-b.offset < size {
+// GrowNoZero is equivalent to Grow, except the new segment is not zeroed. Use
+// with caution!
+func (m *OutMessage) GrowNoZero(n int) (p unsafe.Pointer) {
+	// Will we overflow the buffer?
+	o := m.payloadOffset
+	if len(m.payload)-o < n {
 		return
 	}
 
-	p = unsafe.Pointer(uintptr(unsafe.Pointer(&b.storage)) + b.offset)
-	b.offset += size
+	p = unsafe.Pointer(uintptr(unsafe.Pointer(&m.payload)) + uintptr(o))
+	m.payloadOffset = o + n
 
 	return
 }
 
-// Shrink to the supplied size. Panic if the size is greater than Len() or less
-// than OutMessageInitialSize.
-func (b *OutMessage) ShrinkTo(n uintptr) {
-	if n < OutMessageInitialSize || n > b.offset {
-		panic(fmt.Sprintf("ShrinkTo(%d) out of range for offset %d", n, b.offset))
+// ShrinkTo shrinks m to the given size. It panics if the size is greater than
+// Len() or less than OutMessageHeaderSize.
+func (m *OutMessage) ShrinkTo(n int) {
+	if n < OutMessageHeaderSize || n > m.Len() {
+		panic(fmt.Sprintf(
+			"ShrinkTo(%d) out of range (current Len: %d)",
+			n,
+			m.Len()))
 	}
 
-	b.offset = n
+	m.payloadOffset = n - OutMessageHeaderSize
 }
 
-// Equivalent to growing by the length of p, then copying p over the new
-// segment. Panics if there is not enough room available.
-func (b *OutMessage) Append(src []byte) {
-	p := b.GrowNoZero(uintptr(len(src)))
+// Append is equivalent to growing by len(src), then copying src over the new
+// segment. Int panics if there is not enough room available.
+func (m *OutMessage) Append(src []byte) {
+	p := m.GrowNoZero(len(src))
 	if p == nil {
 		panic(fmt.Sprintf("Can't grow %d bytes", len(src)))
 	}
@@ -114,10 +132,9 @@ func (b *OutMessage) Append(src []byte) {
 	return
 }
 
-// Equivalent to growing by the length of s, then copying s over the new
-// segment. Panics if there is not enough room available.
-func (b *OutMessage) AppendString(src string) {
-	p := b.GrowNoZero(uintptr(len(src)))
+// AppendString is like Append, but accepts string input.
+func (m *OutMessage) AppendString(src string) {
+	p := m.GrowNoZero(len(src))
 	if p == nil {
 		panic(fmt.Sprintf("Can't grow %d bytes", len(src)))
 	}
@@ -128,12 +145,20 @@ func (b *OutMessage) AppendString(src string) {
 	return
 }
 
-// Return the current size of the buffer.
-func (b *OutMessage) Len() int {
-	return int(b.offset)
+// Len returns the current size of the message, including the leading header.
+func (m *OutMessage) Len() int {
+	return OutMessageHeaderSize + m.payloadOffset
 }
 
-// Return a reference to the current contents of the buffer.
-func (b *OutMessage) Bytes() []byte {
-	return b.storage[:int(b.offset)]
+// Bytes returns a reference to the current contents of the buffer, including
+// the leading header.
+func (m *OutMessage) Bytes() []byte {
+	l := m.Len()
+	sh := reflect.SliceHeader{
+		Data: uintptr(unsafe.Pointer(&m.header)),
+		Len:  l,
+		Cap:  l,
+	}
+
+	return *(*[]byte)(unsafe.Pointer(&sh))
 }

--- a/go/src/vendor/github.com/jacobsa/fuse/internal/buffer/out_message_test.go
+++ b/go/src/vendor/github.com/jacobsa/fuse/internal/buffer/out_message_test.go
@@ -1,0 +1,357 @@
+package buffer
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"reflect"
+	"testing"
+	"unsafe"
+
+	"github.com/jacobsa/fuse/internal/fusekernel"
+	"github.com/kylelemons/godebug/pretty"
+)
+
+func toByteSlice(p unsafe.Pointer, n int) []byte {
+	sh := reflect.SliceHeader{
+		Data: uintptr(p),
+		Len:  n,
+		Cap:  n,
+	}
+
+	return *(*[]byte)(unsafe.Pointer(&sh))
+}
+
+// fillWithGarbage writes random data to [p, p+n).
+func fillWithGarbage(p unsafe.Pointer, n int) (err error) {
+	b := toByteSlice(p, n)
+	_, err = io.ReadFull(rand.Reader, b)
+	return
+}
+
+func randBytes(n int) (b []byte, err error) {
+	b = make([]byte, n)
+	_, err = io.ReadFull(rand.Reader, b)
+	return
+}
+
+// findNonZero finds the offset of the first non-zero byte in [p, p+n). If
+// none, it returns n.
+func findNonZero(p unsafe.Pointer, n int) int {
+	b := toByteSlice(p, n)
+	for i, x := range b {
+		if x != 0 {
+			return i
+		}
+	}
+
+	return n
+}
+
+func TestMemclr(t *testing.T) {
+	// All sizes up to 32 bytes.
+	var sizes []int
+	for i := 0; i <= 32; i++ {
+		sizes = append(sizes, i)
+	}
+
+	// And a few hand-chosen sizes.
+	sizes = append(sizes, []int{
+		39, 41, 64, 127, 128, 129,
+		1<<20 - 1,
+		1 << 20,
+		1<<20 + 1,
+	}...)
+
+	// For each size, fill a buffer with random bytes and then zero it.
+	for _, size := range sizes {
+		size := size
+		t.Run(fmt.Sprintf("size=%d", size), func(t *testing.T) {
+			// Generate
+			b, err := randBytes(size)
+			if err != nil {
+				t.Fatalf("randBytes: %v", err)
+			}
+
+			// Clear
+			var p unsafe.Pointer
+			if len(b) != 0 {
+				p = unsafe.Pointer(&b[0])
+			}
+
+			memclr(p, uintptr(len(b)))
+
+			// Check
+			if i := findNonZero(p, len(b)); i != len(b) {
+				t.Fatalf("non-zero byte at offset %d", i)
+			}
+		})
+	}
+}
+
+func TestOutMessageAppend(t *testing.T) {
+	var om OutMessage
+	om.Reset()
+
+	// Append some payload.
+	const wantPayloadStr = "tacoburrito"
+	wantPayload := []byte(wantPayloadStr)
+	om.Append(wantPayload[:4])
+	om.Append(wantPayload[4:])
+
+	// The result should be a zeroed header followed by the desired payload.
+	const wantLen = OutMessageHeaderSize + len(wantPayloadStr)
+
+	if got, want := om.Len(), wantLen; got != want {
+		t.Errorf("om.Len() = %d, want %d", got, want)
+	}
+
+	b := om.Bytes()
+	if got, want := len(b), wantLen; got != want {
+		t.Fatalf("len(om.Bytes()) = %d, want %d", got, want)
+	}
+
+	want := append(
+		make([]byte, OutMessageHeaderSize),
+		wantPayload...)
+
+	if !bytes.Equal(b, want) {
+		t.Error("messages differ")
+	}
+}
+
+func TestOutMessageAppendString(t *testing.T) {
+	var om OutMessage
+	om.Reset()
+
+	// Append some payload.
+	const wantPayload = "tacoburrito"
+	om.AppendString(wantPayload[:4])
+	om.AppendString(wantPayload[4:])
+
+	// The result should be a zeroed header followed by the desired payload.
+	const wantLen = OutMessageHeaderSize + len(wantPayload)
+
+	if got, want := om.Len(), wantLen; got != want {
+		t.Errorf("om.Len() = %d, want %d", got, want)
+	}
+
+	b := om.Bytes()
+	if got, want := len(b), wantLen; got != want {
+		t.Fatalf("len(om.Bytes()) = %d, want %d", got, want)
+	}
+
+	want := append(
+		make([]byte, OutMessageHeaderSize),
+		wantPayload...)
+
+	if !bytes.Equal(b, want) {
+		t.Error("messages differ")
+	}
+}
+
+func TestOutMessageShrinkTo(t *testing.T) {
+	// Set up a buffer with some payload.
+	var om OutMessage
+	om.Reset()
+	om.AppendString("taco")
+	om.AppendString("burrito")
+
+	// Shrink it.
+	om.ShrinkTo(OutMessageHeaderSize + len("taco"))
+
+	// The result should be a zeroed header followed by "taco".
+	const wantLen = OutMessageHeaderSize + len("taco")
+
+	if got, want := om.Len(), wantLen; got != want {
+		t.Errorf("om.Len() = %d, want %d", got, want)
+	}
+
+	b := om.Bytes()
+	if got, want := len(b), wantLen; got != want {
+		t.Fatalf("len(om.Bytes()) = %d, want %d", got, want)
+	}
+
+	want := append(
+		make([]byte, OutMessageHeaderSize),
+		"taco"...)
+
+	if !bytes.Equal(b, want) {
+		t.Error("messages differ")
+	}
+}
+
+func TestOutMessageHeader(t *testing.T) {
+	var om OutMessage
+	om.Reset()
+
+	// Fill in the header.
+	want := fusekernel.OutHeader{
+		Len:    0xdeadbeef,
+		Error:  -31231917,
+		Unique: 0xcafebabeba5eba11,
+	}
+
+	h := om.OutHeader()
+	if h == nil {
+		t.Fatal("OutHeader returned nil")
+	}
+
+	*h = want
+
+	// Check that the result is as expected.
+	b := om.Bytes()
+	if len(b) != int(unsafe.Sizeof(want)) {
+		t.Fatalf("unexpected length %d; want %d", len(b), unsafe.Sizeof(want))
+	}
+
+	got := *(*fusekernel.OutHeader)(unsafe.Pointer(&b[0]))
+	if diff := pretty.Compare(got, want); diff != "" {
+		t.Errorf("diff -got +want:\n%s", diff)
+	}
+}
+
+func TestOutMessageReset(t *testing.T) {
+	var om OutMessage
+	h := om.OutHeader()
+
+	const trials = 10
+	for i := 0; i < trials; i++ {
+		// Fill the header with garbage.
+		err := fillWithGarbage(unsafe.Pointer(h), int(unsafe.Sizeof(*h)))
+		if err != nil {
+			t.Fatalf("fillWithGarbage: %v", err)
+		}
+
+		// Ensure a non-zero payload length.
+		if p := om.GrowNoZero(128); p == nil {
+			t.Fatal("GrowNoZero failed")
+		}
+
+		// Reset.
+		om.Reset()
+
+		// Check that the length was updated.
+		if got, want := om.Len(), OutMessageHeaderSize; got != want {
+			t.Fatalf("om.Len() = %d, want %d", got, want)
+		}
+
+		// Check that the header was zeroed.
+		if h.Len != 0 {
+			t.Fatalf("non-zero Len %v", h.Len)
+		}
+
+		if h.Error != 0 {
+			t.Fatalf("non-zero Error %v", h.Error)
+		}
+
+		if h.Unique != 0 {
+			t.Fatalf("non-zero Unique %v", h.Unique)
+		}
+	}
+}
+
+func TestOutMessageGrow(t *testing.T) {
+	var om OutMessage
+	om.Reset()
+
+	// Set up garbage where the payload will soon be.
+	const payloadSize = 1234
+	{
+		p := om.GrowNoZero(payloadSize)
+		if p == nil {
+			t.Fatal("GrowNoZero failed")
+		}
+
+		err := fillWithGarbage(p, payloadSize)
+		if err != nil {
+			t.Fatalf("fillWithGarbage: %v", err)
+		}
+
+		om.ShrinkTo(OutMessageHeaderSize)
+	}
+
+	// Call Grow.
+	if p := om.Grow(payloadSize); p == nil {
+		t.Fatal("Grow failed")
+	}
+
+	// Check the resulting length in two ways.
+	const wantLen = payloadSize + OutMessageHeaderSize
+	if got, want := om.Len(), wantLen; got != want {
+		t.Errorf("om.Len() = %d, want %d", got)
+	}
+
+	b := om.Bytes()
+	if got, want := len(b), wantLen; got != want {
+		t.Fatalf("len(om.Len()) = %d, want %d", got)
+	}
+
+	// Check that the payload was zeroed.
+	for i, x := range b[OutMessageHeaderSize:] {
+		if x != 0 {
+			t.Fatalf("non-zero byte 0x%02x at payload offset %d", x, i)
+		}
+	}
+}
+
+func BenchmarkOutMessageReset(b *testing.B) {
+	// A single buffer, which should fit in some level of CPU cache.
+	b.Run("Single buffer", func(b *testing.B) {
+		var om OutMessage
+		for i := 0; i < b.N; i++ {
+			om.Reset()
+		}
+
+		b.SetBytes(int64(unsafe.Offsetof(om.payload)))
+	})
+
+	// Many megabytes worth of buffers, which should defeat the CPU cache.
+	b.Run("Many buffers", func(b *testing.B) {
+		// The number of messages; intentionally a power of two.
+		const numMessages = 128
+
+		var oms [numMessages]OutMessage
+		if s := unsafe.Sizeof(oms); s < 128<<20 {
+			panic(fmt.Sprintf("Array is too small; total size: %d", s))
+		}
+
+		for i := 0; i < b.N; i++ {
+			oms[i%numMessages].Reset()
+		}
+
+		b.SetBytes(int64(unsafe.Offsetof(oms[0].payload)))
+	})
+}
+
+func BenchmarkOutMessageGrowShrink(b *testing.B) {
+	// A single buffer, which should fit in some level of CPU cache.
+	b.Run("Single buffer", func(b *testing.B) {
+		var om OutMessage
+		for i := 0; i < b.N; i++ {
+			om.Grow(MaxReadSize)
+			om.ShrinkTo(OutMessageHeaderSize)
+		}
+
+		b.SetBytes(int64(MaxReadSize))
+	})
+
+	// Many megabytes worth of buffers, which should defeat the CPU cache.
+	b.Run("Many buffers", func(b *testing.B) {
+		// The number of messages; intentionally a power of two.
+		const numMessages = 128
+
+		var oms [numMessages]OutMessage
+		if s := unsafe.Sizeof(oms); s < 128<<20 {
+			panic(fmt.Sprintf("Array is too small; total size: %d", s))
+		}
+
+		for i := 0; i < b.N; i++ {
+			oms[i%numMessages].Grow(MaxReadSize)
+			oms[i%numMessages].ShrinkTo(OutMessageHeaderSize)
+		}
+
+		b.SetBytes(int64(MaxReadSize))
+	})
+}

--- a/go/src/vendor/github.com/jacobsa/fuse/internal/buffer/runtime_go1.8.s
+++ b/go/src/vendor/github.com/jacobsa/fuse/internal/buffer/runtime_go1.8.s
@@ -12,18 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package buffer
+// +build amd64 arm64 ppc64 ppc64le
+// +build go1.8
 
-import "unsafe"
-
-//go:noescape
-
-// Zero the n bytes starting at p.
+// Assembly code isn't subject to visibility restrictions, so we can jump
+// directly into package runtime.
 //
-// REQUIRES: the region does not contain any Go pointers.
-func memclr(p unsafe.Pointer, n uintptr)
+// Technique copied from here:
+//     https://github.com/golang/go/blob/d8c6dac/src/os/signal/sig.s
 
-//go:noescape
+#include "textflag.h"
 
-// Copy from src to dst, allowing overlap.
-func memmove(dst unsafe.Pointer, src unsafe.Pointer, n uintptr)
+#ifdef GOARCH_ppc64
+#define JMP BR
+#endif
+#ifdef GOARCH_ppc64le
+#define JMP BR
+#endif
+
+TEXT ·memclr(SB),NOSPLIT,$0-16
+	JMP runtime·memclrNoHeapPointers(SB)
+
+TEXT ·memmove(SB),NOSPLIT,$0-24
+	JMP runtime·memmove(SB)

--- a/go/src/vendor/github.com/jacobsa/fuse/internal/buffer/runtime_other.s
+++ b/go/src/vendor/github.com/jacobsa/fuse/internal/buffer/runtime_other.s
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // +build amd64 arm64 ppc64 ppc64le
+// +build !go1.8
 
 // Assembly code isn't subject to visibility restrictions, so we can jump
 // directly into package runtime.

--- a/go/src/vendor/github.com/jacobsa/fuse/mount.go
+++ b/go/src/vendor/github.com/jacobsa/fuse/mount.go
@@ -21,7 +21,8 @@ import (
 	"golang.org/x/net/context"
 )
 
-// A type that knows how to serve ops read from a connection.
+// Server is an interface for any type that knows how to serve ops read from a
+// connection.
 type Server interface {
 	// Read and serve ops from the supplied connection until EOF. Do not return
 	// until all operations have been responded to. Must not be called more than
@@ -29,8 +30,8 @@ type Server interface {
 	ServeOps(*Connection)
 }
 
-// Attempt to mount a file system on the given directory, using the supplied
-// Server to serve connection requests. This function blocks until the file
+// Mount attempts to mount a file system on the given directory, using the
+// supplied Server to serve connection requests. It blocks until the file
 // system is successfully mounted.
 func Mount(
 	dir string,

--- a/go/src/vendor/github.com/jacobsa/fuse/mounted_file_system.go
+++ b/go/src/vendor/github.com/jacobsa/fuse/mounted_file_system.go
@@ -16,8 +16,8 @@ package fuse
 
 import "golang.org/x/net/context"
 
-// A struct representing the status of a mount operation, with a method that
-// waits for unmounting.
+// MountedFileSystem represents the status of a mount operation, with a method
+// that waits for unmounting.
 type MountedFileSystem struct {
 	dir string
 
@@ -26,15 +26,16 @@ type MountedFileSystem struct {
 	joinStatusAvailable chan struct{}
 }
 
-// Return the directory on which the file system is mounted (or where we
+// Dir returns the directory on which the file system is mounted (or where we
 // attempted to mount it.)
 func (mfs *MountedFileSystem) Dir() string {
 	return mfs.dir
 }
 
-// Block until a mounted file system has been unmounted. Do not return
-// successfully until all ops read from the connection have been responded to
-// (i.e. the file system server has finished processing all in-flight ops).
+// Join blocks until a mounted file system has been unmounted. It does not
+// return successfully until all ops read from the connection have been
+// responded to (i.e. the file system server has finished processing all
+// in-flight ops).
 //
 // The return value will be non-nil if anything unexpected happened while
 // serving. May be called multiple times.

--- a/go/src/vendor/github.com/jacobsa/fuse/samples/memfs/memfs_go18_test.go
+++ b/go/src/vendor/github.com/jacobsa/fuse/samples/memfs/memfs_go18_test.go
@@ -1,0 +1,5 @@
+// +build go1.8
+
+package memfs_test
+
+const atLeastGo18 = true

--- a/go/src/vendor/github.com/jacobsa/fuse/samples/memfs/memfs_others_test.go
+++ b/go/src/vendor/github.com/jacobsa/fuse/samples/memfs/memfs_others_test.go
@@ -1,0 +1,5 @@
+// +build !go1.8
+
+package memfs_test
+
+const atLeastGo18 = false

--- a/go/src/vendor/github.com/jacobsa/fuse/unmount.go
+++ b/go/src/vendor/github.com/jacobsa/fuse/unmount.go
@@ -14,8 +14,8 @@
 
 package fuse
 
-// Attempt to unmount the file system whose mount point is the supplied
-// directory.
+// Unmount attempts to unmount the file system whose mount point is the
+// supplied directory.
 func Unmount(dir string) error {
 	return unmount(dir)
 }


### PR DESCRIPTION
Fixes:

```
  # koding/klient
  vendor/github.com/jacobsa/fuse/internal/buffer.memclr: relocation target runtime.memclr not defined
  vendor/github.com/jacobsa/fuse/internal/buffer.memclr: undefined: "runtime.memclr"
```

For go1.8.