### PR TITLE
Resend Invitation doesn't work 

### DIFF
--- a/node_modules_koding/bongo/lib/model/save.coffee
+++ b/node_modules_koding/bongo/lib/model/save.coffee
@@ -50,7 +50,7 @@ module.exports = helpers =
     { constructor } = model
     unless err
       { ops: docs } = results
-      if id = docs[0]?._id
+      if docs? and id = docs[0]?._id
         model.data._id = id
     callback?.call model, err, docs, isNew
     @emit 'save'


### PR DESCRIPTION
## Description

https://github.com/koding/koding/blob/master/node_modules_koding/bongo/lib/model/save.coffee#L52
Results objects came like this
```CommandResult { result: { ok: 1, n: 1 }, connection: null }```

It doesn't have `ops` attribute for update operations

http://recordit.co/2cz8kvVxS8

## Motivation and Context
Fixes: #10270 


You could try it out to see the result
by doing `./run exec coffee <below-coffee-file>`
Credit: @gokmen 
```
mongo = require 'mongodb'
client = mongo.MongoClient
client.connect "mongodb://#{process.env.KONFIG_MONGO}", (err, db) ->
  coll = db.collection('jInvitations')
  name = "add new name"
  data = { name, code: new Date() }
  coll.insert data, (safe:yes), (err, res) ->
    console.log "result ->", err, res, res?.ops
```

