### PR TITLE
klientctl: prevent CLI errors when running kd commands

### DIFF
--- a/go/src/koding/klientctl/ctlcli/ctlcli.go
+++ b/go/src/koding/klientctl/ctlcli/ctlcli.go
@@ -89,17 +89,19 @@ func CommandHelper(ctx *cli.Context, cmd string) Helper {
 }
 
 // ExitAction implements a cli.Command's Action field for an ExitingCommand type.
-func ExitAction(f ExitingCommand, log logging.Logger, cmdName string) func(*cli.Context) {
-	return func(c *cli.Context) {
+func ExitAction(f ExitingCommand, log logging.Logger, cmdName string) cli.ActionFunc {
+	return func(c *cli.Context) error {
 		exit := f(c, log, cmdName)
 		Close()
 		ExitFunc(exit)
+
+		return nil
 	}
 }
 
 // ExitErrAction implements a cli.Command's Action field for an ExitingErrCommand
-func ExitErrAction(f ExitingErrCommand, log logging.Logger, cmdName string) func(*cli.Context) {
-	return func(c *cli.Context) {
+func ExitErrAction(f ExitingErrCommand, log logging.Logger, cmdName string) cli.ActionFunc {
+	return func(c *cli.Context) error {
 		exit, err := f(c, log, cmdName)
 		if err != nil {
 			log.Error("ExitErrAction encountered error. err:%s", err)
@@ -109,12 +111,14 @@ func ExitErrAction(f ExitingErrCommand, log logging.Logger, cmdName string) func
 
 		Close()
 		ExitFunc(exit)
+
+		return nil
 	}
 }
 
 // FactoryAction implements a cli.Command's Action field.
-func FactoryAction(factory CommandFactory, log logging.Logger, cmdName string) func(*cli.Context) {
-	return func(c *cli.Context) {
+func FactoryAction(factory CommandFactory, log logging.Logger, cmdName string) cli.ActionFunc {
+	return func(c *cli.Context) error {
 		cmd := factory(c, log, cmdName)
 		exit, err := cmd.Run()
 
@@ -131,11 +135,13 @@ func FactoryAction(factory CommandFactory, log logging.Logger, cmdName string) f
 
 		Close()
 		ExitFunc(exit)
+
+		return nil
 	}
 }
 
 // FactoryCompletion implements codeganstas cli.Command's bash completion field
-func FactoryCompletion(factory CommandFactory, log logging.Logger, cmdName string) func(*cli.Context) {
+func FactoryCompletion(factory CommandFactory, log logging.Logger, cmdName string) cli.BashCompleteFunc {
 	return func(c *cli.Context) {
 		cmd := factory(c, log, cmdName)
 

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -648,13 +648,15 @@ func run(args []string) {
 
 // ExitWithMessage takes a ExitingWithMessageCommand type and returns a
 // codegansta/cli friendly command Action.
-func ExitWithMessage(f ExitingWithMessageCommand, log logging.Logger, cmd string) func(*cli.Context) {
-	return func(c *cli.Context) {
+func ExitWithMessage(f ExitingWithMessageCommand, log logging.Logger, cmd string) cli.ActionFunc {
+	return func(c *cli.Context) error {
 		s, e := f(c, log, cmd)
 		if s != "" {
 			fmt.Println(s)
 		}
 		ctlcli.Close()
 		os.Exit(e)
+
+		return nil
 	}
 }


### PR DESCRIPTION
This PR removes following error reported by KD's CLI library:

```
DEPRECATED Action signature.  Must be `cli.ActionFunc`.  This is an error in the application.  Please contact the distributor of this application if this is not you.  See https://github.com/urfave/cli/blob/master/CHANGELOG.md#deprecated-cli-app-action-signature
```