### PR TITLE
kd/machine: Add supervised client.

### DIFF
--- a/go/src/koding/klient/machine/client/supervised.go
+++ b/go/src/koding/klient/machine/client/supervised.go
@@ -112,7 +112,7 @@ func (s *Supervised) call(f func(Client) error) error {
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
 	defer cancel()
 
-	if _ = <-ctx.Done(); ctx.Err() == context.DeadlineExceeded {
+	if <-ctx.Done(); ctx.Err() == context.DeadlineExceeded {
 		// Client is still disconnected. Return it as is.
 		return nil
 	}

--- a/go/src/koding/klient/machine/client/supervised.go
+++ b/go/src/koding/klient/machine/client/supervised.go
@@ -12,7 +12,7 @@ type DynamicClientFunc func() (Client, error)
 
 // Supervised is a decorator type for Clients which will wait for valid client
 // if the current client is Disconnected. This type is meant to handle temporary
-// network issues or cases when underlaying client is not set up yet. Eg. when
+// network issues or cases when underlying client is not set up yet. Eg. when
 // program started but haven't made connection to remote machine yet.
 type Supervised struct {
 	dcf     DynamicClientFunc
@@ -109,7 +109,7 @@ func (s *Supervised) call(f func(Client) error) error {
 		timer := time.NewTimer(s.timeout)
 		select {
 		case <-ctx.Done():
-			// Client changed. Use new client.
+			// Client changed. Use a new one.
 			timer.Stop()
 			c, err = s.dcf()
 			if err != nil {

--- a/go/src/koding/klient/machine/client/supervised.go
+++ b/go/src/koding/klient/machine/client/supervised.go
@@ -1,0 +1,126 @@
+package client
+
+import (
+	"context"
+	"time"
+
+	"koding/klient/machine/index"
+)
+
+// DynamicClientFunc is an adapter that allows to dynamically provide clients.
+type DynamicClientFunc func() (Client, error)
+
+// Supervised is a decorator type for Clients which will wait for valid client
+// if the current client is Disconnected. This type is meant to handle temporary
+// network issues or cases when underlaying client is not set up yet. Eg. when
+// program started but haven't made connection to remote machine yet.
+type Supervised struct {
+	dcf     DynamicClientFunc
+	timeout time.Duration
+}
+
+// NewSupervised creates a new Supervised client instance.
+func NewSupervised(dcf DynamicClientFunc, timeout time.Duration) *Supervised {
+	return &Supervised{
+		timeout: timeout,
+		dcf:     dcf,
+	}
+}
+
+// CurrentUser calls registered Client's CurrentUser method and returns its
+// result if it's not produced by Disconnected client. If it is, this function
+// will wait until valid client is available or timeout is reached.
+func (s *Supervised) CurrentUser() (user string, err error) {
+	if e := s.call(func(c Client) error {
+		user, err = c.CurrentUser()
+		return err
+	}); e != nil {
+		return "", e
+	}
+
+	return
+}
+
+// SSHAddKeys calls registered Client's SSHAddKeys method and returns its result
+// if it's not produced by Disconnected client. If it is, this function will
+// wait until valid client is available or timeout is reached.
+func (s *Supervised) SSHAddKeys(username string, keys ...string) (err error) {
+	if e := s.call(func(c Client) error {
+		err = c.SSHAddKeys(username, keys...)
+		return err
+	}); e != nil {
+		return e
+	}
+
+	return
+}
+
+// MountHeadIndex calls registered Client's MountHeadIndex method and returns
+// its result if it's not produced by Disconnected client. If it is, this
+// function will wait until valid client is available or timeout is reached.
+func (s *Supervised) MountHeadIndex(path string) (absPath string, count int, diskSize int64, err error) {
+	if e := s.call(func(c Client) error {
+		absPath, count, diskSize, err = c.MountHeadIndex(path)
+		return err
+	}); e != nil {
+		return "", 0, 0, e
+	}
+
+	return
+}
+
+// MountGetIndex calls registered Client's MountGetIndex method and returns its
+// result if it's not produced by Disconnected client. If it is, this function
+// will wait until valid client is available or timeout is reached.
+func (s *Supervised) MountGetIndex(path string) (idx *index.Index, err error) {
+	if e := s.call(func(c Client) error {
+		idx, err = c.MountGetIndex(path)
+		return err
+	}); e != nil {
+		return nil, e
+	}
+
+	return
+}
+
+// Context calls registered Client's Context method and returns its result. If
+// there is an error during client retrieving, this function will return
+// canceled context.
+func (s *Supervised) Context() context.Context {
+	c, err := s.dcf()
+	if err == nil {
+		return c.Context()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	return ctx
+}
+
+func (s *Supervised) call(f func(Client) error) error {
+	c, err := s.dcf()
+	if err != nil {
+		return err
+	}
+
+	ctx := c.Context()
+	if err = f(c); err == ErrDisconnected {
+		timer := time.NewTimer(s.timeout)
+		select {
+		case <-ctx.Done():
+			// Client changed. Use new client.
+			timer.Stop()
+			c, err = s.dcf()
+			if err != nil {
+				return err
+			}
+			return f(c)
+		case <-timer.C:
+			// Client is still disconnected. Return it as is.
+			return nil
+		}
+	}
+
+	return err
+}

--- a/go/src/koding/klient/machine/client/supervised_test.go
+++ b/go/src/koding/klient/machine/client/supervised_test.go
@@ -59,7 +59,7 @@ func TestSupervisedWait(t *testing.T) {
 	select {
 	case <-hitC:
 		if err == client.ErrDisconnected {
-			t.Fatalf("want err != %[1]v; got %[1]v", client.ErrDisconnected)
+			t.Fatal("want err != client.ErrDisconnected")
 		}
 	case <-time.After(time.Second):
 		t.Fatalf("test timed out after 1s")

--- a/go/src/koding/klient/machine/client/supervised_test.go
+++ b/go/src/koding/klient/machine/client/supervised_test.go
@@ -1,9 +1,67 @@
-package client
+package client_test
 
 import (
 	"testing"
+	"time"
+
+	"koding/klient/machine/client"
+	"koding/klient/machine/client/testutil"
 )
 
-func TestSupervised(t *testing.T) {
-	t.Skip("not implemented")
+func TestSupervisedWait(t *testing.T) {
+	serv := &testutil.Server{}
+
+	dc, err := client.NewDynamic(testutil.DynamicOpts(serv, testutil.NewBuilder(nil)))
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	defer dc.Close()
+
+	dcf := func() (client.Client, error) { return dc.Client(), nil }
+
+	// Server is off, so the timeout should be reached.
+	const timeout = 50 * time.Millisecond
+	spv := client.NewSupervised(dcf, timeout)
+	startC, hitC := make(chan struct{}), make(chan time.Time)
+
+	go func() {
+		<-startC
+		_, err = spv.CurrentUser()
+		hitC <- time.Now()
+	}()
+
+	now := time.Now()
+	close(startC)
+	select {
+	case called := <-hitC:
+		if tret := called.Sub(now); tret < timeout {
+			t.Fatalf("want return at least after %v; got %v", timeout, tret)
+		}
+		if err != client.ErrDisconnected {
+			t.Fatalf("want err = %v; got %v", client.ErrDisconnected, err)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("test timed out after 1s")
+	}
+
+	// Server starts to be responsive while Supervisor waits for it.
+	spv = client.NewSupervised(dcf, 2*time.Second)
+	startC, hitC = make(chan struct{}), make(chan time.Time)
+
+	go func() {
+		<-startC
+		_, err = spv.CurrentUser()
+		hitC <- time.Now()
+	}()
+
+	close(startC)
+	serv.TurnOn()
+	select {
+	case <-hitC:
+		if err == client.ErrDisconnected {
+			t.Fatalf("want err != %[1]v; got %[1]v", client.ErrDisconnected)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("test timed out after 1s")
+	}
 }

--- a/go/src/koding/klient/machine/client/supervised_test.go
+++ b/go/src/koding/klient/machine/client/supervised_test.go
@@ -1,0 +1,9 @@
+package client
+
+import (
+	"testing"
+)
+
+func TestSupervised(t *testing.T) {
+	t.Skip("not implemented")
+}


### PR DESCRIPTION
Supervised client type is meant to handle temporary network issues or cases when underlying client is not set up yet. Eg. when KD started but haven't made connection to remote machine.

## How Has This Been Tested?
Unit tests.

Current package coverage: 59.1% of statements

Question: is seems that `klientctl` and `klient` tests haven't been handled by `codecov` yet. @mehmetalisavas are these packages going to be scanned by `codeconv`? 

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
