### PR TITLE
Enable ratelimiting back

### DIFF
--- a/config/generateKonfig.coffee
+++ b/config/generateKonfig.coffee
@@ -253,7 +253,7 @@ module.exports = (options, credentials) ->
     uri                           : { address: options.customDomain.public }
     # TODO: average request count per hour for a user should be measured and a reasonable limit should be set
     nodejsRateLimiter             : { enabled: no, guestRules: [{ interval: 3600, limit: 5000 }], userRules: [{ interval: 3600, limit: 10000 }] } # limit: request limit per rate limit window, interval: rate limit window duration in seconds
-    nodejsRateLimiterForApi       : { enabled: no, guestRules: [{ interval: 60,   limit: 10 }],   userRules: [{ interval: 60,   limit: 300 }] }   # limit: request limit per rate limit window, interval: rate limit window duration in seconds
+    nodejsRateLimiterForApi       : { enabled: yes, guestRules: [{ interval: 60,   limit: 10 }],   userRules: [{ interval: 60,   limit: 300 }] }   # limit: request limit per rate limit window, interval: rate limit window duration in seconds
     webserver                     : { port: 8080 }
     social                        : { port: 3030, login: "#{credentials.rabbitmq.login}", queueName: options.socialQueueName, kitePort: 8760, kiteKey: "#{credentials.kiteHome}/kite.key" }
     boxproxy                      : { port: parseInt(options.publicPort, 10) }

--- a/config/generateKonfig.coffee
+++ b/config/generateKonfig.coffee
@@ -210,6 +210,7 @@ module.exports = (options, credentials) ->
     clientUploadS3BucketName      : options.clientUploadS3BucketName
 
     kiteHome                      : credentials.kiteHome
+    redis                         : credentials.redis
     mongo                         : credentials.mongo
     postgres                      : credentials.postgres
     mq                            : credentials.rabbitmq

--- a/node_modules_koding/bongo/lib/bongo.coffee
+++ b/node_modules_koding/bongo/lib/bongo.coffee
@@ -82,7 +82,7 @@ module.exports = class Bongo extends EventEmitter
   constructor: (options) ->
 
     { @mq, @mongo, @resourceName, @root, @metrics, @cache
-      @fetchClient, @verbose, models, @kite, @mqConfig } = options
+      @fetchClient, @verbose, models, @kite, @mqConfig, @redisClient } = options
 
     @setClient @mongo  if @mongo
     Model.setCache @cache  if @cache

--- a/node_modules_koding/bongo/lib/expressify.coffee
+++ b/node_modules_koding/bongo/lib/expressify.coffee
@@ -10,16 +10,8 @@ module.exports = (options = {}) ->
   { rateLimitOptions } = options
 
   if rateLimitOptions?.enabled
-    # monitoring redis was already unreachable for ages
-    # TODO(cihangir): replace rate limiting package
-    redisClient = require('redis').createClient(
-      '6379'
-      '127.0.0.1'
-      {}
-    )
-
     { userRules, guestRules } = rateLimitOptions
-    rateLimiter = new RateLimit redisClient, userRules
+    rateLimiter = new RateLimit bongo.redisClient, userRules
 
   sendMetrics = (start, message) ->
 

--- a/servers/lib/server/bongo.coffee
+++ b/servers/lib/server/bongo.coffee
@@ -12,8 +12,15 @@ options =
 
 cache = require('lru-cache')(options)
 
+redisClient = require('redis').createClient(
+  KONFIG.redis.port
+  KONFIG.redis.host
+  {}
+)
+
 module.exports = koding = new Bongo
   cache       : cache
+  redisClient : redisClient
   mongo       : mongoReplSet or mongo
   root        : projectRoot
   models      : 'workers/social/lib/social/models'

--- a/workers/social/lib/social/main.coffee
+++ b/workers/social/lib/social/main.coffee
@@ -31,10 +31,16 @@ mqConfig = { host: mq.host, port: mq.port, login: mq.login, password: mq.passwor
 # TODO exchange version must be injected here, when we have that support
 mqConfig.exchangeName = "#{socialapi.eventExchangeName}:0"
 
+redisClient = require('redis').createClient(
+  KONFIG.redis.port
+  KONFIG.redis.host
+  {}
+)
 
 koding = new Bongo {
   verbose     : social.verbose
   root        : __dirname
+  redisClient : redisClient
   mongo       : mongoReplSet or mongo
   models      : './models'
   resourceName: social.queueName


### PR DESCRIPTION
I have investigated 
* writing a new package for ratelimiting using mongodb backend but it would take unnecessary time for this purpose at this moment
* investigated mashape kong, it has awesome features but installing it fail-safe would require great amount of work.
* investigated aws api gateway, that would cost unnecessarily just for rate limiting

and decided to add back redis, our reservation will end at the end of this month, i will downgrade our instance to the smallest possible ( 12$ per month without reservation ~9$ with reservation )