### PR TITLE
Kite api access over social api

### DIFF
--- a/client/app/lib/components/list/index.coffee
+++ b/client/app/lib/components/list/index.coffee
@@ -139,6 +139,10 @@ Row = ({ source, className, sectionIndex, rowIndex }) ->
 
 
 Header = ({ source, index }) ->
+
+  unless headerAtIndex = source.renderSectionHeaderAtIndex index
+    return null
+
   <div className={classnames 'ListView-SectionHeader'}>
-    {source.renderSectionHeaderAtIndex index}
+    {headerAtIndex}
   </div>

--- a/client/app/lib/flux/teams/stores/teamapitokensstore.coffee
+++ b/client/app/lib/flux/teams/stores/teamapitokensstore.coffee
@@ -20,12 +20,12 @@ module.exports = class TeamAPITokensStore extends KodingFluxStore
 
     apiTokenIds.withMutations (apiTokenIds) ->
       apiTokens.forEach (apiToken) ->
-        apiTokenIds.set apiToken.code, toImmutable apiToken
+        apiTokenIds.set apiToken._id, toImmutable apiToken
 
   delete: (apiTokenIds, { apiTokenId }) ->
 
     apiTokenIds.delete apiTokenId
 
-
   add: (apiTokenIds, { apiToken }) ->
-    apiTokenIds.set apiToken.code, toImmutable apiToken
+
+    apiTokenIds.set apiToken._id, toImmutable apiToken

--- a/client/app/lib/kite/kites/kloud.coffee
+++ b/client/app/lib/kite/kites/kloud.coffee
@@ -208,7 +208,7 @@ module.exports = class KodingKiteKloudKite extends require('../kodingkite')
             kontrol.kites.kloud.singleton?.reconnect?()
             @_reconnectedOnce = yes
 
-          KiteLogger.failed 'kloud', 'info'
+          KiteLogger.failed 'kloud', 'info', payload
 
         # If kite somehow unregistered from Kontrol and Kloud is failing
         # to find it in Kontrol registry we are getting this `not found`
@@ -218,7 +218,7 @@ module.exports = class KodingKiteKloudKite extends require('../kodingkite')
         else if err.message is 'not found' and currentState is Machine.State.Running
 
           @resolveRequestingInfos machineId, { State: Machine.State.Stopped }
-          KiteLogger.failed 'kloud', 'info'
+          KiteLogger.failed 'kloud', 'info', payload
 
           kd.warn '[kloud:info] failed, Kite not found in Kontrol registry!', err
 

--- a/client/app/lib/kite/kodingkite.coffee
+++ b/client/app/lib/kite/kodingkite.coffee
@@ -79,7 +79,7 @@ module.exports = class KodingKite extends kd.Object
         _resolve = resolve
         _args    = [rpcMethod, [params], callback]
 
-        KiteLogger.queued name, rpcMethod
+        KiteLogger.queued name, rpcMethod, params
 
         @waitForConnection _args
 
@@ -87,13 +87,13 @@ module.exports = class KodingKite extends kd.Object
 
           .then (args) =>
 
-            KiteLogger.started name, rpcMethod
+            KiteLogger.started name, rpcMethod, params
 
             resolve (@transport?.tell args...
 
               .then (res) ->
 
-                KiteLogger.success name, rpcMethod
+                KiteLogger.success name, rpcMethod, params
                 return res
 
               .catch (err) =>
@@ -101,7 +101,7 @@ module.exports = class KodingKite extends kd.Object
                 if _errPromise = @handleKiteError err, args
                   return _errPromise
 
-                KiteLogger.failed name, rpcMethod, err
+                KiteLogger.failed name, rpcMethod, params, err
                 throw err
 
             )
@@ -110,7 +110,7 @@ module.exports = class KodingKite extends kd.Object
 
           .catch (err) =>
 
-            KiteLogger.failed name, rpcMethod, err
+            KiteLogger.failed name, rpcMethod, params, err
             reject @_kiteInvalidError
 
       unless @_state is CONNECTED
@@ -122,7 +122,7 @@ module.exports = class KodingKite extends kd.Object
 
       console.warn '[KITE][INVALID]', this
 
-      KiteLogger.failed name, rpcMethod
+      KiteLogger.failed name, rpcMethod, params
       Promise.reject @_kiteInvalidError
 
 

--- a/client/app/lib/kite/kodingkontrol.coffee
+++ b/client/app/lib/kite/kodingkontrol.coffee
@@ -258,10 +258,10 @@ module.exports = class KodingKontrol extends KontrolJS = (kitejs.Kontrol)
           resolve (
             kite.transport?.tell args...
               .then (res) ->
-                KiteLogger.success name, args.first
+                KiteLogger.success name, args.first, args
                 return res
               .catch (err) ->
-                KiteLogger.failed name, args.first
+                KiteLogger.failed name, args.first, args
                 throw err
           )
 

--- a/client/app/lib/kitelogger.coffee
+++ b/client/app/lib/kitelogger.coffee
@@ -8,15 +8,14 @@ module.exports = class KiteLogger
 
   @buffer = kd.utils.dict()
 
-  @log = (kiteName, rpcCall, state, err) ->
-
+  @log = (kiteName, rpcCall, state, args, err) ->
 
     # Comment-out following lines if you need extensive logging
     # for all the kite calls from client side ~ GG
     #
-    # key = "#{kiteName}.#{rpcCall}"
-    # kd[_log] "[KITELOGGER][#{state}]", key
-    # kd.error "[KITELOGGER][#{state}]", err  if err
+    key = "#{kiteName}.#{rpcCall}"
+    kd.info  "[KITELOGGER][#{state}]", key, args
+    kd.error "[KITELOGGER][#{state}]", err  if err
 
     key = "#{kiteName}.#{rpcCall}:#{state}"
 
@@ -24,8 +23,8 @@ module.exports = class KiteLogger
     @buffer[key]++
 
   ['failed', 'success', 'queued', 'started'].forEach (helper) =>
-    @[helper] = (kiteName, rpcCall, err) ->
-      @log kiteName, rpcCall, helper, err
+    @[helper] = (kiteName, rpcCall, args, err) ->
+      @log kiteName, rpcCall, helper, args, err
 
   @consume = ->
 

--- a/client/app/lib/views/sessionlist/accountsessionlistitem.coffee
+++ b/client/app/lib/views/sessionlist/accountsessionlistitem.coffee
@@ -34,7 +34,7 @@ module.exports = class AccountSessionListItem extends KDListItemView
 
   pistachio: ->
 
-    { groupName, lastAccess, lastLoginDate, clientId } = @getData()
+    { groupName, lastAccess, lastLoginDate, clientId, _conf } = @getData()
 
     hostname = globals.config.domains.main
 
@@ -47,6 +47,14 @@ module.exports = class AccountSessionListItem extends KDListItemView
 
     if kookies.get('clientId') is clientId
       cssClass = 'active'
+
+    # There is an issue on this field, I'll take a look it after
+    # when we have a field called `data` on a given Bongo Model
+    # we won't able to reach that data under `data` field from instance
+    # but somehow this `_conf` field keeps the raw data ~ GG
+    if _conf?.data?.apiSession
+      cssClass = 'api'
+
     @session = new kd.CustomHTMLView
       cssClass: 'group-name'
       partial: group

--- a/client/home/lib/styl/homeapitoken.styl
+++ b/client/home/lib/styl/homeapitoken.styl
@@ -19,7 +19,7 @@
     line-height             14px
 
 .HomeApp-ApiToken--footer--button-wrapper
-  padding                   26px 0 17px 0
+  padding                   30px 0 17px 0
   cursor                    pointer
 
   .custom-link-view.HomeAppView--button.primary.disabled
@@ -48,15 +48,15 @@
   font-weight               400
   padding-top               4px
   line-height               22px
-  text-rendering            geometricPrecision
   letter-spacing            0.15px
+  font-family               monospace
+  font-size                 14px
 
 .HomeApp-ApiToken--api-token-detail
   color                     #ACACAC
   font-weight               300
   line-height               14px
   letter-spacing            0.14px
-  text-rendering            geometricPrecision
   font-size                 14px
   font-style                italic
 

--- a/client/home/lib/styl/homemyaccount.styl
+++ b/client/home/lib/styl/homemyaccount.styl
@@ -344,9 +344,10 @@ Home My Account styles
 
   &.sessions
     .session-info
-      fl()
       display               block
       margin                10px 0 0 0px
+      fl()
+
       .last-access
         text-align          left
         font-size           14px
@@ -363,7 +364,7 @@ Home My Account styles
         color               #929292
         ellipsis()
 
-
+      .api:after
       .active:after
         content             'Active'
         font-size           12px
@@ -378,6 +379,14 @@ Home My Account styles
         margin-top          3px
         display             inline-block
         vertical-align      top
+
+      .active:after
+        content             'Active'
+
+      .api:after
+        content             'API Session'
+        width               68px
+        background-color    #999
 
     .delete-button
       fr()

--- a/client/home/lib/utilities/components/apiaccess/apitoken.coffee
+++ b/client/home/lib/utilities/components/apiaccess/apitoken.coffee
@@ -36,7 +36,7 @@ module.exports = class ApiToken extends React.Component
             apiToken = remote.revive @props.apiToken.toJS()
             apiToken.remove (err) =>
               return showError err  if err
-              TeamFlux.actions.deleteApiToken @props.apiToken.get 'code'
+              TeamFlux.actions.deleteApiToken @props.apiToken.get '_id'
               modal.destroy()
 
 

--- a/client/home/lib/utilities/components/apiaccess/apitoken.coffee
+++ b/client/home/lib/utilities/components/apiaccess/apitoken.coffee
@@ -39,25 +39,27 @@ module.exports = class ApiToken extends React.Component
               TeamFlux.actions.deleteApiToken @props.apiToken.get '_id'
               modal.destroy()
 
-
   render: ->
 
     { code, createdAt, username } = @props.apiToken.toJS()
-    createdAt = timeago createdAt
 
+    _code = code
+    _code = '********-****-****-****-************'  if code is '*'
+
+    createdAt = timeago createdAt
     className = 'HomeApp-ApiToken--api-wrapper'
     className = "#{className}--disabled"  unless @props.toggleState
 
     <div>
       <div className={className}>
         <div ref='token' className='HomeApp-ApiToken--api-token'>
-          {code}
+          {_code}
         </div>
         <div className='HomeApp-ApiToken--api-token-detail'>
           {createdAt} by {username}
         </div>
       </div>
-      <CopyButton callback={@bound 'copyApiToken'} />
+      <CopyButton code={code} callback={@bound 'copyApiToken'} />
       <DeleteButton callback={@bound 'deleteApiToken'}/>
     </div>
 
@@ -65,5 +67,6 @@ module.exports = class ApiToken extends React.Component
 DeleteButton = ({ callback }) ->
   <a className='HomeApp-ApiToken--custom-link-view delete-api-token fr' onClick={callback}>DELETE</a>
 
-CopyButton = ({ callback }) ->
+CopyButton = ({ code, callback }) ->
+  return null  if code is '*'
   <a className='HomeApp-ApiToken--custom-link-view copy-api-token' onClick={callback}>COPY</a>

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "url-join": "1.1.0",
     "url-parse": "1.1.7",
     "uuid": "3.0.1",
+    "uuid-validate": "0.0.2",
     "validator": "6.2.1",
     "winston": "2.3.0",
     "winston-papertrail": "1.0.4",

--- a/servers/lib/server/handlers/api/createuser.test.coffee
+++ b/servers/lib/server/handlers/api/createuser.test.coffee
@@ -140,7 +140,7 @@ runTests = -> describe 'server.handlers.api.createuser', ->
           headers  : { Authorization : "Bearer #{apiToken.code}" }
           body     : { username, email : generateRandomEmail 'yandex.com' }
 
-        expectedBody = 'api token usage is not enabled for this group'
+        expectedBody = 'api token usage is not enabled for this team'
         request.post createUserRequestParams, (err, res, body) ->
           expect(err).to.not.exist
           expect(res.statusCode).to.be.equal 403

--- a/website/swagger.json
+++ b/website/swagger.json
@@ -43,6 +43,10 @@
       "name": "JCredentialData"
     },
     {
+      "description": "Model Kloud",
+      "name": "Kloud"
+    },
+    {
       "description": "Model JMachine",
       "name": "JMachine"
     },
@@ -3864,6 +3868,32 @@
                   "$ref": "#/definitions/DefaultResponse"
                 }
               ]
+            }
+          }
+        }
+      }
+    },
+    "/remote.api/Kloud.ping": {
+      "post": {
+        "tags": [
+          "Kloud"
+        ],
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [],
+        "description": "calls kite.ping on Kloud on behalf of loggedin user",
+        "responses": {
+          "200": {
+            "description": "Request processed succesfully",
+            "schema": {
+              "$ref": "#/definitions/DefaultResponse"
+            }
+          },
+          "401": {
+            "description": "Unauthorized request",
+            "schema": {
+              "$ref": "#/definitions/UnauthorizedRequest"
             }
           }
         }

--- a/workers/social/lib/social/main.coffee
+++ b/workers/social/lib/social/main.coffee
@@ -138,7 +138,7 @@ do ->
 
   options = { rateLimitOptions : KONFIG.nodejsRateLimiter }
 
-  app.post '/remote.api/:model/:id?', (require './remoteapi') koding
+  app.post '/remote.api/:token?/:model/:id?', (require './remoteapi') koding
 
   app.get  '/remote.api', (req, res) ->
     res.send 'REST API is OK'

--- a/workers/social/lib/social/models/apitoken.coffee
+++ b/workers/social/lib/social/models/apitoken.coffee
@@ -126,7 +126,10 @@ module.exports = class JApiToken extends jraphical.Module
   remove$: permit
     advanced: PERMISSION_EDIT_GROUPS
     success: (client, callback) ->
-      @remove callback
+      JSession.remove { clientId: @getAt 'code' }, (err) =>
+        return callback err  if err
+        @remove callback
+
 
   @createSessionByToken = (token, callback) ->
 

--- a/workers/social/lib/social/models/apitoken.coffee
+++ b/workers/social/lib/social/models/apitoken.coffee
@@ -1,4 +1,4 @@
-hat           = require 'hat'
+uuid          = require 'uuid'
 async         = require 'async'
 JGroup        = require './group'
 JAccount      = require './account'
@@ -40,7 +40,7 @@ module.exports = class JApiToken extends jraphical.Module
       code             :
         type           : String
         required       : yes
-        default        : hat
+        default        : uuid.v4
       group            :
         type           : String
         required       : yes
@@ -89,7 +89,6 @@ module.exports = class JApiToken extends jraphical.Module
       (next) ->
         # creating token
         token = new JApiToken
-          code     : hat()
           group    : group
           originId : account.getId()
 

--- a/workers/social/lib/social/models/apitoken.coffee
+++ b/workers/social/lib/social/models/apitoken.coffee
@@ -167,8 +167,7 @@ module.exports = class JApiToken extends jraphical.Module
           groupName : group.getAt 'slug'
           data      : { apiSession: yes }
 
-        JSession.createNewSession sessionData, (err, sessionObj) ->
-          # TODO add duplicate check here ~ GG
+        JSession.fetchSessionByData { clientId: token }, sessionData, (err, sessionObj) ->
           return next err  if err
           return next new KodingError 'Failed to create session!'  unless sessionObj
           session = sessionObj

--- a/workers/social/lib/social/models/apitoken.coffee
+++ b/workers/social/lib/social/models/apitoken.coffee
@@ -14,6 +14,8 @@ module.exports = class JApiToken extends jraphical.Module
 
   Validators = require './group/validators'
 
+  @API_TOKEN_LIMIT = 5
+
   PERMISSION_EDIT_GROUPS = [
     { permission: 'edit groups',     superadmin: yes }
     { permission: 'edit own groups', validateWith: Validators.group.admin }
@@ -78,10 +80,10 @@ module.exports = class JApiToken extends jraphical.Module
           next()
 
       (next) ->
-        limitError = "You can't have more than #{JGroup.API_TOKEN_LIMIT} API tokens"
+        limitError = "You can't have more than #{JApiToken.API_TOKEN_LIMIT} API tokens"
         JApiToken.count { group : groupObj.slug }, (err, count) ->
           return next err                         if err
-          return next new KodingError limitError  if count >= JGroup.API_TOKEN_LIMIT
+          return next new KodingError limitError  if count >= JApiToken.API_TOKEN_LIMIT
           next()
 
       (next) ->

--- a/workers/social/lib/social/models/apitoken.test.coffee
+++ b/workers/social/lib/social/models/apitoken.test.coffee
@@ -72,7 +72,7 @@ runTests = -> describe 'workers.social.apitoken', ->
       group         = generateRandomString()
       groupData     = {}
       options       = { context : { group }, createGroup : yes, groupData }
-      expectedError = 'API usage is not enabled for this group.'
+      expectedError = 'API usage is not enabled for this team.'
 
       withConvertedUser options, ({ client, account }) ->
 

--- a/workers/social/lib/social/models/apitoken.test.coffee
+++ b/workers/social/lib/social/models/apitoken.test.coffee
@@ -114,7 +114,7 @@ runTests = -> describe 'workers.social.apitoken', ->
           data  = { group, account }
           queue = []
 
-          for i in [0...JGroup.API_TOKEN_LIMIT]
+          for i in [0...JApiToken.API_TOKEN_LIMIT]
             queue.push (next) ->
               JApiToken.create data, (err, token) ->
                 expect(err).to.not.exist
@@ -122,7 +122,7 @@ runTests = -> describe 'workers.social.apitoken', ->
                 next()
 
           queue.push (next) ->
-            expectedError = "You can't have more than #{JGroup.API_TOKEN_LIMIT} API tokens"
+            expectedError = "You can't have more than #{JApiToken.API_TOKEN_LIMIT} API tokens"
             JApiToken.create data, (err, token) ->
               expect(err?.message).to.be.equal expectedError
               expect(token).to.not.exist

--- a/workers/social/lib/social/models/apitoken.test.coffee
+++ b/workers/social/lib/social/models/apitoken.test.coffee
@@ -58,7 +58,7 @@ runTests = -> describe 'workers.social.apitoken', ->
           (next) ->
             data = { group : generateRandomString(), account }
             JApiToken.create data, (err, token) ->
-              expect(err?.message).to.be.equal 'group not found!'
+              expect(err?.message).to.be.equal 'No such team!'
               expect(token).to.not.exist
               next()
 

--- a/workers/social/lib/social/models/computeproviders/kloud.coffee
+++ b/workers/social/lib/social/models/computeproviders/kloud.coffee
@@ -51,13 +51,16 @@ module.exports = class Kloud extends Base
 
   do ->
 
-    options          =
-      url            : "http://localhost:#{KONFIG.kloud.port}/kite"
-      autoConnect    : yes
-      autoReconnect  : yes
-      transportClass : SockJs
-      auth           :
-        type         : 'kloudctl'
-        key          : KONFIG.kloud.secretKey
+    options               =
+      url                 : "http://localhost:#{KONFIG.publicPort}/kloud/kite"
+      autoConnect         : yes
+      autoReconnect       : yes
+      transportClass      : SockJs
+      auth                :
+        key               : KONFIG.kloud.secretKey
+        type              : 'kloudSecret'
+      heartbeatTimeout    : 30 * 1000 # 30 seconds
+      # Force XHR for all kind of kite connection
+      protocols_whitelist : ['xhr-polling']
 
     Kloud.transport = new Kite options

--- a/workers/social/lib/social/models/computeproviders/kloud.coffee
+++ b/workers/social/lib/social/models/computeproviders/kloud.coffee
@@ -1,0 +1,69 @@
+{ Base, secure, signature } = require 'bongo'
+
+KONFIG       = require 'koding-config-manager'
+async        = require 'async'
+_            = require 'underscore'
+
+KodingError  = require '../../error'
+KodingLogger = require '../kodinglogger'
+
+{ Kite }     = require 'kite.js'
+SockJs       = require 'node-sockjs-client'
+
+# Kloud wrapper on social backend
+#
+module.exports = class Kloud extends Base
+
+  @trait __dirname, '../../traits/protected'
+  { permit } = require '../group/permissionset'
+
+  @share()
+
+  @set
+    permissions    :
+      'kite ping'  : ['member']
+    sharedMethods  :
+      static       :
+        ping       : (signature Function)
+
+  TIMEOUT = 10000
+
+  getArgs = (client, args) ->
+
+    args[0] ?= {}
+    args[0].impersonate = client.connection.delegate.profile.nickname
+    return args
+
+
+  # calls kite.ping on Kloud on behalf of loggedin user
+  #
+  @ping  = (client, callback) ->
+    @tell client, 'kite.ping', [], callback
+
+  @ping$ = permit 'kite ping', { success: @ping }
+
+
+  @tell = (client, method, args = [], callback) ->
+
+    @transport
+      .tell method, getArgs client, args
+      .then  (res) ->
+        callback null, res
+        return res
+      .timeout TIMEOUT
+      .catch (err) ->
+        callback err
+
+
+  do ->
+
+    options          =
+      url            : "http://localhost:#{KONFIG.kloud.port}/kite"
+      autoConnect    : yes
+      autoReconnect  : yes
+      transportClass : SockJs
+      auth           :
+        type         : 'kloudctl'
+        key          : KONFIG.kloud.secretKey
+
+    Kloud.transport = new Kite options

--- a/workers/social/lib/social/models/computeproviders/kloud.coffee
+++ b/workers/social/lib/social/models/computeproviders/kloud.coffee
@@ -1,14 +1,8 @@
 { Base, secure, signature } = require 'bongo'
 
-KONFIG       = require 'koding-config-manager'
-async        = require 'async'
-_            = require 'underscore'
-
-KodingError  = require '../../error'
-KodingLogger = require '../kodinglogger'
-
-{ Kite }     = require 'kite.js'
-SockJs       = require 'node-sockjs-client'
+{ Kite } = require 'kite.js'
+SockJs   = require 'node-sockjs-client'
+KONFIG   = require 'koding-config-manager'
 
 # Kloud wrapper on social backend
 #

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -518,8 +518,8 @@ module.exports = class JStackTemplate extends Module
 
     success: revive
 
-      shouldReviveClient   : yes
-      shouldReviveProvider : no
+      shouldReviveClient    : yes
+      shouldReviveProvider  : no
       shouldFetchGroupLimit : yes
 
     , (client, callback) ->

--- a/workers/social/lib/social/models/group/index.coffee
+++ b/workers/social/lib/social/models/group/index.coffee
@@ -28,8 +28,6 @@ module.exports = class JGroup extends Module
     { permission: 'edit own groups', validateWith: Validators.group.admin }
   ]
 
-  @API_TOKEN_LIMIT = 5
-
   @trait __dirname, '../../traits/filterable'
   @trait __dirname, '../../traits/protected'
   @trait __dirname, '../../traits/joinable'

--- a/workers/social/lib/social/models/group/index.coffee
+++ b/workers/social/lib/social/models/group/index.coffee
@@ -909,11 +909,11 @@ module.exports = class JGroup extends Module
     advanced: PERMISSION_EDIT_GROUPS
     success: (client, callback) ->
       JApiToken = require '../apitoken'
-      selector  = { group : @getAt 'slug' }
+      selector  = { group: @getAt 'slug' }
 
       JApiToken.some selector, {}, (err, apiTokens) ->
         return callback err, []  if err or not apiTokens
-        JGroup.mergeApiTokensWithUsername apiTokens, callback
+        JGroup.mergeApiTokensWithUsername client, apiTokens, callback
 
 
   baseFetcherOfGroupStaff: (options) ->
@@ -1704,18 +1704,28 @@ module.exports = class JGroup extends Module
       return callback null, accounts
 
 
-  @mergeApiTokensWithUsername: (apiTokens, callback) ->
+  SHADOW_CODE = '*'
 
+  @mergeApiTokensWithUsername: (client, apiTokens, callback) ->
+
+    originId  = client.connection.delegate.getId()
     JAccount  = require '../account'
     originIds = apiTokens.map (apiToken) -> apiToken.originId
 
     JAccount.some { _id: { $in: originIds } }, {}, (err, accounts) ->
       return callback err, []  if err or not accounts
 
-      accounts.forEach (account) ->
-        apiTokens.forEach (apiToken) ->
-          if account._id.toString() is apiToken.originId.toString?()
+      apiTokens = apiTokens.map (apiToken) ->
+
+        if not apiToken.originId.equals originId
+          apiToken.code = SHADOW_CODE
+        accounts.forEach (account) ->
+          if account._id.equals apiToken.originId
             apiToken.username = account.profile.nickname
+        return apiToken
+
+      .sort (apiToken) ->
+        not apiToken.originId.equals originId
 
       return callback null, apiTokens
 

--- a/workers/social/lib/social/models/models.json
+++ b/workers/social/lib/social/models/models.json
@@ -6,6 +6,7 @@
   "ComputeProvider": "/computeproviders/computeprovider.coffee",
   "JCredential": "/computeproviders/credential.coffee",
   "JCredentialData": "/computeproviders/credentialdata.coffee",
+  "Kloud": "/computeproviders/kloud.coffee",
   "JMachine": "/computeproviders/machine.coffee",
   "JProvisioner": "/computeproviders/provisioner.coffee",
   "JSnapshot": "/computeproviders/snapshot.coffee",

--- a/workers/social/lib/social/models/session.coffee
+++ b/workers/social/lib/social/models/session.coffee
@@ -103,7 +103,7 @@ module.exports = class JSession extends Model
 
   @createNewSession = (data, callback) ->
 
-    data.clientId = uuid.v4()
+    data.clientId ?= uuid.v4()
 
     session = new JSession data
     session.save (err) ->

--- a/workers/social/lib/social/models/session.coffee
+++ b/workers/social/lib/social/models/session.coffee
@@ -138,8 +138,10 @@ module.exports = class JSession extends Model
   #
   # i dont like this function name but following the same principle with
   # fetchSession ~ CS
-  @fetchSessionByData = (data, callback) ->
-    @one data, (err, session) =>
+  @fetchSessionByData = (query, data, callback) ->
+    [callback, data] = [data, callback]  unless callback
+    data = query  unless data
+    @one query, (err, session) =>
       return callback err  if err
       return callback null, session  if session?
       @createNewSession data, callback

--- a/workers/social/lib/social/remoteapi.coffee
+++ b/workers/social/lib/social/remoteapi.coffee
@@ -1,6 +1,7 @@
 KONFIG    = require 'koding-config-manager'
 apiErrors = require './apierrors'
 { clone } = require 'underscore'
+isUUID    = require 'uuid-validate'
 
 purify = (data) ->
 
@@ -61,7 +62,11 @@ getToken = (req) ->
 
 parseRequest = (req, res) ->
 
-  { model, id } = req.params
+  { token, model, id } = req.params
+
+  if token and not id and not isUUID token
+    [ model, id ] = [token, model]
+    token = undefined
 
   unless model
     sendApiError res, apiErrors.invalidInput
@@ -73,11 +78,12 @@ parseRequest = (req, res) ->
     sendApiError res, apiErrors.invalidInput
     return
 
-  unless sessionToken = getToken req
+  if not token and not token = getToken req
     sendApiError res, apiErrors.unauthorizedRequest
     return
 
-  return { model, id, method, sessionToken }
+  return { model, id, method, token }
+
 
 
 verifySession = (Models, sessionToken, callback) ->


### PR DESCRIPTION
Based on the requirements for secure `remote.api` calls I've decided to support `JApiToken`'s with `remote.api` see #10359 Which will provide us better management over api calls. `JApiToken` was designed to serve as team itself not as user but since it has `originId` as creator's `JAccount._id` we can use it for the same purpose. But, to prevent any possible security issues I've updated fetchers for apiTokens to shadow token codes which are not belong to current user. Current user as an admin can revoke (delete) anyone else's token but they cannot see them. For this purpose I've updated some UI around that as well.

![image](https://cloud.githubusercontent.com/assets/42368/22133507/5fa9b244-de75-11e6-9d6b-41c892839a1d.png)

There is still a limit of `5` token per team but there is no limitation per user, a user can have `10` tokens for different teams also a user can have more than `1` token per team as well.

Once this is done, I'll add support tokens in api routes support into this one which will allow us to use these tokens in anywhere we want. Final result will be like;

`https://your-team.koding.com/remote.api/xxx.../JStackTemplate.build/{JStackTemplate._id}`

where `xxx...` will be the token you've created under Api Tokens section.

I've also updated the format of api tokens as I'm using `uuid-v4` for now and I'll decline requests for other types of apiTokens (current apiToken list in db will be removed)
