### PR TITLE
kd: add --force flag for "config reset"

### DIFF
--- a/go/src/koding/klientctl/config.go
+++ b/go/src/koding/klientctl/config.go
@@ -168,8 +168,11 @@ func ConfigUse(c *cli.Context, log logging.Logger, _ string) (int, error) {
 }
 
 func ConfigReset(c *cli.Context, log logging.Logger, _ string) (int, error) {
-	if err := cfg.Reset(); err != nil {
-		fmt.Fprintln(os.Stderr, "Error resetting configuration:", err)
+	opts := &cfg.ResetOpts{
+		Force: c.Bool("force"),
+	}
+
+	if err := cfg.Reset(opts); err != nil {
 		return 1, err
 	}
 

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -477,7 +477,13 @@ func run(args []string) {
 				}, {
 					Name:   "reset",
 					Usage:  "Resets configuration to the default value fetched from Koding.",
-					Action: ctlcli.ExitErrAction(ConfigReset, log, "set"),
+					Action: ctlcli.ExitErrAction(ConfigReset, log, "reset"),
+					Flags: []cli.Flag{
+						cli.BoolFlag{
+							Name:  "force",
+							Usage: "Force retrieving configuration from Koding.",
+						},
+					},
 				}},
 			},
 			cli.Command{


### PR DESCRIPTION
Default configuration is cached in konfig.bolt once
retrieved from kloud. On subsequent call to "config reset",
kd reads the defaults from the cache instead of calling
kloud.

If for any reason we need to ignore cached defaults
(e.g. they changed in development environment), we
can do so by using --force flag.