### PR TITLE
kd: do not fetch kloud kite from Kontrol

### DIFF
--- a/go/src/koding/klientctl/endpoint/kloud/kloud.go
+++ b/go/src/koding/klientctl/endpoint/kloud/kloud.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/koding/kite"
 	kitecfg "github.com/koding/kite/config"
-	"github.com/koding/kite/protocol"
 	"github.com/koding/logging"
 )
 
@@ -153,21 +152,7 @@ func (kt *KiteTransport) kloud() (*kite.Client, error) {
 	kloud := kt.kite().NewClient(kt.konfig().Endpoints.Kloud().Public.String())
 
 	if err := kloud.DialTimeout(kt.dialTimeout()); err != nil {
-		query := &protocol.KontrolQuery{
-			Name:        "kloud",
-			Environment: kt.kiteConfig().Environment,
-		}
-
-		clients, err := kt.kite().GetKites(query)
-		if err != nil {
-			return nil, err
-		}
-
-		kloud = kt.kite().NewClient(clients[0].URL)
-
-		if err := kloud.DialTimeout(kt.DialTimeout); err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 
 	kt.kKloud = kloud


### PR DESCRIPTION
The code responsible for the kontrol fallback was
written before kd started to use single baseurl
for all the services. Also it was not possible
to overwrite the configuration at the point,
so it was infact a workaround for incomplete
configuration.

Since then "kd config set" and "kd config reset"
were introduced to ensure proper configuration.

Additionally there's a security risk involved
with the current implementation: there is
nothing to prevent a malicious user to use
KD's kite.key to register a malicious kite
named "kloud" to the production Kontrol.

This way the user could e.g. steal passwords
by logging auth.passwordLogin requests.
