### PR TITLE
kd/auth: add --token support for "auth login" command

### DIFF
--- a/go/src/koding/db/mongodb/modelhelper/stacktemplate.go
+++ b/go/src/koding/db/mongodb/modelhelper/stacktemplate.go
@@ -77,7 +77,7 @@ func HasTemplateAccess(tmpl *models.StackTemplate, username string) error {
 			return ErrNoAccess
 		}
 	case models.AccessGroup:
-		if ok, err := HasAnyRole(username, tmpl.Group, DefaultRoles...); err != nil || !ok {
+		if ok, err := IsParticipant(username, tmpl.Group); err != nil || !ok {
 			return ErrNoAccess
 		}
 	default:

--- a/go/src/koding/klientctl/auth.go
+++ b/go/src/koding/klientctl/auth.go
@@ -122,8 +122,11 @@ func AuthLogin(c *cli.Context, log logging.Logger, _ string) (int, error) {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "\t")
 		enc.Encode(resp)
-	} else {
+	} else if resp.GroupName != "" {
 		fmt.Fprintln(os.Stdout, "Successfully logged in to the following team:", resp.GroupName)
+	} else {
+		fmt.Fprintf(os.Stdout, "Successfully authenticated to Koding.\n\nPlease run \"kd auth login "+
+			"[--team myteam]\" in order to login to your team.\n")
 	}
 
 	return 0, nil

--- a/go/src/koding/klientctl/auth.go
+++ b/go/src/koding/klientctl/auth.go
@@ -107,7 +107,9 @@ func AuthLogin(c *cli.Context, log logging.Logger, _ string) (int, error) {
 
 	if resp.KiteKey != "" {
 		k.KiteKey = resp.KiteKey
-		k.Endpoints = resp.Metadata.Endpoints
+		if resp.Metadata != nil {
+			k.Endpoints = resp.Metadata.Endpoints
+		}
 
 		if err := configstore.Use(k); err != nil {
 			return 1, err

--- a/go/src/koding/klientctl/auth.go
+++ b/go/src/koding/klientctl/auth.go
@@ -57,7 +57,8 @@ func AuthLogin(c *cli.Context, log logging.Logger, _ string) (int, error) {
 	authClient := &auth.Client{
 		Kloud: kloudClient,
 		Kontrol: &kontrol.Client{
-			Kloud: kloudClient,
+			Kloud:  kloudClient,
+			Konfig: k,
 		},
 	}
 

--- a/go/src/koding/klientctl/auth.go
+++ b/go/src/koding/klientctl/auth.go
@@ -11,7 +11,7 @@ import (
 	"koding/kites/kloud/stack"
 	"koding/klientctl/endpoint/auth"
 	"koding/klientctl/endpoint/kloud"
-	_ "koding/klientctl/endpoint/kontrol"
+	"koding/klientctl/endpoint/kontrol"
 	"koding/klientctl/endpoint/team"
 	"koding/klientctl/helper"
 

--- a/go/src/koding/klientctl/auth.go
+++ b/go/src/koding/klientctl/auth.go
@@ -11,6 +11,7 @@ import (
 	"koding/kites/kloud/stack"
 	"koding/klientctl/endpoint/auth"
 	"koding/klientctl/endpoint/kloud"
+	_ "koding/klientctl/endpoint/kontrol"
 	"koding/klientctl/endpoint/team"
 	"koding/klientctl/helper"
 
@@ -55,6 +56,9 @@ func AuthLogin(c *cli.Context, log logging.Logger, _ string) (int, error) {
 
 	authClient := &auth.Client{
 		Kloud: kloudClient,
+		Kontrol: &kontrol.Client{
+			Kloud: kloudClient,
+		},
 	}
 
 	teamClient := &team.Client{
@@ -68,10 +72,11 @@ func AuthLogin(c *cli.Context, log logging.Logger, _ string) (int, error) {
 	log.Debug("auth: transport test: %s", err)
 
 	opts := &auth.LoginOptions{
-		Team: c.String("team"),
+		Team:  c.String("team"),
+		Token: c.String("token"),
 	}
 
-	if err != nil {
+	if err != nil && opts.Token == "" {
 		opts.Username, err = helper.Ask("Username [%s]: ", config.CurrentUser.Username)
 		if err != nil {
 			return 1, err

--- a/go/src/koding/klientctl/endpoint/auth/auth.go
+++ b/go/src/koding/klientctl/endpoint/auth/auth.go
@@ -7,6 +7,7 @@ import (
 	"koding/kites/kloud/stack"
 	"koding/klientctl/ctlcli"
 	"koding/klientctl/endpoint/kloud"
+	_ "koding/klientctl/endpoint/kontrol"
 )
 
 var DefaultClient = &Client{}
@@ -38,12 +39,14 @@ func (s Sessions) Slice() []*Session {
 
 type LoginOptions struct {
 	Team     string
+	Token    string
 	Username string
 	Password string
 }
 
 type Client struct {
-	Kloud *kloud.Client
+	Kloud   *kloud.Client
+	Kontrol *kontrol.Client
 
 	once     sync.Once // for c.init()
 	sessions Sessions
@@ -61,7 +64,14 @@ func (c *Client) Login(opts *LoginOptions) (*stack.PasswordLoginResponse, error)
 
 	// We ignore any cached session for the given login request,
 	// as it might be already invalid from a different client.
-	if opts.Username != "" && opts.Password != "" {
+	if opts.Token != "" {
+		req := &kontrol.RegisterRequest{
+			AuthType: "token",
+			Token:    opts.Token,
+		}
+
+		err = c.kontrol().Call("registerMachine", req, &resp.KiteKey)
+	} else if opts.Username != "" && opts.Password != "" {
 		req := &stack.PasswordLoginRequest{
 			LoginRequest: *req,
 			Username:     opts.Username,
@@ -77,12 +87,14 @@ func (c *Client) Login(opts *LoginOptions) (*stack.PasswordLoginResponse, error)
 		return nil, err
 	}
 
-	session := &Session{
-		ClientID: resp.LoginResponse.ClientID,
-		Team:     resp.LoginResponse.GroupName,
-	}
+	if resp.GroupName != "" {
+		session := &Session{
+			ClientID: resp.ClientID,
+			Team:     resp.GroupName,
+		}
 
-	c.sessions[session.Team] = session
+		c.sessions[session.Team] = session
+	}
 
 	return &resp, nil
 }
@@ -127,6 +139,13 @@ func (c *Client) kloud() *kloud.Client {
 		return c.Kloud
 	}
 	return kloud.DefaultClient
+}
+
+func (c *Client) kontrol() *kontrol.Client {
+	if c.Kontrol != nil {
+		return c.Kontrol
+	}
+	return kontrol.DefaultClient
 }
 
 func Login(opts *LoginOptions) (*stack.PasswordLoginResponse, error) { return DefaultClient.Login(opts) }

--- a/go/src/koding/klientctl/endpoint/auth/auth.go
+++ b/go/src/koding/klientctl/endpoint/auth/auth.go
@@ -7,7 +7,7 @@ import (
 	"koding/kites/kloud/stack"
 	"koding/klientctl/ctlcli"
 	"koding/klientctl/endpoint/kloud"
-	_ "koding/klientctl/endpoint/kontrol"
+	"koding/klientctl/endpoint/kontrol"
 )
 
 var DefaultClient = &Client{}

--- a/go/src/koding/klientctl/endpoint/auth/auth.go
+++ b/go/src/koding/klientctl/endpoint/auth/auth.go
@@ -96,6 +96,10 @@ func (c *Client) Login(opts *LoginOptions) (*stack.PasswordLoginResponse, error)
 		c.sessions[session.Team] = session
 	}
 
+	if resp.GroupName == "" {
+		resp.GroupName = opts.Team
+	}
+
 	return &resp, nil
 }
 

--- a/go/src/koding/klientctl/endpoint/kloud/kloud.go
+++ b/go/src/koding/klientctl/endpoint/kloud/kloud.go
@@ -21,6 +21,7 @@ import (
 // a kiteTransport, but plain net/rpc can also be
 // used.
 type Transport interface {
+	Connect(url string) (Transport, error)
 	Call(method string, arg, reply interface{}) error
 }
 
@@ -93,13 +94,15 @@ type KiteTransport struct {
 	// If nil, DefaultLog is going to be used instead.
 	Log logging.Logger
 
-	k      *kite.Kite
-	kCfg   *kitecfg.Config
-	kKloud *kite.Client
+	k       *kite.Kite
+	kCfg    *kitecfg.Config
+	kClient *kite.Client
 }
 
-var _ Transport = (*KiteTransport)(nil)
-var _ stack.Validator = (*KiteTransport)(nil)
+var (
+	_ Transport       = (*KiteTransport)(nil)
+	_ stack.Validator = (*KiteTransport)(nil)
+)
 
 func (kt *KiteTransport) Call(method string, arg, reply interface{}) error {
 	k, err := kt.kloud()
@@ -117,6 +120,18 @@ func (kt *KiteTransport) Call(method string, arg, reply interface{}) error {
 	}
 
 	return nil
+}
+
+func (kt *KiteTransport) Connect(url string) (Transport, error) {
+	k, err := kt.newClient(url)
+	if err != nil {
+		return nil, err
+	}
+
+	ktCopy := *kt
+	ktCopy.kClient = k
+
+	return &ktCopy, nil
 }
 
 func (kt *KiteTransport) kite() *kite.Kite {
@@ -145,26 +160,35 @@ func (kt *KiteTransport) kiteConfig() *kitecfg.Config {
 }
 
 func (kt *KiteTransport) kloud() (*kite.Client, error) {
-	if kt.kKloud != nil {
-		return kt.kKloud, nil
+	if kt.kClient != nil {
+		return kt.kClient, nil
 	}
 
-	kloud := kt.kite().NewClient(kt.konfig().Endpoints.Kloud().Public.String())
-
-	if err := kloud.DialTimeout(kt.dialTimeout()); err != nil {
+	kloud, err := kt.newClient(kt.konfig().Endpoints.Kloud().Public.String())
+	if err != nil {
 		return nil, err
 	}
 
-	kt.kKloud = kloud
+	kt.kClient = kloud
+
+	return kt.kClient, nil
+}
+
+func (kt *KiteTransport) newClient(url string) (*kite.Client, error) {
+	k := kt.kite().NewClient(url)
+
+	if err := k.DialTimeout(kt.dialTimeout()); err != nil {
+		return nil, err
+	}
 
 	if kitekey := kt.kiteConfig().KiteKey; kitekey != "" {
-		kt.kKloud.Auth = &kite.Auth{
+		k.Auth = &kite.Auth{
 			Type: "kiteKey",
 			Key:  kitekey,
 		}
 	}
 
-	return kt.kKloud, nil
+	return k, nil
 }
 
 func (kt *KiteTransport) dialTimeout() time.Duration {

--- a/go/src/koding/klientctl/endpoint/kontrol/kontrol.go
+++ b/go/src/koding/klientctl/endpoint/kontrol/kontrol.go
@@ -1,18 +1,78 @@
 package kontrol
 
-import "koding/klientctl/endpoint/kloud"
+import (
+	cfg "koding/kites/config"
+	"koding/klientctl/config"
+	"koding/klientctl/endpoint/kloud"
+)
 
+// RegisterRequest represents a request payload
+// for one of kontrol's method - registerMachine.
 type RegisterRequest struct {
-	AuthType string
-	Token    string
+	AuthType string // authentication type - here "token"
+	Token    string // temporary token
 }
 
+// DefaultClient represents a Client, which default
+// behaviour is to use default kloud client and
+// default configuration read from configstore.
 var DefaultClient = &Client{}
 
+// Client is a conveniance wrapper for kite.Client
+// that is connected to Kontrol.
+//
+// The wrapper uses kite configuration which is
+// already built by kloud's client and uses
+// kontrol url read from configstore.
 type Client struct {
-	Kloud *kloud.Client
+	Kloud  *kloud.Client
+	Konfig *cfg.Konfig
+
+	t kloud.Transport
 }
 
+// Call invokes the given method with the given request payload.
+//
+// If call succeeds, result is unmarshaled to the resp value.
 func (c *Client) Call(method string, req, resp interface{}) error {
-	return nil
+	t, err := c.transport()
+	if err != nil {
+		return err
+	}
+
+	return t.Call(method, req, resp)
 }
+
+func (c *Client) kloud() *kloud.Client {
+	if c.Kloud != nil {
+		return c.Kloud
+	}
+	return kloud.DefaultClient
+}
+
+func (c *Client) konfig() *cfg.Konfig {
+	if c.Konfig != nil {
+		return c.Konfig
+	}
+	return config.Konfig
+}
+
+func (c *Client) transport() (kloud.Transport, error) {
+	if c.t != nil {
+		return c.t, nil
+	}
+
+	t, err := c.kloud().Transport.Connect(c.konfig().Endpoints.Kontrol().Public.String())
+	if err != nil {
+		return nil, err
+	}
+
+	c.t = t
+
+	return c.t, nil
+}
+
+// Call invokes the given method with the given request payload on the DefaultClient.
+//
+// If call succeeds, result is unmarshaled to the resp value.
+func Call(method string, req, resp interface{}) error { return DefaultClient.Call(method, req, resp) }

--- a/go/src/koding/klientctl/endpoint/kontrol/kontrol.go
+++ b/go/src/koding/klientctl/endpoint/kontrol/kontrol.go
@@ -1,0 +1,18 @@
+package kontrol
+
+import "koding/klientctl/endpoint/kloud"
+
+type RegisterRequest struct {
+	AuthType string
+	Token    string
+}
+
+var DefaultClient = &Client{}
+
+type Client struct {
+	Kloud *kloud.Client
+}
+
+func (c *Client) Call(method string, req, resp interface{}) error {
+	return nil
+}

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -428,6 +428,10 @@ func run(args []string) {
 								Usage: "Specify a Koding endpoint to log in.",
 								Value: config.Konfig.Endpoints.Koding.Public.String(),
 							},
+							cli.StringFlag{
+								Name:  "token",
+								Usage: "Use temporary token to authenticate to your Koding account.",
+							},
 						},
 					},
 					// command: kd auth register

--- a/go/src/koding/klientctl/main_test.go
+++ b/go/src/koding/klientctl/main_test.go
@@ -197,6 +197,8 @@ func (ft *FakeTransport) Call(method string, arg, reply interface{}) error {
 	return nil
 }
 
+func (ft *FakeTransport) Connect(string) (kloud.Transport, error) { return ft, nil }
+
 func (*FakeTransport) Valid() (_ error) { return }
 
 func nonil(err ...error) error {


### PR DESCRIPTION
This PR adds --token support for the "auth login" command.

Current implementation of `kd install` uses token to authenticate with kontrol. The `install-kd.sh` script is going to be reworked to use just kd for installation / authentication, so kd itself needs to be able to use the token to auth to Koding, complementary to password login.