### PR TITLE
klient/machine: balance method for Create request should not GC mounted machines

### DIFF
--- a/go/src/koding/klient/machine/machinegroup/create_test.go
+++ b/go/src/koding/klient/machine/machinegroup/create_test.go
@@ -142,7 +142,7 @@ func TestCreateBalanceStaleMount(t *testing.T) {
 		id      = machine.ID("serv")
 	)
 
-	wd, m, clean, err := mounttest.MountDirs()
+	wd, m, clean, err := mounttest.MountDirs("")
 	if err != nil {
 		t.Fatalf("want err = nil; got %v", err)
 	}


### PR DESCRIPTION
Create method obtains machines from kloud. If stack is reinitialized or some machines are removed in other way, Klient will GC no longer available machines from bolt cache.

This PR prevents client for removing machines that are no longer available but have mounted folders (which will be disconnected). It allows to make a copy of mounted data or switch mount to another machine(future plans).

User needs to `kd machine umount` manually in order to GC resources.

Depends on: ~#10367~

**Code coverage**:  47.5% of statements

## How Has This Been Tested?
Unit tests.

## Screenshots (if appropriate):
none

## Types of changes
- [x] New feature (non-breaking change which adds functionality)