### PR TITLE
models/computeprovider: remove duplicate slug field

### DIFF
--- a/website/swagger.json
+++ b/website/swagger.json
@@ -643,9 +643,6 @@
         "accessLevel": {
           "type": "string"
         },
-        "slug": {
-          "type": "string"
-        },
         "originId": {
           "type": "string"
         },

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -116,9 +116,6 @@ module.exports = class JStackTemplate extends Module
         ]
         default       : 'private'
 
-      slug            :
-        type          : String
-
       originId        :
         type          : ObjectId
         required      : yes


### PR DESCRIPTION
Merge problem on my end, sorry.

Fixes:

```
$ scripts/wercker/run-command node_modules/coffeelint/bin/coffeelint --quiet .
  ✗ workers/social/lib/social/models/computeproviders/stacktemplate.coffee
     ✗ #119: Duplicate key defined in object or class.
```

https://app.wercker.com/buildstep/58852e3dca5bd2010060ef36