### PR TITLE
Undo CSS removal for stack template

### DIFF
--- a/client/app/lib/styl/computeproviders.styl
+++ b/client/app/lib/styl/computeproviders.styl
@@ -274,3 +274,45 @@ computeproviders.styl
 
         strong
           font-weight       bold
+
+.kdmodal.ContentModal.content-modal
+  &.stack-template-preview
+  &.expanded-stack-template-preview
+
+    .kdmodal-inner
+      height                100%
+
+    .kdmodal-content
+      height                100%
+      border-bottom         1px solid #e4e4e4
+
+      .kdtabview
+        noScrollbar()
+
+    .kdtabhandlecontainer
+      border-bottom         1px solid #e4e4e4
+
+    .kdtabhandle
+    .kdtabhandlecontainer
+      height                42px !important
+      line-height           42px
+      box-shadow            none
+
+    .kdtabhandle
+      top                   1px
+      color                 #575757
+
+      &.active
+        box-shadow          none
+        bg                  color, #FFF !important
+        border              1px solid #E4E4E4
+        border-bottom       1px solid #FFF
+        rounded             4px 4px 0 0
+
+    .ace_gutter
+      bg                    color, #FFF
+      border-left           1px solid #e4e4e4
+
+    .ace_scroller
+      border-right          1px solid #e4e4e4
+      right                 0 !important


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
References https://github.com/koding/koding/issues/10396

## Description
<!--- Describe your changes in detail -->
CSS was removed a week ago with https://github.com/koding/koding/commit/cdb9d5463b57818d7ded6cbc578d166d98c728e3 and has been put back to fix CSS for the stack template preview modal.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
