### PR TITLE
Cache "has card" info in the group.

### DIFF
--- a/go/src/koding/db/models/group.go
+++ b/go/src/koding/db/models/group.go
@@ -66,6 +66,8 @@ type Customer struct {
 	// IsMember indicates that created customer on stripe is not an admin in the
 	// group.
 	IsMember string `bson:"isMember" json:"isMember"`
+	// HasCard holds the card info of a team
+	HasCard bool `bson:"hasCard" json:"hasCard"`
 }
 
 // IsSubActive checks if subscription is in valid state for operation

--- a/go/src/socialapi/workers/payment/api/card.go
+++ b/go/src/socialapi/workers/payment/api/card.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"errors"
-	"koding/db/mongodb/modelhelper"
 	"net/http"
 	"net/url"
 
@@ -33,16 +32,7 @@ func HasCreditCard(u *url.URL, h http.Header, _ interface{}, context *models.Con
 		return response.NewBadRequest(models.ErrNotLoggedIn)
 	}
 
-	group, err := modelhelper.GetGroup(context.GroupName)
-	if err != nil {
-		return response.NewBadRequest(err)
-	}
-
-	if group.Payment.Customer.ID == "" {
-		return response.NewNotFound()
-	}
-
-	err = payment.CheckCustomerHasSource(group.Payment.Customer.ID)
+	err := payment.HasCreditCard(context.GroupName)
 	if err == payment.ErrCustomerSourceNotExists {
 		return response.NewNotFound()
 	}

--- a/go/src/socialapi/workers/payment/subscription.go
+++ b/go/src/socialapi/workers/payment/subscription.go
@@ -198,9 +198,12 @@ func syncGroupWithCustomerID(cusID string) error {
 		subStatus = cus.Subs.Values[0].Status
 	}
 
+	hasCard := checkCustomerHasSourceWithCustomer(cus) == nil
+
 	// if subID and subStatus are same, update not needed
 	if group.Payment.Subscription.ID == subID &&
-		stripe.SubStatus(group.Payment.Subscription.Status) == subStatus {
+		stripe.SubStatus(group.Payment.Subscription.Status) == subStatus &&
+		group.Payment.Customer.HasCard == hasCard {
 		return nil
 	}
 
@@ -210,6 +213,7 @@ func syncGroupWithCustomerID(cusID string) error {
 			"$set": modelhelper.Selector{
 				"payment.subscription.id":     subID,
 				"payment.subscription.status": string(subStatus),
+				"payment.customer.hasCard":    hasCard,
 			},
 		},
 	)

--- a/go/src/socialapi/workers/payment/webhook.go
+++ b/go/src/socialapi/workers/payment/webhook.go
@@ -157,6 +157,10 @@ func customerSourceCreatedHandler(raw []byte) error {
 		return err
 	}
 
+	if err := syncGroupWithCustomerID(req.Customer.ID); err != nil {
+		return err
+	}
+
 	const eventName = "entered credit card"
 
 	return sendEventForCustomer(req.Customer.ID, eventName, nil)
@@ -166,6 +170,10 @@ func customerSourceDeletedHandler(raw []byte) error {
 	var req stripe.Card
 	err := json.Unmarshal(raw, &req)
 	if err != nil {
+		return err
+	}
+
+	if err := syncGroupWithCustomerID(req.Customer.ID); err != nil {
 		return err
 	}
 

--- a/workers/social/lib/social/render/scriptblock.coffee
+++ b/workers/social/lib/social/render/scriptblock.coffee
@@ -104,6 +104,14 @@ module.exports = (options = {}, callback) ->
 
         currentGroup = group  if group
 
+        if currentGroup?.payment?.customer?.hasCard?
+          hasCard = yes
+          return fin()
+
+        hasCreditCard client, (err) ->
+          hasCard = not err?
+          return fin()
+
         fin()
 
     (fin) ->
@@ -152,11 +160,6 @@ module.exports = (options = {}, callback) ->
         if user then userId = user.getId()
         else console.error '[scriptblock] user not found', err
         fin()
-
-    (fin) ->
-      hasCreditCard client, (err) ->
-        hasCard = not err?
-        return fin()
 
   ]
 


### PR DESCRIPTION
Checking if team has CC takes about 400ms in each page load, cache it in the group so we will have a faster way to lookup it. If group does not have the info, fetch it from the socialapi, it will return up-to-date info while updating the database.