### PR TITLE
Shared VM invitation is not displayed on sidebar by default if it's rejected before or it's not the first time the participant is accessing that vm.

### DIFF
--- a/client/app/lib/components/sidebar/index.coffee
+++ b/client/app/lib/components/sidebar/index.coffee
@@ -45,8 +45,6 @@ module.exports = class Sidebar extends React.Component
       privateStackTemplates        : EnvironmentFlux.getters.privateStackTemplates
       sharedMachines               : EnvironmentFlux.getters.sharedMachines
       collaborationMachines        : EnvironmentFlux.getters.collaborationMachines
-      sharedMachineListItems       : EnvironmentFlux.getters.sharedMachineListItems
-      activeInvitationMachineId    : EnvironmentFlux.getters.activeInvitationMachineId
       activeLeavingSharedMachineId : EnvironmentFlux.getters.activeLeavingSharedMachineId
       requiredInvitationMachine    : EnvironmentFlux.getters.requiredInvitationMachine
       differentStackResourcesStore : EnvironmentFlux.getters.differentStackResourcesStore
@@ -54,9 +52,6 @@ module.exports = class Sidebar extends React.Component
       team                         : TeamFlux.getters.team
       selectedTemplateId           : EnvironmentFlux.getters.selectedTemplateId
     }
-
-
-  popoverNeeded: (machine) -> machine.get('_id') is @state.activeInvitationMachineId
 
 
   componentWillMount: ->
@@ -164,22 +159,6 @@ module.exports = class Sidebar extends React.Component
 
     if @state.requiredInvitationMachine
       setActiveInvitationMachineId { machine : @state.requiredInvitationMachine }
-
-
-  renderInvitationWidget: ->
-
-    isRendered = no
-
-    (@state.sharedMachines.concat @state.collaborationMachines).toList().map (machine) =>
-
-      if not isRendered and @popoverNeeded machine
-        isRendered = yes
-        item = @state.sharedMachineListItems.get machine.get '_id'
-
-        <SharingMachineInvitationWidget
-          key="InvitationWidget-#{machine.get '_id'}"
-          listItem={item}
-          machine={machine} />
 
 
   prepareStacks:  ->
@@ -292,7 +271,6 @@ module.exports = class Sidebar extends React.Component
         {@renderDifferentStackResources()}
         {@renderStacks()}
         {@renderSharedMachines()}
-        {@renderInvitationWidget()}
       </div>
       <div className='Sidebar-logo-wrapper'>
         {@renderLogo()}

--- a/client/app/lib/components/sidebarmachineslistitem/index.coffee
+++ b/client/app/lib/components/sidebarmachineslistitem/index.coffee
@@ -15,6 +15,8 @@ LeaveSharedMachineWidget       = require './leavesharedmachinewidget'
 SidebarWorkspacesListItem      = require './sidebarworkspaceslistitem'
 isMachineSettingsIconEnabled   = require 'app/util/isMachineSettingsIconEnabled'
 ConnectedManagedMachineWidget  = require './connectedmanagedmachinewidget'
+SharingMachineInvitationWidget = require 'app/components/sidebarmachineslistitem/sharingmachineinvitationwidget'
+
 
 require './styl/sidebarmachineslistItem.styl'
 require './styl/sidebarwidget.styl'
@@ -31,6 +33,7 @@ module.exports = class SidebarMachinesListItem extends React.Component
   getDataBindings: ->
     activeMachine : EnvironmentFlux.getters.activeMachine
     activeLeavingMachine : EnvironmentFlux.getters.activeLeavingSharedMachineId
+    activeInvitationMachineId : EnvironmentFlux.getters.activeInvitationMachineId
 
 
   constructor: (props) ->
@@ -39,10 +42,9 @@ module.exports = class SidebarMachinesListItem extends React.Component
 
     status = @machine ['status', 'state']
 
-    @state = {
+    @state =
       collapsed: yes
       showLeaveSharedMachineWidget : no
-    }
 
     @listenMachineEvents()
 
@@ -136,7 +138,6 @@ module.exports = class SidebarMachinesListItem extends React.Component
         />
 
 
-
   renderLeaveSharedMachine: ->
 
     return null  if @machine('type') is 'own' or @machine 'hasOldOwner'
@@ -158,7 +159,6 @@ module.exports = class SidebarMachinesListItem extends React.Component
       className='MachineSettings'
       onClick={@bound 'handleMachineSettingsClick'}>
     </span>
-
 
 
   handleMachineSettingsClick: (event) ->
@@ -203,6 +203,17 @@ module.exports = class SidebarMachinesListItem extends React.Component
       />
 
 
+  renderInvitationWidget: ->
+
+    return null  unless @state.coordinates
+    return null  unless @props.machine.get('_id') is @state.activeInvitationMachineId
+
+    <SharingMachineInvitationWidget
+      key="InvitationWidget-#{@props.machine.get '_id'}"
+      coordinates={@state.coordinates}
+      machine={@props.machine} />
+
+
   render: ->
 
     return null  unless @props.showInSidebar
@@ -226,6 +237,7 @@ module.exports = class SidebarMachinesListItem extends React.Component
         {@renderMachineSettingsIcon()}
       </Link>
       {@renderLeaveSharedMachine()}
+      {@renderInvitationWidget()}
       {@renderConnectedManagedMachineWidget()}
     </div>
 

--- a/client/app/lib/components/sidebarmachineslistitem/sharingmachineinvitationwidget.coffee
+++ b/client/app/lib/components/sidebarmachineslistitem/sharingmachineinvitationwidget.coffee
@@ -1,15 +1,12 @@
 React                    = require 'app/react'
-ReactDOM                 = require 'react-dom'
 actions                  = require 'app/flux/environment/actions'
 SidebarWidget            = require './sidebarwidget'
 InvitationWidgetUserPart = require './invitationwidgetuserpart'
 Tracker                  = require 'app/util/tracker'
 
+
 module.exports = class SharingMachineInvitationWidget extends React.Component
 
-  coordinates:
-    top : 0
-    left: 0
 
   onRejectClicked: ->
 
@@ -25,26 +22,9 @@ module.exports = class SharingMachineInvitationWidget extends React.Component
     Tracker.track Tracker.VM_ACCEPTED_SHARED
 
 
-  componentDidUpdate: -> @setCoordinates()
-
-
-  componentWillMount: -> @setCoordinates()
-
-
-  setCoordinates: ->
-
-    listItemNode = ReactDOM.findDOMNode @props.listItem
-
-    if listItemNode
-      clientRect    = listItemNode.getBoundingClientRect()
-      { top, left, width } = clientRect
-      left = left + width
-      @coordinates = { top, left }
-
-
   render: ->
 
-    coordinates = @coordinates
+    coordinates = @props.coordinates
 
     return null  if not coordinates.top and not coordinates.left
 


### PR DESCRIPTION
where we render the shared machine invitation widget was in wrong place. The problem was the widget coordinates are calculated after it is rendered.
 
## Description
Update place of render Invitation widget functionality from `sidebar.coffee` to `sidebarlistitem.coffee`. 
Remove redundant funcs and variables.

## Motivation and Context
Fixes: #10400 

## Screenshots (if appropriate):
http://recordit.co/3xgCwegWpT

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
