### PR TITLE
klient/machine: improve indexing performance with concurrent file scanning

### DIFF
--- a/go/src/koding/klient/machine/index/index.go
+++ b/go/src/koding/klient/machine/index/index.go
@@ -23,7 +23,7 @@ type Entry struct {
 	MTime int64       `json:"mtime"` // File data change time since EPOCH.
 	Mode  os.FileMode `json:"mode"`  // File mode and permission bits.
 	Size  int64       `json:"size"`  // Size of the file.
-	SHA1  []byte      `json:"sha1"`  // SHA-1 hash of file content.
+	Hash  []byte      `json:"hash"`  // Hash of file content.
 }
 
 // NewEntryFile creates new Entry from a file stored under path argument.
@@ -41,7 +41,7 @@ func NewEntryFile(root, path string, info os.FileInfo) (e *Entry, err error) {
 		return nil, err
 	}
 
-	// Compute file's SHA-1 sum.
+	// Compute file's hash sum.
 	var sum []byte
 	if !info.IsDir() {
 		if sum, err = readCRC32(path); err != nil {
@@ -55,7 +55,7 @@ func NewEntryFile(root, path string, info os.FileInfo) (e *Entry, err error) {
 		MTime: info.ModTime().UnixNano(),
 		Mode:  info.Mode(),
 		Size:  info.Size(),
-		SHA1:  sum,
+		Hash:  sum,
 	}, nil
 }
 

--- a/go/src/koding/klient/machine/index/index.go
+++ b/go/src/koding/klient/machine/index/index.go
@@ -1,8 +1,8 @@
 package index
 
 import (
-	"crypto/sha1"
 	"encoding/json"
+	"hash/crc32"
 	"io"
 	"os"
 	"path/filepath"
@@ -44,7 +44,7 @@ func NewEntryFile(root, path string, info os.FileInfo) (e *Entry, err error) {
 	// Compute file's SHA-1 sum.
 	var sum []byte
 	if !info.IsDir() {
-		if sum, err = readSHA1(path); err != nil {
+		if sum, err = readCRC32(path); err != nil {
 			return nil, err
 		}
 	}
@@ -59,15 +59,15 @@ func NewEntryFile(root, path string, info os.FileInfo) (e *Entry, err error) {
 	}, nil
 }
 
-// readSHA1 computes SHA-1 sum from a given file content.
-func readSHA1(path string) ([]byte, error) {
+// readCRC32 computes CRC-32 checksum of a given file content.
+func readCRC32(path string) ([]byte, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
 	defer file.Close()
 
-	hash := sha1.New()
+	hash := crc32.NewIEEE()
 	if _, err := io.Copy(hash, file); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
First step when creating a mount is to create the index from remote FS. For entire Koding repository we have following numbers:

**Scanning time**:  43.349127583s
**Files**:  212972
**Files time**:  2.838µs
**Files Disk Size**:  3.6 GiB
**Files Disk Size time**:  16.514726ms

The most time consuming operation is SHA-1 sum of stored files (which is expected and cached after the first scan). This operation can be made concurrently and that's what this PR introduces. Time measurements after the change:

**Scanning time**:  19.260137022s (improvement: **225%**)
**Files**:  212972
**Files time**:  8.605µs
**Files Disk Size**:  3.6 GiB
**Files Disk Size time**:  16.457452ms

## Motivation and Context
Decrease mount initialization time (which currently times out after one minute - due to Kite connection deadline).

## How Has This Been Tested?
Existing unit tests passed.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

