### PR TITLE
Split client side bundle into css & third party vendor module bundles

### DIFF
--- a/client/app/lib/shortcutscontroller.coffee
+++ b/client/app/lib/shortcutscontroller.coffee
@@ -1,4 +1,4 @@
-Shortcuts      = require 'shortcuts'
+Shortcuts      = require '@koding/shortcuts'
 _              = require 'lodash'
 kd             = require 'kd'
 globals        = require 'globals'

--- a/client/ide/lib/collaborationcontroller.coffee
+++ b/client/ide/lib/collaborationcontroller.coffee
@@ -1,10 +1,7 @@
 _                             = require 'lodash'
-sinkrow                       = require 'sinkrow'
 kd                            = require 'kd'
-KDModalView                   = kd.ModalView
 FSFile                        = require 'app/util/fs/fsfile'
 nick                          = require 'app/util/nick'
-getCollaborativeChannelPrefix = require 'app/util/getCollaborativeChannelPrefix'
 showError                     = require 'app/util/showError'
 whoami                        = require 'app/util/whoami'
 RealtimeManager               = require './realtimemanager'
@@ -16,13 +13,12 @@ envHelpers                    = require './collaboration/helpers/environment'
 CollaborationStateMachine     = require './collaboration/collaborationstatemachine'
 environmentDataProvider       = require 'app/userenvironmentdataprovider'
 IDELayoutManager              = require './workspace/idelayoutmanager'
-IDEView                       = require './views/tabview/ideview'
 BaseModalView                 = require 'app/providers/views/basemodalview'
 actionTypes                   = require 'app/flux/environment/actiontypes'
 generateCollaborationLink     = require 'app/util/generateCollaborationLink'
 Tracker                       = require 'app/util/tracker'
 IDEHelpers                    = require 'ide/idehelpers'
-ContentModal = require 'app/components/contentModal'
+ContentModal                  = require 'app/components/contentModal'
 
 { warn } = kd
 

--- a/client/package.json
+++ b/client/package.json
@@ -79,7 +79,6 @@
     "reselect": "2.5.4",
     "seamless-immutable": "7.0.1",
     "shortcuts": "0.5.7",
-    "sinkrow": "koding/sinkrow#v0.1.3",
     "timeago": "0.2.0",
     "twitter-text": "1.14.3",
     "validator": "6.2.1"

--- a/client/package.json
+++ b/client/package.json
@@ -123,6 +123,7 @@
     "css-loader": "0.26.1",
     "expect": "1.20.2",
     "express": "4.14.0",
+    "extract-text-webpack-plugin": "2.0.0-rc.0",
     "file-loader": "0.9.0",
     "glob": "7.1.1",
     "happypack": "3.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -155,6 +155,7 @@
     "stylus-loader": "2.4.0",
     "url-loader": "0.5.7",
     "webpack": "2.2.0",
+    "webpack-bundle-analyzer": "2.2.1",
     "webpack-notifier": "1.5.0",
     "yargs": "6.6.0"
   }

--- a/client/package.json
+++ b/client/package.json
@@ -6,6 +6,7 @@
     "@koding/bongo-client": "koding/bongo-client#v0.4",
     "@koding/getscript": "0.1.0",
     "@koding/inherits-underscore": "0.2.0",
+    "@koding/shortcuts": "0.6.0",
     "accounting": "0.4.1",
     "algoliasearch": "3.20.3",
     "async": "2.1.4",
@@ -78,7 +79,6 @@
     "redux-thunk": "2.1.0",
     "reselect": "2.5.4",
     "seamless-immutable": "7.0.1",
-    "shortcuts": "0.5.7",
     "timeago": "0.2.0",
     "twitter-text": "1.14.3",
     "validator": "6.2.1"

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
     "bluebird": "3.4.7",
     "bowser": "1.6.0",
     "brace": "koding/brace#koding",
-    "card-validator": "3.0.1",
+    "card-validator": "4.0.0",
     "classnames": "2.2.5",
     "component-os": "0.0.1",
     "convert-source-map": "1.3.0",

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@koding/bongo-client": "koding/bongo-client#v0.4",
     "@koding/getscript": "0.1.0",
-    "@koding/inherits-underscore": "0.2.0",
+    "@koding/inherits-underscore": "0.3.0",
     "@koding/shortcuts": "0.6.0",
     "accounting": "0.4.1",
     "algoliasearch": "3.20.3",

--- a/client/package.json
+++ b/client/package.json
@@ -38,7 +38,7 @@
     "kd-shim-jquery-sketchpad": "0.1.1",
     "kd-shim-jspath": "0.2.0",
     "kd-shim-sockjs-client": "0.3.4",
-    "kd.js": "1.1.27",
+    "kd.js": "1.1.29",
     "keycode": "2.1.8",
     "kite.js": "0.5.2",
     "konstraints": "0.1.5",

--- a/client/webpack.config.coffee
+++ b/client/webpack.config.coffee
@@ -2,7 +2,8 @@
 
 module.exports =
   context: CLIENT_PATH
-  entry: [ './app/lib/index.coffee' ]
+  entry:
+    main: './app/lib/index.coffee'
   output: require('./webpack/config.output')()
   resolve: require('./webpack/config.resolve')()
   module: require('./webpack/config.module')()

--- a/client/webpack/config.module.coffee
+++ b/client/webpack/config.module.coffee
@@ -2,6 +2,7 @@ path = require 'path'
 
 { CLIENT_PATH, PUBNUB_PATH } = require './constants'
 generateAMDLoaders = require './util/generateAMDLoaders'
+ExtractTextPlugin = require 'extract-text-webpack-plugin'
 
 thirdPartyLoaders = ->
   return [{
@@ -45,21 +46,30 @@ stylModulesLoader = ->
   return {
     test: /\.stylus$/
     include: CLIENT_PATH
-    use: ['happypack/loader?id=styl-modules']
+    loader: ExtractTextPlugin.extract
+      fallbackLoader: 'style-loader'
+      loader: [
+        'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]'
+        'stylus-loader'
+      ]
   }
 
 stylGlobalLoader = ->
   return {
     test: /\.styl$/
     include: CLIENT_PATH
-    use: ['happypack/loader?id=styl-global']
+    loader: ExtractTextPlugin.extract
+      fallbackLoader: 'style-loader'
+      loader: [ 'css-loader', 'stylus-loader' ]
   }
 
 cssModulesLoader = ->
   return {
     test: /\.css$/,
     include: /flexboxgrid/,
-    use: ['happypack/loader?id=css-modules']
+    loader: ExtractTextPlugin.extract
+      fallbackLoader: 'style-loader'
+      loader: [ 'css-loader?modules' ]
   }
 
 cssGlobalLoader = ->
@@ -67,7 +77,9 @@ cssGlobalLoader = ->
     test: /\.css$/
     include: CLIENT_PATH
     exclude: /flexboxgrid/,
-    use: ['happypack/loader?id=css-global']
+    loader: ExtractTextPlugin.extract
+      fallbackLoader: 'style-loader'
+      loader: [ 'css-loader' ]
   }
 
 staticAssetLoaders = ->

--- a/client/webpack/config.plugins.coffee
+++ b/client/webpack/config.plugins.coffee
@@ -1,8 +1,10 @@
 path = require 'path'
 webpack = require 'webpack'
-HappyPack = require './util/HappyPack'
 CopyWebpackPlugin = require 'copy-webpack-plugin'
 ProgressBarPlugin = require 'progress-bar-webpack-plugin'
+
+HappyPack = require './util/HappyPack'
+isExternal = require './util/isExternal'
 
 { CLIENT_PATH, THIRD_PARTY_PATH,
   BUILD_PATH, COMMON_STYLES_PATH } = require './constants'
@@ -69,5 +71,9 @@ module.exports = (options) ->
         }
       }
     }
+
+    new webpack.optimize.CommonsChunkPlugin
+      name: 'vendor'
+      minChunks: (mod) -> isExternal mod
 
   ]

--- a/client/webpack/config.plugins.coffee
+++ b/client/webpack/config.plugins.coffee
@@ -2,12 +2,13 @@ path = require 'path'
 webpack = require 'webpack'
 CopyWebpackPlugin = require 'copy-webpack-plugin'
 ProgressBarPlugin = require 'progress-bar-webpack-plugin'
+ExtractTextPlugin = require 'extract-text-webpack-plugin'
 
 HappyPack = require './util/HappyPack'
 isExternal = require './util/isExternal'
 
 { CLIENT_PATH, THIRD_PARTY_PATH,
-  BUILD_PATH, COMMON_STYLES_PATH } = require './constants'
+  BUILD_PATH, COMMON_STYLES_PATH, CSS_BUNDLE_FILE } = require './constants'
 
 module.exports = (options) ->
 
@@ -23,42 +24,7 @@ module.exports = (options) ->
 
     new HappyPack {
       id: 'coffee'
-      loaders: [
-        'pistachio-loader'
-        'coffee-loader'
-        'cjsx-loader'
-      ]
-    }
-
-    new HappyPack {
-      id: 'styl-modules',
-      loaders: [
-        'style-loader'
-        'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]'
-        'stylus-loader'
-      ]
-    }
-    new HappyPack {
-      id: 'styl-global',
-      loaders: [
-        'style-loader'
-        'css-loader'
-        'stylus-loader'
-      ]
-    }
-    new HappyPack {
-      id: 'css-global',
-      loaders: [
-        'style-loader'
-        'css-loader'
-      ]
-    }
-    new HappyPack {
-      id: 'css-modules',
-      loaders: [
-        'style-loader'
-        'css-loader?modules'
-      ]
+      loaders: [ 'pistachio-loader', 'coffee-loader', 'cjsx-loader' ]
     }
 
     new webpack.LoaderOptionsPlugin {
@@ -75,5 +41,9 @@ module.exports = (options) ->
     new webpack.optimize.CommonsChunkPlugin
       name: 'vendor'
       minChunks: (mod) -> isExternal mod
+
+    new ExtractTextPlugin
+      filename: CSS_BUNDLE_FILE
+      allChunks: yes
 
   ]

--- a/client/webpack/config.plugins.development.coffee
+++ b/client/webpack/config.plugins.development.coffee
@@ -1,10 +1,20 @@
 WebpackNotifierPlugin = require 'webpack-notifier'
+{ BundleAnalyzerPlugin } = require 'webpack-bundle-analyzer'
 
 module.exports = ->
 
   return [
-    new WebpackNotifierPlugin {
+
+    new WebpackNotifierPlugin
       title: 'Koding Frontend'
       alwaysNotify: yes
-    }
+
+    new BundleAnalyzerPlugin
+      analyzerMode: 'static'
+      reportFilename: 'report.html'
+      # change this to true if you want the see the analyze to open
+      # automatically on each bundle change. Otherwise you can click to the link
+      # on terminal after rebundle.
+      openAnalyzer: no
+
   ]

--- a/client/webpack/constants.coffee
+++ b/client/webpack/constants.coffee
@@ -19,8 +19,8 @@ ENV_TEST = 'test'
 
 MANIFEST_FILE = 'bant.json'
 APP_MAIN_FOLDER = 'lib'
-CSS_BUNDLE_FILE = 'bundle.css'
 JS_BUNDLE_FILE = 'bundle.[name].js'
+CSS_BUNDLE_FILE = 'bundle.[name].css'
 
 module.exports = {
   VERSION

--- a/client/webpack/constants.coffee
+++ b/client/webpack/constants.coffee
@@ -19,8 +19,8 @@ ENV_TEST = 'test'
 
 MANIFEST_FILE = 'bant.json'
 APP_MAIN_FOLDER = 'lib'
-JS_BUNDLE_FILE = 'bundle.js'
 CSS_BUNDLE_FILE = 'bundle.css'
+JS_BUNDLE_FILE = 'bundle.[name].js'
 
 module.exports = {
   VERSION

--- a/client/webpack/util/isExternal.coffee
+++ b/client/webpack/util/isExternal.coffee
@@ -1,0 +1,7 @@
+module.exports = isExternal = (mod) ->
+
+  { userRequest } = mod
+
+  return no  if 'string' isnt typeof userRequest
+
+  return userRequest.indexOf('node_modules') >= 0

--- a/workers/social/lib/social/render/scriptblock.coffee
+++ b/workers/social/lib/social/render/scriptblock.coffee
@@ -72,7 +72,8 @@ module.exports = (options = {}, callback) ->
       };
     </script>
 
-    <script src="/a/p/p/#{KONFIG.version}/bundle.js"></script>
+    <script src="/a/p/p/#{KONFIG.version}/bundle.vendor.js"></script>
+    <script src="/a/p/p/#{KONFIG.version}/bundle.main.js"></script>
 
     #{if argv.t then "<script src=\"/a/js/tests.js\"></script>" else ''}
 

--- a/workers/social/lib/social/render/styleblock.coffee
+++ b/workers/social/lib/social/render/styleblock.coffee
@@ -15,4 +15,6 @@ module.exports = (options = {}) ->
   <link rel="fluid-icon" href="/a/images/logos/fluid512.png" title="Koding" />
   <link href="https://plus.google.com/+KodingInc" rel="publisher" />
   <link href='https://chrome.google.com/webstore/detail/koding/fgbjpbdfegnodokpoejnbhnblcojccal' rel='chrome-webstore-item'>
+  <link rel="stylesheet" type="text/css" href="/a/p/p/#{KONFIG.version}/bundle.vendor.css" />
+  <link rel="stylesheet" type="text/css" href="/a/p/p/#{KONFIG.version}/bundle.main.css" />
   """


### PR DESCRIPTION
This is the initial effort to create separate bundles for load optimizations. It introduces 2 main changes:

- Uses a util called `isExternal` to determine if a required module is an external module (meaning under `client/node_modules` folder).
- uses [`CommonsChunkPlugin`](https://webpack.js.org/plugins/commons-chunk-plugin/) to create 2 main bundles (`bundle.main.js` and `bundle.vendor.js`) by utilizing `isExternal` util.
- uses [`ExtractTextPlugin`] to create a separate bundle for style files.
  - Since we now have 2 different bundles (see above) we make sure that we have 2 different style bundles (`bundle.main.css` and `bundle.vendor.css`) as well, using `allChunks: true` option of `ExtractTextPlugin`

----

### Before

![image](https://cloud.githubusercontent.com/assets/1783869/22394077/3893ab7e-e51e-11e6-817a-e62cfcbfea34.png)

### After

![image](https://cloud.githubusercontent.com/assets/1783869/22394079/3d87de20-e51e-11e6-8ad8-5b9c6e70e17b.png)

----

`bundle.main.js` and `bundle.main.css` will be our main application code separate from the third party vendor code we are using, we can ship them without changing anything.

As long as we make sure that our `node_modules` are not being updated, both `bundle.vendor.js` and `bundle.vendor.css` can be cached regardless of the version of `koding` we are shipping, some brainstorm would be really good in this subject. /cc @cihangir @szkl 

There are 2 main way of doing this in my mind:
- Since we already cache our `node_modules`, we can cache vendor bundles as long as cache is still valid.
- We can make a checksum comparison of vendor bundles (both css, and js) as `after build step`, and then we can invalidate the vendor cache if comparison fails.

What do you guys think?