### PR TITLE
Small fix to not ignore errors from tunnelproxy addClientService

### DIFF
--- a/go/src/koding/kites/tunnelproxy/server.go
+++ b/go/src/koding/kites/tunnelproxy/server.go
@@ -338,7 +338,7 @@ func (s *Server) addClient(ident, name, vhost string, services map[string]*Tunne
 
 		e := s.tunnels.addClientService(ident, tun)
 		if e != nil {
-			e = multierror.Append(e, err)
+			err = multierror.Append(err, e)
 		}
 	}
 

--- a/go/src/koding/kites/tunnelproxy/server.go
+++ b/go/src/koding/kites/tunnelproxy/server.go
@@ -330,7 +330,7 @@ func (s *Server) addClient(ident, name, vhost string, services map[string]*Tunne
 	s.tunnels.addClient(ident, name, vhost)
 	s.idents[vhost] = ident
 
-	err := new(multierror.Error)
+	var err error
 	for _, tun := range toList(services, vhost) {
 		if tun.Name != "kite" && tun.Name != "kites" {
 			s.opts.Log.Warning("unsupported %q service added during initial registration", tun.Name)
@@ -342,7 +342,7 @@ func (s *Server) addClient(ident, name, vhost string, services map[string]*Tunne
 		}
 	}
 
-	if err := err.ErrorOrNil(); err != nil {
+	if err != nil {
 		s.opts.Log.Error("error registering services for %q: %s", ident, err)
 	}
 


### PR DESCRIPTION
## Description
Fixing code because a multierror object was instanced but was never used and errors was being ignored in the loop.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
