### PR TITLE
kloud: escape variables in comments / stub payload_ variables

### DIFF
--- a/go/src/koding/kites/kloud/stack/provider/builder.go
+++ b/go/src/koding/kites/kloud/stack/provider/builder.go
@@ -603,7 +603,7 @@ func (b *Builder) InterpolateField(resource map[string]interface{}, resourceName
 			res["depends_on"] = []interface{}{}
 		}
 
-		triggers[field] = s
+		triggers[field] = EscapeDeadVariables(s)
 	}
 }
 

--- a/go/src/koding/kites/kloud/stack/provider/plan.go
+++ b/go/src/koding/kites/kloud/stack/provider/plan.go
@@ -9,6 +9,11 @@ import (
 	"golang.org/x/net/context"
 )
 
+var escapeVars = []string{
+	"userInput_",
+	"payload_",
+}
+
 func (bs *BaseStack) HandlePlan(ctx context.Context) (interface{}, error) {
 	arg, ok := ctx.Value(stack.PlanRequestKey).(*stack.PlanRequest)
 	if !ok {
@@ -68,8 +73,10 @@ func (bs *BaseStack) HandlePlan(ctx context.Context) (interface{}, error) {
 	// Plan request is made right away the template is saved, it may
 	// not have all the credentials provided yet. We set them all to
 	// to dummy values to make the template pass terraform parsing.
-	if err := bs.Builder.Template.FillVariables("userInput_"); err != nil {
-		return nil, err
+	for _, name := range escapeVars {
+		if err := bs.Builder.Template.FillVariables(name); err != nil {
+			return nil, err
+		}
 	}
 
 	if len(arg.Variables) != 0 {

--- a/go/src/koding/kites/kloud/stack/provider/variable.go
+++ b/go/src/koding/kites/kloud/stack/provider/variable.go
@@ -92,6 +92,7 @@ var escape = func(v *Variable) string {
 func EscapeDeadVariables(userdata string) string {
 	var buf bytes.Buffer
 
+	eofNL := strings.HasSuffix(userdata, "\n")
 	scanner := bufio.NewScanner(strings.NewReader(userdata))
 
 	for scanner.Scan() {
@@ -107,5 +108,13 @@ func EscapeDeadVariables(userdata string) string {
 		fmt.Fprintln(&buf, ReplaceVariablesFunc(s, ReadVariables(s), escape))
 	}
 
-	return buf.String()
+	// Scanning from strings.Reader is not going to fail, even if, there's
+	// no recovery from the failure.
+	_ = scanner.Err()
+
+	if eofNL {
+		return buf.String()
+	}
+
+	return strings.TrimRight(buf.String(), "\r\n")
 }

--- a/go/src/koding/kites/kloud/stack/provider/variable.go
+++ b/go/src/koding/kites/kloud/stack/provider/variable.go
@@ -1,7 +1,9 @@
 package provider
 
 import (
+	"bufio"
 	"bytes"
+	"fmt"
 	"strings"
 )
 
@@ -11,6 +13,13 @@ type Variable struct {
 	Name string
 	From int
 	To   int
+}
+
+var _ fmt.Stringer = (*Variable)(nil)
+
+// String implements the fmt.Stringer interface.
+func (v *Variable) String() string {
+	return "${var." + v.Name + "}"
 }
 
 // ReadVariables gives a list of variables read from s.
@@ -53,17 +62,50 @@ func ReadVariables(s string) []Variable {
 
 // ReplaceVariables replaces all variables with the given blank.
 func ReplaceVariables(s string, vars []Variable, blank string) string {
+	return ReplaceVariablesFunc(s, vars, func(*Variable) string { return blank })
+}
+
+// ReplaceVariablesFunc replaces all variables with the result of fn function.
+func ReplaceVariablesFunc(s string, vars []Variable, fn func(*Variable) string) string {
 	var buf bytes.Buffer
 	var last int
 
 	for _, v := range vars {
 		buf.WriteString(s[last:v.From])
-		buf.WriteString(blank)
+		buf.WriteString(fn(&v))
 
 		last = v.To
 	}
 
 	buf.WriteString(s[last:])
+
+	return buf.String()
+}
+
+var escape = func(v *Variable) string {
+	return "$" + v.String()
+}
+
+// EscapeDeadVariables escapes variables which are commented out.
+//
+// The comment format is hardcoded to work for Bash-like shells.
+func EscapeDeadVariables(userdata string) string {
+	var buf bytes.Buffer
+
+	scanner := bufio.NewScanner(strings.NewReader(userdata))
+
+	for scanner.Scan() {
+		s := scanner.Text()
+
+		isComment := strings.HasPrefix(strings.TrimSpace(s), "#")
+
+		if !isComment {
+			fmt.Fprintln(&buf, s)
+			continue
+		}
+
+		fmt.Fprintln(&buf, ReplaceVariablesFunc(s, ReadVariables(s), escape))
+	}
 
 	return buf.String()
 }

--- a/go/src/koding/kites/kloud/stack/provider/variable_test.go
+++ b/go/src/koding/kites/kloud/stack/provider/variable_test.go
@@ -106,6 +106,10 @@ func TestEscapeDeadVariables(t *testing.T) {
 			"# ${var.one}\n#${var.two}\n   #    ${var.three}\n",
 			"# $${var.one}\n#$${var.two}\n   #    $${var.three}\n",
 		},
+		"multiple in multiple lines without eofNL": {
+			"# ${var.one}\n#${var.two}\n   #    ${var.three}",
+			"# $${var.one}\n#$${var.two}\n   #    $${var.three}",
+		},
 	}
 
 	for name, cas := range cases {

--- a/go/src/koding/kites/kloud/stack/provider/variable_test.go
+++ b/go/src/koding/kites/kloud/stack/provider/variable_test.go
@@ -88,3 +88,33 @@ func TestVariables(t *testing.T) {
 		})
 	}
 }
+
+func TestEscapeDeadVariables(t *testing.T) {
+	cases := map[string]struct {
+		userdata string
+		want     string
+	}{
+		"simple": {
+			"# ${var.something}\n",
+			"# $${var.something}\n",
+		},
+		"multiple in single line": {
+			"# ${var.one}${var.two}   ${var.three}\n",
+			"# $${var.one}$${var.two}   $${var.three}\n",
+		},
+		"multiple in multiple lines": {
+			"# ${var.one}\n#${var.two}\n   #    ${var.three}\n",
+			"# $${var.one}\n#$${var.two}\n   #    $${var.three}\n",
+		},
+	}
+
+	for name, cas := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := provider.EscapeDeadVariables(cas.userdata)
+
+			if got != cas.want {
+				t.Fatalf("got %q, want %q", got, cas.want)
+			}
+		})
+	}
+}

--- a/go/src/koding/klient/remote/kitepinger/pingtracker_test.go
+++ b/go/src/koding/klient/remote/kitepinger/pingtracker_test.go
@@ -346,10 +346,10 @@ func TestPing(t *testing.T) {
 	}
 
 	msSince := time.Since(summaryFromChan.NewStatusTime).Nanoseconds() / 1000000
-	if msSince > 5 {
+	if msSince > 10 {
 		t.Errorf(
 			"Expected the new status time to me from a X ms ago. Wanted %dms, Got %dms",
-			5, msSince,
+			10, msSince,
 		)
 	}
 

--- a/go/src/koding/klient/remote/machine/machine_test.go
+++ b/go/src/koding/klient/remote/machine/machine_test.go
@@ -165,6 +165,9 @@ func TestMachineDialOnce(tt *testing.T) {
 }
 
 func TestWaitUntilOnline(tt *testing.T) {
+	const grace = 20 * time.Millisecond
+	const timeout = 50 * time.Millisecond
+
 	Convey("Give a Machine", tt, func() {
 		m := &Machine{}
 
@@ -178,9 +181,9 @@ func TestWaitUntilOnline(tt *testing.T) {
 				start := time.Now()
 				select {
 				case <-m.WaitUntilOnline():
-				case <-time.After(50 * time.Millisecond):
+				case <-time.After(timeout):
 				}
-				So(time.Now(), ShouldHappenWithin, 10*time.Millisecond, start)
+				So(time.Now(), ShouldHappenWithin, grace, start)
 			})
 		})
 
@@ -194,9 +197,9 @@ func TestWaitUntilOnline(tt *testing.T) {
 				start := time.Now()
 				select {
 				case <-m.WaitUntilOnline():
-				case <-time.After(50 * time.Millisecond):
+				case <-time.After(timeout):
 				}
-				So(time.Now(), ShouldNotHappenWithin, 10*time.Millisecond, start)
+				So(time.Now(), ShouldNotHappenWithin, grace, start)
 			})
 		})
 
@@ -216,7 +219,7 @@ func TestWaitUntilOnline(tt *testing.T) {
 				start := time.Now()
 				select {
 				case <-m.WaitUntilOnline():
-				case <-time.After(50 * time.Millisecond):
+				case <-time.After(timeout):
 				}
 				// It should block for 25ms, with an additional 10ms for runtime to be safe.
 				So(time.Now(), ShouldNotHappenWithin, 35*time.Millisecond, start)

--- a/scripts/test-kd.sh
+++ b/scripts/test-kd.sh
@@ -2,11 +2,7 @@
 
 set -euo pipefail
 
-
-go test -v koding/klient/remote... \
-  koding/klientctl... \
-  koding/mountcli...
-#  koding/fuseklient/transport...
+go test -v koding/klientctl/... koding/mountcli/...
 
 # Manually testing individual functions because Fuse is having issues
 # on wercker currently.


### PR DESCRIPTION
This PR:

- escapes variables from commented-out lines in user\_data
- stubs ${var.payload_*} during plan request, so no need to send blanks explicitely