### PR TITLE
Improve JSON-encoded index size.

### DIFF
--- a/go/src/koding/klient/machine/index/cache.go
+++ b/go/src/koding/klient/machine/index/cache.go
@@ -9,12 +9,18 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 const tempIndexDirPrefix = "koding_index_"
 
 // Cached allows to cache and reuse previously created index.
 type Cached struct {
+	// Rescan is a time duration after which the cached file will be rescanned.
+	// Eg. If cached file is modified at time point A, cache will not try
+	// to update changes when called between A+`Rescan`.
+	Rescan time.Duration
+
 	// Function used to retrieve temporary directory. If nil, os.TempDir will be
 	// used.
 	TempDir func() string
@@ -27,13 +33,13 @@ func (c *Cached) GetCachedIndex(root string) (*Index, error) {
 	var cs ChangeSlice
 
 	// Load or create index.
-	idx, path, err := c.getCachedIndex(root)
+	idx, path, createdAt, err := c.getCachedIndex(root)
 	if err != nil {
 		// Generate new index.
 		if idx, err = NewIndexFiles(root); err != nil {
 			return nil, err
 		}
-	} else {
+	} else if createdAt.IsZero() || time.Since(createdAt) > c.Rescan {
 		// Update loaded index.
 		cs = idx.Compare(root)
 		idx.Apply(root, cs)
@@ -68,7 +74,7 @@ func (c *Cached) HeadCachedIndex(root string) (count int, diskSize int64, err er
 
 // getCachedIndex looks up for index stored in one of temporary directories.
 // If provided index is found, it will be loaded to memory and returned.
-func (c *Cached) getCachedIndex(root string) (idx *Index, path string, err error) {
+func (c *Cached) getCachedIndex(root string) (idx *Index, path string, createdAt time.Time, err error) {
 	name := hashSHA1(root)
 	// Find index in temporary directories.
 	for _, tempdir := range c.indexTempDirs(-1) {
@@ -79,22 +85,27 @@ func (c *Cached) getCachedIndex(root string) (idx *Index, path string, err error
 	}
 
 	if path == "" || err != nil {
-		return nil, "", errors.New("index file not found")
+		return nil, "", time.Time{}, errors.New("index file not found")
 	}
 
 	// Read index content.
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, "", err
+		return nil, "", time.Time{}, err
 	}
 	defer f.Close()
 
 	idx = NewIndex()
 	if err = json.NewDecoder(f).Decode(idx); err != nil {
-		return nil, "", err
+		return nil, "", time.Time{}, err
 	}
 
-	return idx, path, nil
+	// Get file mtime.
+	if info, err := os.Stat(path); err == nil {
+		createdAt = info.ModTime()
+	}
+
+	return idx, path, createdAt, nil
 }
 
 // createTempPath creates a valid path to index file.

--- a/go/src/koding/klient/machine/index/handler.go
+++ b/go/src/koding/klient/machine/index/handler.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // Request defines cached index operations that are requested from
 // client to remote machine.
 type Request struct {
-	Path string `json:"remotePath"` // Path to the folder we want to mount.
+	Rescan time.Duration `json:"rescan"`     // Rescan directory if index is older than Rescan.
+	Path   string        `json:"remotePath"` // Path to the folder we want to mount.
 }
 
 // HeadResponse contains the basic info about requested index.
@@ -79,7 +81,7 @@ func preparePath(path string) (string, error) {
 
 	info, err := os.Stat(absPath)
 	if os.IsNotExist(err) {
-		return "", errors.New("remote path does not exist")
+		return "", fmt.Errorf("remote path %s does not exist", absPath)
 	} else if err != nil {
 		return "", fmt.Errorf("cannot stat remote path: %s", err)
 	}


### PR DESCRIPTION
This PR introduces a few non-breaking changes that are meant to reduce index size after serializing to JSON format.

- JSON tags were shortened to 1 character.
- File name is stored only as a map key - no longer as map value member.
- When JSON marshaling, index is gzipped and base64 encoded, then sent as a string.
- Index cache will not rescan file tree if `Rescan` time will be greater than cached file age.

These changes results in:

- JSON encoded index size for Koding repo, decreased from 81MB to 6.1MB (**1328%**).
- Marshaling time increased from 1.31s to 1.63 (**24%**)
- Retrieving index from cache decreased from: 4.55s to 1.42s

Also, I was trying to use gob encoding but it resulted with greater JSON object size (8MB).

## Motivation and Context
Reduce the amount of data that needs to be sent between local and remote machine during mount initialization.

## How Has This Been Tested?
Existing Unit tests + added the case for Rescan.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
