### PR TITLE
machine/index: make index a tree for fast traverse ops

### DIFF
--- a/go/src/koding/klient/machine/index/benchmark_test.go
+++ b/go/src/koding/klient/machine/index/benchmark_test.go
@@ -1,0 +1,45 @@
+package index
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"flag"
+	"io"
+	"testing"
+	"time"
+)
+
+var repo = flag.String("repo", "", "")
+
+func TestRepo(t *testing.T) {
+	if *repo == "" {
+		t.Skip("missing -repo path, skipping...")
+	}
+
+	start := time.Now()
+	idx, err := NewIndexFiles(*repo)
+	if err != nil {
+		t.Fatalf("NewIndexFiles()=%s", err)
+	}
+	end := time.Now()
+
+	var buf, cbuf bytes.Buffer
+
+	if err := json.NewEncoder(&buf).Encode(idx); err != nil {
+		t.Fatalf("Encode()=%s", err)
+	}
+
+	gw := gzip.NewWriter(&cbuf)
+
+	if _, err := io.Copy(gw, bytes.NewReader(buf.Bytes())); err != nil {
+		t.Fatalf("Copy()=%s", err)
+	}
+
+	gw.Close()
+
+	t.Logf("Index build time: %s", end.Sub(start))
+	t.Logf("Index file count: %d", idx.Count(-1))
+	t.Logf("Index size: %.4f MiB", float64(buf.Len())/1024/1024)
+	t.Logf("Compressed index size: %.4f MiB", float64(cbuf.Len())/1024/1024)
+}

--- a/go/src/koding/klient/machine/index/benchmark_test.go
+++ b/go/src/koding/klient/machine/index/benchmark_test.go
@@ -2,10 +2,8 @@ package index
 
 import (
 	"bytes"
-	"compress/gzip"
 	"encoding/json"
 	"flag"
-	"io"
 	"testing"
 	"time"
 )
@@ -24,22 +22,13 @@ func TestRepo(t *testing.T) {
 	}
 	end := time.Now()
 
-	var buf, cbuf bytes.Buffer
+	var buf bytes.Buffer
 
 	if err := json.NewEncoder(&buf).Encode(idx); err != nil {
 		t.Fatalf("Encode()=%s", err)
 	}
 
-	gw := gzip.NewWriter(&cbuf)
-
-	if _, err := io.Copy(gw, bytes.NewReader(buf.Bytes())); err != nil {
-		t.Fatalf("Copy()=%s", err)
-	}
-
-	gw.Close()
-
 	t.Logf("Index build time: %s", end.Sub(start))
 	t.Logf("Index file count: %d", idx.Count(-1))
 	t.Logf("Index size: %.4f MiB", float64(buf.Len())/1024/1024)
-	t.Logf("Compressed index size: %.4f MiB", float64(cbuf.Len())/1024/1024)
 }

--- a/go/src/koding/klient/machine/index/node.go
+++ b/go/src/koding/klient/machine/index/node.go
@@ -1,0 +1,163 @@
+package index
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+type Node struct {
+	Sub   map[string]*Node `json:"d,omitempty"`
+	Entry *Entry           `json:"e,omitempty"`
+}
+
+func newNode() *Node {
+	return &Node{
+		Sub:   make(map[string]*Node),
+		Entry: &Entry{},
+	}
+}
+
+func (nd *Node) Add(name string, entry *Entry) {
+	for {
+		node := name
+
+		if i := strings.IndexRune(name, '/'); i != -1 {
+			node, name = name[:i], name[i+1:]
+		} else {
+			name = ""
+		}
+
+		sub, ok := nd.Sub[node]
+		if !ok {
+			sub = newNode()
+			nd.Sub[node] = sub
+		}
+
+		if name == "" {
+			sub.Entry = entry
+			return
+		}
+
+		nd = sub
+	}
+}
+
+func (nd *Node) Del(name string) {
+	for {
+		node := name
+
+		if i := strings.IndexRune(name, '/'); i != -1 {
+			node, name = name[:i], name[i+1:]
+		} else {
+			name = ""
+		}
+
+		if name == "" {
+			delete(nd.Sub, node)
+			return
+		}
+
+		sub, ok := nd.Sub[node]
+		if !ok {
+			return
+		}
+
+		nd = sub
+	}
+}
+
+func (nd *Node) Count(maxsize int64) (count int) {
+	if maxsize == 0 {
+		return 0 // no-op
+	}
+
+	cur, stack := (*Node)(nil), []*Node{nd}
+
+	for len(stack) != 0 {
+		cur, stack = stack[0], stack[1:]
+
+		if cur.Entry != nil && (maxsize < 0 || cur.Entry.Size <= maxsize) && cur != nd {
+			count++
+		}
+
+		for _, nd := range cur.Sub {
+			stack = append(stack, nd)
+		}
+	}
+
+	return count
+}
+
+func (nd *Node) DiskSize(maxsize int64) (size int64) {
+	if maxsize == 0 {
+		return 0 // no-op
+	}
+
+	stack := []*Node{nd}
+
+	for len(stack) != 0 {
+		nd, stack = stack[0], stack[1:]
+
+		if nd.Entry != nil && (maxsize < 0 || nd.Entry.Size <= maxsize) {
+			size += nd.Entry.Size
+		}
+
+		for _, nd := range nd.Sub {
+			stack = append(stack, nd)
+		}
+	}
+
+	return size
+}
+
+func (nd *Node) ForEach(fn func(string, *Entry)) {
+	type node struct {
+		path string
+		node *Node
+	}
+
+	n, stack := node{}, make([]node, 0, len(nd.Sub))
+
+	for path, nd := range nd.Sub {
+		stack = append(stack, node{
+			path: path,
+			node: nd,
+		})
+	}
+
+	for len(stack) != 0 {
+		n, stack = stack[0], stack[1:]
+
+		for path, nd := range n.node.Sub {
+			stack = append(stack, node{
+				path: filepath.Join(n.path, path),
+				node: nd,
+			})
+		}
+
+		fn(n.path, n.node.Entry)
+	}
+}
+
+func (nd *Node) Lookup(name string) (*Node, bool) {
+	for {
+		node := name
+
+		if i := strings.IndexRune(name, '/'); i != -1 {
+			node, name = name[:i], name[i+1:]
+		} else {
+			name = ""
+		}
+
+		sub, ok := nd.Sub[node]
+		if !ok {
+			return nil, false
+		}
+
+		if name == "" {
+			return sub, true
+		}
+
+		nd = sub
+	}
+}

--- a/go/src/koding/klient/machine/index/node_test.go
+++ b/go/src/koding/klient/machine/index/node_test.go
@@ -1,0 +1,379 @@
+package index_test
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"koding/klient/machine/index"
+)
+
+func fixture() *index.Node {
+	return &index.Node{
+		Entry: &index.Entry{
+			Size: 0,
+		},
+		Sub: map[string]*index.Node{
+			"addresses": {
+				Entry: &index.Entry{
+					Size: 0,
+				},
+				Sub: map[string]*index.Node{
+					"addresser.go": {
+						Entry: &index.Entry{
+							Size: 714,
+						},
+					},
+					"addresses.go": {
+						Entry: &index.Entry{
+							Size: 2428,
+						},
+					},
+					"addresses_test.go": {
+						Entry: &index.Entry{
+							Size: 3095,
+						},
+					},
+					"cached.go": {
+						Entry: &index.Entry{
+							Size: 2036,
+						},
+					},
+				},
+			},
+			"aliases": {
+				Entry: &index.Entry{
+					Size: 0,
+				},
+				Sub: map[string]*index.Node{
+					"aliaser.go": {
+						Entry: &index.Entry{
+							Size: 596,
+						},
+					},
+					"aliases.go": {
+						Entry: &index.Entry{
+							Size: 3218,
+						},
+					},
+					"aliases_test.go": {
+						Entry: &index.Entry{
+							Size: 1831,
+						},
+					},
+					"cached.go": {
+						Entry: &index.Entry{
+							Size: 2196,
+						},
+					},
+				},
+			},
+			"clients": {
+				Entry: &index.Entry{
+					Size: 0,
+				},
+				Sub: map[string]*index.Node{
+					"clients.go": {
+						Entry: &index.Entry{
+							Size: 4003,
+						},
+					},
+					"clients_test.go": {
+						Entry: &index.Entry{
+							Size: 1783,
+						},
+					},
+				},
+			},
+			"create.go": {
+				Entry: &index.Entry{
+					Size: 3660,
+				},
+			},
+			"create_test.go": {
+				Entry: &index.Entry{
+					Size: 4582,
+				},
+			},
+			"id.go": {
+				Entry: &index.Entry{
+					Size: 1272,
+				},
+			},
+			"id_test.go": {
+				Entry: &index.Entry{
+					Size: 1979,
+				},
+			},
+			"idset": {
+				Entry: &index.Entry{
+					Size: 0,
+				},
+				Sub: map[string]*index.Node{
+					"idset.go": {
+						Entry: &index.Entry{
+							Size: 1288,
+						},
+					},
+					"idset_test.go": {
+						Entry: &index.Entry{
+							Size: 4231,
+						},
+					},
+				},
+			},
+			"kite.go": {
+				Entry: &index.Entry{
+					Size: 4152,
+				},
+			},
+			"machinegroup.go": {
+				Entry: &index.Entry{
+					Size: 6839,
+				},
+			},
+			"machinegroup_test.go": {
+				Entry: &index.Entry{
+					Size: 6592,
+				},
+			},
+			"mount.go": {
+				Entry: &index.Entry{
+					Size: 9346,
+				},
+			},
+			"mount_test.go": {
+				Entry: &index.Entry{
+					Size: 8824,
+				},
+			},
+			"mounts": {
+				Entry: &index.Entry{
+					Size: 0,
+				},
+				Sub: map[string]*index.Node{
+					"cached.go": {
+						Entry: &index.Entry{
+							Size: 2465,
+						},
+					},
+					"mounter.go": {
+						Entry: &index.Entry{
+							Size: 1000,
+						},
+					},
+					"mounts.go": {
+						Entry: &index.Entry{
+							Size: 4133,
+						},
+					},
+					"mounts_test.go": {
+						Entry: &index.Entry{
+							Size: 5330,
+						},
+					},
+				},
+			},
+			"ssh.go": {
+				Entry: &index.Entry{
+					Size: 2831,
+				},
+			},
+			"ssh_test.go": {
+				Entry: &index.Entry{
+					Size: 3567,
+				},
+			},
+		},
+	}
+}
+
+func TestNodeLookup(t *testing.T) {
+	cases := map[string]int64{
+		"addresses":              0,
+		"addresses/addresses.go": 2428,
+		"machinegroup.go":        6839,
+		"idset/idset_test.go":    4231,
+	}
+
+	root := fixture()
+
+	for name, size := range cases {
+		t.Run(name, func(t *testing.T) {
+			nd, ok := root.Lookup(name)
+			if !ok {
+				t.Fatalf("Lookup(%q) failed", name)
+			}
+
+			if nd.Entry.Size != size {
+				t.Fatalf("got %d, want %d", size, nd.Entry.Size)
+			}
+		})
+	}
+}
+
+func TestNodeCount(t *testing.T) {
+	cases := map[int64]int{
+		-1:   32,
+		0:    0,
+		4000: 22,
+		6000: 28,
+	}
+
+	root := fixture()
+
+	for maxsize, count := range cases {
+		t.Run(fmt.Sprintf("maxsize %d", maxsize), func(t *testing.T) {
+			got := root.Count(maxsize)
+
+			if got != count {
+				t.Fatalf("got %d, want %d", got, count)
+			}
+		})
+	}
+}
+
+func TestNodeDiskSize(t *testing.T) {
+	cases := map[int64]int64{
+		-1:   93991,
+		0:    0,
+		4000: 35959,
+		6000: 62390,
+	}
+
+	root := fixture()
+
+	for maxsize, size := range cases {
+		t.Run(fmt.Sprintf("maxsize %d", maxsize), func(t *testing.T) {
+			got := root.DiskSize(maxsize)
+
+			if got != size {
+				t.Fatalf("got %d, want %d", got, size)
+			}
+		})
+	}
+}
+
+func TestNodeAdd(t *testing.T) {
+	cases := []struct {
+		name  string
+		count int
+	}{
+		{"addresses/cached_test.go", 33},
+		{"notify.go", 34},
+		{"notify/notify.go", 36},
+		{"proxy/fuse/fuse.go", 39},
+		{"notify", 39},
+		{"notify/", 39},
+	}
+
+	root := fixture()
+	entry := &index.Entry{
+		Size: 0xD,
+	}
+
+	for _, cas := range cases {
+		t.Run(cas.name, func(t *testing.T) {
+			root.Add(cas.name, entry)
+
+			nd, ok := root.Lookup(cas.name)
+			if !ok {
+				t.Fatalf("Lookup(%q) failed", cas.name)
+			}
+
+			count := root.Count(-1)
+
+			if count != cas.count {
+				t.Fatalf("got %d, want %d", count, cas.count)
+			}
+
+			if nd.Entry.Size != entry.Size {
+				t.Fatalf("got %d, want %d", nd.Entry.Size, entry.Size)
+			}
+		})
+	}
+}
+
+func TestNodeDel(t *testing.T) {
+	cases := []struct {
+		name  string
+		count int
+	}{
+		{"addresses/addresser.go", 31},
+		{"addresses/", 27},
+		{"aliases", 22},
+		{"id.go", 21},
+		{"id.go", 21},          // no-op
+		{"nonexisting.go", 21}, // no-op
+	}
+
+	root := fixture()
+
+	for _, cas := range cases {
+		t.Run(cas.name, func(t *testing.T) {
+			root.Del(cas.name)
+
+			if _, ok := root.Lookup(cas.name); ok {
+				t.Fatalf("%q was not deleted", cas.name)
+			}
+
+			count := root.Count(-1)
+
+			if count != cas.count {
+				t.Fatalf("got %d, want %d", count, cas.count)
+			}
+		})
+	}
+}
+
+func TestNodeForEach(t *testing.T) {
+	root := fixture()
+
+	want := []string{
+		"addresses",
+		"addresses/addresser.go",
+		"addresses/addresses.go",
+		"addresses/addresses_test.go",
+		"addresses/cached.go",
+		"aliases",
+		"aliases/aliaser.go",
+		"aliases/aliases.go",
+		"aliases/aliases_test.go",
+		"aliases/cached.go",
+		"clients",
+		"clients/clients.go",
+		"clients/clients_test.go",
+		"create.go",
+		"create_test.go",
+		"id.go",
+		"id_test.go",
+		"idset",
+		"idset/idset.go",
+		"idset/idset_test.go",
+		"kite.go",
+		"machinegroup.go",
+		"machinegroup_test.go",
+		"mount.go",
+		"mount_test.go",
+		"mounts",
+		"mounts/cached.go",
+		"mounts/mounter.go",
+		"mounts/mounts.go",
+		"mounts/mounts_test.go",
+		"ssh.go",
+		"ssh_test.go",
+	}
+
+	var got []string
+
+	root.ForEach(func(name string, _ *index.Entry) {
+		got = append(got, name)
+	})
+
+	sort.Strings(got)
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Currently index is not suitable for get operations - in order to list all files under specific directory, one would need to get all index keys, and match them with path prefix of the specific directory. In case of big mounts, this operation is not feasible (e.g. koding repo can have around 330k files when built).

This PR reworks the underlying data structure to a tree.

Coverage: 98.5%

As a side-goal the index size dropped by 13.25% (due to the fact paths prefixes are stored only once).

Before:

```
$ go test -run TestRepo -repo /Users/rjeczalik/src/github.com/koding/koding -v
=== RUN   TestRepo
--- PASS: TestRepo (29.45s)
        benchmark_test.go:41: Index build time: 26.226116212s
        benchmark_test.go:42: Index file count: 409715
        benchmark_test.go:43: Index size: 10.1013 MiB
PASS
ok      koding/klient/machine/index     29.500s
```

After:

```
$ go test -run TestRepo -repo /Users/rjeczalik/src/github.com/koding/koding -v
=== RUN   TestRepo
--- PASS: TestRepo (28.87s)
        benchmark_test.go:31: Index build time: 26.516737166s
        benchmark_test.go:32: Index file count: 409715
        benchmark_test.go:33: Index size: 8.7630 MiB
PASS
ok      koding/klient/machine/index     28.925s
```


