### PR TITLE
Lock-free index Change coalescing logic.

### DIFF
--- a/go/src/koding/klient/machine/index/cache.go
+++ b/go/src/koding/klient/machine/index/cache.go
@@ -12,7 +12,9 @@ import (
 	"time"
 )
 
-const tempIndexDirPrefix = "koding_index_"
+// TempIndexDirPrefix defines the prefix of temporary index file created by
+// Cached structure.
+const TempIndexDirPrefix = "koding_index_"
 
 // Cached allows to cache and reuse previously created index.
 type Cached struct {
@@ -113,7 +115,7 @@ func (c *Cached) createTempPath(root string) (path string, err error) {
 	if dirs := c.indexTempDirs(1); len(dirs) > 0 {
 		path = dirs[0]
 	} else {
-		if path, err = ioutil.TempDir(c.tempDir(), tempIndexDirPrefix); err != nil {
+		if path, err = ioutil.TempDir(c.tempDir(), TempIndexDirPrefix); err != nil {
 			return "", err
 		}
 	}
@@ -140,7 +142,7 @@ func (c *Cached) indexTempDirs(n int) []string {
 		names, err := d.Readdirnames(100)
 
 		for i := range names {
-			if strings.HasPrefix(names[i], tempIndexDirPrefix) {
+			if strings.HasPrefix(names[i], TempIndexDirPrefix) {
 				dirs = append(dirs, filepath.Join(c.tempDir(), names[i]))
 			}
 		}

--- a/go/src/koding/klient/machine/index/cache_test.go
+++ b/go/src/koding/klient/machine/index/cache_test.go
@@ -1,4 +1,4 @@
-package index
+package index_test
 
 import (
 	"io/ioutil"
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"koding/klient/machine/index"
 )
 
 func TestCachedIndexCreate(t *testing.T) {
@@ -22,7 +24,7 @@ func TestCachedIndexCreate(t *testing.T) {
 	}
 	defer clean()
 
-	c := &Cached{TempDir: tempDir}
+	c := &index.Cached{TempDir: tempDir}
 	idx, err := c.GetCachedIndex(root)
 	if err != nil {
 		t.Fatalf("want err = nil; got %v", err)
@@ -66,7 +68,7 @@ func TestCahcedIndexUpdated(t *testing.T) {
 	}
 	defer clean()
 
-	c := &Cached{
+	c := &index.Cached{
 		Rescan:  30 * time.Second,
 		TempDir: tempDir,
 	}
@@ -137,11 +139,11 @@ func tmpDirInfo(tempDir string) (dirnames, idxs []string, err error) {
 		}
 
 		dir, file := filepath.Split(path)
-		if info.IsDir() && strings.HasPrefix(file, tempIndexDirPrefix) {
+		if info.IsDir() && strings.HasPrefix(file, index.TempIndexDirPrefix) {
 			dirnames = append(dirnames, path)
 		}
 
-		if strings.HasPrefix(filepath.Base(dir), tempIndexDirPrefix) {
+		if strings.HasPrefix(filepath.Base(dir), index.TempIndexDirPrefix) {
 			if filepath.Join(tempDir, filepath.Base(dir), file) != path {
 				return nil
 			}

--- a/go/src/koding/klient/machine/index/change.go
+++ b/go/src/koding/klient/machine/index/change.go
@@ -1,0 +1,27 @@
+package index
+
+// ChangeMeta indicates what change has been done on a given file.
+type ChangeMeta uint32
+
+const (
+	ChangeMetaUpdate ChangeMeta = 1 << iota // File was updated.
+	ChangeMetaRemove                        // File was removed.
+	ChangeMetaAdd                           // File was added.
+
+	ChangeMetaLarge ChangeMeta = 1 << (8 + iota) // File size is above 4GB.
+)
+
+// Change describes single file change.
+type Change struct {
+	Name      string     `json:"name"`      // The relative name of the file.
+	Size      uint32     `json:"size"`      // Size of the file truncated to 32 bits.
+	Meta      ChangeMeta `json:"meta"`      // The type of operation made on file entry.
+	CreatedAt int64      `json:"createdAt"` // Change creation time since EPOCH.
+}
+
+// ChangeSlice stores multiple changes.
+type ChangeSlice []Change
+
+func (cs ChangeSlice) Len() int           { return len(cs) }
+func (cs ChangeSlice) Swap(i, j int)      { cs[i], cs[j] = cs[j], cs[i] }
+func (cs ChangeSlice) Less(i, j int) bool { return cs[i].Name < cs[j].Name }

--- a/go/src/koding/klient/machine/index/change.go
+++ b/go/src/koding/klient/machine/index/change.go
@@ -14,7 +14,6 @@ const (
 // Change describes single file change.
 type Change struct {
 	Name      string     `json:"name"`      // The relative name of the file.
-	Size      uint32     `json:"size"`      // Size of the file truncated to 32 bits.
 	Meta      ChangeMeta `json:"meta"`      // The type of operation made on file entry.
 	CreatedAt int64      `json:"createdAt"` // Change creation time since EPOCH.
 }

--- a/go/src/koding/klient/machine/index/change.go
+++ b/go/src/koding/klient/machine/index/change.go
@@ -1,26 +1,80 @@
 package index
 
+import (
+	"sync/atomic"
+	"time"
+)
+
 // ChangeMeta indicates what change has been done on a given file.
-type ChangeMeta uint32
+type ChangeMeta uint64
 
 const (
 	ChangeMetaUpdate ChangeMeta = 1 << iota // File was updated.
 	ChangeMetaRemove                        // File was removed.
 	ChangeMetaAdd                           // File was added.
 
-	ChangeMetaLarge ChangeMeta = 1 << (8 + iota) // File size is above 4GB.
+	ChangeMetaLarge  ChangeMeta = 1 << (8 + iota) // File size is above 4GB.
+	ChangeMetaRemote                              // remote->local synchronization.
+	ChangeMetaLocal                               // local->remote synchronization.
 )
+
+// Coalesce coalesces two meta-data changes and saves the result to called
+// object. The rules of coalescing are:
+//
+//  U - update; D - remove(delete); A - add; L - local; R - remote.
+//
+//      | UL | DL | AL | UR | DR | AR |
+//      +----+----+----+----+----+----+----
+//      | UL | DL | AL | UL | AL | UL | UL
+//      +----+----+----+----+----+----+----
+//           | DL | UL | DL | DL | DL | DL
+//           +----+----+----+----+----+----
+//                | AL | UL | AL | UL | AL
+//                +----+----+----+----+----
+//                     | UR | DR | AR | UR
+//                     +----+----+----+----
+//                          | DR | UR | DR
+//                          +----+----+----
+//                               | AR | AR
+//                               +----+----
+//
+// All other flags are OR-ed. The coalesce matrix must be kept triangular.
+func (cm *ChangeMeta) Coalesce(newer ChangeMeta) {
+	atomic.StoreUint64((*uint64)(cm), uint64(newer))
+}
 
 // Change describes single file change.
 type Change struct {
-	Name      string     `json:"name"`      // The relative name of the file.
-	Meta      ChangeMeta `json:"meta"`      // The type of operation made on file entry.
-	CreatedAt int64      `json:"createdAt"` // Change creation time since EPOCH.
+	name string     // The relative name of the file.
+	made int64      // Change creation time since EPOCH.
+	meta ChangeMeta // The type of operation made on file entry.
+}
+
+// NewChange creates a new Change object.
+func NewChange(name string, meta ChangeMeta) *Change {
+	return &Change{
+		name: name,
+		meta: meta,
+		made: time.Now().UTC().UnixNano(),
+	}
+}
+
+// Name returns the relative slashed path to changed file.
+func (c *Change) Name() string { return c.name }
+
+// MadeUnixNano returns creation time since EPOCH in UTC time zone.
+func (c *Change) MadeUnixNano() int64 {
+	return atomic.LoadInt64(&c.made)
+}
+
+// Meta returns meta data information about Change type and direction.
+func (c *Change) Meta() ChangeMeta {
+	return ChangeMeta(atomic.LoadUint64((*uint64)(&c.meta)))
 }
 
 // ChangeSlice stores multiple changes.
-type ChangeSlice []Change
+type ChangeSlice []*Change
 
 func (cs ChangeSlice) Len() int           { return len(cs) }
 func (cs ChangeSlice) Swap(i, j int)      { cs[i], cs[j] = cs[j], cs[i] }
-func (cs ChangeSlice) Less(i, j int) bool { return cs[i].Name < cs[j].Name }
+func (cs ChangeSlice) Less(i, j int) bool { return cs[i].name < cs[j].name }

--- a/go/src/koding/klient/machine/index/change_test.go
+++ b/go/src/koding/klient/machine/index/change_test.go
@@ -1,0 +1,147 @@
+package index
+
+import (
+	"testing"
+)
+
+func TestChangeMetaCoalesce(t *testing.T) {
+	tests := map[string]struct {
+		A      ChangeMeta
+		B      ChangeMeta
+		Result ChangeMeta
+	}{
+		"UL+UL=UL": {
+			A:      ChangeMetaUpdate | ChangeMetaLocal,
+			B:      ChangeMetaUpdate | ChangeMetaLocal,
+			Result: ChangeMetaUpdate | ChangeMetaLocal,
+		},
+		"DL+UL=DL": {
+			A:      ChangeMetaRemove | ChangeMetaLocal,
+			B:      ChangeMetaUpdate | ChangeMetaLocal,
+			Result: ChangeMetaRemove | ChangeMetaLocal,
+		},
+		"DL+DL=DL": {
+			A:      ChangeMetaRemove | ChangeMetaLocal,
+			B:      ChangeMetaRemove | ChangeMetaLocal,
+			Result: ChangeMetaRemove | ChangeMetaLocal,
+		},
+		"AL+UL=AL": {
+			A:      ChangeMetaAdd | ChangeMetaLocal,
+			B:      ChangeMetaUpdate | ChangeMetaLocal,
+			Result: ChangeMetaAdd | ChangeMetaLocal,
+		},
+		"AL+DL=UL": {
+			A:      ChangeMetaAdd | ChangeMetaLocal,
+			B:      ChangeMetaRemove | ChangeMetaLocal,
+			Result: ChangeMetaUpdate | ChangeMetaLocal,
+		},
+		"AL+AL=AL": {
+			A:      ChangeMetaAdd | ChangeMetaLocal,
+			B:      ChangeMetaAdd | ChangeMetaLocal,
+			Result: ChangeMetaAdd | ChangeMetaLocal,
+		},
+		"UR+UL=UL": {
+			A:      ChangeMetaUpdate | ChangeMetaRemote,
+			B:      ChangeMetaUpdate | ChangeMetaLocal,
+			Result: ChangeMetaUpdate | ChangeMetaLocal,
+		},
+		"UR+DL=DL": {
+			A:      ChangeMetaUpdate | ChangeMetaRemote,
+			B:      ChangeMetaRemove | ChangeMetaLocal,
+			Result: ChangeMetaRemove | ChangeMetaLocal,
+		},
+		"UR+AL=UL": {
+			A:      ChangeMetaUpdate | ChangeMetaRemote,
+			B:      ChangeMetaAdd | ChangeMetaLocal,
+			Result: ChangeMetaUpdate | ChangeMetaLocal,
+		},
+		"UR+UR=UR": {
+			A:      ChangeMetaUpdate | ChangeMetaRemote,
+			B:      ChangeMetaUpdate | ChangeMetaRemote,
+			Result: ChangeMetaUpdate | ChangeMetaRemote,
+		},
+		"DR+UL=AL": {
+			A:      ChangeMetaRemove | ChangeMetaRemote,
+			B:      ChangeMetaUpdate | ChangeMetaLocal,
+			Result: ChangeMetaAdd | ChangeMetaLocal,
+		},
+		"DR+DL=DL": {
+			A:      ChangeMetaRemove | ChangeMetaRemote,
+			B:      ChangeMetaRemove | ChangeMetaLocal,
+			Result: ChangeMetaRemove | ChangeMetaLocal,
+		},
+		"DR+AL=AL": {
+			A:      ChangeMetaRemove | ChangeMetaRemote,
+			B:      ChangeMetaAdd | ChangeMetaLocal,
+			Result: ChangeMetaAdd | ChangeMetaLocal,
+		},
+		"DR+UR=DR": {
+			A:      ChangeMetaRemove | ChangeMetaRemote,
+			B:      ChangeMetaUpdate | ChangeMetaRemote,
+			Result: ChangeMetaRemove | ChangeMetaRemote,
+		},
+		"DR+DR=DR": {
+			A:      ChangeMetaRemove | ChangeMetaRemote,
+			B:      ChangeMetaRemove | ChangeMetaRemote,
+			Result: ChangeMetaRemove | ChangeMetaRemote,
+		},
+		"AR+UL=UL": {
+			A:      ChangeMetaAdd | ChangeMetaRemote,
+			B:      ChangeMetaUpdate | ChangeMetaLocal,
+			Result: ChangeMetaUpdate | ChangeMetaLocal,
+		},
+		"AR+DL=DL": {
+			A:      ChangeMetaAdd | ChangeMetaRemote,
+			B:      ChangeMetaRemove | ChangeMetaLocal,
+			Result: ChangeMetaRemove | ChangeMetaLocal,
+		},
+		"AR+AL=UL": {
+			A:      ChangeMetaAdd | ChangeMetaRemote,
+			B:      ChangeMetaAdd | ChangeMetaLocal,
+			Result: ChangeMetaUpdate | ChangeMetaLocal,
+		},
+		"AR+UR=AR": {
+			A:      ChangeMetaAdd | ChangeMetaRemote,
+			B:      ChangeMetaUpdate | ChangeMetaRemote,
+			Result: ChangeMetaAdd | ChangeMetaRemote,
+		},
+		"AR+DR=UR": {
+			A:      ChangeMetaAdd | ChangeMetaRemote,
+			B:      ChangeMetaRemove | ChangeMetaRemote,
+			Result: ChangeMetaUpdate | ChangeMetaRemote,
+		},
+		"AR+AR=AR": {
+			A:      ChangeMetaAdd | ChangeMetaRemote,
+			B:      ChangeMetaAdd | ChangeMetaRemote,
+			Result: ChangeMetaAdd | ChangeMetaRemote,
+		},
+		"INV+A=AL": {
+			A:      0,
+			B:      ChangeMetaAdd,
+			Result: ChangeMetaAdd | ChangeMetaLocal,
+		},
+		"AL+AL+OTHER META": {
+			A:      ChangeMetaAdd | ChangeMetaLocal | ChangeMetaLarge,
+			B:      ChangeMetaAdd | ChangeMetaLocal,
+			Result: ChangeMetaAdd | ChangeMetaLocal | ChangeMetaLarge,
+		},
+	}
+
+	for name, test := range tests {
+		test := test // Capture range variable.
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			older, newer := test.A, test.B
+			if older.Coalesce(newer); older != test.Result {
+				t.Errorf("want meta = %b; got %b", test.Result, older)
+			}
+
+			// Order of Coalescing should not matter.
+			older, newer = test.B, test.A
+			if older.Coalesce(newer); older != test.Result {
+				t.Errorf("want meta = %b; got %b", test.Result, older)
+			}
+		})
+	}
+}

--- a/go/src/koding/klient/machine/index/change_test.go
+++ b/go/src/koding/klient/machine/index/change_test.go
@@ -10,117 +10,117 @@ func TestChangeMetaCoalesce(t *testing.T) {
 		B      ChangeMeta
 		Result ChangeMeta
 	}{
-		"UL+UL=UL": {
+		"UL_UL_UL": {
 			A:      ChangeMetaUpdate | ChangeMetaLocal,
 			B:      ChangeMetaUpdate | ChangeMetaLocal,
 			Result: ChangeMetaUpdate | ChangeMetaLocal,
 		},
-		"DL+UL=DL": {
+		"DL_UL_DL": {
 			A:      ChangeMetaRemove | ChangeMetaLocal,
 			B:      ChangeMetaUpdate | ChangeMetaLocal,
 			Result: ChangeMetaRemove | ChangeMetaLocal,
 		},
-		"DL+DL=DL": {
+		"DL_DL_DL": {
 			A:      ChangeMetaRemove | ChangeMetaLocal,
 			B:      ChangeMetaRemove | ChangeMetaLocal,
 			Result: ChangeMetaRemove | ChangeMetaLocal,
 		},
-		"AL+UL=AL": {
+		"AL_UL_AL": {
 			A:      ChangeMetaAdd | ChangeMetaLocal,
 			B:      ChangeMetaUpdate | ChangeMetaLocal,
 			Result: ChangeMetaAdd | ChangeMetaLocal,
 		},
-		"AL+DL=UL": {
+		"AL_DL_UL": {
 			A:      ChangeMetaAdd | ChangeMetaLocal,
 			B:      ChangeMetaRemove | ChangeMetaLocal,
 			Result: ChangeMetaUpdate | ChangeMetaLocal,
 		},
-		"AL+AL=AL": {
+		"AL_AL_AL": {
 			A:      ChangeMetaAdd | ChangeMetaLocal,
 			B:      ChangeMetaAdd | ChangeMetaLocal,
 			Result: ChangeMetaAdd | ChangeMetaLocal,
 		},
-		"UR+UL=UL": {
+		"UR_UL_UL": {
 			A:      ChangeMetaUpdate | ChangeMetaRemote,
 			B:      ChangeMetaUpdate | ChangeMetaLocal,
 			Result: ChangeMetaUpdate | ChangeMetaLocal,
 		},
-		"UR+DL=DL": {
+		"UR_DL_DL": {
 			A:      ChangeMetaUpdate | ChangeMetaRemote,
 			B:      ChangeMetaRemove | ChangeMetaLocal,
 			Result: ChangeMetaRemove | ChangeMetaLocal,
 		},
-		"UR+AL=UL": {
+		"UR_AL_UL": {
 			A:      ChangeMetaUpdate | ChangeMetaRemote,
 			B:      ChangeMetaAdd | ChangeMetaLocal,
 			Result: ChangeMetaUpdate | ChangeMetaLocal,
 		},
-		"UR+UR=UR": {
+		"UR_UR_UR": {
 			A:      ChangeMetaUpdate | ChangeMetaRemote,
 			B:      ChangeMetaUpdate | ChangeMetaRemote,
 			Result: ChangeMetaUpdate | ChangeMetaRemote,
 		},
-		"DR+UL=AL": {
+		"DR_UL_AL": {
 			A:      ChangeMetaRemove | ChangeMetaRemote,
 			B:      ChangeMetaUpdate | ChangeMetaLocal,
 			Result: ChangeMetaAdd | ChangeMetaLocal,
 		},
-		"DR+DL=DL": {
+		"DR_DL_DL": {
 			A:      ChangeMetaRemove | ChangeMetaRemote,
 			B:      ChangeMetaRemove | ChangeMetaLocal,
 			Result: ChangeMetaRemove | ChangeMetaLocal,
 		},
-		"DR+AL=AL": {
+		"DR_AL_AL": {
 			A:      ChangeMetaRemove | ChangeMetaRemote,
 			B:      ChangeMetaAdd | ChangeMetaLocal,
 			Result: ChangeMetaAdd | ChangeMetaLocal,
 		},
-		"DR+UR=DR": {
+		"DR_UR_DR": {
 			A:      ChangeMetaRemove | ChangeMetaRemote,
 			B:      ChangeMetaUpdate | ChangeMetaRemote,
 			Result: ChangeMetaRemove | ChangeMetaRemote,
 		},
-		"DR+DR=DR": {
+		"DR_DR_DR": {
 			A:      ChangeMetaRemove | ChangeMetaRemote,
 			B:      ChangeMetaRemove | ChangeMetaRemote,
 			Result: ChangeMetaRemove | ChangeMetaRemote,
 		},
-		"AR+UL=UL": {
+		"AR_UL_UL": {
 			A:      ChangeMetaAdd | ChangeMetaRemote,
 			B:      ChangeMetaUpdate | ChangeMetaLocal,
 			Result: ChangeMetaUpdate | ChangeMetaLocal,
 		},
-		"AR+DL=DL": {
+		"AR_DL_DL": {
 			A:      ChangeMetaAdd | ChangeMetaRemote,
 			B:      ChangeMetaRemove | ChangeMetaLocal,
 			Result: ChangeMetaRemove | ChangeMetaLocal,
 		},
-		"AR+AL=UL": {
+		"AR_AL_UL": {
 			A:      ChangeMetaAdd | ChangeMetaRemote,
 			B:      ChangeMetaAdd | ChangeMetaLocal,
 			Result: ChangeMetaUpdate | ChangeMetaLocal,
 		},
-		"AR+UR=AR": {
+		"AR_UR_AR": {
 			A:      ChangeMetaAdd | ChangeMetaRemote,
 			B:      ChangeMetaUpdate | ChangeMetaRemote,
 			Result: ChangeMetaAdd | ChangeMetaRemote,
 		},
-		"AR+DR=UR": {
+		"AR_DR_UR": {
 			A:      ChangeMetaAdd | ChangeMetaRemote,
 			B:      ChangeMetaRemove | ChangeMetaRemote,
 			Result: ChangeMetaUpdate | ChangeMetaRemote,
 		},
-		"AR+AR=AR": {
+		"AR_AR_AR": {
 			A:      ChangeMetaAdd | ChangeMetaRemote,
 			B:      ChangeMetaAdd | ChangeMetaRemote,
 			Result: ChangeMetaAdd | ChangeMetaRemote,
 		},
-		"INV+A=AL": {
+		"INV_A_AL": {
 			A:      0,
 			B:      ChangeMetaAdd,
 			Result: ChangeMetaAdd | ChangeMetaLocal,
 		},
-		"AL+AL+OTHER META": {
+		"AL_AL_OTHER META": {
 			A:      ChangeMetaAdd | ChangeMetaLocal | ChangeMetaLarge,
 			B:      ChangeMetaAdd | ChangeMetaLocal,
 			Result: ChangeMetaAdd | ChangeMetaLocal | ChangeMetaLarge,

--- a/go/src/koding/klient/machine/index/change_test.go
+++ b/go/src/koding/klient/machine/index/change_test.go
@@ -174,7 +174,7 @@ func TestChangeMetaCoalesceConcurrent(t *testing.T) {
 		}()
 	}
 
-	// Initialize array with 99 invalid changes and one valid. This should
+	// Initialize array with N >> 1 invalid changes and one valid. This should
 	// always result with valid change after coalescing.
 	var cms = make([]index.ChangeMeta, 2000)
 	cms[rand.Intn(len(cms))] = index.ChangeMetaAdd

--- a/go/src/koding/klient/machine/index/change_test.go
+++ b/go/src/koding/klient/machine/index/change_test.go
@@ -1,10 +1,12 @@
-package index
+package index_test
 
 import (
 	"math/rand"
 	"sync"
 	"testing"
 	"time"
+
+	"koding/klient/machine/index"
 )
 
 func init() {
@@ -14,124 +16,124 @@ func init() {
 
 func TestChangeMetaCoalesce(t *testing.T) {
 	tests := map[string]struct {
-		A      ChangeMeta
-		B      ChangeMeta
-		Result ChangeMeta
+		A      index.ChangeMeta
+		B      index.ChangeMeta
+		Result index.ChangeMeta
 	}{
 		"UL_UL_UL": {
-			A:      ChangeMetaUpdate | ChangeMetaLocal,
-			B:      ChangeMetaUpdate | ChangeMetaLocal,
-			Result: ChangeMetaUpdate | ChangeMetaLocal,
+			A:      index.ChangeMetaUpdate | index.ChangeMetaLocal,
+			B:      index.ChangeMetaUpdate | index.ChangeMetaLocal,
+			Result: index.ChangeMetaUpdate | index.ChangeMetaLocal,
 		},
 		"DL_UL_DL": {
-			A:      ChangeMetaRemove | ChangeMetaLocal,
-			B:      ChangeMetaUpdate | ChangeMetaLocal,
-			Result: ChangeMetaRemove | ChangeMetaLocal,
+			A:      index.ChangeMetaRemove | index.ChangeMetaLocal,
+			B:      index.ChangeMetaUpdate | index.ChangeMetaLocal,
+			Result: index.ChangeMetaRemove | index.ChangeMetaLocal,
 		},
 		"DL_DL_DL": {
-			A:      ChangeMetaRemove | ChangeMetaLocal,
-			B:      ChangeMetaRemove | ChangeMetaLocal,
-			Result: ChangeMetaRemove | ChangeMetaLocal,
+			A:      index.ChangeMetaRemove | index.ChangeMetaLocal,
+			B:      index.ChangeMetaRemove | index.ChangeMetaLocal,
+			Result: index.ChangeMetaRemove | index.ChangeMetaLocal,
 		},
 		"AL_UL_AL": {
-			A:      ChangeMetaAdd | ChangeMetaLocal,
-			B:      ChangeMetaUpdate | ChangeMetaLocal,
-			Result: ChangeMetaAdd | ChangeMetaLocal,
+			A:      index.ChangeMetaAdd | index.ChangeMetaLocal,
+			B:      index.ChangeMetaUpdate | index.ChangeMetaLocal,
+			Result: index.ChangeMetaAdd | index.ChangeMetaLocal,
 		},
 		"AL_DL_UL": {
-			A:      ChangeMetaAdd | ChangeMetaLocal,
-			B:      ChangeMetaRemove | ChangeMetaLocal,
-			Result: ChangeMetaUpdate | ChangeMetaLocal,
+			A:      index.ChangeMetaAdd | index.ChangeMetaLocal,
+			B:      index.ChangeMetaRemove | index.ChangeMetaLocal,
+			Result: index.ChangeMetaUpdate | index.ChangeMetaLocal,
 		},
 		"AL_AL_AL": {
-			A:      ChangeMetaAdd | ChangeMetaLocal,
-			B:      ChangeMetaAdd | ChangeMetaLocal,
-			Result: ChangeMetaAdd | ChangeMetaLocal,
+			A:      index.ChangeMetaAdd | index.ChangeMetaLocal,
+			B:      index.ChangeMetaAdd | index.ChangeMetaLocal,
+			Result: index.ChangeMetaAdd | index.ChangeMetaLocal,
 		},
 		"UR_UL_UL": {
-			A:      ChangeMetaUpdate | ChangeMetaRemote,
-			B:      ChangeMetaUpdate | ChangeMetaLocal,
-			Result: ChangeMetaUpdate | ChangeMetaLocal,
+			A:      index.ChangeMetaUpdate | index.ChangeMetaRemote,
+			B:      index.ChangeMetaUpdate | index.ChangeMetaLocal,
+			Result: index.ChangeMetaUpdate | index.ChangeMetaLocal,
 		},
 		"UR_DL_DL": {
-			A:      ChangeMetaUpdate | ChangeMetaRemote,
-			B:      ChangeMetaRemove | ChangeMetaLocal,
-			Result: ChangeMetaRemove | ChangeMetaLocal,
+			A:      index.ChangeMetaUpdate | index.ChangeMetaRemote,
+			B:      index.ChangeMetaRemove | index.ChangeMetaLocal,
+			Result: index.ChangeMetaRemove | index.ChangeMetaLocal,
 		},
 		"UR_AL_UL": {
-			A:      ChangeMetaUpdate | ChangeMetaRemote,
-			B:      ChangeMetaAdd | ChangeMetaLocal,
-			Result: ChangeMetaUpdate | ChangeMetaLocal,
+			A:      index.ChangeMetaUpdate | index.ChangeMetaRemote,
+			B:      index.ChangeMetaAdd | index.ChangeMetaLocal,
+			Result: index.ChangeMetaUpdate | index.ChangeMetaLocal,
 		},
 		"UR_UR_UR": {
-			A:      ChangeMetaUpdate | ChangeMetaRemote,
-			B:      ChangeMetaUpdate | ChangeMetaRemote,
-			Result: ChangeMetaUpdate | ChangeMetaRemote,
+			A:      index.ChangeMetaUpdate | index.ChangeMetaRemote,
+			B:      index.ChangeMetaUpdate | index.ChangeMetaRemote,
+			Result: index.ChangeMetaUpdate | index.ChangeMetaRemote,
 		},
 		"DR_UL_AL": {
-			A:      ChangeMetaRemove | ChangeMetaRemote,
-			B:      ChangeMetaUpdate | ChangeMetaLocal,
-			Result: ChangeMetaAdd | ChangeMetaLocal,
+			A:      index.ChangeMetaRemove | index.ChangeMetaRemote,
+			B:      index.ChangeMetaUpdate | index.ChangeMetaLocal,
+			Result: index.ChangeMetaAdd | index.ChangeMetaLocal,
 		},
 		"DR_DL_DL": {
-			A:      ChangeMetaRemove | ChangeMetaRemote,
-			B:      ChangeMetaRemove | ChangeMetaLocal,
-			Result: ChangeMetaRemove | ChangeMetaLocal,
+			A:      index.ChangeMetaRemove | index.ChangeMetaRemote,
+			B:      index.ChangeMetaRemove | index.ChangeMetaLocal,
+			Result: index.ChangeMetaRemove | index.ChangeMetaLocal,
 		},
 		"DR_AL_AL": {
-			A:      ChangeMetaRemove | ChangeMetaRemote,
-			B:      ChangeMetaAdd | ChangeMetaLocal,
-			Result: ChangeMetaAdd | ChangeMetaLocal,
+			A:      index.ChangeMetaRemove | index.ChangeMetaRemote,
+			B:      index.ChangeMetaAdd | index.ChangeMetaLocal,
+			Result: index.ChangeMetaAdd | index.ChangeMetaLocal,
 		},
 		"DR_UR_DR": {
-			A:      ChangeMetaRemove | ChangeMetaRemote,
-			B:      ChangeMetaUpdate | ChangeMetaRemote,
-			Result: ChangeMetaRemove | ChangeMetaRemote,
+			A:      index.ChangeMetaRemove | index.ChangeMetaRemote,
+			B:      index.ChangeMetaUpdate | index.ChangeMetaRemote,
+			Result: index.ChangeMetaRemove | index.ChangeMetaRemote,
 		},
 		"DR_DR_DR": {
-			A:      ChangeMetaRemove | ChangeMetaRemote,
-			B:      ChangeMetaRemove | ChangeMetaRemote,
-			Result: ChangeMetaRemove | ChangeMetaRemote,
+			A:      index.ChangeMetaRemove | index.ChangeMetaRemote,
+			B:      index.ChangeMetaRemove | index.ChangeMetaRemote,
+			Result: index.ChangeMetaRemove | index.ChangeMetaRemote,
 		},
 		"AR_UL_UL": {
-			A:      ChangeMetaAdd | ChangeMetaRemote,
-			B:      ChangeMetaUpdate | ChangeMetaLocal,
-			Result: ChangeMetaUpdate | ChangeMetaLocal,
+			A:      index.ChangeMetaAdd | index.ChangeMetaRemote,
+			B:      index.ChangeMetaUpdate | index.ChangeMetaLocal,
+			Result: index.ChangeMetaUpdate | index.ChangeMetaLocal,
 		},
 		"AR_DL_DL": {
-			A:      ChangeMetaAdd | ChangeMetaRemote,
-			B:      ChangeMetaRemove | ChangeMetaLocal,
-			Result: ChangeMetaRemove | ChangeMetaLocal,
+			A:      index.ChangeMetaAdd | index.ChangeMetaRemote,
+			B:      index.ChangeMetaRemove | index.ChangeMetaLocal,
+			Result: index.ChangeMetaRemove | index.ChangeMetaLocal,
 		},
 		"AR_AL_UL": {
-			A:      ChangeMetaAdd | ChangeMetaRemote,
-			B:      ChangeMetaAdd | ChangeMetaLocal,
-			Result: ChangeMetaUpdate | ChangeMetaLocal,
+			A:      index.ChangeMetaAdd | index.ChangeMetaRemote,
+			B:      index.ChangeMetaAdd | index.ChangeMetaLocal,
+			Result: index.ChangeMetaUpdate | index.ChangeMetaLocal,
 		},
 		"AR_UR_AR": {
-			A:      ChangeMetaAdd | ChangeMetaRemote,
-			B:      ChangeMetaUpdate | ChangeMetaRemote,
-			Result: ChangeMetaAdd | ChangeMetaRemote,
+			A:      index.ChangeMetaAdd | index.ChangeMetaRemote,
+			B:      index.ChangeMetaUpdate | index.ChangeMetaRemote,
+			Result: index.ChangeMetaAdd | index.ChangeMetaRemote,
 		},
 		"AR_DR_UR": {
-			A:      ChangeMetaAdd | ChangeMetaRemote,
-			B:      ChangeMetaRemove | ChangeMetaRemote,
-			Result: ChangeMetaUpdate | ChangeMetaRemote,
+			A:      index.ChangeMetaAdd | index.ChangeMetaRemote,
+			B:      index.ChangeMetaRemove | index.ChangeMetaRemote,
+			Result: index.ChangeMetaUpdate | index.ChangeMetaRemote,
 		},
 		"AR_AR_AR": {
-			A:      ChangeMetaAdd | ChangeMetaRemote,
-			B:      ChangeMetaAdd | ChangeMetaRemote,
-			Result: ChangeMetaAdd | ChangeMetaRemote,
+			A:      index.ChangeMetaAdd | index.ChangeMetaRemote,
+			B:      index.ChangeMetaAdd | index.ChangeMetaRemote,
+			Result: index.ChangeMetaAdd | index.ChangeMetaRemote,
 		},
 		"INV_A_AL": {
 			A:      0,
-			B:      ChangeMetaAdd,
-			Result: ChangeMetaAdd | ChangeMetaLocal,
+			B:      index.ChangeMetaAdd,
+			Result: index.ChangeMetaAdd | index.ChangeMetaLocal,
 		},
 		"AL_AL_OTHER META": {
-			A:      ChangeMetaAdd | ChangeMetaLocal | ChangeMetaLarge,
-			B:      ChangeMetaAdd | ChangeMetaLocal,
-			Result: ChangeMetaAdd | ChangeMetaLocal | ChangeMetaLarge,
+			A:      index.ChangeMetaAdd | index.ChangeMetaLocal | index.ChangeMetaLarge,
+			B:      index.ChangeMetaAdd | index.ChangeMetaLocal,
+			Result: index.ChangeMetaAdd | index.ChangeMetaLocal | index.ChangeMetaLarge,
 		},
 	}
 
@@ -158,8 +160,8 @@ func TestChangeMetaCoalesceConcurrent(t *testing.T) {
 	const workersN = 10
 
 	var wg sync.WaitGroup
-	cmC := make(chan ChangeMeta)
-	cm := ChangeMeta(0)
+	cmC := make(chan index.ChangeMeta)
+	cm := index.ChangeMeta(0)
 
 	wg.Add(workersN)
 	for i := 0; i < workersN; i++ {
@@ -174,8 +176,8 @@ func TestChangeMetaCoalesceConcurrent(t *testing.T) {
 
 	// Initialize array with 99 invalid changes and one valid. This should
 	// always result with valid change after coalescing.
-	var cms = make([]ChangeMeta, 2000)
-	cms[rand.Intn(len(cms))] = ChangeMetaAdd
+	var cms = make([]index.ChangeMeta, 2000)
+	cms[rand.Intn(len(cms))] = index.ChangeMetaAdd
 	for i := range cms {
 		cmC <- cms[i]
 	}
@@ -183,7 +185,7 @@ func TestChangeMetaCoalesceConcurrent(t *testing.T) {
 	close(cmC)
 	wg.Wait()
 
-	if want := ChangeMetaAdd | ChangeMetaLocal; cm != want {
+	if want := index.ChangeMetaAdd | index.ChangeMetaLocal; cm != want {
 		t.Errorf("want cm = %b; got %b", want, cm)
 	}
 }
@@ -192,11 +194,11 @@ func TestChangeCoalesceConcurrent(t *testing.T) {
 	const workersN = 10
 
 	// The oldest change in this test.
-	oldest := NewChange("change", 0)
+	oldest := index.NewChange("change", 0)
 
 	var wg sync.WaitGroup
-	cC := make(chan *Change)
-	c := NewChange("change", ChangeMetaUpdate)
+	cC := make(chan *index.Change)
+	c := index.NewChange("change", index.ChangeMetaUpdate)
 
 	wg.Add(workersN)
 	for i := 0; i < workersN; i++ {
@@ -209,9 +211,9 @@ func TestChangeCoalesceConcurrent(t *testing.T) {
 		}()
 	}
 
-	var cs = make([]*Change, 200)
+	var cs = make([]*index.Change, 200)
 	randIdx := rand.Intn(len(cs))
-	newest := NewChange("change", ChangeMetaRemove)
+	newest := index.NewChange("change", index.ChangeMetaRemove)
 	for i := range cs {
 		if i == randIdx {
 			cC <- oldest
@@ -223,7 +225,7 @@ func TestChangeCoalesceConcurrent(t *testing.T) {
 	close(cC)
 	wg.Wait()
 
-	if want, cm := ChangeMetaRemove|ChangeMetaLocal, c.Meta(); cm != want {
+	if want, cm := index.ChangeMetaRemove|index.ChangeMetaLocal, c.Meta(); cm != want {
 		t.Errorf("want cm = %b; got %b", want, cm)
 	}
 

--- a/go/src/koding/klient/machine/index/index.go
+++ b/go/src/koding/klient/machine/index/index.go
@@ -219,7 +219,6 @@ func (idx *Index) Compare(root string) (cs ChangeSlice) {
 		if !ok {
 			cs = append(cs, Change{
 				Name:      name,
-				Size:      safeTruncate(info.Size()),
 				Meta:      ChangeMetaAdd | markLargeMeta(info.Size()),
 				CreatedAt: time.Now().UnixNano(),
 			})
@@ -234,7 +233,6 @@ func (idx *Index) Compare(root string) (cs ChangeSlice) {
 			nd.Entry.Size != info.Size() {
 			cs = append(cs, Change{
 				Name:      name,
-				Size:      safeTruncate(info.Size()),
 				Meta:      ChangeMetaUpdate | markLargeMeta(info.Size()),
 				CreatedAt: time.Now().UnixNano(),
 			})
@@ -265,16 +263,6 @@ func (idx *Index) Compare(root string) (cs ChangeSlice) {
 	idx.mu.RUnlock()
 
 	return cs
-}
-
-// safeTruncate converts signed integer to unsigned one returning 0 for negative
-// values of provided argument.
-func safeTruncate(n int64) uint32 {
-	if n < 0 {
-		return 0
-	}
-
-	return uint32(n)
 }
 
 // markLargeMeta adds large file flag for files which size is over 4GiB.

--- a/go/src/koding/klient/machine/index/index.go
+++ b/go/src/koding/klient/machine/index/index.go
@@ -291,7 +291,7 @@ func (idx *Index) Apply(root string, cs ChangeSlice) {
 			idx.mu.RUnlock()
 
 			// Entry was updated/added after the event was created.
-			if ok && nd.Entry.MTime > cs[i].MadeUnixNano() {
+			if ok && nd.Entry.MTime > cs[i].CreatedAtUnixNano() {
 				continue
 			}
 			fallthrough

--- a/go/src/koding/klient/machine/index/index.go
+++ b/go/src/koding/klient/machine/index/index.go
@@ -87,32 +87,6 @@ func readCRC32(path string) ([]byte, error) {
 	return hash.Sum(nil), nil
 }
 
-// ChangeMeta indicates what change has been done on a given file.
-type ChangeMeta uint32
-
-const (
-	ChangeMetaUpdate ChangeMeta = 1 << iota // File was updated.
-	ChangeMetaRemove                        // File was removed.
-	ChangeMetaAdd                           // File was added.
-
-	ChangeMetaLarge ChangeMeta = 1 << (8 + iota) // File size is above 4GB.
-)
-
-// Change describes single file change.
-type Change struct {
-	Name      string     `json:"name"`      // The relative name of the file.
-	Size      uint32     `json:"size"`      // Size of the file truncated to 32 bits.
-	Meta      ChangeMeta `json:"meta"`      // The type of operation made on file entry.
-	CreatedAt int64      `json:"createdAt"` // Change creation time since EPOCH.
-}
-
-// ChangeSlice stores multiple changes.
-type ChangeSlice []Change
-
-func (cs ChangeSlice) Len() int           { return len(cs) }
-func (cs ChangeSlice) Swap(i, j int)      { cs[i], cs[j] = cs[j], cs[i] }
-func (cs ChangeSlice) Less(i, j int) bool { return cs[i].Name < cs[j].Name }
-
 // Index stores a virtual working tree state. It recursively records objects in
 // a given root path and allows to efficiently detect changes on it.
 type Index struct {

--- a/go/src/koding/klient/machine/index/index_test.go
+++ b/go/src/koding/klient/machine/index/index_test.go
@@ -31,93 +31,54 @@ var filetree = map[string]int64{
 func TestIndex(t *testing.T) {
 	tests := map[string]struct {
 		Op      func(string) error
-		Changes []Change
+		Changes ChangeSlice
 	}{
 		"add file": {
 			Op: writeFile("d/test.bin", 40*1024),
-			Changes: []Change{
-				{
-					Name: "d",
-					Meta: ChangeMetaUpdate,
-				},
-				{
-					Name: "d/test.bin",
-					Meta: ChangeMetaAdd,
-				},
+			Changes: ChangeSlice{
+				NewChange("d", ChangeMetaUpdate),
+				NewChange("d/test.bin", ChangeMetaAdd),
 			},
 		},
 		"add dir": {
 			Op: addDir("e"),
-			Changes: []Change{
-				{
-					Name: "e",
-					Meta: ChangeMetaAdd,
-				},
+			Changes: ChangeSlice{
+				NewChange("e", ChangeMetaAdd),
 			},
 		},
 		"remove file": {
 			Op: rmAllFile("c/cb.bin"),
-			Changes: []Change{
-				{
-					Name: "c",
-					Meta: ChangeMetaUpdate,
-				},
-				{
-					Name: "c/cb.bin",
-					Meta: ChangeMetaRemove,
-				},
+			Changes: ChangeSlice{
+				NewChange("c", ChangeMetaUpdate),
+				NewChange("c/cb.bin", ChangeMetaRemove),
 			},
 		},
 		"remove dir": {
 			Op: rmAllFile("c"),
-			Changes: []Change{
-				{
-					Name: "c",
-					Meta: ChangeMetaRemove,
-				},
-				{
-					Name: "c/ca.txt",
-					Meta: ChangeMetaRemove,
-				},
-				{
-					Name: "c/cb.bin",
-					Meta: ChangeMetaRemove,
-				},
+			Changes: ChangeSlice{
+				NewChange("c", ChangeMetaRemove),
+				NewChange("c/ca.txt", ChangeMetaRemove),
+				NewChange("c/cb.bin", ChangeMetaRemove),
 			},
 		},
 		"rename file": {
 			Op: mvFile("b.bin", "c/cc.bin"),
-			Changes: []Change{
-				{
-					Name: "b.bin",
-					Meta: ChangeMetaRemove,
-				},
-				{
-					Name: "c",
-					Meta: ChangeMetaUpdate,
-				},
-				{
-					Name: "c/cc.bin",
-					Meta: ChangeMetaAdd,
-				},
+			Changes: ChangeSlice{
+				NewChange("b.bin", ChangeMetaRemove),
+				NewChange("c", ChangeMetaUpdate),
+				NewChange("c/cc.bin", ChangeMetaAdd),
 			},
 		},
 		"write file": {
 			Op: writeFile("b.bin", 1024),
-			Changes: []Change{
-				{
-					Name: "b.bin",
-					Meta: ChangeMetaUpdate,
-				},
+			Changes: ChangeSlice{
+				NewChange("b.bin", ChangeMetaUpdate),
 			},
 		},
 		"chmod file": {
 			Op: chmodFile("d/dc/dca.txt", 0766),
-			Changes: []Change{
-				{
-					Name: "d/dc/dca.txt",
-					Meta: ChangeMetaUpdate,
-				},
+			Changes: ChangeSlice{
+				NewChange("d/dc/dca.txt", ChangeMetaUpdate),
 			},
 		},
 	}
@@ -153,10 +114,10 @@ func TestIndex(t *testing.T) {
 
 			// Copy time from result to tests.
 			for i, tc := range test.Changes {
-				if cs[i].Name != tc.Name {
+				if cs[i].Name() != tc.Name() {
 					t.Errorf("want change name = %q; got %q", tc.Name, cs[i].Name)
 				}
-				if cs[i].Meta != tc.Meta {
+				if cs[i].Meta() != tc.Meta() {
 					t.Errorf("want change meta = %bb; got %bb", tc.Meta, cs[i].Meta)
 				}
 			}

--- a/go/src/koding/klient/machine/index/index_test.go
+++ b/go/src/koding/klient/machine/index/index_test.go
@@ -197,7 +197,7 @@ func TestIndexJSON(t *testing.T) {
 	}
 
 	if cs := idx.Compare(root); len(cs) != 0 {
-		t.Errorf("want no index.Changes after apply; got %#v", cs)
+		t.Errorf("want no changes after apply; got %#v", cs)
 	}
 }
 

--- a/go/src/koding/klient/machine/index/index_test.go
+++ b/go/src/koding/klient/machine/index/index_test.go
@@ -42,7 +42,6 @@ func TestIndex(t *testing.T) {
 				},
 				{
 					Name: "d/test.bin",
-					Size: 40 * 1024,
 					Meta: ChangeMetaAdd,
 				},
 			},
@@ -156,9 +155,6 @@ func TestIndex(t *testing.T) {
 			for i, tc := range test.Changes {
 				if cs[i].Name != tc.Name {
 					t.Errorf("want change name = %q; got %q", tc.Name, cs[i].Name)
-				}
-				if tc.Size != 0 && cs[i].Size != tc.Size {
-					t.Errorf("want change size = %v; got %v", tc.Size, cs[i].Size)
 				}
 				if cs[i].Meta != tc.Meta {
 					t.Errorf("want change meta = %bb; got %bb", tc.Meta, cs[i].Meta)

--- a/go/src/koding/klient/machine/index/index_unix_test.go
+++ b/go/src/koding/klient/machine/index/index_unix_test.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-package index
+package index_test
 
 import "syscall"
 

--- a/go/src/koding/klient/machine/index/index_windows_test.go
+++ b/go/src/koding/klient/machine/index/index_windows_test.go
@@ -1,6 +1,6 @@
 // +build windows
 
-package index
+package index_test
 
 // Sync is a no-op on Windows. This file is here only to make windows builds
 // work.


### PR DESCRIPTION
This PR adds logic required by syncer when more than one FS change describing identical file came to synchronization queue. Local machine changes have higher priority than remote ones.

See `ChangeMeta.Coalesce` method comment for more information.

## How Has This Been Tested?
Unit tests

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

