### PR TITLE
klient/machine: add DiskBlocks method to dynamic Client

### DIFF
--- a/go/src/koding/klient/machine/client/client.go
+++ b/go/src/koding/klient/machine/client/client.go
@@ -22,6 +22,9 @@ type Client interface {
 	// directory.
 	MountGetIndex(string) (*index.Index, error)
 
+	// DiskBlocks gets basic information about volume pointed by provided path.
+	DiskBlocks(string) (uint64, uint64, uint64, uint64, error)
+
 	// Context returns client's Context.
 	Context() context.Context
 }

--- a/go/src/koding/klient/machine/client/clienttest/client.go
+++ b/go/src/koding/klient/machine/client/clienttest/client.go
@@ -131,6 +131,14 @@ func (c *Client) MountGetIndex(path string) (*index.Index, error) {
 	return index.NewIndexFiles(path)
 }
 
+// DiskBlocks gets faked information about file-system.
+func (c *Client) DiskBlocks(path string) (size, total, free, used uint64, err error) {
+	// TODO(ppknap): replace with non-faked data when we have platform
+	// independent logic for disk stat operation.
+	size, total, free, used = 512, 1e9, 9e8, 1e9-9e8
+	return
+}
+
 // SetContext sets provided context to test client.
 func (c *Client) SetContext(ctx context.Context) {
 	c.mu.Lock()

--- a/go/src/koding/klient/machine/client/disconnected.go
+++ b/go/src/koding/klient/machine/client/disconnected.go
@@ -66,6 +66,11 @@ func (*Disconnected) MountGetIndex(_ string) (*index.Index, error) {
 	return nil, ErrDisconnected
 }
 
+// DiskBlocks always returns ErrDisconnected error.
+func (*Disconnected) DiskBlocks(_ string) (_, _, _, _ uint64, _ error) {
+	return 0, 0, 0, 0, ErrDisconnected
+}
+
 // Context returns disconnected client's context.
 func (d *Disconnected) Context() context.Context {
 	return d.ctx


### PR DESCRIPTION
Filesystem block information is required by FUSE. This PR just extends machine client to this (already implemented) method.

## Motivation and Context
Required by mounts.

## How Has This Been Tested?
No test - it's just a connector to already implemented logic.

