### PR TITLE
klient/machine: add helper function that checks if two index meta changes are similar

### DIFF
--- a/go/src/koding/klient/machine/client/dynamic.go
+++ b/go/src/koding/klient/machine/client/dynamic.go
@@ -167,12 +167,12 @@ func (dc *Dynamic) cron() {
 		// Create new client.
 		dc.log.Info("Reinitializing client with %s address: %s", a.Network, a.Value)
 		ctx, cancel := context.WithCancel(context.Background())
-		c := dc.opts.Builder.Build(ctx, a)
 
+		dc.mu.Lock()
+		c := dc.opts.Builder.Build(ctx, a)
 		// Update current address.
 		addr = a
 
-		dc.mu.Lock()
 		if dc.cancel != nil {
 			dc.cancel()
 		}

--- a/go/src/koding/klient/machine/index/change.go
+++ b/go/src/koding/klient/machine/index/change.go
@@ -105,7 +105,7 @@ func (cm *ChangeMeta) Coalesce(newer ChangeMeta) ChangeMeta {
 
 // Similar checks if provided meta changes can be considered similar. This means
 // if the same synchronization logic can be applied to provided meta changes.
-func AreSimilar(a, b ChangeMeta) bool {
+func Similar(a, b ChangeMeta) bool {
 	// Default to local change direction when not set.
 	if a&(ChangeMetaRemote|ChangeMetaLocal) == 0 {
 		a |= ChangeMetaLocal

--- a/go/src/koding/klient/machine/index/change_test.go
+++ b/go/src/koding/klient/machine/index/change_test.go
@@ -234,7 +234,7 @@ func TestChangeCoalesceConcurrent(t *testing.T) {
 	}
 }
 
-func TestAreSimilar(t *testing.T) {
+func TestSimilar(t *testing.T) {
 	tests := map[string]struct {
 		A      index.ChangeMeta
 		B      index.ChangeMeta
@@ -282,7 +282,7 @@ func TestAreSimilar(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			if similar := index.AreSimilar(test.A, test.B); similar != test.Result {
+			if similar := index.Similar(test.A, test.B); similar != test.Result {
 				t.Errorf("want similar = %t; got %t", test.Result, similar)
 			}
 		})

--- a/go/src/koding/klient/machine/index/change_test.go
+++ b/go/src/koding/klient/machine/index/change_test.go
@@ -216,9 +216,9 @@ func TestChangeCoalesceConcurrent(t *testing.T) {
 	newest := index.NewChange("change", index.ChangeMetaRemove)
 	for i := range cs {
 		if i == randIdx {
-			cC <- oldest
-		} else {
 			cC <- newest
+		} else {
+			cC <- oldest
 		}
 	}
 
@@ -229,7 +229,62 @@ func TestChangeCoalesceConcurrent(t *testing.T) {
 		t.Errorf("want cm = %b; got %b", want, cm)
 	}
 
-	if want, caun := oldest.CreatedAtUnixNano(), c.CreatedAtUnixNano(); caun != want {
+	if want, caun := newest.CreatedAtUnixNano(), c.CreatedAtUnixNano(); caun != want {
 		t.Errorf("want caun = %d; got %d", want, caun)
+	}
+}
+
+func TestAreSimilar(t *testing.T) {
+	tests := map[string]struct {
+		A      index.ChangeMeta
+		B      index.ChangeMeta
+		Result bool
+	}{
+		"UL is UL": {
+			A:      index.ChangeMetaUpdate | index.ChangeMetaLocal,
+			B:      index.ChangeMetaUpdate | index.ChangeMetaLocal,
+			Result: true,
+		},
+		"U is UL": {
+			A:      index.ChangeMetaUpdate,
+			B:      index.ChangeMetaUpdate | index.ChangeMetaLocal,
+			Result: true,
+		},
+		"UL is U": {
+			A:      index.ChangeMetaUpdate | index.ChangeMetaLocal,
+			B:      index.ChangeMetaUpdate,
+			Result: true,
+		},
+		"UR is not UL": {
+			A:      index.ChangeMetaUpdate | index.ChangeMetaRemote,
+			B:      index.ChangeMetaUpdate | index.ChangeMetaLocal,
+			Result: false,
+		},
+		"UL is not UR": {
+			A:      index.ChangeMetaUpdate | index.ChangeMetaLocal,
+			B:      index.ChangeMetaUpdate | index.ChangeMetaRemote,
+			Result: false,
+		},
+		"AL is not DL": {
+			A:      index.ChangeMetaAdd | index.ChangeMetaLocal,
+			B:      index.ChangeMetaRemove | index.ChangeMetaLocal,
+			Result: false,
+		},
+		"UL is not DL": {
+			A:      index.ChangeMetaUpdate | index.ChangeMetaLocal,
+			B:      index.ChangeMetaRemove | index.ChangeMetaLocal,
+			Result: false,
+		},
+	}
+
+	for name, test := range tests {
+		test := test // Capture range variable.
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if similar := index.AreSimilar(test.A, test.B); similar != test.Result {
+				t.Errorf("want similar = %t; got %t", test.Result, similar)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Motivation and Context
Detect and split changes for cases like "add- modify - delete" chain of file events.

## How Has This Been Tested?
Unit tests