### PR TITLE
Codecov: disable comments until issue resolved

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,7 @@
 codecov:
   notify:
     require_ci_to_pass: true
-comment:
-  behavior: default
-  layout: header, diff
-  require_changes: true
+comment: off
 coverage:
   precision: 2
   range:


### PR DESCRIPTION
We have an open issue on Codecov but the issue still persist until it's fixed this disables comments.
 https://github.com/codecov/support/issues/346
