### PR TITLE
make it more obvious that this is a request for online meeting

### DIFF
--- a/docs/demo.html
+++ b/docs/demo.html
@@ -24,7 +24,7 @@ title: Request a Demo
 <main class="Micropage">
   <div class="Micropage--container">
 
-    <h1>Request a Demo</h1>
+    <h1>Let's meet face to face!</h1>
 
     <h3 class="form-success hidden">
       We just received your request for a 1-on-1 demo. One of our teammates will reach out to you in the next 48 hours to get it scheduled.
@@ -40,7 +40,7 @@ title: Request a Demo
     <form id="SignupForm" novalidate data-persist="garlic" data-domain="true">
 
       <div class="SignupFieldset">
-        <h3>Want to instantly code and collaborate on any project in your company?</h3>
+        <h3>If your organization is above 10 developers, we are happy to allocate an hour and talk about your organization's needs, demo Koding, answer all your questions.</h3>
       </div>
 
       <div class="SignupFieldset">


### PR DESCRIPTION
people seem to fill it because they think this is a way to get access to the platform.

ps. also remove "phone" field. we don't need it.
