### PR TITLE
Klient machine mount file system notification logic (without FUSE) 

### DIFF
--- a/go/src/koding/klient/app/klient.go
+++ b/go/src/koding/klient/app/klient.go
@@ -36,6 +36,7 @@ import (
 	mclient "koding/klient/machine/client"
 	"koding/klient/machine/index"
 	"koding/klient/machine/machinegroup"
+	"koding/klient/machine/mount/notify/silent"
 	"koding/klient/machine/mount/sync/discard"
 	kos "koding/klient/os"
 	"koding/klient/remote"
@@ -325,6 +326,7 @@ func NewKlient(conf *KlientConfig) (*Klient, error) {
 	machinesOpts := &machinegroup.GroupOpts{
 		Storage:         storage.NewEncodingStorage(db, []byte("machines")),
 		Builder:         mclient.NewKiteBuilder(k),
+		NotifyBuilder:   silent.SilentBuilder{},
 		SyncBuilder:     discard.DiscardBuilder{},
 		DynAddrInterval: 2 * time.Second,
 		PingInterval:    15 * time.Second,

--- a/go/src/koding/klient/machine/machinegroup/machinegroup.go
+++ b/go/src/koding/klient/machine/machinegroup/machinegroup.go
@@ -16,6 +16,7 @@ import (
 	"koding/klient/machine/machinegroup/mounts"
 	"koding/klient/machine/machinegroup/syncs"
 	"koding/klient/machine/mount"
+	"koding/klient/machine/mount/notify"
 	msync "koding/klient/machine/mount/sync"
 	"koding/klient/storage"
 
@@ -34,6 +35,9 @@ type GroupOpts struct {
 
 	// Builder is a factory used to build clients.
 	Builder client.Builder
+
+	// NotifyBuilder defines a factory used to build FS notification objects.
+	NotifyBuilder notify.Builder
 
 	// SyncBuilder defines a factory used to build file synchronization objects.
 	SyncBuilder msync.Builder
@@ -60,6 +64,9 @@ func (opts *GroupOpts) Valid() error {
 	}
 	if opts.Builder == nil {
 		return errors.New("client builder is nil")
+	}
+	if opts.NotifyBuilder == nil {
+		return errors.New("file system notification builder is nil")
 	}
 	if opts.SyncBuilder == nil {
 		return errors.New("synchronization builder is nil")
@@ -127,9 +134,10 @@ func New(opts *GroupOpts) (*Group, error) {
 
 	// Create syncs object for synced mounts.
 	syncsOpts := syncs.SyncsOpts{
-		WorkDir:     opts.WorkDir,
-		SyncBuilder: opts.SyncBuilder,
-		Log:         g.log,
+		WorkDir:       opts.WorkDir,
+		NotifyBuilder: opts.NotifyBuilder,
+		SyncBuilder:   opts.SyncBuilder,
+		Log:           g.log,
 	}
 	g.sync, err = syncs.New(syncsOpts)
 	if err != nil {

--- a/go/src/koding/klient/machine/machinegroup/machinegroup_test.go
+++ b/go/src/koding/klient/machine/machinegroup/machinegroup_test.go
@@ -15,6 +15,7 @@ import (
 	"koding/klient/machine/machinegroup/mounts"
 	"koding/klient/machine/mount"
 	"koding/klient/machine/mount/mounttest"
+	"koding/klient/machine/mount/notify/silent"
 	"koding/klient/machine/mount/sync/discard"
 	"koding/klient/storage"
 
@@ -211,6 +212,7 @@ func testOptionsStorage(wd string, b client.Builder, st storage.ValueInterface) 
 	return &GroupOpts{
 		Storage:         st,
 		Builder:         b,
+		NotifyBuilder:   silent.SilentBuilder{},
 		SyncBuilder:     discard.DiscardBuilder{},
 		DynAddrInterval: 10 * time.Millisecond,
 		PingInterval:    50 * time.Millisecond,

--- a/go/src/koding/klient/machine/machinegroup/syncs/syncs_test.go
+++ b/go/src/koding/klient/machine/machinegroup/syncs/syncs_test.go
@@ -10,6 +10,7 @@ import (
 	"koding/klient/machine/machinegroup/syncs"
 	"koding/klient/machine/mount"
 	"koding/klient/machine/mount/mounttest"
+	"koding/klient/machine/mount/notify/silent"
 	"koding/klient/machine/mount/sync/discard"
 )
 
@@ -23,11 +24,12 @@ func TestSyncsAdd(t *testing.T) {
 	// Create new supervisor.
 	mountID := mount.MakeID()
 	s, err := syncs.New(syncs.SyncsOpts{
-		WorkDir:     wd,
-		SyncBuilder: discard.DiscardBuilder{},
+		WorkDir:       wd,
+		NotifyBuilder: silent.SilentBuilder{},
+		SyncBuilder:   discard.DiscardBuilder{},
 	})
 	if err != nil {
-		t.Fatalf("want err != nil; got nil")
+		t.Fatalf("want err = nil; got %v", err)
 	}
 	defer s.Close()
 
@@ -35,7 +37,7 @@ func TestSyncsAdd(t *testing.T) {
 		return clienttest.NewClient(), nil
 	}
 	if err := s.Add(mountID, m, dynClient); err != nil {
-		t.Fatalf("want err != nil; got nil")
+		t.Fatalf("want err = nil; got %v", err)
 	}
 	if err := s.Add(mountID, m, dynClient); err == nil {
 		t.Error("want err != nil; got nil")
@@ -58,18 +60,19 @@ func TestSyncsDrop(t *testing.T) {
 	// Create new sync.
 	mountID := mount.MakeID()
 	s, err := syncs.New(syncs.SyncsOpts{
-		WorkDir:     wd,
-		SyncBuilder: discard.DiscardBuilder{},
+		WorkDir:       wd,
+		NotifyBuilder: silent.SilentBuilder{},
+		SyncBuilder:   discard.DiscardBuilder{},
 	})
 	if err != nil {
-		t.Fatalf("want err != nil; got nil")
+		t.Fatalf("want err = nil; got %v", err)
 	}
 	defer s.Close()
 
 	if err := s.Add(mountID, m, func() (client.Client, error) {
 		return clienttest.NewClient(), nil
 	}); err != nil {
-		t.Fatalf("want err != nil; got nil")
+		t.Fatalf("want err = nil; got %v", err)
 	}
 
 	if err := s.Drop(mountID); err != nil {

--- a/go/src/koding/klient/machine/mount/notify/notify.go
+++ b/go/src/koding/klient/machine/mount/notify/notify.go
@@ -1,0 +1,43 @@
+package notify
+
+import (
+	"context"
+
+	"koding/klient/machine/index"
+	"koding/klient/machine/mount"
+)
+
+// BuildOpts represents the context that can be used by external notifiers to
+// build their own type. Built notifier should only read from provided indexes
+// and, if changes occur, commit observed changes using Cache interface.
+type BuildOpts struct {
+	MountID mount.ID    // identifier of synced mount.
+	Mount   mount.Mount // single mount with absolute paths.
+
+	Cache    Cache  // index file system change consumer.
+	CacheDir string // absolute path to locally cached files.
+
+	RemoteIdx *index.Index // known state of remote index.
+	LocalIdx  *index.Index // known state of local index.
+}
+
+// Builder represents a factory method which external notifiers must implement
+// in order to create their instances.
+type Builder interface {
+	// Build uses provided build options to create Notifier instance.
+	Build(opts *BuildOpts) (Notifier, error)
+}
+
+// Notifier is an interface which must be implemented by external notifiers.
+type Notifier interface {
+	// Close cleans up notifier resources, if any.
+	Close()
+}
+
+// Cache represents external synchronization devices that can apply provided
+// change to both underlying file system and its indexes.
+type Cache interface {
+	// Commit notifies syncers about observed file system change. Resulted
+	// context will be canceled if the change was applied or dropped.
+	Commit(*index.Change) context.Context
+}

--- a/go/src/koding/klient/machine/mount/notify/silent/silent.go
+++ b/go/src/koding/klient/machine/mount/notify/silent/silent.go
@@ -1,0 +1,20 @@
+package silent
+
+import "koding/klient/machine/mount/notify"
+
+// SilentBuilder is a factory for Silent notification objects.
+type SilentBuilder struct{}
+
+// Build satisfies notify.Builder interface. It produces Silent objects. Build
+// options are not used.
+func (SilentBuilder) Build(_ *notify.BuildOpts) (notify.Notifier, error) {
+	return Silent{}, nil
+}
+
+// Silent is a notification object that doesn't produce any notifications. This
+// means that this type should be used only in tests which don't care about
+// file system notifications.
+type Silent struct{}
+
+// Close satisfies notify.Notifier interface. It does nothing.
+func (Silent) Close() {}

--- a/go/src/koding/klient/machine/mount/sync/sync.go
+++ b/go/src/koding/klient/machine/mount/sync/sync.go
@@ -20,9 +20,9 @@ const (
 	RemoteIndexName = "index.remote" // file name of remote directory index.
 )
 
-// BuildOpts represents a context that can be used by external syncers to build
-// their own type. Built syncer should update indexes after syncing and manage
-// received events.
+// BuildOpts represents the context that can be used by external syncers to
+// build their own type. Built syncer should update indexes after syncing and
+// manage received events.
 type BuildOpts struct {
 	RemoteIdx *index.Index // known state of remote index.
 	LocalIdx  *index.Index // known state of local index.

--- a/go/src/koding/klient/machine/mount/sync/sync_test.go
+++ b/go/src/koding/klient/machine/mount/sync/sync_test.go
@@ -10,6 +10,7 @@ import (
 	"koding/klient/machine/client/clienttest"
 	"koding/klient/machine/mount"
 	"koding/klient/machine/mount/mounttest"
+	"koding/klient/machine/mount/notify/silent"
 	msync "koding/klient/machine/mount/sync"
 	"koding/klient/machine/mount/sync/discard"
 )
@@ -124,7 +125,8 @@ func defaultSyncOpts(wd string) msync.SyncOpts {
 		ClientFunc: func() (client.Client, error) {
 			return clienttest.NewClient(), nil
 		},
-		SyncBuilder: discard.DiscardBuilder{},
-		WorkDir:     wd,
+		NotifyBuilder: silent.SilentBuilder{},
+		SyncBuilder:   discard.DiscardBuilder{},
+		WorkDir:       wd,
 	}
 }


### PR DESCRIPTION
This PR adds FS notification logic for mount notifiers (like FUSE).

Depends on: ~#10530~

## How Has This Been Tested?
Unit tests

## Types of changes
- [x] New feature (non-breaking change which adds functionality)