### PR TITLE
Klient mount logging of synchronization events

### DIFF
--- a/go/src/koding/klient/machine/machinegroup/syncs/syncs.go
+++ b/go/src/koding/klient/machine/machinegroup/syncs/syncs.go
@@ -17,6 +17,11 @@ import (
 	"github.com/koding/logging"
 )
 
+// debugAll must be set in order to debug print all synced events. Worker
+// events may produce a lot of events so we keep logging disabled even in
+// "normal" debug mode.
+var debugAll = os.Getenv("KD_DEBUG_MOUNT") != ""
+
 // SyncsOpts are the options used to configure Syncs object.
 type SyncsOpts struct {
 	// WorkDir is a working directory that will be used by Syncs object. The
@@ -117,11 +122,6 @@ func New(opts SyncsOpts) (*Syncs, error) {
 // worker consumes and executes synchronization events from all stored mounts.
 func (s *Syncs) worker() {
 	defer s.wg.Done()
-
-	// debugAll must be set in order to debug print all synced events. Worker
-	// events may produce a lot of events so we keep logging disabled even in
-	// "normal" debug mode.
-	debugAll := os.Getenv("KD_DEBUG_MOUNT") != ""
 
 	for {
 		select {


### PR DESCRIPTION
This PR adds mount synchronization event logging useful for mount tests.

- in debug mode only events that errored are logged.
- it is possible to log all events switching debug mode on and setting `KD_DEBUG_MOUNT` env var.

Depends on: ~#10532~, ~#10530~

## How Has This Been Tested?
Unit tests

## Types of changes
- [x] New feature (non-breaking change which adds functionality)