### PR TITLE
Klient machine code styling improvements.

### DIFF
--- a/go/src/koding/klient/machine/client/dynamic.go
+++ b/go/src/koding/klient/machine/client/dynamic.go
@@ -132,10 +132,12 @@ func (dc *Dynamic) Addr(network string) (machine.Addr, error) {
 
 // Close stops the dynamic client. After this function is called, client is
 // in disconnected state and each contexts returned by it are closed.
-func (dc *Dynamic) Close() {
+func (dc *Dynamic) Close() error {
 	dc.once.Do(func() {
 		close(dc.stop)
 	})
+
+	return nil
 }
 
 func (dc *Dynamic) cron() {

--- a/go/src/koding/klient/machine/index/index.go
+++ b/go/src/koding/klient/machine/index/index.go
@@ -287,7 +287,7 @@ func (idx *Index) Apply(root string, cs ChangeSlice) {
 			// Check if the event is still valid or if it was replaced by newer
 			// change.
 			idx.mu.RLock()
-			nd, ok := idx.root.Lookup(cs[i].Name())
+			nd, ok := idx.root.Lookup(cs[i].Path())
 			idx.mu.RUnlock()
 
 			// Entry was updated/added after the event was created.
@@ -299,11 +299,11 @@ func (idx *Index) Apply(root string, cs ChangeSlice) {
 			// Check if the file still exists, since it could be removed before
 			// Apply was called. If the file exists, create new entry from it
 			// and replace its value inside index map.
-			path := filepath.Join(root, filepath.FromSlash(cs[i].Name()))
+			path := filepath.Join(root, filepath.FromSlash(cs[i].Path()))
 			info, err := os.Lstat(path)
 			if os.IsNotExist(err) {
 				idx.mu.Lock()
-				idx.root.Del(cs[i].Name())
+				idx.root.Del(cs[i].Path())
 				idx.mu.Unlock()
 				continue
 			}

--- a/go/src/koding/klient/machine/index/index_test.go
+++ b/go/src/koding/klient/machine/index/index_test.go
@@ -116,8 +116,8 @@ func TestIndex(t *testing.T) {
 
 			// Copy time from result to tests.
 			for i, tc := range test.Changes {
-				if cs[i].Name() != tc.Name() {
-					t.Errorf("want index.Change name = %q; got %q", tc.Name, cs[i].Name)
+				if cs[i].Path() != tc.Path() {
+					t.Errorf("want index.Change path = %q; got %q", tc.Path(), cs[i].Path())
 				}
 				if cs[i].Meta() != tc.Meta() {
 					t.Errorf("want index.Change meta = %bb; got %bb", tc.Meta, cs[i].Meta)

--- a/go/src/koding/klient/machine/machinegroup/machinegroup.go
+++ b/go/src/koding/klient/machine/machinegroup/machinegroup.go
@@ -181,9 +181,8 @@ func New(opts *GroupOpts) (*Group, error) {
 }
 
 // Close closes Group's underlying clients.
-func (g *Group) Close() {
-	g.sync.Close()
-	g.client.Close()
+func (g *Group) Close() error {
+	return nonil(g.sync.Close(), g.client.Close())
 }
 
 // bootstrap initializes machine group workers and checks loaded data for
@@ -276,4 +275,13 @@ func (g *Group) dynamicClient(mountID mount.ID) client.DynamicClientFunc {
 
 		return g.client.Client(id)
 	}
+}
+
+func nonil(err ...error) error {
+	for _, e := range err {
+		if e != nil {
+			return e
+		}
+	}
+	return nil
 }

--- a/go/src/koding/klient/machine/machinegroup/syncs/syncs.go
+++ b/go/src/koding/klient/machine/machinegroup/syncs/syncs.go
@@ -237,7 +237,7 @@ func (s *Syncs) Drop(mountID mount.ID) (err error) {
 }
 
 // Close closes and removes all stored syncs.
-func (s *Syncs) Close() {
+func (s *Syncs) Close() error {
 	s.once.Do(func() {
 		s.mu.Lock()
 		s.closed = true
@@ -250,4 +250,6 @@ func (s *Syncs) Close() {
 		close(s.stopC)
 		s.wg.Wait()
 	})
+
+	return nil
 }

--- a/go/src/koding/klient/machine/mount/notify/notify.go
+++ b/go/src/koding/klient/machine/mount/notify/notify.go
@@ -2,6 +2,7 @@ package notify
 
 import (
 	"context"
+	"io"
 
 	"koding/klient/machine/index"
 	"koding/klient/machine/mount"
@@ -31,7 +32,7 @@ type Builder interface {
 // Notifier is an interface which must be implemented by external notifiers.
 type Notifier interface {
 	// Close cleans up notifier resources, if any.
-	Close()
+	io.Closer
 }
 
 // Cache represents external synchronization devices that can apply provided

--- a/go/src/koding/klient/machine/mount/notify/silent/silent.go
+++ b/go/src/koding/klient/machine/mount/notify/silent/silent.go
@@ -17,4 +17,4 @@ func (SilentBuilder) Build(_ *notify.BuildOpts) (notify.Notifier, error) {
 type Silent struct{}
 
 // Close satisfies notify.Notifier interface. It does nothing.
-func (Silent) Close() {}
+func (Silent) Close() error { return nil }

--- a/go/src/koding/klient/machine/mount/sync/anteroom.go
+++ b/go/src/koding/klient/machine/mount/sync/anteroom.go
@@ -54,11 +54,11 @@ func (a *Anteroom) Commit(c *index.Change) context.Context {
 		return ctx
 	}
 
-	ev, ok := a.evs[c.Name()]
+	ev, ok := a.evs[c.Path()]
 	if !ok {
 		// Event for the file doesn't exist. Add new one to evs and queue.
 		ev = NewEvent(context.Background(), a, c)
-		a.evs[c.Name()] = ev
+		a.evs[c.Path()] = ev
 		a.queue.Push(ev)
 		a.wakeup()
 
@@ -88,7 +88,7 @@ func (a *Anteroom) Commit(c *index.Change) context.Context {
 		// Change is deprecated. Re-push new change to the queue but keep
 		// context from old event.
 		newEv := NewEventCopy(ev)
-		a.evs[c.Name()] = newEv
+		a.evs[c.Path()] = newEv
 		a.queue.Push(newEv)
 		a.wakeup()
 	}
@@ -121,11 +121,11 @@ func (a *Anteroom) Close() {
 		defer a.mu.Unlock()
 
 		// Mark all events as deprecated and detach them from the queue.
-		for name, ev := range a.evs {
+		for path, ev := range a.evs {
 			atomic.StoreUint64((*uint64)(&ev.stat), uint64(statusDeprecated))
 			ev.cancel()
 
-			delete(a.evs, name)
+			delete(a.evs, path)
 		}
 
 		a.closed = true
@@ -190,11 +190,11 @@ func (a *Anteroom) wakeup() {
 
 // detach removes the change from coalescing events map only if stored id
 // is equal to provided one.
-func (a *Anteroom) detach(name string, id uint64) {
+func (a *Anteroom) detach(path string, id uint64) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	if ev, ok := a.evs[name]; ok && ev.ID() == id {
-		delete(a.evs, name)
+	if ev, ok := a.evs[path]; ok && ev.ID() == id {
+		delete(a.evs, path)
 	}
 }

--- a/go/src/koding/klient/machine/mount/sync/anteroom.go
+++ b/go/src/koding/klient/machine/mount/sync/anteroom.go
@@ -115,7 +115,7 @@ func (a *Anteroom) Status() (items int, queued int) {
 
 // Close stops the dynamic client. After this function is called, client is
 // in disconnected state and each contexts returned by it are closed.
-func (a *Anteroom) Close() {
+func (a *Anteroom) Close() error {
 	a.once.Do(func() {
 		a.mu.Lock()
 		defer a.mu.Unlock()
@@ -131,6 +131,8 @@ func (a *Anteroom) Close() {
 		a.closed = true
 		close(a.stopC) // Stop dispatching go-routine.
 	})
+
+	return nil
 }
 
 // dequeue pops events from the queue and sends them to events channel.

--- a/go/src/koding/klient/machine/mount/sync/anteroom_test.go
+++ b/go/src/koding/klient/machine/mount/sync/anteroom_test.go
@@ -151,10 +151,10 @@ func TestAnteroomMultiEvents(t *testing.T) {
 	const eventsN = 1000
 	sent := make(map[string]struct{})
 	for i := 0; i < eventsN; i++ {
-		name := "file" + strconv.Itoa(i) + ".txt"
+		path := "file" + strconv.Itoa(i) + ".txt"
 
-		a.Commit(index.NewChange(name, index.ChangeMetaRemove))
-		sent[name] = struct{}{}
+		a.Commit(index.NewChange(path, index.ChangeMetaRemove))
+		sent[path] = struct{}{}
 	}
 
 	got := make(map[string]struct{})
@@ -164,7 +164,7 @@ func TestAnteroomMultiEvents(t *testing.T) {
 			if ev == nil {
 				t.Fatalf("received nil event")
 			}
-			got[ev.Change().Name()] = struct{}{}
+			got[ev.Change().Path()] = struct{}{}
 		case <-time.After(time.Second):
 			t.Fatalf("timed out after %s", time.Second)
 		}
@@ -186,6 +186,6 @@ func TestAnteroomMultiEvents(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(sent, got) {
-		t.Fatalf("sent event names are not equal to received ones")
+		t.Fatalf("sent event paths are not equal to received ones")
 	}
 }

--- a/go/src/koding/klient/machine/mount/sync/discard/discard.go
+++ b/go/src/koding/klient/machine/mount/sync/discard/discard.go
@@ -23,9 +23,16 @@ type Event struct {
 // Exec satisfies msync.Execer interface. The only thing this method does is
 // closing internal sync event.
 func (e *Event) Exec() error {
-	e.ev.Done()
+	if e.ev.Valid() {
+		e.ev.Done()
+	}
 
 	return nil
+}
+
+// String implements fmt.Stringer interface. It pretty prints internal event.
+func (e *Event) String() string {
+	return e.ev.String() + " - " + "discarded"
 }
 
 // Discard is a no-op synchronization object. It can be used as a stub for other

--- a/go/src/koding/klient/machine/mount/sync/discard/discard.go
+++ b/go/src/koding/klient/machine/mount/sync/discard/discard.go
@@ -80,8 +80,10 @@ func (d *Discard) ExecStream(evC <-chan *msync.Event) <-chan msync.Execer {
 }
 
 // Close stops all created synchronization streams.
-func (d *Discard) Close() {
+func (d *Discard) Close() error {
 	d.once.Do(func() {
 		close(d.stopC)
 	})
+
+	return nil
 }

--- a/go/src/koding/klient/machine/mount/sync/event.go
+++ b/go/src/koding/klient/machine/mount/sync/event.go
@@ -95,7 +95,7 @@ func (e *Event) Valid() bool {
 // event should be GC if it haven't been yet.
 func (e *Event) Done() {
 	if atomic.SwapUint64((*uint64)(&e.stat), uint64(statusDone)) != uint64(statusDeprecated) {
-		e.parent.detach(e.change.Name(), e.id)
+		e.parent.detach(e.change.Path(), e.id)
 		e.cancel()
 	}
 }

--- a/go/src/koding/klient/machine/mount/sync/event.go
+++ b/go/src/koding/klient/machine/mount/sync/event.go
@@ -20,6 +20,22 @@ const (
 	statusDone                         // Event is completed.
 )
 
+// String returns textual representation of event status.
+func (s status) String() string {
+	switch s {
+	case statusPush:
+		return "PUSH"
+	case statusPop:
+		return "POP_"
+	case statusDeprecated:
+		return "DEPR"
+	case statusDone:
+		return "DONE"
+	}
+
+	return "UNKN"
+}
+
 // Event wraps index change with context.Context. When more index.Changes arrive
 // to anteroom, they are coalesced and have the same context.
 type Event struct {
@@ -82,4 +98,9 @@ func (e *Event) Done() {
 		e.parent.detach(e.change.Name(), e.id)
 		e.cancel()
 	}
+}
+
+// String implements fmt.Stringer interface it pretty prints stored event.
+func (e *Event) String() string {
+	return status(atomic.LoadUint64((*uint64)(&e.stat))).String() + " " + e.change.String()
 }

--- a/go/src/koding/klient/machine/mount/sync/sync.go
+++ b/go/src/koding/klient/machine/mount/sync/sync.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -42,6 +43,9 @@ type Execer interface {
 	// Exec starts synchronization of stored syncing job. It should update
 	// indexes and clean up synced Event.
 	Exec() error
+
+	// fmt.Stringer defines human readable information about the event.
+	fmt.Stringer
 }
 
 // Syncer is an interface which must be implemented by external syncer.


### PR DESCRIPTION
This PR adds mount synchronization event logging useful for mount tests.

- `index.Change.name` was replaced by `index.Change.path`.
- all `Close()` methods now implement `io.Closer` interface (`Close() error`)

Depends on: ~#10531~, ~#10532~

## How Has This Been Tested?
n/a

## Types of changes
- [x] New feature (non-breaking change which adds functionality)