### PR TITLE
Klient machine: add diskBlocks function to notifier build options

### DIFF
--- a/go/src/koding/klient/machine/mount/notify/notify.go
+++ b/go/src/koding/klient/machine/mount/notify/notify.go
@@ -4,9 +4,13 @@ import (
 	"context"
 	"io"
 
+	"koding/klient/fs"
 	"koding/klient/machine/index"
 	"koding/klient/machine/mount"
 )
+
+// DiskBlocks retrieves information about remote directory volume.
+type DiskBlocks func() (fs.DiskInfo, err error)
 
 // BuildOpts represents the context that can be used by external notifiers to
 // build their own type. Built notifier should only read from provided indexes
@@ -17,6 +21,8 @@ type BuildOpts struct {
 
 	Cache    Cache  // index file system change consumer.
 	CacheDir string // absolute path to locally cached files.
+
+	DiskBlocks DiskBlocks // remote directory volume info.
 
 	RemoteIdx *index.Index // known state of remote index.
 	LocalIdx  *index.Index // known state of local index.

--- a/go/src/koding/klient/machine/mount/notify/notify.go
+++ b/go/src/koding/klient/machine/mount/notify/notify.go
@@ -9,8 +9,8 @@ import (
 	"koding/klient/machine/mount"
 )
 
-// DiskBlocks retrieves information about remote directory volume.
-type DiskBlocks func() (fs.DiskInfo, err error)
+// DiskInfo retrieves information about remote directory volume.
+type DiskInfo func() (fs.DiskInfo, error)
 
 // BuildOpts represents the context that can be used by external notifiers to
 // build their own type. Built notifier should only read from provided indexes
@@ -22,7 +22,7 @@ type BuildOpts struct {
 	Cache    Cache  // index file system change consumer.
 	CacheDir string // absolute path to locally cached files.
 
-	DiskBlocks DiskBlocks // remote directory volume info.
+	DiskInfo DiskInfo // remote directory volume info.
 
 	RemoteIdx *index.Index // known state of remote index.
 	LocalIdx  *index.Index // known state of local index.

--- a/go/src/koding/klient/machine/mount/sync/sync.go
+++ b/go/src/koding/klient/machine/mount/sync/sync.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"koding/klient/fs"
 	"koding/klient/machine"
 	"koding/klient/machine/client"
 	"koding/klient/machine/index"
@@ -185,12 +186,13 @@ func NewSync(mountID mount.ID, m mount.Mount, opts SyncOpts) (*Sync, error) {
 
 	// Create file system notification object.
 	s.n, err = opts.NotifyBuilder.Build(&notify.BuildOpts{
-		MountID:   mountID,
-		Mount:     m,
-		Cache:     s.a,
-		CacheDir:  filepath.Join(s.opts.WorkDir, "data"),
-		RemoteIdx: s.ridx,
-		LocalIdx:  s.lidx,
+		MountID:    mountID,
+		Mount:      m,
+		Cache:      s.a,
+		CacheDir:   filepath.Join(s.opts.WorkDir, "data"),
+		DiskBlocks: s.diskBlocks(),
+		RemoteIdx:  s.ridx,
+		LocalIdx:   s.lidx,
 	})
 	if err != nil {
 		return nil, nonil(err, s.a.Close())
@@ -286,6 +288,19 @@ func (s *Sync) updateLocal() error {
 
 	s.lidx.Apply(dataPath, cs)
 	return index.SaveIndex(s.lidx, filepath.Join(s.opts.WorkDir, LocalIndexName))
+}
+
+func (s *Sync) diskBlocks() notify.DiskBlocks {
+	const (
+		rt = 10 * time.Second // How long client should wait for valid connection.
+		ct = 5 * time.Minute  // How long client responses will be cached.
+	)
+
+	cached := client.NewCached(client.NewSupervised(s.opts.ClientFunc, rt), ct)
+
+	return func() (fs.DiskInfo, error) {
+		return cached.DiskInfo(s.m.RemotePath)
+	}
 }
 
 func nonil(err ...error) error {

--- a/go/src/koding/klient/machine/mount/sync/sync.go
+++ b/go/src/koding/klient/machine/mount/sync/sync.go
@@ -186,13 +186,13 @@ func NewSync(mountID mount.ID, m mount.Mount, opts SyncOpts) (*Sync, error) {
 
 	// Create file system notification object.
 	s.n, err = opts.NotifyBuilder.Build(&notify.BuildOpts{
-		MountID:    mountID,
-		Mount:      m,
-		Cache:      s.a,
-		CacheDir:   filepath.Join(s.opts.WorkDir, "data"),
-		DiskBlocks: s.diskBlocks(),
-		RemoteIdx:  s.ridx,
-		LocalIdx:   s.lidx,
+		MountID:   mountID,
+		Mount:     m,
+		Cache:     s.a,
+		CacheDir:  filepath.Join(s.opts.WorkDir, "data"),
+		DiskInfo:  s.diskInfo(),
+		RemoteIdx: s.ridx,
+		LocalIdx:  s.lidx,
 	})
 	if err != nil {
 		return nil, nonil(err, s.a.Close())
@@ -290,7 +290,7 @@ func (s *Sync) updateLocal() error {
 	return index.SaveIndex(s.lidx, filepath.Join(s.opts.WorkDir, LocalIndexName))
 }
 
-func (s *Sync) diskBlocks() notify.DiskBlocks {
+func (s *Sync) diskInfo() notify.DiskInfo {
 	const (
 		rt = 10 * time.Second // How long client should wait for valid connection.
 		ct = 5 * time.Minute  // How long client responses will be cached.
@@ -309,5 +309,6 @@ func nonil(err ...error) error {
 			return e
 		}
 	}
+
 	return nil
 }


### PR DESCRIPTION
DiskBlocks function is needed for some parts of FUSE logic, this PR adds this function with all benefits of dynamic clients and cache.

Depends on: ~#10531~, ~#10543~

## How Has This Been Tested?
n/a

## Types of changes
- [x] New feature (non-breaking change which adds functionality)