### PR TITLE
klient/machine: add suport for tilde prefix in remote mount path

### DIFF
--- a/go/src/koding/klient/machine/index/handler.go
+++ b/go/src/koding/klient/machine/index/handler.go
@@ -77,9 +77,11 @@ func Get(req *Request) (*GetResponse, error) {
 // preparePath performs basic checks and makes a given path usable for local
 // file system.
 func preparePath(path string) (string, error) {
+	const tilde = "~" + string(os.PathSeparator)
+
 	switch isAbs := filepath.IsAbs(path); {
 	case isAbs:
-	case !isAbs && len(path) > 1 && path[:2] == "~/":
+	case !isAbs && len(path) > 1 && path[:2] == tilde:
 		path = strings.Replace(path, "~", config.CurrentUser.HomeDir, 1)
 	default:
 		return "", fmt.Errorf("remote path format is invalid: %s", path)


### PR DESCRIPTION
this PR adds support for mount commands with tilde prefix:

```sh
$ kd machine mount red_orange:~/remote_path ~/local_path
```

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
