### PR TITLE
machine/index: add EntryPromiseUnlink meta

### DIFF
--- a/go/src/koding/klient/machine/index/index.go
+++ b/go/src/koding/klient/machine/index/index.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"sort"
 	"sync"
+	"sync/atomic"
 
 	"github.com/djherbis/times"
 )
@@ -20,13 +21,12 @@ import (
 // Version stores current version of index.
 const Version = 1
 
-// EntryMeta describes entry metadata.
-type EntryMeta int32
-
+// Entry group describes values of an Entry.Meta field.
 const (
-	EntryPromiseAdd EntryMeta = iota << 1
+	EntryPromiseAdd = iota << 1
 	EntryPromiseUpdate
 	EntryPromiseDel
+	EntryPromiseUnlink
 )
 
 // Entry represents a single file registered to index.
@@ -35,9 +35,29 @@ type Entry struct {
 	CTime int64       `json:"c"` // Metadata change time since EPOCH.
 	MTime int64       `json:"m"` // File data change time since EPOCH.
 	Size  int64       `json:"s"` // Size of the file.
-	Aux   uint64      `json:"-"` // Auxiliary data, fuse uses it to store fuseops.InodeID.
+	Inode uint64      `json:"-"` // fuseops.InodeID
+	Ref   int32       `json:"-"` // inode's reference count
 	Mode  os.FileMode `json:"o"` // File mode and permission bits.
-	Meta  EntryMeta   `json:"-"` // Entry metadata.
+	Meta  int32       `json:"-"` // Entry metadata; written under (*Index).mu, read with atomic op
+}
+
+// The following methods are conveniance helpers for a lock-free
+// access of Entry's fields.
+func (e *Entry) GetInode() uint64      { return atomic.LoadUint64(&e.Inode) }
+func (e *Entry) SetInode(inode uint64) { atomic.StoreUint64(&e.Inode, inode) }
+func (e *Entry) IncRef() int32         { return atomic.AddInt32(&e.Ref, 1) }
+func (e *Entry) DecRef() int32         { return atomic.AddInt32(&e.Ref, -1) }
+func (e *Entry) Has(meta int32) bool   { return atomic.LoadInt32(&e.Meta)&meta == meta }
+
+// SwapMeta flips the value of a Meta field, setting the set
+// bits and unsetting the unset ones.
+//
+// As it uses multiple atomic ops, it is safe to call only
+// when protected by (*Index).mu.
+func (e *Entry) SwapMeta(set, unset int32) int32 {
+	meta := (atomic.LoadInt32(&e.Meta) | set) &^ unset
+	atomic.StoreInt32(&e.Meta, meta)
+	return meta
 }
 
 // NewEntryFile creates new Entry from a file stored under path argument.
@@ -185,9 +205,8 @@ func (idx *Index) addEntryWorker(root string, wg *sync.WaitGroup, fC <-chan *fil
 // If the node is already marked as newly added, the method is a no-op.
 func (idx *Index) PromiseAdd(path string, entry *Entry) {
 	idx.mu.Lock()
-	defer idx.mu.Unlock()
-
 	idx.root.PromiseAdd(path, entry)
+	idx.mu.Unlock()
 }
 
 // PromiseDel marks a node under the given path as deleted.
@@ -196,9 +215,18 @@ func (idx *Index) PromiseAdd(path string, entry *Entry) {
 // method is no-op.
 func (idx *Index) PromiseDel(path string) {
 	idx.mu.Lock()
-	defer idx.mu.Unlock()
-
 	idx.root.PromiseDel(path)
+	idx.mu.Unlock()
+}
+
+// PromiseUnlink marks a node under the given path as unlinked.
+//
+// If the node does not exist or is already marked as unlinked,
+// the method is a no-op.
+func (idx *Index) PromiseUnlink(path string) {
+	idx.mu.Lock()
+	idx.root.PromiseUnlink(path)
+	idx.mu.Unlock()
 }
 
 // Count returns the number of entries stored in index. Only items which size is

--- a/go/src/koding/klient/machine/index/node.go
+++ b/go/src/koding/klient/machine/index/node.go
@@ -111,46 +111,64 @@ func (nd *Node) Del(path string) {
 // If entry.Aux is non-zero, the effictive node's Aux is overwritten
 // with this value.
 //
-// If the given entry was previously marked as deleted,
-// the flag will be removed.
-//
 // Rest of entry's fields are currently ignored.
 func (nd *Node) PromiseAdd(path string, entry *Entry) {
 	var newE *Entry
 
 	if nd, ok := nd.lookup(path, true); ok {
 		newE = nd.Entry
+
+		if entry.Inode != 0 {
+			newE.SetInode(entry.Inode)
+		}
+
+		if entry.Mode != 0 {
+			// BUG(rjeczalik): this is not safe when nd is read elsewhere.
+			//
+			// This field is read by fuse.ReadDir and PromiseAdd is called
+			// by fuse.CreateFile or fuse.MkDir, and fuse.ReadDir is not
+			// called until one of the former returns.
+			//
+			// However this should be changed to an atomic op once the field
+			// is read by something else.
+			newE.Mode = entry.Mode
+		}
+
 	} else {
 		newE = newEntry()
-	}
-
-	if entry.Mode != 0 {
 		newE.Mode = entry.Mode
+		newE.Inode = entry.Inode
 	}
 
-	if entry.Aux != 0 {
-		newE.Aux = entry.Aux
-	}
-
-	newE.Meta = (newE.Meta | EntryPromiseAdd) &^ EntryPromiseDel
+	newE.SwapMeta(EntryPromiseAdd, EntryPromiseDel|EntryPromiseUnlink)
 
 	nd.Add(path, newE)
 }
 
 // PromiseDel marks a node under the given path as deleted.
 //
-// If the node does not exist or is already marked as deleted, the
+// If the node does not exist or is already marked as deleted, then
 // method is no-op.
-//
-// If the given entry was previously marked as added,
-// the flag will be removed.
 func (nd *Node) PromiseDel(path string) {
 	nd, ok := nd.Lookup(path)
 	if !ok {
 		return
 	}
 
-	nd.Entry.Meta = (nd.Entry.Meta | EntryPromiseDel) &^ EntryPromiseAdd
+	nd.Entry.SwapMeta(EntryPromiseDel, EntryPromiseAdd)
+}
+
+// PromiseUnlink marks a node under the given path as unlinked.
+//
+// If the node does not exist or is already marked as unlinked, then
+// method is no-op.
+func (nd *Node) PromiseUnlink(path string) {
+	nd, ok := nd.Lookup(path)
+	if !ok {
+		return
+	}
+
+	nd.Entry.SwapMeta(EntryPromiseUnlink, EntryPromiseAdd)
 }
 
 // Count counts nodes which Entry.Size is at most maxsize.
@@ -294,11 +312,11 @@ func (nd *Node) IsDir() bool {
 
 // Deleted tells whether node is marked as deleted.
 func (nd *Node) Deleted() bool {
-	return nd.Entry.Meta&EntryPromiseDel != 0
+	return nd.Entry.Has(EntryPromiseDel)
 }
 
 func (nd *Node) undelete() {
-	nd.Entry.Meta &^= EntryPromiseDel
+	nd.Entry.SwapMeta(0, EntryPromiseDel|EntryPromiseUnlink)
 }
 
 func (nd *Node) shallowCopy() *Node {


### PR DESCRIPTION
This PR:

- adds EntryPromiseUnlink meta
- adds Entry.Ref field
- adds utility helpers for atomic read of Entry's fields

The fuse.Unlink method decrements Entry.Ref, however when it reaches 0 the file cannot be deleted right away, as it may still be referenced by process owning a file handle. Once ForgetInode is called, if inode is marked with EntryPromiseUnlink, the file is effectively deleted from cache.