### PR TITLE
notify/fuse: first working implementation

### DIFF
--- a/go/src/koding/klient/fs/fs.go
+++ b/go/src/koding/klient/fs/fs.go
@@ -9,7 +9,6 @@ import (
 	"path"
 	"path/filepath"
 	"sync"
-	"syscall"
 
 	"github.com/koding/kite"
 	"github.com/koding/kite/dnode"
@@ -391,17 +390,10 @@ func GetDiskInfo(r *kite.Request) (interface{}, error) {
 		return nil, errors.New("{ path: [string] }")
 	}
 
-	stfs := syscall.Statfs_t{}
-	if err := syscall.Statfs(params.Path, &stfs); err != nil {
+	di, err := Statfs(params.Path)
+	if err != nil {
 		return nil, err
 	}
-
-	di := &DiskInfo{
-		BlockSize:   uint32(stfs.Bsize),
-		BlocksTotal: stfs.Blocks,
-		BlocksFree:  stfs.Bfree,
-	}
-	di.BlocksUsed = di.BlocksTotal - di.BlocksFree
 
 	return di, nil
 }

--- a/go/src/koding/klient/fs/fs.go
+++ b/go/src/koding/klient/fs/fs.go
@@ -378,6 +378,7 @@ type DiskInfo struct {
 	BlocksTotal uint64 `json:"blocksTotal"`
 	BlocksFree  uint64 `json:"blocksFree"`
 	BlocksUsed  uint64 `json:"blocksUsed"`
+	IOSize      int32  `json:"ioSize"`
 }
 
 // GetDiskInfo returns DiskInfo about the mount at the specified path.

--- a/go/src/koding/klient/fs/statfs.go
+++ b/go/src/koding/klient/fs/statfs.go
@@ -1,0 +1,12 @@
+// +build !linux,!darwin
+
+package fs
+
+import (
+	"errors"
+	"runtime"
+)
+
+func Statfs(string) (*DiskInfo, error) {
+	return nil, errors.New("not implemented on " + runtime.GOOS)
+}

--- a/go/src/koding/klient/fs/statfs_darwin.go
+++ b/go/src/koding/klient/fs/statfs_darwin.go
@@ -1,0 +1,21 @@
+package fs
+
+import "syscall"
+
+func Statfs(path string) (*DiskInfo, error) {
+	var stfs syscall.Statfs_t
+
+	if err := syscall.Statfs(path, &stfs); err != nil {
+		return nil, err
+	}
+
+	di := &DiskInfo{
+		BlockSize:   uint32(stfs.Bsize),
+		BlocksTotal: stfs.Blocks,
+		BlocksFree:  stfs.Bfree,
+		IOSize:      stfs.Iosize,
+	}
+	di.BlocksUsed = di.BlocksTotal - di.BlocksFree
+
+	return di, nil
+}

--- a/go/src/koding/klient/fs/statfs_linux.go
+++ b/go/src/koding/klient/fs/statfs_linux.go
@@ -1,0 +1,20 @@
+package fs
+
+import "syscall"
+
+func Statfs(path string) (*DiskInfo, error) {
+	var stfs syscall.Statfs_t
+
+	if err := syscall.Statfs(path, &stfs); err != nil {
+		return nil, err
+	}
+
+	di := &DiskInfo{
+		BlockSize:   uint32(stfs.Bsize),
+		BlocksTotal: stfs.Blocks,
+		BlocksFree:  stfs.Bfree,
+	}
+	di.BlocksUsed = di.BlocksTotal - di.BlocksFree
+
+	return di, nil
+}

--- a/go/src/koding/klient/machine/index/entry.go
+++ b/go/src/koding/klient/machine/index/entry.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"fmt"
+
 	"github.com/djherbis/times"
 )
 
@@ -110,6 +111,47 @@ func NewEntryFile(path string) (*Entry, error) {
 	}
 
 	return NewEntryFileInfo(info), nil
+}
+
+// Copy returns a deep copy of the e value.
+//
+// RefCount field is ignored and set to 0.
+func (e *Entry) Copy() *Entry {
+	return &Entry{
+		real: realEntry{
+			CTime: e.CTime(),
+			MTime: e.MTime(),
+			Size:  e.Size(),
+			Mode:  e.Mode(),
+		},
+		virtual: virtualEntry{
+			inode:    e.Inode(),
+			refCount: 0,
+			promise:  e.Promise(),
+		},
+	}
+}
+
+// MergeIn overwrites e's fields with f's ones, but only
+// with those values the are non-zero.
+//
+// RefCount and Promise fields are ignored.
+func (e *Entry) MergeIn(f *Entry) {
+	if t := f.CTime(); t != 0 {
+		e.SetCTime(t)
+	}
+	if t := f.MTime(); t != 0 {
+		e.SetMTime(t)
+	}
+	if n := f.Size(); n != 0 {
+		e.SetSize(n)
+	}
+	if m := f.Mode(); m != 0 {
+		e.SetMode(m)
+	}
+	if n := f.Inode(); n != 0 {
+		e.SetInode(n)
+	}
 }
 
 // CTime atomically gets entry change time in UNIX nano format.

--- a/go/src/koding/klient/machine/index/node.go
+++ b/go/src/koding/klient/machine/index/node.go
@@ -101,17 +101,10 @@ func (nd *Node) PromiseAdd(path string, entry *Entry) {
 
 	if nd, ok := nd.lookup(path, true); ok {
 		newE = nd.Entry
-
-		if entry.Inode() != 0 {
-			newE.SetInode(entry.Inode())
-		}
-		if entry.Mode() != 0 {
-			newE.SetMode(entry.Mode())
-		}
-
+		newE.MergeIn(entry)
 	} else {
 		newE = NewEntry(entry.Size(), entry.Mode())
-		newE.SetInode(entry.Inode())
+		newE.MergeIn(entry)
 	}
 
 	newE.SwapPromise(EntryPromiseAdd, EntryPromiseDel|EntryPromiseUnlink)
@@ -351,14 +344,17 @@ func (nd *Node) undelete() {
 }
 
 func (nd *Node) shallowCopy() *Node {
-	if len(nd.Sub) != 0 {
+	if nd.Sub != nil {
 		sub := make(map[string]*Node, len(nd.Sub))
 
 		for k, v := range nd.Sub {
 			sub[k] = v
 		}
 
-		nd.Sub = sub
+		return &Node{
+			Sub:   sub,
+			Entry: nd.Entry,
+		}
 	}
 
 	return nd

--- a/go/src/koding/klient/machine/mount/notify/fuse/export_test.go
+++ b/go/src/koding/klient/machine/mount/notify/fuse/export_test.go
@@ -1,0 +1,4 @@
+package fuse
+
+// TrimRightNull exports trimRightNull for testing purposes.
+var TrimRightNull = trimRightNull

--- a/go/src/koding/klient/machine/mount/notify/fuse/filesystem.go
+++ b/go/src/koding/klient/machine/mount/notify/fuse/filesystem.go
@@ -45,6 +45,7 @@ func block(path string) *fs.DiskInfo {
 		BlockSize:   uint32(stfs.Bsize),
 		BlocksTotal: stfs.Blocks,
 		BlocksFree:  stfs.Bfree,
+		IOSize:      stfs.Iosize,
 	}
 
 	di.BlocksUsed = di.BlocksTotal - di.BlocksFree
@@ -54,7 +55,6 @@ func block(path string) *fs.DiskInfo {
 
 // Build implements the notify.Builder interface.
 func (builder) Build(opts *notify.BuildOpts) (notify.Notifier, error) {
-
 	o := &Opts{
 		Index:    opts.Index,
 		Cache:    opts.Cache,
@@ -165,7 +165,7 @@ func NewFilesystem(opts *Opts) (*Filesystem, error) {
 		inodes: map[fuseops.InodeID]string{
 			fuseops.RootInodeID: "",
 		},
-		seqHandle: uint64(fuseops.RootInodeID),
+		seqHandle: uint64(3),
 		handles:   make(map[fuseops.HandleID]*os.File),
 	}
 
@@ -234,6 +234,10 @@ func (fs *Filesystem) add(path string) (id fuseops.InodeID) {
 func (fs *Filesystem) addHandle(f *os.File) (id fuseops.HandleID) {
 	for {
 		fs.seqHandle++
+
+		if fs.seqHandle < 3 {
+			fs.seqHandle = 3
+		}
 
 		id = fuseops.HandleID(fs.seqHandle)
 
@@ -425,13 +429,7 @@ func (fs *Filesystem) mkfile(path string, mode os.FileMode) (id fuseops.InodeID,
 		return 0, 0, err
 	}
 
-	if err := f.Close(); err != nil {
-		return 0, 0, err
-	}
-
-	if f, err = os.OpenFile(absPath, os.O_RDWR, 0644); err != nil {
-		return 0, 0, err
-	}
+	_ = f.Chmod(mode)
 
 	entry := index.NewEntry(0, mode)
 	entry.IncRefCount()
@@ -444,8 +442,6 @@ func (fs *Filesystem) mkfile(path string, mode os.FileMode) (id fuseops.InodeID,
 	entry.SetInode(uint64(id))
 
 	fs.Index.PromiseAdd(path, entry)
-
-	_ = f.Chmod(mode)
 
 	return id, h, nil
 }
@@ -491,17 +487,15 @@ func (fs *Filesystem) rm(ctx stdcontext.Context, nd *index.Node, path string) er
 }
 
 func (fs *Filesystem) update(ctx stdcontext.Context, f *os.File, nd *index.Node) error {
-	if err := f.Sync(); err != nil {
-		return err
-	}
+	err := f.Sync()
 
-	updateSize(f, nd)
+	_ = updateSize(f, nd)
 
-	return fs.yield(ctx, f.Name(), index.ChangeMetaLocal|index.ChangeMetaUpdate)
+	return nonil(err, fs.yield(ctx, f.Name(), index.ChangeMetaLocal|index.ChangeMetaUpdate))
 }
 
 func (fs *Filesystem) open(ctx stdcontext.Context, nd *index.Node, path string) (*os.File, fuseops.HandleID, error) {
-	f, err := fs.openFile(ctx, path)
+	f, err := fs.openFile(ctx, path, nd.Entry.Mode())
 	if err != nil {
 		return nil, 0, err
 	}
@@ -515,18 +509,21 @@ func (fs *Filesystem) open(ctx stdcontext.Context, nd *index.Node, path string) 
 	return f, id, nil
 }
 
-func (fs *Filesystem) openFile(ctx stdcontext.Context, path string) (*os.File, error) {
-	flag := os.O_RDWR
+func (fs *Filesystem) openFile(ctx stdcontext.Context, path string, mode os.FileMode) (*os.File, error) {
 	path = fs.path(path)
 
-	f, err := os.OpenFile(path, flag, 0644)
+	f, err := os.OpenFile(path, os.O_RDWR, mode)
 	if os.IsNotExist(err) {
 		err = fs.yield(ctx, path, index.ChangeMetaAdd|index.ChangeMetaRemote)
 		if err != nil {
 			return nil, err
 		}
 
-		f, err = os.OpenFile(path, flag, 0644)
+		f, err = os.OpenFile(path, os.O_RDWR, mode)
+	}
+
+	if os.IsPermission(err) {
+		f, err = os.OpenFile(path, os.O_RDONLY, mode)
 	}
 
 	return f, err

--- a/go/src/koding/klient/machine/mount/notify/fuse/filesystem.go
+++ b/go/src/koding/klient/machine/mount/notify/fuse/filesystem.go
@@ -1,0 +1,619 @@
+package fuse
+
+import (
+	stdcontext "context"
+	"errors"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"koding/kites/config"
+	"koding/klient/fs"
+	"koding/klient/machine/index"
+	"koding/klient/machine/mount/notify"
+
+	"github.com/jacobsa/fuse"
+	origfuse "github.com/jacobsa/fuse"
+	"github.com/jacobsa/fuse/fuseops"
+	"github.com/jacobsa/fuse/fuseutil"
+	"golang.org/x/net/context"
+)
+
+// TODO(rjeczalik): add promise update ops, so attrs updates are served
+// right away, without waiting for index update.
+
+// TODO(rjeczalik): symlink support: add index.Entry.Nlink field and
+// add support for in Unlink, ForgotInode and CreateSymlink methods.
+
+// Builder provides a default notify.Builder for the FUSE filesystem.
+var Builder notify.Builder = builder{}
+
+type builder struct{}
+
+func block(path string) *fs.DiskInfo {
+	stfs := syscall.Statfs_t{}
+
+	if err := syscall.Statfs(path, &stfs); err != nil {
+		return nil
+	}
+
+	di := &fs.DiskInfo{
+		BlockSize:   uint32(stfs.Bsize),
+		BlocksTotal: stfs.Blocks,
+		BlocksFree:  stfs.Bfree,
+	}
+
+	di.BlocksUsed = di.BlocksTotal - di.BlocksFree
+
+	return di
+}
+
+// Build implements the notify.Builder interface.
+func (builder) Build(opts *notify.BuildOpts) (notify.Notifier, error) {
+
+	o := &Opts{
+		Index:    opts.Index,
+		Cache:    opts.Cache,
+		CacheDir: opts.CacheDir,
+		Mount:    filepath.Base(opts.Mount.Path),
+		MountDir: opts.Mount.Path,
+		// intentionally separate env to not enable fuse logging
+		// for regular kd debug
+		Debug: os.Getenv("KD_MOUNT_DEBUG") == "1",
+	}
+
+	// TODO(ppknap) get disk info from client.
+	if o.Disk == nil {
+		o.Disk = block(opts.CacheDir)
+	}
+
+	if err := o.Valid(); err != nil {
+		return nil, err
+	}
+
+	return NewFilesystem(o)
+}
+
+// Opts configures FUSE filesystem.
+type Opts struct {
+	Index    *index.Index // metadata index
+	Disk     *fs.DiskInfo // filesystem information
+	Cache    notify.Cache // used to request cache updates
+	CacheDir string       // path of the cache directory of the mount; must end with a dangling /
+	Mount    string       // name of the mount
+	MountDir string       // path of the mount directory
+	User     *config.User // owner of the mount; if nil, config.CurrentUser is used
+	Debug    bool         // turns on fuse debug logging
+}
+
+// Valid implements the stack.Validator interface.
+func (o *Opts) Valid() error {
+	const sep = string(os.PathSeparator)
+
+	if o.Index == nil {
+		return errors.New("index is nil")
+	}
+	if o.Cache == nil {
+		return errors.New("cache is nil")
+	}
+	if o.MountDir == "" {
+		return errors.New("mount directory is empty")
+	}
+	if o.CacheDir == "" {
+		return errors.New("cache directory is empty")
+	}
+	if !strings.HasSuffix(o.CacheDir, sep) {
+		o.CacheDir = o.CacheDir + sep
+	}
+	return nil
+}
+
+func (opts *Opts) user() *config.User {
+	if opts.User != nil {
+		return opts.User
+	}
+	return config.CurrentUser
+}
+
+type dir struct {
+	files  []string
+	offset int
+}
+
+// Filesystem implements fuseutil.FileSystem.
+//
+// List operations are backend by index.
+// Write and read operations are backed by cache,
+// which is populated lazily by notify.Cache.
+type Filesystem struct {
+	// NotImplementedFileSystem provides stubs for the following methods:
+	//
+	//   - MkNode
+	//   - CreateSymlink
+	//   - ReadSymlink
+	//
+	fuseutil.NotImplementedFileSystem
+	Opts
+
+	cancel func()
+
+	mu        sync.RWMutex
+	seq       uint64
+	inodes    map[fuseops.InodeID]string
+	seqHandle uint64
+	handles   map[fuseops.HandleID]*os.File
+}
+
+var _ fuseutil.FileSystem = (*Filesystem)(nil)
+
+// NewFilesystem creates new Filesystem value.
+func NewFilesystem(opts *Opts) (*Filesystem, error) {
+	if err := os.MkdirAll(opts.MountDir, 0755); err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	fs := &Filesystem{
+		Opts:   *opts,
+		cancel: cancel,
+		seq:    uint64(fuseops.RootInodeID),
+		inodes: map[fuseops.InodeID]string{
+			fuseops.RootInodeID: "",
+		},
+		seqHandle: uint64(fuseops.RootInodeID),
+		handles:   make(map[fuseops.HandleID]*os.File),
+	}
+
+	// Best-effort attempt of unmounting already existing mount.
+	_ = Umount(fs.MountDir)
+
+	m, err := origfuse.Mount(opts.MountDir, fuseutil.NewFileSystemServer(fs), fs.Config())
+	if err != nil {
+		return nil, err
+	}
+
+	go m.Join(ctx)
+
+	return fs, nil
+}
+
+// Close implements the notify.Notifier interface.
+func (fs *Filesystem) Close() error {
+	fs.cancel()
+	fs.Destroy()
+
+	return Umount(fs.MountDir)
+}
+
+func (fs *Filesystem) Config() *fuse.MountConfig {
+	var logger *log.Logger
+
+	if fs.Debug {
+		logger = log.New(os.Stderr, "fuse", log.LstdFlags|log.Lshortfile)
+	}
+
+	return &fuse.MountConfig{
+		FSName:                  fs.Mount,
+		VolumeName:              filepath.Base(fs.MountDir),
+		DisableWritebackCaching: true,
+		EnableVnodeCaching:      false,
+		Options:                 map[string]string{"allow_other": ""},
+		DebugLogger:             logger,
+		ErrorLogger:             logger,
+	}
+}
+
+func (fs *Filesystem) DebugString() string {
+	return fs.Index.DebugString()
+}
+
+func (fs *Filesystem) add(path string) (id fuseops.InodeID) {
+	for {
+		fs.seq++
+
+		if fs.seq <= fuseops.RootInodeID {
+			fs.seq = fuseops.RootInodeID + 1
+		}
+
+		id = fuseops.InodeID(fs.seq)
+
+		if _, ok := fs.inodes[id]; !ok {
+			fs.inodes[id] = path
+			break
+		}
+	}
+
+	return id
+}
+
+func (fs *Filesystem) addHandle(f *os.File) (id fuseops.HandleID) {
+	for {
+		fs.seqHandle++
+
+		id = fuseops.HandleID(fs.seqHandle)
+
+		if _, ok := fs.handles[id]; !ok {
+			fs.handles[id] = f
+			break
+		}
+	}
+
+	return id
+}
+
+func (fs *Filesystem) lookupInodeID(dir, base string, entry *index.Entry) (id fuseops.InodeID) {
+	// Fast path - check if InodeID was already associated with index node.
+	if id = fuseops.InodeID(entry.Inode()); id != 0 {
+		return id
+	}
+
+	path := filepath.Join(dir, base)
+
+	fs.mu.Lock()
+	id = fs.add(path)
+	entry.SetInode(uint64(id))
+	fs.mu.Unlock()
+
+	return id
+}
+
+func (fs *Filesystem) get(id fuseops.InodeID) (*index.Node, string, bool) {
+	fs.mu.RLock()
+	path, ok := fs.inodes[id]
+	fs.mu.RUnlock()
+
+	if !ok {
+		return nil, "", false
+	}
+
+	nd, ok := fs.Index.Lookup(path)
+	if !ok {
+		return nil, "", false
+	}
+
+	return nd, path, true
+}
+
+func (fs *Filesystem) getDir(id fuseops.InodeID) (*index.Node, string, error) {
+	nd, path, ok := fs.get(id)
+	if !ok {
+		return nil, "", fuse.ENOENT
+	}
+
+	if !isdir(nd.Entry) {
+		return nil, "", fuse.EIO
+	}
+
+	return nd, path, nil
+}
+
+func (fs *Filesystem) getFile(id fuseops.InodeID) (*index.Node, string, error) {
+	nd, path, ok := fs.get(id)
+	if !ok {
+		return nil, "", fuse.ENOENT
+	}
+
+	if isdir(nd.Entry) {
+		return nil, "", fuse.EIO
+	}
+
+	return nd, path, nil
+}
+
+func (fs *Filesystem) del(id fuseops.InodeID) {
+	fs.mu.Lock()
+	delete(fs.inodes, id)
+	fs.mu.Unlock()
+}
+
+func (fs *Filesystem) delHandle(id fuseops.HandleID) error {
+	fs.mu.Lock()
+	f, nd, ok := fs.getHandle(id)
+	delete(fs.handles, id)
+	fs.mu.Unlock()
+
+	if !ok {
+		return nil
+	}
+
+	nd.Entry.DecRefCount()
+
+	return f.Close()
+}
+
+func (fs *Filesystem) getHandle(id fuseops.HandleID) (*os.File, *index.Node, bool) {
+	f, ok := fs.handles[id]
+	if !ok {
+		return nil, nil, false
+	}
+
+	path := f.Name()
+
+	if strings.HasPrefix(path, fs.CacheDir) {
+		path = path[len(fs.CacheDir):]
+	}
+
+	nd, ok := fs.Index.Lookup(path)
+	if !ok || nd.Deleted() {
+		return nil, nil, false
+	}
+
+	return f, nd, true
+}
+
+func (fs *Filesystem) yield(ctx stdcontext.Context, path string, meta index.ChangeMeta) error {
+	c := fs.Cache.Commit(index.NewChange(path, meta))
+
+	select {
+	case <-c.Done():
+		return ignore(c.Err())
+	case <-ctx.Done():
+		return ignore(ctx.Err())
+	}
+}
+
+func (fs *Filesystem) attr(entry *index.Entry) fuseops.InodeAttributes {
+	mtime := time.Unix(0, entry.MTime())
+	ctime := time.Unix(0, entry.CTime())
+
+	return fuseops.InodeAttributes{
+		Size:   uint64(entry.Size()),
+		Nlink:  1, // TODO(rjeczalik): symlink / hardlink implementation
+		Mode:   entry.Mode(),
+		Atime:  mtime,
+		Mtime:  mtime,
+		Ctime:  ctime,
+		Crtime: ctime,
+		Uid:    uint32(fs.user().Uid),
+		Gid:    uint32(fs.user().Gid),
+	}
+}
+
+func (fs *Filesystem) newAttr(mode os.FileMode) fuseops.InodeAttributes {
+	t := time.Now()
+
+	return fuseops.InodeAttributes{
+		Size:   0,
+		Nlink:  1,
+		Mode:   mode,
+		Atime:  t,
+		Mtime:  t,
+		Ctime:  t,
+		Crtime: t,
+		Uid:    uint32(fs.user().Uid),
+		Gid:    uint32(fs.user().Gid),
+	}
+}
+
+func (fs *Filesystem) path(loc string) string {
+	return filepath.Join(fs.CacheDir, loc)
+}
+
+func (fs *Filesystem) mkdir(path string, mode os.FileMode) (id fuseops.InodeID, err error) {
+	if err = os.MkdirAll(fs.path(path), mode); err != nil {
+		return 0, err
+	}
+
+	entry := index.NewEntry(0, mode|os.ModeDir)
+	entry.IncRefCount()
+
+	fs.mu.Lock()
+	id = fs.add(path)
+	fs.mu.Unlock()
+
+	entry.SetInode(uint64(id))
+
+	fs.Index.PromiseAdd(path, entry)
+
+	return id, nil
+}
+
+func (fs *Filesystem) mkfile(path string, mode os.FileMode) (id fuseops.InodeID, h fuseops.HandleID, err error) {
+	absPath := fs.path(path)
+
+	if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+		return 0, 0, err
+	}
+
+	f, err := os.Create(absPath)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	if err := f.Close(); err != nil {
+		return 0, 0, err
+	}
+
+	if f, err = os.OpenFile(absPath, os.O_RDWR, 0644); err != nil {
+		return 0, 0, err
+	}
+
+	entry := index.NewEntry(0, mode)
+	entry.IncRefCount()
+
+	fs.mu.Lock()
+	id = fs.add(path)
+	h = fs.addHandle(f)
+	fs.mu.Unlock()
+
+	entry.SetInode(uint64(id))
+
+	fs.Index.PromiseAdd(path, entry)
+
+	_ = f.Chmod(mode)
+
+	return id, h, nil
+}
+
+func (fs *Filesystem) move(ctx stdcontext.Context, oldpath, newpath string) error {
+	absOld := fs.path(oldpath)
+	absNew := fs.path(newpath)
+
+	if _, err := os.Stat(absOld); os.IsNotExist(err) {
+		if err = fs.yield(ctx, oldpath, index.ChangeMetaRemote|index.ChangeMetaAdd); err != nil {
+			return err
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(absNew), 0755); err != nil {
+		return err
+	}
+
+	return os.Rename(fs.path(oldpath), fs.path(newpath))
+}
+
+func (fs *Filesystem) unlink(ctx stdcontext.Context, nd *index.Node, path string) error {
+	fs.Index.PromiseUnlink(path, nd)
+
+	if n := nd.Entry.DecRefCount(); n > 0 {
+		return nil
+	}
+
+	return fs.rm(ctx, nd, path)
+}
+
+func (fs *Filesystem) rm(ctx stdcontext.Context, nd *index.Node, path string) error {
+	fs.Index.PromiseDel(path, nd)
+	nd.Entry.SetInode(0)
+
+	path = fs.path(path)
+
+	if err := os.Remove(path); os.IsNotExist(err) {
+		return nil
+	}
+
+	return fs.yield(ctx, path, index.ChangeMetaLocal|index.ChangeMetaRemove)
+}
+
+func (fs *Filesystem) update(ctx stdcontext.Context, f *os.File, nd *index.Node) error {
+	if err := f.Sync(); err != nil {
+		return err
+	}
+
+	updateSize(f, nd)
+
+	return fs.yield(ctx, f.Name(), index.ChangeMetaLocal|index.ChangeMetaUpdate)
+}
+
+func (fs *Filesystem) open(ctx stdcontext.Context, nd *index.Node, path string) (*os.File, fuseops.HandleID, error) {
+	f, err := fs.openFile(ctx, path)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	fs.mu.Lock()
+	id := fs.addHandle(f)
+	fs.mu.Unlock()
+
+	nd.Entry.IncRefCount()
+
+	return f, id, nil
+}
+
+func (fs *Filesystem) openFile(ctx stdcontext.Context, path string) (*os.File, error) {
+	flag := os.O_RDWR
+	path = fs.path(path)
+
+	f, err := os.OpenFile(path, flag, 0644)
+	if os.IsNotExist(err) {
+		err = fs.yield(ctx, path, index.ChangeMetaAdd|index.ChangeMetaRemote)
+		if err != nil {
+			return nil, err
+		}
+
+		f, err = os.OpenFile(path, flag, 0644)
+	}
+
+	return f, err
+}
+
+func (fs *Filesystem) openInode(ctx stdcontext.Context, id fuseops.InodeID) (*os.File, fuseops.HandleID, error) {
+	nd, path, err := fs.getFile(id)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return fs.open(ctx, nd, path)
+}
+
+func (fs *Filesystem) openHandle(id fuseops.HandleID) (*os.File, error) {
+	fs.mu.RLock()
+	f, ok := fs.handles[id]
+	fs.mu.RUnlock()
+
+	if !ok {
+		return nil, fuse.ENOENT
+	}
+
+	return f, nil
+}
+
+func (fs *Filesystem) openHandleNode(id fuseops.HandleID) (*os.File, *index.Node, error) {
+	fs.mu.RLock()
+	f, nd, ok := fs.getHandle(id)
+	fs.mu.RUnlock()
+
+	if !ok {
+		return nil, nil, fuse.ENOENT
+	}
+
+	return f, nd, nil
+}
+
+func trimRightNull(p []byte) []byte {
+	for i := len(p) - 1; i >= 0; i-- {
+		if p[i] != 0 {
+			break
+		}
+
+		p = p[:i]
+	}
+
+	return p
+}
+
+func updateSize(f *os.File, nd *index.Node) error {
+	fi, err := f.Stat()
+	if err != nil {
+		return err
+	}
+
+	nd.Entry.SetSize(fi.Size())
+
+	return nil
+}
+
+func direntType(entry *index.Entry) fuseutil.DirentType {
+	if isdir(entry) {
+		return fuseutil.DT_Directory
+	}
+	return fuseutil.DT_File
+}
+
+func isdir(entry *index.Entry) bool {
+	return entry.Mode()&os.ModeDir == os.ModeDir
+}
+
+func nonil(err ...error) error {
+	for _, e := range err {
+		if e != nil {
+			return e
+		}
+	}
+	return nil
+}
+
+// ignore filters out context.Canceled errors.
+func ignore(err error) error {
+	switch err {
+	case context.Canceled, stdcontext.Canceled:
+		return nil
+	default:
+		return err
+	}
+}

--- a/go/src/koding/klient/machine/mount/notify/fuse/fuse.go
+++ b/go/src/koding/klient/machine/mount/notify/fuse/fuse.go
@@ -123,7 +123,9 @@ func (fs *Filesystem) SetInodeAttributes(ctx context.Context, op *fuseops.SetIno
 		}
 	}
 
-	return fs.yield(ctx, path, index.ChangeMetaLocal|index.ChangeMetaUpdate)
+	fs.commit(path, index.ChangeMetaLocal|index.ChangeMetaUpdate)
+
+	return nil
 }
 
 // MkDir creates new directory inside specified parent directory. It returns
@@ -152,7 +154,9 @@ func (fs *Filesystem) MkDir(ctx context.Context, op *fuseops.MkDirOp) error {
 
 	op.Entry.Attributes = fs.newAttr(op.Mode)
 
-	return fs.yield(ctx, path, index.ChangeMetaAdd|index.ChangeMetaLocal)
+	fs.commit(path, index.ChangeMetaAdd|index.ChangeMetaLocal)
+
+	return nil
 }
 
 // CreateFile creates an empty file with specified name and mode. It returns an
@@ -179,7 +183,9 @@ func (fs *Filesystem) CreateFile(ctx context.Context, op *fuseops.CreateFileOp) 
 
 	op.Entry.Attributes = fs.newAttr(op.Mode)
 
-	return fs.yield(ctx, path, index.ChangeMetaAdd|index.ChangeMetaLocal)
+	fs.commit(path, index.ChangeMetaAdd|index.ChangeMetaLocal)
+
+	return nil
 }
 
 // Rename changes a file or directory from old name and parent to new name and
@@ -226,10 +232,10 @@ func (fs *Filesystem) Rename(ctx context.Context, op *fuseops.RenameOp) error {
 	fs.Index.PromiseDel(oldPath, oldNd)
 	fs.Index.PromiseAdd(newPath, entry)
 
-	return nonil(
-		fs.yield(ctx, oldPath, index.ChangeMetaLocal|index.ChangeMetaRemove),
-		fs.yield(ctx, newPath, index.ChangeMetaLocal|index.ChangeMetaAdd),
-	)
+	fs.commit(oldPath, index.ChangeMetaLocal|index.ChangeMetaRemove)
+	fs.commit(newPath, index.ChangeMetaLocal|index.ChangeMetaAdd)
+
+	return nil
 }
 
 // RmDir deletes a directory from remote and list of live nodes.
@@ -258,7 +264,9 @@ func (fs *Filesystem) RmDir(ctx context.Context, op *fuseops.RmDirOp) error {
 		return err
 	}
 
-	return fs.yield(ctx, path, index.ChangeMetaLocal|index.ChangeMetaRemove)
+	fs.commit(path, index.ChangeMetaLocal|index.ChangeMetaRemove)
+
+	return nil
 }
 
 // Unlink removes entry from specified parent directory.
@@ -415,7 +423,9 @@ func (fs *Filesystem) WriteFile(ctx context.Context, op *fuseops.WriteFileOp) er
 
 	updateSize(f, nd)
 
-	return fs.yield(ctx, f.Name(), index.ChangeMetaLocal|index.ChangeMetaUpdate)
+	fs.commit(f.Name(), index.ChangeMetaLocal|index.ChangeMetaUpdate)
+
+	return nil
 }
 
 // SyncFile sends file contents from local to remote.

--- a/go/src/koding/klient/machine/mount/notify/fuse/fuse.go
+++ b/go/src/koding/klient/machine/mount/notify/fuse/fuse.go
@@ -1,0 +1,478 @@
+package fuse
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+
+	"koding/klient/machine/index"
+
+	"github.com/jacobsa/fuse"
+	"github.com/jacobsa/fuse/fuseops"
+	"github.com/jacobsa/fuse/fuseutil"
+	"golang.org/x/net/context"
+)
+
+// StatFS sets filesystem metadata.
+//
+// Required for fuse.FileSystem.
+func (fs *Filesystem) StatFS(ctx context.Context, op *fuseops.StatFSOp) error {
+	if fs.Disk == nil {
+		return fuse.ENOENT
+	}
+
+	op.Blocks = fs.Disk.BlocksTotal
+	op.BlockSize = fs.Disk.BlockSize
+	op.BlocksFree = fs.Disk.BlocksFree
+	op.BlocksAvailable = fs.Disk.BlocksTotal - fs.Disk.BlocksUsed
+
+	return nil
+}
+
+// LookUpInode finds entry in context of specific parent directory and sets
+// its attributes. It assumes parent directory has already been seen.
+//
+// Required for fuse.FileSystem.
+func (fs *Filesystem) LookUpInode(ctx context.Context, op *fuseops.LookUpInodeOp) error {
+	dir, path, err := fs.getDir(op.Parent)
+	if err != nil {
+		return err
+	}
+
+	nd, ok := dir.Sub[op.Name]
+	if !ok || nd.Deleted() {
+		return fuse.ENOENT
+	}
+
+	op.Entry.Child = fs.lookupInodeID(path, op.Name, nd.Entry)
+	op.Entry.Attributes = fs.attr(nd.Entry)
+
+	return nil
+}
+
+// GetInodeAttributes set attributes for a specified Node.
+//
+// Required for fuse.FileSystem.
+func (fs *Filesystem) GetInodeAttributes(ctx context.Context, op *fuseops.GetInodeAttributesOp) error {
+	nd, _, ok := fs.get(op.Inode)
+	if !ok {
+		return fuse.ENOENT
+	}
+
+	op.Attributes = fs.attr(nd.Entry)
+
+	return nil
+}
+
+// SetInodeAttributes sets specified attributes to file or directory.
+//
+// Required for fuse.FileSystem.
+func (fs *Filesystem) SetInodeAttributes(ctx context.Context, op *fuseops.SetInodeAttributesOp) error {
+	nd, path, ok := fs.get(op.Inode)
+	if !ok {
+		return fuse.ENOENT
+	}
+
+	f, err := fs.openFile(ctx, path)
+	if err != nil {
+		return err
+	}
+
+	op.Attributes = fs.attr(nd.Entry)
+
+	if op.Size != nil {
+		if err := f.Truncate(int64(*op.Size)); err != nil {
+			return nonil(err, f.Close())
+		}
+
+		op.Attributes.Size = *op.Size
+	}
+
+	if op.Mode != nil {
+		if err := f.Chmod(*op.Mode); err != nil {
+			return nonil(err, f.Close())
+		}
+
+		op.Attributes.Mode = *op.Mode
+	}
+
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	if op.Atime != nil || op.Mtime != nil {
+		if op.Atime != nil {
+			op.Attributes.Atime = *op.Atime
+		}
+
+		if op.Mtime != nil {
+			op.Attributes.Mtime = *op.Mtime
+		}
+
+		if err := os.Chtimes(path, op.Attributes.Atime, op.Attributes.Mtime); err != nil {
+			return err
+		}
+	}
+
+	return fs.yield(ctx, path, index.ChangeMetaLocal|index.ChangeMetaUpdate)
+}
+
+// MkDir creates new directory inside specified parent directory. It returns
+// `fuse.EEXIST` if a file or directory already exists with specified name.
+//
+// Note: `mkdir` command checks if directory exists before calling this method,
+// so you won't see the error from here if you're using `mkdir`.
+//
+// Required for fuse.FileSystem.
+func (fs *Filesystem) MkDir(ctx context.Context, op *fuseops.MkDirOp) error {
+	dir, path, err := fs.getDir(op.Parent)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := dir.Sub[op.Name]; ok {
+		return fuse.EEXIST
+	}
+
+	path = filepath.Join(path, op.Name)
+
+	op.Entry.Child, err = fs.mkdir(path, op.Mode)
+	if err != nil {
+		return err
+	}
+
+	op.Entry.Attributes = fs.newAttr(op.Mode)
+
+	return fs.yield(ctx, path, index.ChangeMetaAdd|index.ChangeMetaLocal)
+}
+
+// CreateFile creates an empty file with specified name and mode. It returns an
+// error if specified parent directory doesn't exist. but not if file already
+// exists.
+//
+// Required for fuse.FileSystem.
+func (fs *Filesystem) CreateFile(ctx context.Context, op *fuseops.CreateFileOp) error {
+	dir, path, err := fs.getDir(op.Parent)
+	if err != nil {
+		return err
+	}
+
+	if nd, ok := dir.Sub[op.Name]; ok && !nd.Deleted() {
+		return fuse.EEXIST
+	}
+
+	path = filepath.Join(path, op.Name)
+
+	op.Entry.Child, op.Handle, err = fs.mkfile(path, op.Mode)
+	if err != nil {
+		return err
+	}
+
+	op.Entry.Attributes = fs.newAttr(op.Mode)
+
+	return fs.yield(ctx, path, index.ChangeMetaAdd|index.ChangeMetaLocal)
+}
+
+// Rename changes a file or directory from old name and parent to new name and
+// parent.
+//
+// Note if a new name already exists, we still go ahead and rename it. While
+// the old and new entries are the same, we throw out the old one and create
+// new entry for it.
+//
+// Required for fuse.FileSystem.
+func (fs *Filesystem) Rename(ctx context.Context, op *fuseops.RenameOp) error {
+	oldDir, oldPath, err := fs.getDir(op.OldParent)
+	if err != nil {
+		return err
+	}
+
+	newDir, newPath, err := fs.getDir(op.NewParent)
+	if err != nil {
+		return err
+	}
+
+	oldNd, ok := oldDir.Sub[op.OldName]
+	if !ok {
+		return fuse.ENOENT
+	}
+
+	if _, ok := newDir.Sub[op.NewName]; ok {
+		return fuse.EEXIST
+	}
+
+	oldPath = filepath.Join(oldPath, op.OldName)
+	newPath = filepath.Join(newPath, op.NewName)
+
+	if err := fs.move(ctx, oldPath, newPath); err != nil {
+		return err
+	}
+
+	entry := index.NewEntry(0, oldDir.Entry.Mode())
+
+	id := fuseops.InodeID(oldNd.Entry.Inode())
+
+	fs.mu.Lock()
+	delete(fs.inodes, id)
+	id = fs.add(newPath)
+	entry.SetInode(uint64(id))
+	fs.mu.Unlock()
+
+	fs.Index.PromiseDel(oldPath, oldNd)
+	fs.Index.PromiseAdd(newPath, entry)
+
+	return nonil(
+		fs.yield(ctx, oldPath, index.ChangeMetaLocal|index.ChangeMetaRemove),
+		fs.yield(ctx, newPath, index.ChangeMetaLocal|index.ChangeMetaAdd),
+	)
+}
+
+// RmDir deletes a directory from remote and list of live nodes.
+//
+// Note: `rm -r` calls Unlink method on each directory entry.
+//
+// Required for fuse.FileSystem.
+func (fs *Filesystem) RmDir(ctx context.Context, op *fuseops.RmDirOp) error {
+	dir, path, err := fs.getDir(op.Parent)
+	if err != nil {
+		return err
+	}
+
+	nd, ok := dir.Sub[op.Name]
+	if !ok || nd.Deleted() {
+		return fuse.ENOENT
+	}
+
+	if !isdir(nd.Entry) {
+		return fuse.EIO
+	}
+
+	path = filepath.Join(path, op.Name)
+
+	if err := fs.rm(ctx, nd, path); err != nil {
+		return err
+	}
+
+	return fs.yield(ctx, path, index.ChangeMetaLocal|index.ChangeMetaRemove)
+}
+
+// Unlink removes entry from specified parent directory.
+//
+// Required for fuse.FileSystem.
+func (fs *Filesystem) Unlink(ctx context.Context, op *fuseops.UnlinkOp) error {
+	dir, path, err := fs.getDir(op.Parent)
+	if err != nil {
+		return err
+	}
+
+	nd, ok := dir.Sub[op.Name]
+	if !ok || nd.Deleted() {
+		return fuse.ENOENT
+	}
+
+	return fs.unlink(ctx, nd, filepath.Join(path, op.Name))
+}
+
+// ForgetInode
+func (fs *Filesystem) ForgetInode(ctx context.Context, op *fuseops.ForgetInodeOp) error {
+	nd, path, ok := fs.get(op.Inode)
+	if !ok {
+		return nil // no-op
+	}
+
+	if nd.Entry.HasPromise(index.EntryPromiseUnlink) {
+		return fs.rm(ctx, nd, path)
+	}
+
+	return nil
+}
+
+// OpenDir opens a directory, ie. indicates operations are to be done on this
+// directory.
+//
+// Required for fuse.FileSystem.
+func (fs *Filesystem) OpenDir(ctx context.Context, op *fuseops.OpenDirOp) error {
+	_, _, err := fs.getDir(op.Inode)
+	return err
+}
+
+// ReleaseDirHandle removes a directory under the given handle ID for open ones.
+//
+// Required for fuse.FileSystem.
+func (fs *Filesystem) ReleaseDirHandle(ctx context.Context, op *fuseops.ReleaseDirHandleOp) error {
+	return nil
+}
+
+// ReadDir reads entries in a specific directory.
+//
+// Required for fuse.FileSystem.
+func (fs *Filesystem) ReadDir(ctx context.Context, op *fuseops.ReadDirOp) error {
+	dir, path, err := fs.getDir(op.Inode)
+	if err != nil {
+		return err
+	}
+
+	files := make([]string, 0, len(dir.Sub))
+
+	for name, nd := range dir.Sub {
+		if !nd.Deleted() {
+			files = append(files, name)
+		}
+	}
+
+	if int(op.Offset) >= len(files) {
+		return fuse.EIO
+	}
+
+	sort.Strings(files)
+
+	files = files[int(op.Offset):]
+
+	dirent := make([]*fuseutil.Dirent, 0, len(files))
+
+	for i, file := range files {
+		sub := dir.Sub[file]
+
+		dirent = append(dirent, &fuseutil.Dirent{
+			Offset: op.Offset + fuseops.DirOffset(i+1),
+			Inode:  fs.lookupInodeID(path, file, sub.Entry),
+			Name:   file,
+			Type:   direntType(sub.Entry),
+		})
+	}
+
+	sum := 0
+
+	// TODO(rjeczalik): we can estimate how many entries to return by
+	// looking at op.Dst size.
+	for _, dir := range dirent {
+		n := fuseutil.WriteDirent(op.Dst[sum:], *dir)
+		if n == 0 {
+			break
+		}
+
+		sum += n
+	}
+
+	op.BytesRead = sum
+
+	return nil
+}
+
+// OpenFile opens a File, ie. indicates operations are to be done on this file.
+//
+// Required for fuse.FileSystem.
+func (fs *Filesystem) OpenFile(ctx context.Context, op *fuseops.OpenFileOp) error {
+	_, h, err := fs.openInode(ctx, op.Inode)
+	if err != nil {
+		return err
+	}
+
+	op.KeepPageCache = false
+	op.Handle = h
+
+	return nil
+}
+
+// ReadFile reads contents of a specified file starting from specified offset.
+// It returns `io.EIO` if specified offset is larger than the length of contents
+// of the file.
+//
+// Required for fuse.FileSystem.
+func (fs *Filesystem) ReadFile(ctx context.Context, op *fuseops.ReadFileOp) error {
+	f, err := fs.openHandle(op.Handle)
+	if err != nil {
+		return err
+	}
+
+	op.BytesRead, err = f.ReadAt(op.Dst, op.Offset)
+	if err == io.EOF {
+		err = nil // ignore io.EOF errors
+	}
+
+	return err
+}
+
+// WriteFile write specified contents to specified file at specified offset.
+//
+// Required for fuse.FileSystem.
+func (fs *Filesystem) WriteFile(ctx context.Context, op *fuseops.WriteFileOp) error {
+	f, nd, err := fs.openHandleNode(op.Handle)
+	if err != nil {
+		return err
+	}
+
+	if _, err = f.WriteAt(trimRightNull(op.Data), op.Offset); err != nil {
+		return err
+	}
+
+	updateSize(f, nd)
+
+	return fs.yield(ctx, f.Name(), index.ChangeMetaLocal|index.ChangeMetaUpdate)
+}
+
+// SyncFile sends file contents from local to remote.
+//
+// Required for fuse.FileSystem.
+func (fs *Filesystem) SyncFile(ctx context.Context, op *fuseops.SyncFileOp) error {
+	f, nd, err := fs.openHandleNode(op.Handle)
+	if err != nil {
+		return err
+	}
+
+	return fs.update(ctx, f, nd)
+}
+
+// FlushFile yields file updates on a locally cached file.
+//
+// Required for fuse.FileSystem.
+func (fs *Filesystem) FlushFile(ctx context.Context, op *fuseops.FlushFileOp) error {
+	if op.Handle == 0 {
+		return nil
+	}
+
+	f, nd, err := fs.openHandleNode(op.Handle)
+	if err != nil {
+		return err
+	}
+
+	return fs.update(ctx, f, nd)
+}
+
+// ReleaseFileHandle releases file handle. It does not return errors even if it
+// fails since this op doesn't affect anything.
+//
+// Required for fuse.FileSystem.
+func (fs *Filesystem) ReleaseFileHandle(_ context.Context, op *fuseops.ReleaseFileHandleOp) error {
+	_ = fs.delHandle(op.Handle)
+	return nil
+}
+
+func (fs *Filesystem) Destroy() {
+	fs.mu.Lock()
+	for _, f := range fs.handles {
+		_ = f.Close()
+	}
+	fs.handles = make(map[fuseops.HandleID]*os.File)
+	fs.mu.Unlock()
+}
+
+func Umount(dir string) error {
+	if runtime.GOOS == "linux" {
+		return fuse.Unmount(dir)
+	}
+
+	// Under Darwin fuse.Umount uses syscall.Umount without syscall.MNT_FORCE flag,
+	// so we replace that implementation with diskutil.
+	p, err := exec.Command("diskutil", "unmount", "force", dir).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %s", err, bytes.TrimSpace(p))
+	}
+
+	return nil
+}

--- a/go/src/koding/klient/machine/mount/notify/fuse/fuse_test.go
+++ b/go/src/koding/klient/machine/mount/notify/fuse/fuse_test.go
@@ -1,0 +1,46 @@
+package fuse_test
+
+import (
+	"bytes"
+	"testing"
+
+	"koding/klient/machine/mount/notify/fuse"
+)
+
+func TestTrimRightNull(t *testing.T) {
+	cases := map[string]struct {
+		p    []byte
+		want []byte
+	}{
+		"no null": {
+			[]byte("a string"),
+			[]byte("a string"),
+		},
+		"null-terminated": {
+			[]byte{'a', ' ', 's', 't', 'r', 'i', 'n', 'g', 0},
+			[]byte("a string"),
+		},
+		"null-padded": {
+			[]byte{'a', ' ', 's', 't', 'r', 'i', 'n', 'g', 0, 0, 0, 0, 0, 0},
+			[]byte("a string"),
+		},
+		"null only": {
+			[]byte{0},
+			[]byte{},
+		},
+		"multiple null only": {
+			[]byte{0, 0, 0, 0, 0, 0},
+			[]byte{},
+		},
+	}
+
+	for name, cas := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := fuse.TrimRightNull(cas.p)
+
+			if bytes.Compare(got, cas.want) != 0 {
+				t.Fatalf("got %v, want %v", got, cas.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds first working implementation of FUSE-based notifier for a mount subsystem.

Deps: ~#10588 #10590~

There's going to be another PR with cmd/loopfuse - a tool I used to test current implementation. Since rsync-based syncer is not yet integrated, I did not write any integration tests just to not have to rework them after the rsync is in. The integration tests we're going to write separately after gathering feedback from more wide internal testing.