### PR TITLE
cmd/loopfuse: FUSE-backed mount-like tool for testing/debugging

### DIFF
--- a/go/src/koding/klient/app/klient.go
+++ b/go/src/koding/klient/app/klient.go
@@ -36,7 +36,7 @@ import (
 	mclient "koding/klient/machine/client"
 	"koding/klient/machine/index"
 	"koding/klient/machine/machinegroup"
-	"koding/klient/machine/mount/notify/silent"
+	"koding/klient/machine/mount/notify/fuse"
 	"koding/klient/machine/mount/sync/discard"
 	kos "koding/klient/os"
 	"koding/klient/remote"
@@ -322,7 +322,7 @@ func NewKlient(conf *KlientConfig) (*Klient, error) {
 	machinesOpts := &machinegroup.GroupOpts{
 		Storage:         storage.NewEncodingStorage(db, []byte("machines")),
 		Builder:         mclient.NewKiteBuilder(k),
-		NotifyBuilder:   silent.SilentBuilder{},
+		NotifyBuilder:   fuse.Builder,
 		SyncBuilder:     discard.DiscardBuilder{},
 		DynAddrInterval: 2 * time.Second,
 		PingInterval:    15 * time.Second,

--- a/go/src/koding/klient/machine/mount/notify/fuse/cmd/loopfuse/main.go
+++ b/go/src/koding/klient/machine/mount/notify/fuse/cmd/loopfuse/main.go
@@ -1,0 +1,136 @@
+// +build !windows
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"syscall"
+
+	"koding/klient/fs"
+	"koding/klient/machine/mount/notify/fuse"
+	"koding/klient/machine/mount/notify/fuse/fusetest"
+)
+
+var (
+	verbose = flag.Bool("v", false, "Turn on verbose logging.")
+	tmp     = flag.String("tmp", "", "Existing cache directory to use.")
+)
+
+const usage = `usage: loopfuse [-v] [-tmp]  <src> <dst>
+
+Flags
+
+	-v    Turns on verbose logging.
+	-tmp  Existing cache directory to use.
+
+Arguments
+
+	src  Source directory.
+	dst  Destination directory.
+`
+
+func die(v ...interface{}) {
+	fmt.Fprintln(os.Stderr, v...)
+	os.Exit(1)
+}
+
+func logf(format string, args ...interface{}) {
+	if *verbose {
+		log.Printf(format, args...)
+	}
+}
+
+func main() {
+	flag.Parse()
+
+	if flag.NArg() != 2 {
+		die(usage)
+	}
+
+	src, dst := flag.Arg(0), flag.Arg(1)
+
+	if !filepath.IsAbs(src) {
+		var err error
+		if src, err = filepath.Abs(src); err != nil {
+			die(err)
+		}
+	}
+
+	if _, err := os.Stat(dst); err != nil {
+		die(err)
+	}
+
+	if _, err := os.Stat(src); err != nil {
+		die(err)
+	}
+
+	if *tmp == "" {
+		var err error
+		*tmp, err = ioutil.TempDir("", "loopfuse")
+		if err != nil {
+			die(err)
+		}
+	}
+
+	logf("using cache directory: %s", *tmp)
+	logf("building index for: %q", src)
+
+	bc, err := fusetest.NewBindCache(src, *tmp)
+	if err != nil {
+		die(err)
+	}
+
+	opts := &fuse.Opts{
+		Cache:    bc,
+		CacheDir: *tmp,
+		Remote:   bc.Index(),
+		Mount:    filepath.Base(dst),
+		MountDir: dst,
+		Debug:    *verbose,
+		Disk:     block(dst),
+	}
+
+	fs, err := fuse.NewFilesystem(opts)
+	if err != nil {
+		die(err)
+	}
+
+	ch := make(chan os.Signal, 1)
+
+	signal.Notify(ch, syscall.SIGQUIT)
+
+	go func() {
+		for range ch {
+			fmt.Print(fs.DebugString())
+		}
+	}()
+
+	runtime.KeepAlive(fs)
+
+	select {}
+}
+
+func block(path string) *fs.DiskInfo {
+	stfs := syscall.Statfs_t{}
+
+	if err := syscall.Statfs(path, &stfs); err != nil {
+		die(err)
+	}
+
+	di := &fs.DiskInfo{
+		BlockSize:   uint32(stfs.Bsize),
+		BlocksTotal: stfs.Blocks,
+		BlocksFree:  stfs.Bfree,
+	}
+
+	di.BlocksUsed = di.BlocksTotal - di.BlocksFree
+
+	return di
+}

--- a/go/src/koding/klient/machine/mount/notify/fuse/cmd/loopfuse/main.go
+++ b/go/src/koding/klient/machine/mount/notify/fuse/cmd/loopfuse/main.go
@@ -41,12 +41,6 @@ func die(v ...interface{}) {
 	os.Exit(1)
 }
 
-func logf(format string, args ...interface{}) {
-	if *verbose {
-		log.Printf(format, args...)
-	}
-}
-
 func main() {
 	flag.Parse()
 
@@ -79,8 +73,8 @@ func main() {
 		}
 	}
 
-	logf("using cache directory: %s", *tmp)
-	logf("building index for: %q", src)
+	log.Printf("using cache directory: %s", *tmp)
+	log.Printf("building index for: %s", src)
 
 	bc, err := fusetest.NewBindCache(src, *tmp)
 	if err != nil {
@@ -90,12 +84,14 @@ func main() {
 	opts := &fuse.Opts{
 		Cache:    bc,
 		CacheDir: *tmp,
-		Remote:   bc.Index(),
+		Index:    bc.Index(),
 		Mount:    filepath.Base(dst),
 		MountDir: dst,
 		Debug:    *verbose,
 		Disk:     block(dst),
 	}
+
+	log.Printf("mounting filesystem: %s", dst)
 
 	fs, err := fuse.NewFilesystem(opts)
 	if err != nil {
@@ -113,6 +109,8 @@ func main() {
 	}()
 
 	runtime.KeepAlive(fs)
+
+	log.Printf("all done")
 
 	select {}
 }

--- a/go/src/koding/klient/machine/mount/notify/fuse/fusetest/fusetest.go
+++ b/go/src/koding/klient/machine/mount/notify/fuse/fusetest/fusetest.go
@@ -1,0 +1,260 @@
+package fusetest
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"koding/klient/machine/index"
+	"koding/klient/machine/mount/notify"
+)
+
+type BindCache struct {
+	loc  string
+	tmp  string
+	idx  *index.Index
+	ch   chan change
+	done chan struct{}
+	once sync.Once
+	wg   sync.WaitGroup
+}
+
+var _ notify.Cache = (*BindCache)(nil)
+
+func NewBindCache(loc, tmp string) (*BindCache, error) {
+	idx, err := index.NewIndexFiles(loc)
+	if err != nil {
+		return nil, err
+	}
+
+	bc := &BindCache{
+		loc:  loc,
+		tmp:  tmp,
+		idx:  idx,
+		ch:   make(chan change),
+		done: make(chan struct{}),
+	}
+
+	go bc.process()
+
+	return bc, nil
+}
+
+func (bc *BindCache) Commit(change *index.Change) context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go bc.commit(change, cancel)
+
+	return ctx
+}
+
+func (bc *BindCache) Index() *index.Index {
+	return bc.idx
+}
+
+func (bc *BindCache) Close() error {
+	bc.once.Do(bc.stop)
+	return nil
+}
+
+func (bc *BindCache) stop() {
+	// Ensure all bc.commit goroutines are stopped.
+	close(bc.done)
+	bc.wg.Wait()
+
+	close(bc.ch)
+}
+
+type change struct {
+	*index.Change
+
+	cancel func()
+}
+
+func (bc *BindCache) commit(c *index.Change, cancel func()) {
+	bc.wg.Add(1)
+
+	select {
+	case <-bc.done:
+	case bc.ch <- change{
+		Change: c,
+		cancel: cancel,
+	}:
+	}
+
+	bc.wg.Done()
+}
+
+func (bc *BindCache) process() {
+	for change := range bc.ch {
+		isRemoteSrc := change.Meta()&index.ChangeMetaRemote != 0
+
+		var src, dst string
+		var err error
+
+		if isRemoteSrc {
+			base := change.Path()
+
+			if filepath.IsAbs(base) {
+				if base, err = filepath.Rel(bc.tmp, base); err != nil {
+					log.Printf("BindCache: failed to preprare files for sync: %s", err)
+				}
+			}
+
+			// bind-mount dir source (remote) -> cache dir (local)
+			src = filepath.Join(bc.loc, base)
+			dst = filepath.Join(bc.tmp, base)
+		} else {
+			base := change.Path()
+
+			if filepath.IsAbs(base) {
+				if base, err = filepath.Rel(bc.tmp, base); err != nil {
+					log.Printf("BindCache: failed to preprare files for sync: %s", err)
+				}
+			}
+
+			// cache dir (local) -> bind-mount dir source (remote)
+			src = filepath.Join(bc.tmp, base)
+			dst = filepath.Join(bc.loc, base)
+		}
+
+		switch {
+		case change.Meta()&(index.ChangeMetaAdd|index.ChangeMetaUpdate) != 0:
+			err = copyFilesRecursively(src, dst)
+		case change.Meta()&index.ChangeMetaRemove != 0:
+			err = os.RemoveAll(dst)
+		}
+
+		if err != nil {
+			log.Printf("BindCache: failed to sync files: %s", err)
+		}
+
+		// Update remote index.
+		if !isRemoteSrc {
+			// BUG(rjeczalik): Use when index respects promise ops.
+			// bc.idx.Apply(bc.loc, bc.idx.CompareBranch(change.Path(), bc.loc))
+		}
+
+		change.cancel()
+	}
+}
+
+type CopyError []*FileError
+
+func (ce CopyError) Error() string {
+	var buf bytes.Buffer
+
+	for _, e := range ce {
+		buf.WriteString(e.Error())
+		buf.WriteRune('\n')
+	}
+
+	return buf.String()
+}
+
+type FileError struct {
+	Path string
+	Err  error
+}
+
+func fe(path string, err error) *FileError {
+	return &FileError{
+		Path: path,
+		Err:  err,
+	}
+}
+
+func (fe *FileError) Error() string {
+	return fe.Path + ": " + fe.Err.Error()
+}
+
+func copyFile(src, dst string) error {
+	fsrc, err := os.Open(src)
+	if err != nil {
+		return fe(src, err)
+	}
+	defer fsrc.Close()
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return err
+	}
+
+	tmp, err := ioutil.TempFile(filepath.Split(dst))
+	if err != nil {
+		return fe(dst, err)
+	}
+
+	if _, err = io.Copy(tmp, fsrc); err != nil {
+		return nonil(fe(tmp.Name(), err), tmp.Close(), os.Remove(tmp.Name()))
+	}
+
+	if err = os.Rename(tmp.Name(), dst); err != nil {
+		return nonil(fe(dst, err), tmp.Close(), os.Remove(tmp.Name()))
+	}
+
+	return nil
+}
+
+func copyFilesRecursively(src, dst string) error {
+	fi, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	if !fi.IsDir() {
+		return copyFile(src, dst)
+	}
+
+	var ce CopyError
+
+	filepath.Walk(src, func(path string, fi os.FileInfo, err error) error {
+		if err != nil {
+			ce = append(ce, fe(path, err))
+			return nil
+		}
+
+		if fi.IsDir() {
+			return nil
+		}
+
+		key, err := filepath.Rel(src, path)
+		if err != nil {
+			ce = append(ce, fe(path, err))
+			return nil
+		}
+
+		dst := filepath.Join(dst, key)
+		dir := filepath.Dir(dst)
+
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			ce = append(ce, fe(dir, err))
+			return nil
+		}
+
+		if fe, ok := copyFile(path, dst).(*FileError); ok {
+			ce = append(ce, fe)
+		}
+
+		return nil
+	})
+
+	if len(ce) != 0 {
+		return ce
+	}
+
+	return nil
+}
+
+func nonil(err ...error) error {
+	for _, e := range err {
+		if e != nil {
+			return e
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Deps: ~#10588 #10590 #10591~

This tool implements "mount -o rbind". The following command:

    $ loopfuse /tmp/source /tmp/dest

Bind-mounts /tmp/source directory to a /tmp/dest one. It creates
a cache in the /tmp directory, to fake how real rsync-based
implementation would work.

The -v flag turns on FUSE debug output.

    $ loopfuse -v /tmp/source /tmp/dest

The -tmp flag can be used to persist cache directory for later
inspection or to start a mount with a dirty cache:

    $ loopfuse -v -tmp /tmp/cache /tmp/source /tmp/dest