### PR TITLE
klient/machine: dequeued event doesn't have to be consumed

### DIFF
--- a/go/src/koding/klient/machine/mount/sync/anteroom.go
+++ b/go/src/koding/klient/machine/mount/sync/anteroom.go
@@ -164,7 +164,7 @@ func (a *Anteroom) dequeue() {
 		select {
 		case evC <- ev:
 			if ev = a.queue.Pop(); ev == nil {
-				evC = nil // ueue is empty - turn off event channel.
+				evC = nil // queue is empty - turn off event channel.
 			} else {
 				atomic.StoreUint64((*uint64)(&ev.stat), uint64(statusPop))
 			}

--- a/go/src/koding/klient/machine/mount/sync/anteroom_test.go
+++ b/go/src/koding/klient/machine/mount/sync/anteroom_test.go
@@ -135,12 +135,18 @@ func TestAnteroomPopChange(t *testing.T) {
 		t.Fatalf("want invalid valid event; got valid")
 	}
 
+	select {
+	case <-a.Events(): // pop pending event.
+	case <-time.After(time.Second):
+		t.Fatalf("timed out after %s", time.Second)
+	}
+
 	items, queued := a.Status()
 	if items != 1 {
 		t.Errorf("want 1 items; got %d", items)
 	}
-	if queued != 1 {
-		t.Errorf("want 1 queued event; got %d", queued)
+	if queued != 0 {
+		t.Errorf("want 0 queued event; got %d", queued)
 	}
 }
 


### PR DESCRIPTION
This PR fixes: https://app.wercker.com/buildstep/58aabc9eae740e01002b8837

## Description
Previous test logic assumes that non-consumed event (anteroom's `Events()` method) is always pending in underlying queue. However, it can be popped and pending inside `dequeue()` [goroutine](https://github.com/koding/koding/blob/5291d9411ddf414362dad7eec0c018cd2adc2d02/go/src/koding/klient/machine/mount/sync/anteroom.go#L159). Thus, even if event is not consumed it might not be in queue but rather waiting for being sent to `a.evC` channel.

## Motivation and Context
Bug fix.

## How Has This Been Tested?
Unit tests

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
