### PR TITLE
Machine index improvements

### DIFF
--- a/go/src/koding/klient/machine/index/cache.go
+++ b/go/src/koding/klient/machine/index/cache.go
@@ -43,8 +43,9 @@ func (c *Cached) GetCachedIndex(root string) (*Index, error) {
 		}
 	} else if createdAt.IsZero() || time.Since(createdAt) > c.Rescan {
 		// Update loaded index.
-		cs = idx.Compare(root)
-		idx.Apply(root, cs)
+		for _, c := range idx.Merge(root) {
+			idx.Sync(root, c)
+		}
 	}
 
 	// If index changed or was generated, save it.

--- a/go/src/koding/klient/machine/index/cache_test.go
+++ b/go/src/koding/klient/machine/index/cache_test.go
@@ -55,7 +55,7 @@ func TestCachedIndexCreate(t *testing.T) {
 	}
 }
 
-func TestCahcedIndexUpdated(t *testing.T) {
+func TestCachedIndexUpdated(t *testing.T) {
 	tempDir, cleanTempDir, err := makeTempDir()
 	if err != nil {
 		t.Fatalf("want err = nil; got %v", err)

--- a/go/src/koding/klient/machine/index/change.go
+++ b/go/src/koding/klient/machine/index/change.go
@@ -118,7 +118,7 @@ func (cm *ChangeMeta) String() string {
 
 	var buf [8]byte // Meta is uint64 but we don't need more than 8.
 	for c, i := range cmMapping {
-		w := getPowerof2(uint64(i))
+		w := getPowerOf2(uint64(i))
 		if cpy&uint64(i) != 0 {
 			buf[w] = c
 		} else {
@@ -129,7 +129,7 @@ func (cm *ChangeMeta) String() string {
 	return string(buf[:len(cmMapping)])
 }
 
-func getPowerof2(i uint64) (count int) {
+func getPowerOf2(i uint64) (count int) {
 	for ; i > 1; count++ {
 		i = i >> 1
 	}

--- a/go/src/koding/klient/machine/index/entry.go
+++ b/go/src/koding/klient/machine/index/entry.go
@@ -1,0 +1,199 @@
+package index
+
+import (
+	"os"
+	"sync/atomic"
+	"time"
+
+	"github.com/djherbis/times"
+)
+
+// EntryPromise describes the promised state of index entry.
+type EntryPromise uint32
+
+const (
+	EntryPromiseSync   EntryPromise = 1 << iota // S: sync promise, doesn't exist locally.
+	EntryPromiseAdd                             // A: sync promise after adding, exists locally.
+	EntryPromiseUpdate                          // U: sync promise after updating, exists locally.
+	EntryPromiseDel                             // D: sync promise after deleting, doesn't exist locally.
+	EntryPromiseUnlink                          // N: sync promise after hard delete, doesn't exist locally.
+)
+
+var epMapping = map[byte]EntryPromise{
+	'S': EntryPromiseSync,
+	'A': EntryPromiseAdd,
+	'U': EntryPromiseUpdate,
+	'D': EntryPromiseDel,
+	'N': EntryPromiseUnlink,
+}
+
+// String implements fmt.Stringer interface and pretty prints stored promise.
+func (ep EntryPromise) String() string {
+	var buf [8]byte // Promise is uint32 but we don't need more than 8.
+	for c, i := range epMapping {
+		w := getPowerOf2(uint64(i))
+		if ep&i != 0 {
+			buf[w] = c
+		} else {
+			buf[w] = '-'
+		}
+	}
+
+	return string(buf[:len(epMapping)])
+}
+
+// realEntry describes the part of entry which is independent of underlying file
+// system. The fields of this type can be stored on disk and transferred over
+// network.
+type realEntry struct {
+	CTime int64       `json:"c"` // Metadata change time since EPOCH.
+	MTime int64       `json:"m"` // File data change time since EPOCH.
+	Size  int64       `json:"s"` // Size of the file.
+	Mode  os.FileMode `json:"o"` // File mode and permission bits.
+}
+
+// virtualEntry stores virtual file system dependent data that is lost during
+// serialization and should be recreated by VFS which manages the entries.
+type virtualEntry struct {
+	inode    uint64       // Inode ID of a mounted file.
+	refCount int32        // Reference count of file handlers.
+	promise  EntryPromise // Metadata of files's memory state.
+}
+
+// Entry represents a single file registered to index.
+type Entry struct {
+	real    realEntry
+	virtual virtualEntry
+}
+
+// NewEntry creates a new entry that describes the wile with specified size and
+// mode. VFS are zero values and must be set manually.
+func NewEntry(size int64, mode os.FileMode) *Entry {
+	t := time.Now().UTC().UnixNano()
+	return NewEntryTime(t, t, size, mode)
+}
+
+// NewEntryFileInfo creates a new entry from a given file info.
+func NewEntryFileInfo(info os.FileInfo) *Entry {
+	return NewEntryTime(
+		ctime(info),
+		info.ModTime().UTC().UnixNano(),
+		info.Size(),
+		info.Mode(),
+	)
+}
+
+// NewEntryTime creates a new entry with custom file change and modify times.
+func NewEntryTime(ctime, mtime, size int64, mode os.FileMode) *Entry {
+	return &Entry{
+		real: realEntry{
+			CTime: ctime,
+			MTime: mtime,
+			Size:  size,
+			Mode:  mode,
+		},
+	}
+}
+
+// NewEntryFile creates a new entry which describes the given file.
+func NewEntryFile(path string) (*Entry, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewEntryFileInfo(info), nil
+}
+
+// CTime atomically gets entry change time in UNIX nano format.
+func (e *Entry) CTime() int64 {
+	return atomic.LoadInt64(&e.real.CTime)
+}
+
+// SetCTime atomically sets entry's change time. Time must be in UNIX nano format.
+func (e *Entry) SetCTime(nano int64) {
+	atomic.StoreInt64(&e.real.CTime, nano)
+}
+
+// MTime atomically gets entry modification time in UNIX nano format.
+func (e *Entry) MTime() int64 {
+	return atomic.LoadInt64(&e.real.MTime)
+}
+
+// SetMTime atomically sets entry's modification time. Time must be in UNIX nano
+// format.
+func (e *Entry) SetMTime(nano int64) {
+	atomic.StoreInt64(&e.real.MTime, nano)
+}
+
+// Size atomically gets entry size in bytes.
+func (e *Entry) Size() int64 {
+	return atomic.LoadInt64(&e.real.Size)
+}
+
+// SetSize atomically sets entry's size. The size is provided in bytes.
+func (e *Entry) SetSize(size int64) {
+	atomic.StoreInt64(&e.real.Size, size)
+}
+
+// Mode atomically gets entry file mode.
+func (e *Entry) Mode() os.FileMode {
+	return os.FileMode(atomic.LoadUint32((*uint32)(&e.real.Mode)))
+}
+
+// SetMode atomically sets entry file mode.
+func (e *Entry) SetMode(mode os.FileMode) {
+	atomic.StoreUint32((*uint32)(&e.real.Mode), (uint32)(mode))
+}
+
+// Inode gets virtual file system inode.
+func (e *Entry) Inode() uint64 {
+	return atomic.LoadUint64(&e.virtual.inode)
+}
+
+// SetInode sets virtual file system inode.
+func (e *Entry) SetInode(inode uint64) {
+	atomic.StoreUint64(&e.virtual.inode, inode)
+}
+
+// IncRefCounter increments entry reference counter.
+func (e *Entry) IncRefCounter() int32 {
+	return atomic.AddInt32(&e.virtual.refCount, 1)
+}
+
+// DecRefCounter decrements entry reference counter.
+func (e *Entry) DecRefCounter() int32 {
+	return atomic.AddInt32(&e.virtual.refCount, -1)
+}
+
+// HasPromise checks if provider promise is set in given entry.
+func (e *Entry) HasPromise(promise EntryPromise) bool {
+	return EntryPromise(atomic.LoadUint32((*uint32)(&e.virtual.promise)))&promise == promise
+}
+
+// Deleted checks if the entry is promised to be deleted.
+func (e *Entry) Deleted() bool {
+	return e.HasPromise(EntryPromiseDel) || e.HasPromise(EntryPromiseUnlink)
+}
+
+// SwapPromise flips the value of a promise field, setting the set bits and
+// unsetting the unset ones. This function is thread safe.
+func (e *Entry) SwapPromise(set, unset EntryPromise) EntryPromise {
+	for {
+		older := atomic.LoadUint32((*uint32)(&e.virtual.promise))
+		updated := (older | uint32(set)) &^ uint32(unset)
+
+		if atomic.CompareAndSwapUint32((*uint32)(&e.virtual.promise), older, updated) {
+			return EntryPromise(updated)
+		}
+	}
+}
+
+// ctime gets file's change time in UNIX Nano format.
+func ctime(fi os.FileInfo) int64 {
+	if tspec := times.Get(fi); tspec.HasChangeTime() {
+		return tspec.ChangeTime().UnixNano()
+	}
+
+	return 0
+}

--- a/go/src/koding/klient/machine/index/entry.go
+++ b/go/src/koding/klient/machine/index/entry.go
@@ -14,15 +14,15 @@ import (
 type EntryPromise uint32
 
 const (
-	EntryPromiseSync   EntryPromise = 1 << iota // S: sync promise, doesn't exist locally.
-	EntryPromiseAdd                             // A: sync promise after adding, exists locally.
-	EntryPromiseUpdate                          // U: sync promise after updating, exists locally.
-	EntryPromiseDel                             // D: sync promise after deleting, doesn't exist locally.
-	EntryPromiseUnlink                          // N: sync promise after hard delete, doesn't exist locally.
+	EntryPromiseExist  EntryPromise = 1 << iota // E: promise that file exists, doesn't exist locally.
+	EntryPromiseAdd                             // A: promise after adding, exists locally.
+	EntryPromiseUpdate                          // U: promise after updating, exists locally.
+	EntryPromiseDel                             // D: promise after deleting, doesn't exist locally.
+	EntryPromiseUnlink                          // N: promise after hard delete, doesn't exist locally.
 )
 
 var epMapping = map[byte]EntryPromise{
-	'S': EntryPromiseSync,
+	'E': EntryPromiseExist,
 	'A': EntryPromiseAdd,
 	'U': EntryPromiseUpdate,
 	'D': EntryPromiseDel,

--- a/go/src/koding/klient/machine/index/entry.go
+++ b/go/src/koding/klient/machine/index/entry.go
@@ -14,15 +14,15 @@ import (
 type EntryPromise uint32
 
 const (
-	EntryPromiseExist  EntryPromise = 1 << iota // E: promise that file exists, doesn't exist locally.
-	EntryPromiseAdd                             // A: promise after adding, exists locally.
-	EntryPromiseUpdate                          // U: promise after updating, exists locally.
-	EntryPromiseDel                             // D: promise after deleting, doesn't exist locally.
-	EntryPromiseUnlink                          // N: promise after hard delete, doesn't exist locally.
+	EntryPromiseVirtual EntryPromise = 1 << iota // E: promise that file exists, doesn't exist locally.
+	EntryPromiseAdd                              // A: promise after adding, exists locally.
+	EntryPromiseUpdate                           // U: promise after updating, exists locally.
+	EntryPromiseDel                              // D: promise after deleting, doesn't exist locally.
+	EntryPromiseUnlink                           // N: promise after hard delete, doesn't exist locally.
 )
 
 var epMapping = map[byte]EntryPromise{
-	'E': EntryPromiseExist,
+	'V': EntryPromiseVirtual,
 	'A': EntryPromiseAdd,
 	'U': EntryPromiseUpdate,
 	'D': EntryPromiseDel,

--- a/go/src/koding/klient/machine/index/entry_test.go
+++ b/go/src/koding/klient/machine/index/entry_test.go
@@ -1,0 +1,47 @@
+package index_test
+
+import (
+	"fmt"
+	"testing"
+
+	"koding/klient/machine/index"
+)
+
+func TestEntryPromiseString(t *testing.T) {
+	tests := []struct {
+		EP     index.EntryPromise
+		Result string
+	}{
+		{
+			// 0 //
+			EP:     index.EntryPromiseSync,
+			Result: "S----",
+		},
+		{
+			// 1 //
+			EP:     index.EntryPromiseSync | index.EntryPromiseDel | index.EntryPromiseUnlink,
+			Result: "S--DN",
+		},
+		{
+			// 2 //
+			EP:     index.EntryPromiseAdd,
+			Result: "-A---",
+		},
+		{
+			// 3 //
+			EP:     0,
+			Result: "-----",
+		},
+	}
+
+	for i, test := range tests {
+		test := test // Capture range variable.
+		t.Run(fmt.Sprintf("test_no_%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			if got := test.EP.String(); got != test.Result {
+				t.Errorf("want ep string = %q; got %q", test.Result, got)
+			}
+		})
+	}
+}

--- a/go/src/koding/klient/machine/index/entry_test.go
+++ b/go/src/koding/klient/machine/index/entry_test.go
@@ -14,13 +14,13 @@ func TestEntryPromiseString(t *testing.T) {
 	}{
 		{
 			// 0 //
-			EP:     index.EntryPromiseSync,
-			Result: "S----",
+			EP:     index.EntryPromiseExist,
+			Result: "E----",
 		},
 		{
 			// 1 //
-			EP:     index.EntryPromiseSync | index.EntryPromiseDel | index.EntryPromiseUnlink,
-			Result: "S--DN",
+			EP:     index.EntryPromiseExist | index.EntryPromiseDel | index.EntryPromiseUnlink,
+			Result: "E--DN",
 		},
 		{
 			// 2 //

--- a/go/src/koding/klient/machine/index/entry_test.go
+++ b/go/src/koding/klient/machine/index/entry_test.go
@@ -14,13 +14,13 @@ func TestEntryPromiseString(t *testing.T) {
 	}{
 		{
 			// 0 //
-			EP:     index.EntryPromiseExist,
-			Result: "E----",
+			EP:     index.EntryPromiseVirtual,
+			Result: "V----",
 		},
 		{
 			// 1 //
-			EP:     index.EntryPromiseExist | index.EntryPromiseDel | index.EntryPromiseUnlink,
-			Result: "E--DN",
+			EP:     index.EntryPromiseVirtual | index.EntryPromiseDel | index.EntryPromiseUnlink,
+			Result: "V--DN",
 		},
 		{
 			// 2 //

--- a/go/src/koding/klient/machine/index/index.go
+++ b/go/src/koding/klient/machine/index/index.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"sort"
 	"sync"
+	"text/tabwriter"
 )
 
 // Version stores current version of index.
@@ -357,7 +358,6 @@ func (idx *Index) UnmarshalJSON(data []byte) error {
 	idx.root.Entry = NewEntry(0, 0644|os.ModeDir)
 
 	return nil
-
 }
 
 // DebugString dumps content of the index as a string, suitable for debugging.
@@ -378,9 +378,11 @@ func (idx *Index) DebugString() string {
 	sort.Strings(paths)
 
 	var buf bytes.Buffer
+	tw := tabwriter.NewWriter(&buf, 0, 0, 1, ' ', 0)
 	for _, path := range paths {
-		fmt.Fprintf(&buf, "%s => %#v\n", path, m[path])
+		fmt.Fprintf(tw, "%s\t%v\n", path, m[path])
 	}
+	tw.Flush()
 
 	return buf.String()
 }

--- a/go/src/koding/klient/machine/index/index.go
+++ b/go/src/koding/klient/machine/index/index.go
@@ -64,11 +64,6 @@ func NewIndexFiles(root string) (*Index, error) {
 			return nil
 		}
 
-		// Skip root path.
-		if name, err := filepath.Rel(root, path); err != nil || name == "." {
-			return nil
-		}
-
 		fC <- &fileDesc{path: path, info: info}
 		return nil
 	}
@@ -89,6 +84,11 @@ func (idx *Index) addEntryWorker(root string, wg *sync.WaitGroup, fC <-chan *fil
 		name, err := filepath.Rel(root, f.path)
 		if err != nil {
 			continue
+		}
+
+		// Set root path to zero value.
+		if name == "." {
+			name = ""
 		}
 
 		idx.mu.Lock()
@@ -136,7 +136,8 @@ func (idx *Index) PromiseUnlink(path string, node *Node) {
 
 // Count returns the number of entries stored in index. Only items which size is
 // below provided value are counted. If provided argument is negative, this
-// function will return the number of all entries.
+// function will return the number of all entries. It does not count files
+// marked as virtual or deleted.
 func (idx *Index) Count(maxsize int64) int {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
@@ -144,14 +145,33 @@ func (idx *Index) Count(maxsize int64) int {
 	return idx.root.Count(maxsize)
 }
 
+// CountAll behaves like Count but it counts It does count files marked as
+// virtual or deleted.
+func (idx *Index) CountAll(maxsize int64) int {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
+	return idx.root.CountAll(maxsize)
+}
+
 // DiskSize tells how much disk space would be used by entries stored in index.
 // Only items which size is below provided value are counted. If provided
-// argument is negative, this function will count disk size of all items.
+// argument is negative, this function will count disk size of all items. It
+// does not count size of files marked as virtual or deleted.
 func (idx *Index) DiskSize(maxsize int64) int64 {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
 
 	return idx.root.DiskSize(maxsize)
+}
+
+// DiskSizeAll behaves like DiskSize but it includes files marked as virtual or
+// deleted.
+func (idx *Index) DiskSizeAll(maxsize int64) int64 {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
+	return idx.root.DiskSizeAll(maxsize)
 }
 
 // Lookup looks up a node by the given name.
@@ -162,64 +182,108 @@ func (idx *Index) Lookup(name string) (*Node, bool) {
 	return idx.root.Lookup(name)
 }
 
-// Compare rereads the given file tree rooted at root and compares its entries
-// to previous state of the index. All detected changes will be stored in
-// returned Change slice.
-func (idx *Index) Compare(root string) ChangeSlice {
-	return idx.CompareBranch("", root)
+// Merge calls MergeBranch on all nodes pointed by root path.
+func (idx *Index) Merge(root string) ChangeSlice {
+	return idx.MergeBranch(root, "")
 }
 
-// CompareBranch rereads the given file tree rooted at root and compares its
-// entries with index state rooted at branch node.
+// MergeBranch rereads the given file tree rooted at root and merges its
+// entries with index state rooted at branch node. The called index is treated
+// as remote part. Scanned directory is considered local part. The following
+// rules apply:
+//
+//  1. If file exists in both remote and local, its fileinfos will be compared
+//     with remote entry and if they differs, ChangeMetaUpdate will be created
+//     with the direction specified by the result of ctime and mtime comparison.
+//
+//  2. If file exists in remote but not in local, the entry will have
+//     EntryPromiseVirtual property, and ChangeMetaAdd from remote to local
+//     will be created.
+//
+//  3. If file exists in local but not in remote, the entry will be created in
+//     remote with EntryPromiseAdd property, and ChangeMetaAdd from local to
+//     remote will be produced.
 //
 // All detected changes will be stored in returned Change slice.
 // If branch is empty, the comparison is made against root of the index.
-func (idx *Index) CompareBranch(branch, root string) (cs ChangeSlice) {
+func (idx *Index) MergeBranch(root, branch string) (cs ChangeSlice) {
 	idx.mu.RLock()
-	rt, ok := idx.root.Lookup(branch)
+	rt, ok := idx.root.LookupAll(branch)
 	idx.mu.RUnlock()
 
-	if !ok {
-		rt = newNode()
+	rootBranch := filepath.Join(root, branch)
+	visited := map[string]struct{}{
+		rootBranch: struct{}{}, // Skip root.
 	}
 
-	visited := make(map[string]struct{})
+	if !ok {
+		goto skipBranch
+	}
 
-	rootBranch := filepath.Join(root, branch)
+	idx.mu.RLock()
+	rt.ForEachAll(func(name string, entry *Entry) {
+		nameOS := filepath.FromSlash(name)
+		visited[filepath.Join(rootBranch, nameOS)] = struct{}{}
 
+		info, err := os.Lstat(filepath.Join(rootBranch, nameOS))
+		if os.IsNotExist(err) {
+			// File exists in remote but not in local.
+			entry.SwapPromise(EntryPromiseVirtual, 0)
+			cs = append(cs, NewChange(
+				filepath.ToSlash(filepath.Join(branch, nameOS)),
+				ChangeMetaAdd|ChangeMetaRemote|markLargeMeta(entry.Size()),
+			))
+			return
+		}
+
+		// There is nothing we can do with this error.
+		if err != nil {
+			return
+		}
+
+		// File exists in both remote and local.
+		if entry.MTime() == info.ModTime().UnixNano() && entry.CTime() == ctime(info) &&
+			entry.Size() == info.Size() && entry.Mode() == info.Mode() {
+			// Files are identical.
+			return
+		}
+
+		// Files differ.
+		cs = append(cs, NewChange(
+			filepath.ToSlash(filepath.Join(branch, nameOS)),
+			ChangeMetaUpdate|markLargeMeta(info.Size()),
+		))
+	})
+	idx.mu.RUnlock()
+
+skipBranch:
 	// Walk over current root path and check it files.
 	walkFn := func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil
 		}
 
-		name, err := filepath.Rel(rootBranch, path)
-		if err != nil || name == "." {
+		if _, ok := visited[path]; ok {
 			return nil
 		}
 
-		name = filepath.ToSlash(name)
-
-		idx.mu.RLock()
-		nd, ok := rt.Lookup(name)
-		idx.mu.RUnlock()
-
-		name = filepath.Join(branch, name)
-
-		// Not found in current index - file was added.
-		if !ok {
-			cs = append(cs, NewChange(name, ChangeMetaAdd|markLargeMeta(info.Size())))
+		// File exists in local but not in remote.
+		name, err := filepath.Rel(root, path)
+		if err != nil {
 			return nil
 		}
 
-		// Entry is read only-now. Check for changes.
-		visited[name] = struct{}{}
-		if nd.Entry.MTime() != info.ModTime().UnixNano() ||
-			nd.Entry.CTime() != ctime(info) ||
-			nd.Entry.Size() != info.Size() ||
-			nd.Entry.Mode() != info.Mode() {
-			cs = append(cs, NewChange(name, ChangeMetaUpdate|markLargeMeta(info.Size())))
-		}
+		cs = append(cs, NewChange(
+			filepath.ToSlash(name),
+			ChangeMetaAdd|markLargeMeta(info.Size()),
+		))
+
+		idx.mu.Lock()
+		idx.root.PromiseAdd(
+			filepath.ToSlash(name),
+			NewEntryFileInfo(info),
+		)
+		idx.mu.Unlock()
 
 		return nil
 	}
@@ -227,19 +291,6 @@ func (idx *Index) CompareBranch(branch, root string) (cs ChangeSlice) {
 	if err := filepath.Walk(rootBranch, walkFn); err != nil {
 		return nil
 	}
-
-	// Check for removes.
-	idx.mu.RLock()
-	idx.root.ForEach(func(name string, entry *Entry) {
-		if _, ok := visited[name]; !ok {
-			path := filepath.Join(root, filepath.FromSlash(name))
-
-			if _, err := os.Lstat(path); os.IsNotExist(err) {
-				cs = append(cs, NewChange(name, ChangeMetaRemove|markLargeMeta(entry.Size())))
-			}
-		}
-	})
-	idx.mu.RUnlock()
 
 	return cs
 }
@@ -253,51 +304,41 @@ func markLargeMeta(n int64) ChangeMeta {
 	return ChangeMetaHuge
 }
 
-// Apply modifies index according to provided changes. This function doesn't
-// guarantee that changes from Compare function applied to the index will
-// result in actual directory state.
-func (idx *Index) Apply(root string, cs ChangeSlice) {
-	// Start worker pool.
-	var wg sync.WaitGroup
-	fC := make(chan *fileDesc)
-	for i := 0; i < naturalMin(2*runtime.NumCPU(), len(cs)); i++ {
-		wg.Add(1)
-		go idx.addEntryWorker(root, &wg, fC)
+// Sync modifies index according to provided change path. It checks the file
+// on the underlying file system and updates its corresponding index entry.
+// This function invalidates all promises set in change entry.
+func (idx *Index) Sync(root string, c *Change) {
+	if c == nil {
+		return
 	}
 
-	for i := range cs {
-		switch {
-		case cs[i].Meta()&(ChangeMetaUpdate|ChangeMetaAdd) != 0:
-			// Check if the event is still valid or if it was replaced by newer
-			// change.
-			idx.mu.RLock()
-			nd, ok := idx.root.Lookup(cs[i].Path())
-			idx.mu.RUnlock()
-
-			// Entry was updated/added after the event was created.
-			if ok && nd.Entry.MTime() > cs[i].CreatedAtUnixNano() {
-				continue
-			}
-			fallthrough
-		case cs[i].Meta()&ChangeMetaRemove != 0:
-			// Check if the file still exists, since it could be removed before
-			// Apply was called. If the file exists, create new entry from it
-			// and replace its value inside index map.
-			path := filepath.Join(root, filepath.FromSlash(cs[i].Path()))
-			info, err := os.Lstat(path)
-			if os.IsNotExist(err) {
-				idx.mu.Lock()
-				idx.root.Del(cs[i].Path())
-				idx.mu.Unlock()
-				continue
-			}
-
-			fC <- &fileDesc{path: path, info: info}
-		}
+	info, err := os.Lstat(filepath.Join(root, filepath.FromSlash(c.Path())))
+	if os.IsNotExist(err) {
+		idx.mu.Lock()
+		idx.root.Del(c.Path())
+		idx.mu.Unlock()
+		return
+	} else if err != nil {
+		// Nothing much we can do here.
+		return
 	}
 
-	close(fC)
-	wg.Wait()
+	// Get file node pointed by the change.
+	nd, ok := idx.root.LookupAll(c.Path())
+	if !ok {
+		// Add new entry.
+		idx.mu.Lock()
+		idx.root.Add(c.Path(), NewEntryFileInfo(info))
+		idx.mu.Unlock()
+		return
+	}
+
+	// Update entry and unset all promises.
+	nd.Entry.SetCTime(ctime(info))
+	nd.Entry.SetMTime(info.ModTime().UTC().UnixNano())
+	nd.Entry.SetSize(info.Size())
+	nd.Entry.SetMode(info.Mode())
+	nd.Entry.SwapPromise(0, ^EntryPromise(0))
 }
 
 // naturalMin returns the minimal value of provided arguments but not less than
@@ -353,10 +394,6 @@ func (idx *Index) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// BUG(rjeczalik): Something overwrites the root entry
-	// with a zero value elsewhere. Fix me.
-	idx.root.Entry = NewEntry(0, 0644|os.ModeDir)
-
 	return nil
 }
 
@@ -379,8 +416,8 @@ func (idx *Index) DebugString() string {
 
 	var buf bytes.Buffer
 	tw := tabwriter.NewWriter(&buf, 0, 0, 1, ' ', 0)
-	for _, path := range paths {
-		fmt.Fprintf(tw, "%s\t%v\n", path, m[path])
+	for i, path := range paths {
+		fmt.Fprintf(tw, "%5d %s\t%v\n", i+1, path, m[path])
 	}
 	tw.Flush()
 

--- a/go/src/koding/klient/machine/index/index_test.go
+++ b/go/src/koding/klient/machine/index/index_test.go
@@ -200,7 +200,7 @@ func TestIndexJSON(t *testing.T) {
 	}
 
 	if cs := idx.Compare(root); len(cs) != 0 {
-		t.Errorf("want no changes after apply; got %#v", cs)
+		t.Errorf("want no changes after apply; got %v", cs)
 	}
 }
 

--- a/go/src/koding/klient/machine/index/index_test.go
+++ b/go/src/koding/klient/machine/index/index_test.go
@@ -146,11 +146,11 @@ func TestIndexCount(t *testing.T) {
 	}{
 		"all items": {
 			MaxSize:  -1,
-			Expected: 11,
+			Expected: 12,
 		},
 		"less than 100kiB": {
 			MaxSize:  100 * 1024,
-			Expected: 9,
+			Expected: 10,
 		},
 		"zero": {
 			MaxSize:  0,

--- a/go/src/koding/klient/machine/index/index_test.go
+++ b/go/src/koding/klient/machine/index/index_test.go
@@ -46,6 +46,7 @@ func TestIndex(t *testing.T) {
 		"add dir": {
 			Op: addDir("e"),
 			Changes: index.ChangeSlice{
+				index.NewChange("", index.ChangeMetaUpdate),
 				index.NewChange("e", index.ChangeMetaAdd),
 			},
 		},
@@ -53,22 +54,23 @@ func TestIndex(t *testing.T) {
 			Op: rmAllFile("c/cb.bin"),
 			Changes: index.ChangeSlice{
 				index.NewChange("c", index.ChangeMetaUpdate),
-				index.NewChange("c/cb.bin", index.ChangeMetaRemove),
+				index.NewChange("c/cb.bin", index.ChangeMetaRemote|index.ChangeMetaAdd),
 			},
 		},
 		"remove dir": {
 			Op: rmAllFile("c"),
 			Changes: index.ChangeSlice{
-				index.NewChange("c", index.ChangeMetaRemove),
-				index.NewChange("c/ca.txt", index.ChangeMetaRemove),
-				index.NewChange("c/cb.bin", index.ChangeMetaRemove),
+				index.NewChange("c", index.ChangeMetaRemote|index.ChangeMetaAdd),
+				index.NewChange("c/ca.txt", index.ChangeMetaRemote|index.ChangeMetaAdd),
+				index.NewChange("c/cb.bin", index.ChangeMetaRemote|index.ChangeMetaAdd),
 			},
 			Branch: "c/",
 		},
 		"rename file": {
 			Op: mvFile("b.bin", "c/cc.bin"),
 			Changes: index.ChangeSlice{
-				index.NewChange("b.bin", index.ChangeMetaRemove),
+				index.NewChange("", index.ChangeMetaUpdate),
+				index.NewChange("b.bin", index.ChangeMetaRemote|index.ChangeMetaAdd),
 				index.NewChange("c", index.ChangeMetaUpdate),
 				index.NewChange("c/cc.bin", index.ChangeMetaAdd),
 			},
@@ -111,7 +113,7 @@ func TestIndex(t *testing.T) {
 			// Synchronize underlying file-system.
 			Sync()
 
-			cs := idx.CompareBranch(test.Branch, root)
+			cs := idx.MergeBranch(root, test.Branch)
 			sort.Sort(cs)
 			if len(cs) != len(test.Changes) {
 				t.Fatalf("want index.Changes count = %d; got %d", len(test.Changes), len(cs))
@@ -122,14 +124,16 @@ func TestIndex(t *testing.T) {
 				if cs[i].Path() != tc.Path() {
 					t.Errorf("want index.Change path = %q; got %q", tc.Path(), cs[i].Path())
 				}
-				if cs[i].Meta() != tc.Meta() {
-					t.Errorf("want index.Change meta = %bb; got %bb", tc.Meta, cs[i].Meta)
+				if cm, tm := cs[i].Meta(), tc.Meta(); cm != tm {
+					t.Errorf("want index.Change meta = %s; got %v", tm.String(), cm.String())
 				}
 			}
 
-			idx.Apply(root, cs)
-			if cs = idx.CompareBranch(test.Branch, root); len(cs) != 0 {
-				t.Errorf("want no index.Changes after apply; got %#v", cs)
+			for _, c := range cs {
+				idx.Sync(root, c)
+			}
+			if cs = idx.MergeBranch(root, test.Branch); len(cs) != 0 {
+				t.Errorf("want no index.Changes after sync; got %v", cs)
 			}
 		})
 	}
@@ -199,7 +203,7 @@ func TestIndexJSON(t *testing.T) {
 		t.Fatalf("want err = nil; got %v", err)
 	}
 
-	if cs := idx.Compare(root); len(cs) != 0 {
+	if cs := idx.Merge(root); len(cs) != 0 {
 		t.Errorf("want no changes after apply; got %v", cs)
 	}
 }

--- a/go/src/koding/klient/machine/index/node.go
+++ b/go/src/koding/klient/machine/index/node.go
@@ -108,10 +108,10 @@ func (nd *Node) Del(path string) {
 //
 // If the node is already marked as newly added, the method is a no-op.
 //
-// If entry.Mode is non-zero, the effictive node's entry is overwritten
+// If entry.Mode is non-zero, the effective node's entry is overwritten
 // with this value.
 //
-// If entry.Aux is non-zero, the effictive node's Aux is overwritten
+// If entry.Aux is non-zero, the effective node's Aux is overwritten
 // with this value.
 //
 // Rest of entry's fields are currently ignored.
@@ -121,8 +121,8 @@ func (nd *Node) PromiseAdd(path string, entry *Entry) {
 	if nd, ok := nd.lookup(path, true); ok {
 		newE = nd.Entry
 
-		if entry.Inode != 0 {
-			newE.SetInode(entry.Inode)
+		if entry.inode != 0 {
+			newE.SetInode(entry.inode)
 		}
 
 		if entry.Mode != 0 {
@@ -142,7 +142,7 @@ func (nd *Node) PromiseAdd(path string, entry *Entry) {
 		if entry.Mode != 0 {
 			newE.Mode = entry.Mode
 		}
-		newE.Inode = entry.Inode
+		newE.inode = entry.inode
 	}
 
 	newE.SwapMeta(EntryPromiseAdd, EntryPromiseDel|EntryPromiseUnlink)
@@ -333,7 +333,7 @@ func (nd *Node) IsDir() bool {
 
 // Deleted tells whether node is marked as deleted.
 func (nd *Node) Deleted() bool {
-	return atomic.LoadInt32(&nd.Entry.Meta)&(EntryPromiseDel|EntryPromiseUnlink) != 0
+	return atomic.LoadInt32(&nd.Entry.meta)&(EntryPromiseDel|EntryPromiseUnlink) != 0
 }
 
 func (nd *Node) undelete() {

--- a/go/src/koding/klient/machine/index/node.go
+++ b/go/src/koding/klient/machine/index/node.go
@@ -190,7 +190,7 @@ func (nd *Node) count(maxsize int64, all bool) (count int) {
 			continue
 		}
 
-		if cur.Entry != nil && (maxsize < 0 || cur.Entry.Size() <= maxsize) && cur != nd {
+		if cur.Entry != nil && (maxsize < 0 || cur.Entry.Size() <= maxsize) {
 			count++
 		}
 

--- a/go/src/koding/klient/machine/index/node_test.go
+++ b/go/src/koding/klient/machine/index/node_test.go
@@ -11,179 +11,113 @@ import (
 
 func fixture() *index.Node {
 	return &index.Node{
-		Entry: &index.Entry{
-			Size: 0,
-		},
+		Entry: index.NewEntry(0, 0),
 		Sub: map[string]*index.Node{
 			"addresses": {
-				Entry: &index.Entry{
-					Size: 0,
-				},
+				Entry: index.NewEntry(0, 0),
 				Sub: map[string]*index.Node{
 					"addresser.go": {
-						Entry: &index.Entry{
-							Size: 714,
-						},
+						Entry: index.NewEntry(714, 0),
 					},
 					"addresses.go": {
-						Entry: &index.Entry{
-							Size: 2428,
-						},
+						Entry: index.NewEntry(2428, 0),
 					},
 					"addresses_test.go": {
-						Entry: &index.Entry{
-							Size: 3095,
-						},
+						Entry: index.NewEntry(3095, 0),
 					},
 					"cached.go": {
-						Entry: &index.Entry{
-							Size: 2036,
-						},
+						Entry: index.NewEntry(2036, 0),
 					},
 				},
 			},
 			"aliases": {
-				Entry: &index.Entry{
-					Size: 0,
-				},
+				Entry: index.NewEntry(0, 0),
 				Sub: map[string]*index.Node{
 					"aliaser.go": {
-						Entry: &index.Entry{
-							Size: 596,
-						},
+						Entry: index.NewEntry(596, 0),
 					},
 					"aliases.go": {
-						Entry: &index.Entry{
-							Size: 3218,
-						},
+						Entry: index.NewEntry(3218, 0),
 					},
 					"aliases_test.go": {
-						Entry: &index.Entry{
-							Size: 1831,
-						},
+						Entry: index.NewEntry(1831, 0),
 					},
 					"cached.go": {
-						Entry: &index.Entry{
-							Size: 2196,
-						},
+						Entry: index.NewEntry(2196, 0),
 					},
 				},
 			},
 			"clients": {
-				Entry: &index.Entry{
-					Size: 0,
-				},
+				Entry: index.NewEntry(0, 0),
 				Sub: map[string]*index.Node{
 					"clients.go": {
-						Entry: &index.Entry{
-							Size: 4003,
-						},
+						Entry: index.NewEntry(4003, 0),
 					},
 					"clients_test.go": {
-						Entry: &index.Entry{
-							Size: 1783,
-						},
+						Entry: index.NewEntry(1783, 0),
 					},
 				},
 			},
 			"create.go": {
-				Entry: &index.Entry{
-					Size: 3660,
-				},
+				Entry: index.NewEntry(3660, 0),
 			},
 			"create_test.go": {
-				Entry: &index.Entry{
-					Size: 4582,
-				},
+				Entry: index.NewEntry(4582, 0),
 			},
 			"id.go": {
-				Entry: &index.Entry{
-					Size: 1272,
-				},
+				Entry: index.NewEntry(1272, 0),
 			},
 			"id_test.go": {
-				Entry: &index.Entry{
-					Size: 1979,
-				},
+				Entry: index.NewEntry(1979, 0),
 			},
 			"idset": {
-				Entry: &index.Entry{
-					Size: 0,
-				},
+				Entry: index.NewEntry(0, 0),
 				Sub: map[string]*index.Node{
 					"idset.go": {
-						Entry: &index.Entry{
-							Size: 1288,
-						},
+						Entry: index.NewEntry(1288, 0),
 					},
 					"idset_test.go": {
-						Entry: &index.Entry{
-							Size: 4231,
-						},
+						Entry: index.NewEntry(4231, 0),
 					},
 				},
 			},
 			"kite.go": {
-				Entry: &index.Entry{
-					Size: 4152,
-				},
+				Entry: index.NewEntry(4152, 0),
 			},
 			"machinegroup.go": {
-				Entry: &index.Entry{
-					Size: 6839,
-				},
+				Entry: index.NewEntry(6839, 0),
 			},
 			"machinegroup_test.go": {
-				Entry: &index.Entry{
-					Size: 6592,
-				},
+				Entry: index.NewEntry(6592, 0),
 			},
 			"mount.go": {
-				Entry: &index.Entry{
-					Size: 9346,
-				},
+				Entry: index.NewEntry(9346, 0),
 			},
 			"mount_test.go": {
-				Entry: &index.Entry{
-					Size: 8824,
-				},
+				Entry: index.NewEntry(8824, 0),
 			},
 			"mounts": {
-				Entry: &index.Entry{
-					Size: 0,
-				},
+				Entry: index.NewEntry(0, 0),
 				Sub: map[string]*index.Node{
 					"cached.go": {
-						Entry: &index.Entry{
-							Size: 2465,
-						},
+						Entry: index.NewEntry(2465, 0),
 					},
 					"mounter.go": {
-						Entry: &index.Entry{
-							Size: 1000,
-						},
+						Entry: index.NewEntry(1000, 0),
 					},
 					"mounts.go": {
-						Entry: &index.Entry{
-							Size: 4133,
-						},
+						Entry: index.NewEntry(4133, 0),
 					},
 					"mounts_test.go": {
-						Entry: &index.Entry{
-							Size: 5330,
-						},
+						Entry: index.NewEntry(5330, 0),
 					},
 				},
 			},
 			"ssh.go": {
-				Entry: &index.Entry{
-					Size: 2831,
-				},
+				Entry: index.NewEntry(2831, 0),
 			},
 			"ssh_test.go": {
-				Entry: &index.Entry{
-					Size: 3567,
-				},
+				Entry: index.NewEntry(3567, 0),
 			},
 		},
 	}
@@ -211,8 +145,8 @@ func TestNodeLookup(t *testing.T) {
 				t.Fatalf("Lookup(%q) failed", name)
 			}
 
-			if nd.Entry.Size != size {
-				t.Fatalf("got %d, want %d", size, nd.Entry.Size)
+			if nd.Entry.Size() != size {
+				t.Fatalf("got %d, want %d", size, nd.Entry.Size())
 			}
 		})
 	}
@@ -276,9 +210,7 @@ func TestNodeAdd(t *testing.T) {
 	}
 
 	root := fixture()
-	entry := &index.Entry{
-		Size: 0xD,
-	}
+	entry := index.NewEntry(0xD, 0)
 
 	for _, cas := range cases {
 		t.Run(cas.name, func(t *testing.T) {
@@ -295,8 +227,8 @@ func TestNodeAdd(t *testing.T) {
 				t.Fatalf("got %d, want %d", count, cas.count)
 			}
 
-			if nd.Entry.Size != entry.Size {
-				t.Fatalf("got %d, want %d", nd.Entry.Size, entry.Size)
+			if nd.Entry.Size() != entry.Size() {
+				t.Fatalf("got %d, want %d", nd.Entry.Size(), entry.Size())
 			}
 		})
 	}

--- a/go/src/koding/klient/machine/index/node_test.go
+++ b/go/src/koding/klient/machine/index/node_test.go
@@ -154,10 +154,10 @@ func TestNodeLookup(t *testing.T) {
 
 func TestNodeCount(t *testing.T) {
 	cases := map[int64]int{
-		-1:   32,
+		-1:   33,
 		0:    0,
-		4000: 22,
-		6000: 28,
+		4000: 23,
+		6000: 29,
 	}
 
 	root := fixture()
@@ -199,14 +199,14 @@ func TestNodeAdd(t *testing.T) {
 		name  string
 		count int
 	}{
-		{"addresses/cached_test.go", 33},
-		{"notify.go", 34},
-		{"notify/notify.go", 36},
-		{"proxy/fuse/fuse.go", 39},
-		{"notify", 39},   // no-op
-		{"notify/", 39},  // no-op
-		{"/notify/", 39}, // no-op
-		{"/notify", 39},  // no-op
+		{"addresses/cached_test.go", 34},
+		{"notify.go", 35},
+		{"notify/notify.go", 37},
+		{"proxy/fuse/fuse.go", 40},
+		{"notify", 40},   // no-op
+		{"notify/", 40},  // no-op
+		{"/notify/", 40}, // no-op
+		{"/notify", 40},  // no-op
 	}
 
 	root := fixture()
@@ -239,13 +239,13 @@ func TestNodeDel(t *testing.T) {
 		name  string
 		count int
 	}{
-		{"addresses/addresser.go", 31},
-		{"addresses/", 27},
-		{"aliases", 22},
-		{"id.go", 21},
-		{"id.go", 21},          // no-op
-		{"nonexisting.go", 21}, // no-op
-		{"/kite.go", 20},
+		{"addresses/addresser.go", 32},
+		{"addresses/", 28},
+		{"aliases", 23},
+		{"id.go", 22},
+		{"id.go", 22},          // no-op
+		{"nonexisting.go", 22}, // no-op
+		{"/kite.go", 21},
 	}
 
 	root := fixture()

--- a/go/src/koding/klient/machine/index/node_test.go
+++ b/go/src/koding/klient/machine/index/node_test.go
@@ -271,6 +271,7 @@ func TestNodeForEach(t *testing.T) {
 	root := fixture()
 
 	want := []string{
+		"",
 		"addresses",
 		"addresses/addresser.go",
 		"addresses/addresses.go",

--- a/go/src/koding/klient/machine/mount/notify/notify.go
+++ b/go/src/koding/klient/machine/mount/notify/notify.go
@@ -13,8 +13,7 @@ import (
 type DiskInfo func() (fs.DiskInfo, error)
 
 // BuildOpts represents the context that can be used by external notifiers to
-// build their own type. Built notifier should only read from provided indexes
-// and, if changes occur, commit observed changes using Cache interface.
+// build their own type.
 type BuildOpts struct {
 	MountID mount.ID    // identifier of synced mount.
 	Mount   mount.Mount // single mount with absolute paths.
@@ -24,8 +23,7 @@ type BuildOpts struct {
 
 	DiskInfo DiskInfo // remote directory volume info.
 
-	RemoteIdx *index.Index // known state of remote index.
-	LocalIdx  *index.Index // known state of local index.
+	Index *index.Index // known state of managed index.
 }
 
 // Builder represents a factory method which external notifiers must implement

--- a/go/src/koding/klient/machine/mount/sync/anteroom.go
+++ b/go/src/koding/klient/machine/mount/sync/anteroom.go
@@ -164,7 +164,7 @@ func (a *Anteroom) dequeue() {
 		select {
 		case evC <- ev:
 			if ev = a.queue.Pop(); ev == nil {
-				evC = nil // ueue is empty - turn off event channel.
+				evC = nil // queue is empty - turn off event channel.
 			} else {
 				atomic.StoreUint64((*uint64)(&ev.stat), uint64(statusPop))
 			}

--- a/go/src/koding/klient/machine/mount/sync/sync.go
+++ b/go/src/koding/klient/machine/mount/sync/sync.go
@@ -26,8 +26,7 @@ const IndexFileName = "index"
 // build their own type. Built syncer should update the index after syncing and
 // manage received events.
 type BuildOpts struct {
-	RemoteIdx *index.Index // known state of remote index.
-	LocalIdx  *index.Index // known state of local index.
+	Index *index.Index // known state of synchronized index.
 }
 
 // Builder represents a factory method which external syncers must implement in

--- a/go/src/koding/klient/machine/mount/sync/sync_test.go
+++ b/go/src/koding/klient/machine/mount/sync/sync_test.go
@@ -34,10 +34,7 @@ func TestSyncNew(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(wd, "data")); err != nil {
 		t.Errorf("want err = nil; got %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(wd, msync.LocalIndexName)); err != nil {
-		t.Errorf("want err = nil; got %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(wd, msync.RemoteIndexName)); err != nil {
+	if _, err := os.Stat(filepath.Join(wd, msync.IndexFileName)); err != nil {
 		t.Errorf("want err = nil; got %v", err)
 	}
 
@@ -87,7 +84,7 @@ func TestSyncNew(t *testing.T) {
 	// TODO: All count should be two, since synced file is not the one from
 	// remote directory. This is temporary state since sync will balance
 	// indexes, but should be handled anyway.
-	expected.SyncCount = 1
+	expected.SyncCount = 0
 	expected.SyncDiskSize = info.SyncDiskSize
 
 	if !reflect.DeepEqual(info, expected) {

--- a/go/src/koding/klient/machine/mount/sync/sync_test.go
+++ b/go/src/koding/klient/machine/mount/sync/sync_test.go
@@ -43,19 +43,17 @@ func TestSyncNew(t *testing.T) {
 	if info == nil {
 		t.Fatalf("want info != nil; got nil")
 	}
-	if info.AllDiskSize == 0 {
+	if info.DiskSizeAll == 0 {
 		t.Error("want all disk size > 0")
 	}
 
 	expected := &msync.Info{
-		ID:           mountID,
-		Mount:        m,
-		SyncCount:    0,
-		AllCount:     1,
-		SyncDiskSize: 0,
-		AllDiskSize:  info.AllDiskSize,
-		Queued:       0,
-		Syncing:      0,
+		ID:          mountID,
+		Mount:       m,
+		Count:       1,
+		CountAll:    2,
+		DiskSize:    info.DiskSize,
+		DiskSizeAll: info.DiskSizeAll,
 	}
 
 	if !reflect.DeepEqual(info, expected) {
@@ -81,11 +79,19 @@ func TestSyncNew(t *testing.T) {
 		t.Fatalf("want info != nil; got nil")
 	}
 
-	// TODO: All count should be two, since synced file is not the one from
-	// remote directory. This is temporary state since sync will balance
-	// indexes, but should be handled anyway.
-	expected.SyncCount = 0
-	expected.SyncDiskSize = info.SyncDiskSize
+	expected = &msync.Info{
+		ID:          mountID,
+		Mount:       m,
+		Count:       2,
+		CountAll:    3,
+		DiskSize:    info.DiskSize,
+		DiskSizeAll: info.DiskSizeAll,
+	}
+
+	expected.Count = 2
+	expected.CountAll = 3
+	expected.DiskSize = info.DiskSize
+	expected.DiskSizeAll = info.DiskSizeAll
 
 	if !reflect.DeepEqual(info, expected) {
 		t.Errorf("want info = %#v; got %#v", expected, info)

--- a/go/src/koding/klientctl/machine.go
+++ b/go/src/koding/klientctl/machine.go
@@ -259,12 +259,12 @@ func tabListMountFormatter(w io.Writer, mounts map[string][]sync.Info) {
 				info.ID,
 				alias,
 				info.Mount,
-				info.SyncCount,
-				info.AllCount,
+				info.Count,
+				info.CountAll,
 				info.Queued,
 				info.Syncing,
-				humanize.IBytes(uint64(info.SyncDiskSize)),
-				humanize.IBytes(uint64(info.AllDiskSize)),
+				humanize.IBytes(uint64(info.DiskSize)),
+				humanize.IBytes(uint64(info.DiskSizeAll)),
 			)
 		}
 	}


### PR DESCRIPTION
This PR adds support for Entry promises in index - this means that two indexes for synchronization are no longer needed. Additionally it:

 - Drops Entry checksum(CRC32 Hash) - it was not used at this stage of mount implementation.
 - Adds EntryPromiseVirtual - which means that the file can be shown by FUSE but it's not physically available.
 - Since now, Index will store root Entry during initialization. Its name/path will be empty string `""` and not `"."` since we do not use dots in other entries.
 - `RemoteIdx` and `LocalIdx` were dropped, since now there is only one `Index`.

Depends on: ~#10588~

## Motivation and Context
Simplify sync logic.

## How Has This Been Tested?
Unit tests.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
