### PR TITLE
Use new Notification View in showError util

### DIFF
--- a/client/app/lib/notificationviewcontroller.coffee
+++ b/client/app/lib/notificationviewcontroller.coffee
@@ -27,7 +27,7 @@ module.exports = class NotificationViewController extends kd.Controller
     notification.ref = "notification-#{notification.uid}"
     @uid += 1
     return no for notificationOptions in notifications when notificationOptions.uid is notification.uid
-    notifications.push notification
+    notifications.unshift notification
     if typeof notification.onAdd is 'function'
       notificationOptions.onAdd notification
     @container.updateOptions { notifications }

--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -1148,7 +1148,7 @@ module.exports = class ComputeController extends KDController
         .then (shared) ->
           new kd.NotificationView { title: 'Permissions fixed' }
         .catch (err) ->
-          showError err, 'Failed to fix permissions'
+          showError err
 
 
   checkMachinePermissions: ->

--- a/client/app/lib/providers/computecontroller.ui.coffee
+++ b/client/app/lib/providers/computecontroller.ui.coffee
@@ -84,7 +84,7 @@ module.exports = class ComputeControllerUI
           doXhrRequest { endPoint, type }, (err, res) =>
 
             @hideLoader()
-            return  if showError err, { KodingError: 'Service not available' }
+            return  if showError err
 
             unless hasStackRequiredField requiredFields, 'ssh_private_key'
               showPrivateKeyWarning res.private

--- a/client/app/lib/util/showNotification.coffee
+++ b/client/app/lib/util/showNotification.coffee
@@ -1,16 +1,15 @@
 kd = require 'kd'
-KDNotificationView = kd.NotificationView
-module.exports = (message, options = {}) ->
-  return  if not message or message is ''
 
-  # TODO these css/type parameters will be changed according to error type
-  type = 'growl'
+###
+  Basic Usage showNotification { content: 'Notification Content' }
+  The paramater notification object must have at least content attribute
+  AddNotification func use default params for not provided attributes
+  For ex, { type: 'default', dismissible: no, duration: 2000 }
+###
 
-  options.duration or= 3500
-  options.title      = message
-  # options.css      or= css
-  options.type     or= type
+module.exports = (notification = {}) ->
 
-  options.fn message  if options.fn and typeof options.fn? is 'function'
+  return  unless notification.content
 
-  new KDNotificationView options
+  { addNotification } = kd.singletons.notificationViewController
+  addNotification notification

--- a/client/component-lab/Notification/Notification.stylus
+++ b/client/component-lab/Notification/Notification.stylus
@@ -1,13 +1,29 @@
 @import '~lab/Colors/Colors.stylus'
 
-$notifications-z-index          = 20000
+$notifications-z-index      = 20000
 
 .kd_notification_list
-  position                      fixed
-  top                           30px
-  right                         30px
-  width                         370px
-  z-index                       $notifications-z-index
+  position                  fixed
+  top                       40px
+  right                     10px
+  width                     370px
+  z-index                   $notifications-z-index
+  max-height                calc(100% - 30px)
+  overflow                  hidden
+  overflow-y                auto
+  padding-right             20px
+
+.kd_notification_list::-webkit-scrollbar
+  -webkit-appearance        none
+
+.kd_notification_list::-webkit-scrollbar:vertical
+    width                   7px
+
+.kd_notification_list::-webkit-scrollbar-thumb
+    border-radius           8px
+    border                  2px solid transparent
+    background-color        rgba(43,51,61,0.75)
+
 
 .kd_notification
   position                      relative

--- a/client/component-lab/Notification/NotificationView.coffee
+++ b/client/component-lab/Notification/NotificationView.coffee
@@ -16,143 +16,143 @@ Constants = require './constants'
 
 module.exports = class NotificationView extends React.Component
 
-    constructor: (props) ->
+  constructor: (props) ->
 
-      super props
-      @notificationTimer = null
-      @mounted = no
-      @removeCount = 0
-      @state =
-        removed : no
+    super props
+    @notificationTimer = null
+    @mounted = no
+    @removeCount = 0
+    @state =
+      removed : no
 
 
-    hideNotification: ->
+  hideNotification: ->
 
-      @notificationTimer.clear()  if @notificationTimer
-      @setState { removed : yes }  if @mounted
+    @notificationTimer.clear()  if @notificationTimer
+    @setState { removed : yes }  if @mounted
+    @removeNotification()
+
+
+  removeNotification: ->
+
+    @props.onRemove @props.notification.uid
+
+
+  dismiss: ->
+
+    @hideNotification()  if @props.notification.dismissible
+
+
+  onTransitionEnd: ->
+
+    if @removeCount == 0 and @state.removed
+      @removeCount++
       @removeNotification()
 
 
-    removeNotification: ->
+  autoDismissible: (notification) ->
 
-      @props.onRemove @props.notification.uid
-
-
-    dismiss: ->
-
-      @hideNotification()  if @props.notification.dismissible
+    { dismissible, primaryButtonTitle, secondaryButtonTitle} = notification
+    not dismissible and not primaryButtonTitle and not secondaryButtonTitle
 
 
-    onTransitionEnd: ->
+  componentDidMount: ->
 
-      if @removeCount == 0 and @state.removed
-        @removeCount++
-        @removeNotification()
-
-
-    autoDismissible: (notification) ->
-
-      { dismissible, primaryButtonTitle, secondaryButtonTitle} = notification
-      not dismissible and not primaryButtonTitle and not secondaryButtonTitle
-
-
-    componentDidMount: ->
-
-      transitionEvent = getVendorTransition()
-      element = ReactDOM.findDOMNode this
-      notification = @props.notification
-      @mounted = yes
-      if transitionEvent
-        element.addEventListener transitionEvent, @onTransitionEnd
-        if @autoDismissible notification
-          @notificationTimer = new Helpers.Timer =>
-            @hideNotification()
-          , notification.duration
+    transitionEvent = getVendorTransition()
+    element = ReactDOM.findDOMNode this
+    notification = @props.notification
+    @mounted = yes
+    if transitionEvent
+      element.addEventListener transitionEvent, @onTransitionEnd
+      if @autoDismissible notification
+        @notificationTimer = new Helpers.Timer =>
+          @hideNotification()
+        , notification.duration
 
 
-    handleMouseEnter: ->
+  handleMouseEnter: ->
 
-      if @autoDismissible @props.notification
-        @notificationTimer.pause()
-
-
-    handleMouseLeave: ->
-
-      if @autoDismissible @props.notification
-        @notificationTimer.resume()
+    if @autoDismissible @props.notification
+      @notificationTimer.pause()
 
 
-    handlePrimaryButtonClick: (event) ->
+  handleMouseLeave: ->
 
-      event.preventDefault()
-      notification = @props.notification
-      @hideNotification()
-      if typeof notification.onPrimaryButtonClick is 'function'
-        notification.onPrimaryButtonClick()
+    if @autoDismissible @props.notification
+      @notificationTimer.resume()
 
 
-    handleSecondaryButtonClick: (event) ->
+  handlePrimaryButtonClick: (event) ->
 
-      event.preventDefault()
-      notification = @props.notification
-      @hideNotification()
-      if typeof notification.onSecondaryButtonClick is 'function'
-        notification.onSecondaryButtonClick()
-
-
-    componentWillUnmount: ->
-
-      element = ReactDOM.findDOMNode this
-      transitionEvent = getVendorTransition()
-      element.removeEventListener transitionEvent, @onTransitionEnd
-      @mounted = no
+    event.preventDefault()
+    notification = @props.notification
+    @hideNotification()
+    if typeof notification.onPrimaryButtonClick is 'function'
+      notification.onPrimaryButtonClick()
 
 
-    render: ->
+  handleSecondaryButtonClick: (event) ->
 
-      notification = @props.notification
-      className = classnames [
-        styles.kd_notification
-        styles["kd_notification_#{notification.type}"]
-        styles.kd_notification_dismissible if notification.dismissible and not notification.primaryButtonTitle and not notification.secondaryButtonTitle
-      ]
-      iconClass = classnames [
-        styles.kd_notification_icon
-        styles["kd_notification_icon_#{notification.type}"]
-      ]
-      message = notification.content
-      <div
-        className={className}
-        onMouseEnter={@bound 'handleMouseEnter'}
-        onMouseLeave={@bound 'handleMouseLeave'}>
-        {
-          if notification.type isnt 'default'
-            <Box className={styles.kd_notification_level}>
-              <i className={iconClass}></i>
-            </Box>
-        }
-        <div className={styles.kd_notification_content}>
-          {message}
-        </div>
-        {
-          if notification.dismissible
-            <CloseButton onClick={@bound 'dismiss'} />
-        }
-        {
-          if notification.primaryButtonTitle or notification.secondaryButtonTitle
-            <Actions
-              notification={notification}
-              onPrimaryButtonClick={@bound 'handlePrimaryButtonClick'}
-              onSecondaryButtonClick={@bound 'handleSecondaryButtonClick'} />
-        }
+    event.preventDefault()
+    notification = @props.notification
+    @hideNotification()
+    if typeof notification.onSecondaryButtonClick is 'function'
+      notification.onSecondaryButtonClick()
+
+
+  componentWillUnmount: ->
+
+    element = ReactDOM.findDOMNode this
+    transitionEvent = getVendorTransition()
+    element.removeEventListener transitionEvent, @onTransitionEnd
+    @mounted = no
+
+
+  render: ->
+
+    notification = @props.notification
+    className = classnames [
+      styles.kd_notification
+      styles["kd_notification_#{notification.type}"]
+      styles.kd_notification_dismissible if notification.dismissible and not notification.primaryButtonTitle and not notification.secondaryButtonTitle
+    ]
+    iconClass = classnames [
+      styles.kd_notification_icon
+      styles["kd_notification_icon_#{notification.type}"]
+    ]
+    message = notification.content
+    <div
+      className={className}
+      onMouseEnter={@bound 'handleMouseEnter'}
+      onMouseLeave={@bound 'handleMouseLeave'}>
+      {
+        if notification.type isnt 'default'
+          <Box className={styles.kd_notification_level}>
+            <i className={iconClass}></i>
+          </Box>
+      }
+      <div className={styles.kd_notification_content}>
+        {message}
       </div>
+      {
+        if notification.dismissible
+          <CloseButton onClick={@bound 'dismiss'} />
+      }
+      {
+        if notification.primaryButtonTitle or notification.secondaryButtonTitle
+          <Actions
+            notification={notification}
+            onPrimaryButtonClick={@bound 'handlePrimaryButtonClick'}
+            onSecondaryButtonClick={@bound 'handleSecondaryButtonClick'} />
+      }
+    </div>
 
-    @propTypes :
-      notification : React.PropTypes.object
-      onRemove : React.PropTypes.func
+  @propTypes :
+    notification : React.PropTypes.object
+    onRemove : React.PropTypes.func
 
-    @defaultProps =
-      onRemove: kd.noop
+  @defaultProps =
+    onRemove: kd.noop
 
 
 CloseButton = ({onClick}) ->

--- a/client/component-lab/Notification/NotificationViewContainer.coffee
+++ b/client/component-lab/Notification/NotificationViewContainer.coffee
@@ -19,20 +19,20 @@ module.exports = class NotificationViewContainer extends ReactView
 
   getAnimationProps: ->
 
-      enter :
-        from :
-          transform : 'scale(0.9)'
-          opacity : 0
-        to :
-          transform : ''
-          opacity : ''
-      leave :
-        from :
-          transform : 'scale(1)'
-          opacity : 1
-        to :
-          transform : 'scale(0.9)'
-          opacity : 0
+    enter :
+      from :
+        transform : 'scale(0.9)'
+        opacity : 0
+      to :
+        transform : ''
+        opacity : ''
+    leave :
+      from :
+        transform : 'scale(1)'
+        opacity : 1
+      to :
+        transform : 'scale(0.9)'
+        opacity : 0
 
 
   onNotificationRemove: (uid) =>
@@ -49,12 +49,12 @@ module.exports = class NotificationViewContainer extends ReactView
 
   getNotifications: ->
 
-      @options.notifications.map (notification, index) =>
-        <NotificationView
-          index={index}
-          key={notification.uid}
-          notification={notification}
-          onRemove={@bound 'onNotificationRemove'} />
+    @options.notifications.map (notification, index) =>
+      <NotificationView
+        index={index}
+        key={notification.uid}
+        notification={notification}
+        onRemove={@bound 'onNotificationRemove'} />
 
 
   renderReact: ->

--- a/client/ide/lib/views/tabview/ideview.coffee
+++ b/client/ide/lib/views/tabview/ideview.coffee
@@ -16,7 +16,7 @@ generatePassword      = require 'app/util/generatePassword'
 ProximityNotifier     = require './splithandleproximitynotifier'
 IDEWorkspaceTabView   = require '../../workspace/ideworkspacetabview'
 IDEApplicationTabView = require './ideapplicationtabview.coffee'
-showErrorNotification = require 'app/util/showErrorNotification'
+showError             = require 'app/util/showError'
 Tracker               = require 'app/util/tracker'
 ContentModal          = require 'app/components/contentModal'
 
@@ -261,7 +261,7 @@ module.exports = class IDEView extends IDEWorkspaceTabView
 
     file.fetchPermissions (err, result) =>
 
-      return showErrorNotification err  if err
+      return showError err  if err
 
       { readable, writable } = result
       if notifyIfNoPermissions and not readable
@@ -340,7 +340,7 @@ module.exports = class IDEView extends IDEWorkspaceTabView
 
     file.fetchPermissions (err, result) =>
 
-      return showErrorNotification err  if err
+      return showError err  if err
 
       { readable, writable } = result
       if not readable
@@ -828,7 +828,7 @@ module.exports = class IDEView extends IDEWorkspaceTabView
       @emitChange terminalPane, change, 'TerminalRenamed'
 
     .catch (err) ->
-      showErrorNotification err
+      showError err
 
   renameTerminal: (paneView, machine, newTitle) ->
 

--- a/client/ide/test/views/tabview/ideview.test.coffee
+++ b/client/ide/test/views/tabview/ideview.test.coffee
@@ -12,13 +12,13 @@ IDEEditorPane         = require 'ide/workspace/panes/ideeditorpane'
 IDETailerPane         = require 'ide/workspace/panes/idetailerpane'
 IDETerminalPane       = require 'ide/workspace/panes/ideterminalpane'
 IDEDrawingPane        = require 'ide/workspace/panes/idedrawingpane'
-showErrorNotification = require 'app/util/showErrorNotification'
+showError = require 'app/util/showError'
 IDEApplicationTabView = require 'ide/views/tabview/ideapplicationtabview'
 
 ideView                     = null
 handlePaneRemovedSpy        = null
-showErrorNotificationSpy    = null
-revertShowErrorNotification = null
+showErrorSpy    = null
+revertShowError = null
 
 
 initSpies = ->
@@ -27,8 +27,8 @@ initSpies = ->
   expect.spyOn IDEView.prototype, 'trimUntitledFileName'
   handlePaneRemovedSpy = expect.spyOn IDEView.prototype, 'handlePaneRemoved'
 
-  showErrorNotificationSpy    = expect.createSpy()
-  revertShowErrorNotification = IDEView.__set__ 'showErrorNotification', showErrorNotificationSpy
+  showErrorSpy    = expect.createSpy()
+  revertShowError = IDEView.__set__ 'showError', showErrorSpy
 
 
 createFile = (path = 'foo/path') ->
@@ -79,7 +79,7 @@ describe 'IDEView', ->
   afterEach ->
 
     expect.restoreSpies()
-    revertShowErrorNotification()
+    revertShowError()
 
 
   describe 'constructor', ->
@@ -210,13 +210,13 @@ describe 'IDEView', ->
       expect(IDEHelpers.showFileAccessDeniedError).toHaveBeenCalled()
 
 
-    it 'should showErrorNotification if file.fetchPermissions returns error', ->
+    it 'should showError if file.fetchPermissions returns error', ->
 
       err = { message: 'Everything is something happened.' }
       mock.fsFile.fetchPermissions.toReturnError err
       ideView.createEditor createFile()
 
-      expect(showErrorNotificationSpy).toHaveBeenCalledWith err
+      expect(showErrorSpy).toHaveBeenCalledWith err
 
 
   describe '::createEditorAfterFileCheck', ->

--- a/client/new-stack-editor/lib/index.coffee
+++ b/client/new-stack-editor/lib/index.coffee
@@ -3,7 +3,7 @@ debug = (require 'debug') 'nse'
 kd = require 'kd'
 async = require 'async'
 AppController = require 'app/appcontroller'
-showErrorNotification = require 'app/util/showErrorNotification'
+showError = require 'app/util/showError'
 
 EnvironmentFlux = require 'app/flux/environment'
 
@@ -61,7 +61,7 @@ module.exports = class StackEditorAppController extends AppController
     @fetchStackTemplate templateId, (err, template) =>
 
       if err
-        showErrorNotification err
+        showError err
         return callback err
 
       @stackEditor.setData template, reset

--- a/client/package.json
+++ b/client/package.json
@@ -62,7 +62,7 @@
     "react-flexbox-grid": "0.10.2",
     "react-immutable-render-mixin": "0.9.7",
     "react-input-mask": "0.7.5",
-    "react-flip-move": "2.7.1",
+    "react-flip-move": "2.9.1",
     "react-mixin": "3.0.5",
     "react-modal": "1.6.5",
     "react-portal": "3.0.0",


### PR DESCRIPTION
- [x] update react-flip-move package
- [x] fix styling for notification list
- [x] update showError util to render new notification view

### Default Parameters in ShowError util
- type is `default`
- content is `Something went wrong!`
- dismissible is `yes`
- duration is `3000`
- primaryButtonTitle is `null`
- onPrimaryButtonClick is `null`
- secondaryButtonTitle is `null`
- onSecondaryButtonClick is `null`

### Screencast
http://recordit.co/yxkeWQGqru