### PR TITLE
Bongo: do not pass data to EventEmitter2 constructor

### DIFF
--- a/client/app/lib/views/sessionlist/accountsessionlistitem.coffee
+++ b/client/app/lib/views/sessionlist/accountsessionlistitem.coffee
@@ -34,7 +34,7 @@ module.exports = class AccountSessionListItem extends KDListItemView
 
   pistachio: ->
 
-    { groupName, lastAccess, lastLoginDate, clientId, _conf } = @getData()
+    { groupName, lastAccess, lastLoginDate, clientId, sessionData } = @getData()
 
     hostname = globals.config.domains.main
 
@@ -48,11 +48,7 @@ module.exports = class AccountSessionListItem extends KDListItemView
     if kookies.get('clientId') is clientId
       cssClass = 'active'
 
-    # There is an issue on this field, I'll take a look it after
-    # when we have a field called `data` on a given Bongo Model
-    # we won't able to reach that data under `data` field from instance
-    # but somehow this `_conf` field keeps the raw data ~ GG
-    if _conf?.data?.apiSession
+    if sessionData?.apiSession
       cssClass = 'api'
 
     @session = new kd.CustomHTMLView

--- a/go/src/koding/db/models/session.go
+++ b/go/src/koding/db/models/session.go
@@ -24,7 +24,7 @@ type Session struct {
 	SessionBegan  time.Time     `bson:"sessionBegan"`
 	LastAccess    time.Time     `bson:"lastAccess"`
 	Impersonating bool          `bson:"impersonating"`
-	Data          *Data         `bson:"data,omitempty" json:"data,omitempty"`
+	SessionData   *Data         `bson:"sessionData,omitempty" json:"sessionData,omitempty"`
 }
 
 // Data holds arbitrary data

--- a/go/src/koding/db/mongodb/modelhelper/session.go
+++ b/go/src/koding/db/mongodb/modelhelper/session.go
@@ -128,13 +128,13 @@ func UpdateSessionIP(token string, ip string) error {
 
 // UpdateSessionData updates the transitive data in given session. Overrides the
 // current data if any.
-func UpdateSessionData(clientID string, data map[string]interface{}) error {
+func UpdateSessionData(clientID string, sessionData map[string]interface{}) error {
 	query := func(c *mgo.Collection) error {
 		return c.Update(
 			bson.M{"clientId": clientID},
 			bson.M{
 				"$set": bson.M{
-					"data": data,
+					"sessionData": sessionData,
 				},
 			},
 		)

--- a/go/src/koding/db/mongodb/modelhelper/session_test.go
+++ b/go/src/koding/db/mongodb/modelhelper/session_test.go
@@ -34,11 +34,11 @@ func TestSessionUpdateData(t *testing.T) {
 	key := "chargeID"
 	value := "chargeVal"
 
-	data := map[string]interface{}{
+	customData := map[string]interface{}{
 		key: value,
 	}
 
-	if err := modelhelper.UpdateSessionData(ses.ClientId, data); err != nil {
+	if err := modelhelper.UpdateSessionData(ses.ClientId, customData); err != nil {
 		t.Error(err)
 	}
 

--- a/go/src/koding/db/mongodb/modelhelper/session_test.go
+++ b/go/src/koding/db/mongodb/modelhelper/session_test.go
@@ -22,7 +22,7 @@ func TestSessionUpdateData(t *testing.T) {
 	}
 
 	nonExistingKey := "nonExistingKey"
-	val, err := ses.Data.GetString(nonExistingKey)
+	val, err := ses.SessionData.GetString(nonExistingKey)
 	if err != models.ErrDataKeyNotExists {
 		t.Error("expected ErrDataKeyNotExists, got", err)
 	}
@@ -47,7 +47,7 @@ func TestSessionUpdateData(t *testing.T) {
 		t.Error(err)
 	}
 
-	val, err = ses.Data.GetString(key)
+	val, err = ses.SessionData.GetString(key)
 	if err != nil {
 		t.Error("expected nil, got", err)
 	}

--- a/node_modules_koding/bongo/lib/base/index.coffee
+++ b/node_modules_koding/bongo/lib/base/index.coffee
@@ -102,12 +102,16 @@ module.exports = class Base extends EventEmitter2
       """
 
   constructor:(options = {}) ->
+
     @initializeSharedInstance options
+
     defineProperty this, '_events', { value: {} }, { writeable: yes }
     defineProperty this, 'wildcard', { value: yes }, { writeable: yes }
     defineProperty this, 'maxListeners', { value: 0 }, { writeable: yes }
     defineProperty this, 'listenerTree', { value: {} }, { writeable: yes }
-    super options
+
+    super()
+
     @on '*', (rest...) =>
       @constructor.bongos?.forEach (bongo) =>
         if not @constructor.instanceEvents_?

--- a/node_modules_koding/bongo/package.json
+++ b/node_modules_koding/bongo/package.json
@@ -17,7 +17,7 @@
     "coffee-script": "1.3.3",
     "debug": "2.3.0",
     "dnode": "0.9.x",
-    "eventemitter2": "1.0.3",
+    "eventemitter2": "3.0.1",
     "hat": "0.0.x",
     "jspath": "*",
     "mongodb": "*",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "dogapi": "2.6.0",
     "embedly": "2.1.0",
     "es": "0.5.2",
-    "eventemitter2": "2.2.1",
+    "eventemitter2": "3.0.1",
     "express": "4.14.0",
     "faker": "3.1.0",
     "geoip-lite": "1.1.8",

--- a/website/swagger.json
+++ b/website/swagger.json
@@ -1393,7 +1393,7 @@
         "impersonating": {
           "type": "boolean"
         },
-        "data": {
+        "sessionData": {
           "type": "object"
         }
       }

--- a/workers/social/lib/social/models/apitoken.coffee
+++ b/workers/social/lib/social/models/apitoken.coffee
@@ -165,7 +165,7 @@ module.exports = class JApiToken extends jraphical.Module
           clientId  : token
           username  : account.getAt 'profile.nickname'
           groupName : group.getAt 'slug'
-          data      : { apiSession: yes }
+          sessionData : { apiSession: yes }
 
         JSession.fetchSessionByData { clientId: token }, sessionData, (err, sessionObj) ->
           return next err  if err

--- a/workers/social/lib/social/models/session.coffee
+++ b/workers/social/lib/social/models/session.coffee
@@ -39,7 +39,7 @@ module.exports = class JSession extends Model
       impersonating     : Boolean
       # data holds arbitary transitive session based info, not necessarily
       # should be used. There won't be any kind of index on this field.
-      data              : Object
+      sessionData       : Object
     sharedEvents        :
       instance          : []
       static            : []

--- a/workers/social/lib/social/remoteapi.coffee
+++ b/workers/social/lib/social/remoteapi.coffee
@@ -121,7 +121,7 @@ fetchSession = (Models, token, callback) ->
 
     if session
 
-      if session.getAt 'data.apiSession'
+      if session.getAt 'sessionData.apiSession'
         Models.JApiToken.fetchGroup (session.getAt 'groupName'), (err) ->
           return callback err  if err
           updateSessionTimestamp session, callback


### PR DESCRIPTION
Currently we are passing provided instance data to `EventEmitter2::constructor` which was causing to keep duplicate copy of the data **on every bongo instance** with this change we are reducing the data transfer almost the half for each instance transfer over the wire.

## Before:
```
_remote.api.JSession.activeSession((err, session) =>
    _kd.log(JSON.stringify(session, " ", 2)))

{
  "watchers": {},
  "bongo_": {
    "constructorName": "JSession",
    "instanceId": "aa35842e34881b25a2fd18a31bd50109"
  },
  "newListener": false,
  "verboseMemoryLeak": false,
  "_conf": {
    "_id": "58b10d41143d4801171c4740",
    "groupName": "dori",
    "sessionBegan": "2017-02-25T04:51:13.437Z",
    "lastAccess": "2017-02-25T04:51:13.437Z",
    "username": "gokmen",
    "clientId": "fe21e6e7-a2b1-4665-aee8-ba6bad7e150a",
    "clientIP": "127.0.0.1",
    "otaToken": "5f79f530"
  },
  "clientId": "fe21e6e7-a2b1-4665-aee8-ba6bad7e150a",
  "clientIP": "127.0.0.1",
  "username": "gokmen",
  "otaToken": "5f79f530",
  "groupName": "dori",
  "sessionBegan": "2017-02-25T04:51:13.437Z",
  "lastAccess": "2017-02-25T04:51:13.437Z",
  "_id": "58b10d41143d4801171c4740"
}
```

## After:
```
_remote.api.JSession.activeSession((err, session) =>
    _kd.log(JSON.stringify(session, " ", 2)))

{
  "watchers": {},
  "bongo_": {
    "constructorName": "JSession",
    "instanceId": "aa35842e34881b25a2fd18a31bd50109"
  },
  "newListener": false,
  "verboseMemoryLeak": false,
  "clientId": "fe21e6e7-a2b1-4665-aee8-ba6bad7e150a",
  "clientIP": "127.0.0.1",
  "username": "gokmen",
  "otaToken": "5f79f530",
  "groupName": "dori",
  "sessionBegan": "2017-02-25T04:51:13.437Z",
  "lastAccess": "2017-02-25T04:51:13.437Z",
  "_id": "58b10d41143d4801171c4740"
}
```