### PR TITLE
klient: add -metadata-user flag

### DIFF
--- a/go/src/koding/klient/main.go
+++ b/go/src/koding/klient/main.go
@@ -78,6 +78,7 @@ func main() {
 }
 
 func realMain() int {
+	f.Var(config.CurrentUser, "metadata-user", "Overwrite default user to store the metadata for.")
 	f.Parse(os.Args[1:])
 
 	// For forward-compatibility with go1.5+, where GOMAXPROCS is

--- a/go/src/koding/klient/terminal/command.go
+++ b/go/src/koding/klient/terminal/command.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -17,9 +18,18 @@ import (
 const (
 	sessionPrefix      = "koding"
 	defaultShell       = "/bin/bash"
-	defaultScreenPath  = "/usr/bin/screen"
 	randomStringLength = 24 // 144 bit base64 encoded
 )
+
+var defaultScreenPath = "/usr/bin/screen"
+
+func init() {
+	const embeddedScreen = "/opt/kite/klient/embedded/bin/screen"
+
+	if fi, err := os.Stat(embeddedScreen); err == nil && !fi.IsDir() {
+		defaultScreenPath = embeddedScreen
+	}
+}
 
 type Command struct {
 	// Name is used for starting the terminal instance, it's the program path


### PR DESCRIPTION
The flag is used to specify the user for which the metadata
is going to be written.

It is used in case when klient is run directly under the root
account.