### PR TITLE
klient/machine: move index test helpers to separate package

### DIFF
--- a/go/src/koding/klient/machine/index/cache_test.go
+++ b/go/src/koding/klient/machine/index/cache_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"koding/klient/machine/index"
+	"koding/klient/machine/index/indextest"
 )
 
 func TestCachedIndexCreate(t *testing.T) {
@@ -18,7 +19,7 @@ func TestCachedIndexCreate(t *testing.T) {
 	}
 	defer cleanTempDir()
 
-	root, clean, err := generateTree()
+	root, clean, err := indextest.GenerateTree(filetree)
 	if err != nil {
 		t.Fatalf("want err = nil; got %v", err)
 	}
@@ -62,7 +63,7 @@ func TestCachedIndexUpdated(t *testing.T) {
 	}
 	defer cleanTempDir()
 
-	root, clean, err := generateTree()
+	root, clean, err := indextest.GenerateTree(filetree)
 	if err != nil {
 		t.Fatalf("want err = nil; got %v", err)
 	}
@@ -77,7 +78,7 @@ func TestCachedIndexUpdated(t *testing.T) {
 		t.Fatalf("want err = nil; got %v", err)
 	}
 
-	if err := writeFile("new_file.txt", 1024)(root); err != nil {
+	if err := indextest.WriteFile("new_file.txt", 1024)(root); err != nil {
 		t.Fatalf("want err = nil; got %v", err)
 	}
 

--- a/go/src/koding/klient/machine/index/index_test.go
+++ b/go/src/koding/klient/machine/index/index_test.go
@@ -2,16 +2,11 @@ package index_test
 
 import (
 	"encoding/json"
-	"io"
-	"io/ioutil"
-	"math/rand"
-	"os"
-	"path/filepath"
 	"sort"
 	"testing"
-	"time"
 
 	"koding/klient/machine/index"
+	"koding/klient/machine/index/indextest"
 )
 
 // filetree defines a simple directory structure that will be created for test
@@ -37,28 +32,28 @@ func TestIndex(t *testing.T) {
 		Branch  string
 	}{
 		"add file": {
-			Op: writeFile("d/test.bin", 40*1024),
+			Op: indextest.WriteFile("d/test.bin", 40*1024),
 			Changes: index.ChangeSlice{
 				index.NewChange("d", index.ChangeMetaUpdate),
 				index.NewChange("d/test.bin", index.ChangeMetaAdd),
 			},
 		},
 		"add dir": {
-			Op: addDir("e"),
+			Op: indextest.AddDir("e"),
 			Changes: index.ChangeSlice{
 				index.NewChange("", index.ChangeMetaUpdate),
 				index.NewChange("e", index.ChangeMetaAdd),
 			},
 		},
 		"remove file": {
-			Op: rmAllFile("c/cb.bin"),
+			Op: indextest.RmAllFile("c/cb.bin"),
 			Changes: index.ChangeSlice{
 				index.NewChange("c", index.ChangeMetaUpdate),
 				index.NewChange("c/cb.bin", index.ChangeMetaRemote|index.ChangeMetaAdd),
 			},
 		},
 		"remove dir": {
-			Op: rmAllFile("c"),
+			Op: indextest.RmAllFile("c"),
 			Changes: index.ChangeSlice{
 				index.NewChange("c", index.ChangeMetaRemote|index.ChangeMetaAdd),
 				index.NewChange("c/ca.txt", index.ChangeMetaRemote|index.ChangeMetaAdd),
@@ -67,7 +62,7 @@ func TestIndex(t *testing.T) {
 			Branch: "c/",
 		},
 		"rename file": {
-			Op: mvFile("b.bin", "c/cc.bin"),
+			Op: indextest.MvFile("b.bin", "c/cc.bin"),
 			Changes: index.ChangeSlice{
 				index.NewChange("", index.ChangeMetaUpdate),
 				index.NewChange("b.bin", index.ChangeMetaRemote|index.ChangeMetaAdd),
@@ -76,13 +71,13 @@ func TestIndex(t *testing.T) {
 			},
 		},
 		"write file": {
-			Op: writeFile("b.bin", 1024),
+			Op: indextest.WriteFile("b.bin", 1024),
 			Changes: index.ChangeSlice{
 				index.NewChange("b.bin", index.ChangeMetaUpdate),
 			},
 		},
 		"chmod file": {
-			Op: chmodFile("d/dc/dca.txt", 0766),
+			Op: indextest.ChmodFile("d/dc/dca.txt", 0600),
 			Changes: index.ChangeSlice{
 				index.NewChange("d/dc/dca.txt", index.ChangeMetaUpdate),
 			},
@@ -95,7 +90,7 @@ func TestIndex(t *testing.T) {
 		test := test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			root, clean, err := generateTree()
+			root, clean, err := indextest.GenerateTree(filetree)
 			if err != nil {
 				t.Fatalf("want err = nil; got %v", err)
 			}
@@ -111,7 +106,7 @@ func TestIndex(t *testing.T) {
 			}
 
 			// Synchronize underlying file-system.
-			Sync()
+			indextest.Sync()
 
 			cs := idx.MergeBranch(root, test.Branch)
 			sort.Sort(cs)
@@ -163,7 +158,7 @@ func TestIndexCount(t *testing.T) {
 		test := test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			root, clean, err := generateTree()
+			root, clean, err := indextest.GenerateTree(filetree)
 			if err != nil {
 				t.Fatalf("want err = nil; got %v", err)
 			}
@@ -182,7 +177,7 @@ func TestIndexCount(t *testing.T) {
 }
 
 func TestIndexJSON(t *testing.T) {
-	root, clean, err := generateTree()
+	root, clean, err := indextest.GenerateTree(filetree)
 	if err != nil {
 		t.Fatalf("want err = nil; got %v", err)
 	}
@@ -204,88 +199,6 @@ func TestIndexJSON(t *testing.T) {
 	}
 
 	if cs := idx.Merge(root); len(cs) != 0 {
-		t.Errorf("want no changes after apply; got %v", cs)
-	}
-}
-
-func generateTree() (root string, clean func(), err error) {
-	root, err = ioutil.TempDir("", "mount.index")
-	if err != nil {
-		return "", nil, err
-	}
-	clean = func() { os.RemoveAll(root) }
-
-	for file, size := range filetree {
-		if err := addDir(file)(root); err != nil {
-			clean()
-			return "", nil, err
-		}
-		if err := writeFile(file, size)(root); err != nil {
-			clean()
-			return "", nil, err
-		}
-	}
-
-	return root, clean, nil
-}
-
-func addDir(file string) func(string) error {
-	return func(root string) error {
-		defer Sync()
-
-		dir := filepath.Join(root, filepath.FromSlash(file))
-		if filepath.Ext(dir) != "" {
-			dir = filepath.Dir(dir)
-		}
-
-		return os.MkdirAll(dir, 0777)
-	}
-}
-
-func writeFile(file string, size int64) func(string) error {
-	return func(root string) error {
-		defer Sync()
-
-		if filepath.Ext(file) == "" {
-			return nil
-		}
-
-		lr := io.LimitReader(rand.New(rand.NewSource(time.Now().UnixNano())), size)
-		content, err := ioutil.ReadAll(lr)
-		if err != nil {
-			return err
-		}
-
-		file := filepath.Join(root, filepath.FromSlash(file))
-		return ioutil.WriteFile(file, content, 0666)
-	}
-}
-
-func rmAllFile(file string) func(string) error {
-	return func(root string) error {
-		defer Sync()
-
-		return os.RemoveAll(filepath.Join(root, filepath.FromSlash(file)))
-	}
-}
-
-func mvFile(oldpath, newpath string) func(string) error {
-	return func(root string) error {
-		defer Sync()
-
-		var (
-			oldpath = filepath.Join(root, filepath.FromSlash(oldpath))
-			newpath = filepath.Join(root, filepath.FromSlash(newpath))
-		)
-
-		return os.Rename(oldpath, newpath)
-	}
-}
-
-func chmodFile(file string, mode os.FileMode) func(string) error {
-	return func(root string) error {
-		defer Sync()
-
-		return os.Chmod(filepath.Join(root, filepath.FromSlash(file)), mode)
+		t.Errorf("want no changes after merge; got %v", cs)
 	}
 }

--- a/go/src/koding/klient/machine/index/indextest/indextest.go
+++ b/go/src/koding/klient/machine/index/indextest/indextest.go
@@ -1,0 +1,189 @@
+package indextest
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"time"
+
+	"koding/klient/machine/index"
+
+	"github.com/djherbis/times"
+)
+
+// Compare is a helper function that compares the content of two provided
+// directories. The detected changes will be returned as index change slice.
+// First argument is treated as base index data.
+func Compare(rootA, rootB string) (cs index.ChangeSlice, err error) {
+	idx, err := index.NewIndexFiles(rootA)
+	if err != nil {
+		return nil, err
+	}
+
+	// Merge ony adds files so it will make remote add instead of local delete
+	// we need to fix this.
+	mra := index.ChangeMetaAdd | index.ChangeMetaRemote
+	for _, c := range idx.Merge(rootB) {
+		if c.Meta()&mra == mra {
+			c = index.NewChange(c.Path(), index.ChangeMetaRemove)
+		}
+		cs = append(cs, c)
+	}
+
+	return cs, nil
+}
+
+// GenerateMirrorTrees generates two identical file trees using GenerateTree
+// helper function. This function ensures that ComparePath of two generated
+// directories will not produce any index changes.
+func GenerateMirrorTrees(filetree map[string]int64) (string, string, func(), error) {
+	rootA, cleanA, err := GenerateTree(filetree)
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	rootB, cleanB, err := GenerateTree(filetree)
+	if err != nil {
+		cleanA()
+		return "", "", nil, err
+	}
+
+	clean := func() {
+		cleanB()
+		cleanA()
+	}
+
+	for path := range filetree {
+		if err := makeSimilarTimes(rootA, rootB, path); err != nil {
+			clean()
+			return "", "", nil, err
+		}
+	}
+
+	cs, err := Compare(rootA, rootB)
+	if len(cs) != 0 {
+		err = fmt.Errorf("generated paths are not identical: %v", cs)
+	}
+
+	if err != nil {
+		clean()
+		return "", "", nil, err
+	}
+
+	return rootA, rootB, clean, nil
+}
+
+func makeSimilarTimes(rootA, rootB, path string) error {
+	t, err := times.Stat(filepath.Join(rootA, path))
+	if err != nil {
+		return err
+	}
+
+	if err := os.Chtimes(filepath.Join(rootB, path), t.AccessTime(), t.ModTime()); err != nil {
+		return err
+	}
+
+	// Changing mtime also modifies ctime. Files stored inside rootA may have
+	// different mtime and ctime values so it's needed to Chtimes them as well.
+	return os.Chtimes(filepath.Join(rootA, path), t.AccessTime(), t.ModTime())
+}
+
+// GenerateTree generates a file tree inside a temporary directory. The filetree
+// map has relative paths as keys and file size as value. Clean function must
+// be called in order to clean up resources.
+func GenerateTree(filetree map[string]int64) (root string, clean func(), err error) {
+	root, err = ioutil.TempDir("", "mount.index")
+	if err != nil {
+		return "", nil, err
+	}
+	clean = func() { os.RemoveAll(root) }
+
+	for file, size := range filetree {
+		if err := AddDir(file)(root); err != nil {
+			clean()
+			return "", nil, err
+		}
+		if err := WriteFile(file, size)(root); err != nil {
+			clean()
+			return "", nil, err
+		}
+	}
+
+	return root, clean, nil
+}
+
+// AddDir creates a functor which, when invoked on provided root, will create
+// new directory specified by file argument.
+func AddDir(file string) func(string) error {
+	return func(root string) error {
+		defer Sync()
+
+		dir := filepath.Join(root, filepath.FromSlash(file))
+		if filepath.Ext(dir) != "" {
+			dir = filepath.Dir(dir)
+		}
+
+		return os.MkdirAll(dir, 0777)
+	}
+}
+
+// WriteFile creates a functor which, when invoked on provided root, will create
+// a new file specified by file and size arguments. The content of the file will
+// be randomized.
+func WriteFile(file string, size int64) func(string) error {
+	return func(root string) error {
+		defer Sync()
+
+		if filepath.Ext(file) == "" {
+			return nil
+		}
+
+		lr := io.LimitReader(rand.New(rand.NewSource(time.Now().UnixNano())), size)
+		content, err := ioutil.ReadAll(lr)
+		if err != nil {
+			return err
+		}
+
+		file := filepath.Join(root, filepath.FromSlash(file))
+		return ioutil.WriteFile(file, content, 0666)
+	}
+}
+
+// RmAllFile creates a functor which, when invoked on provided root, will
+// remove all files inside in directory specified by file argument. If the
+// argument describes regural file it will be removed.
+func RmAllFile(file string) func(string) error {
+	return func(root string) error {
+		defer Sync()
+
+		return os.RemoveAll(filepath.Join(root, filepath.FromSlash(file)))
+	}
+}
+
+// MvFile creates a functor which, when invoked on provided root, will move
+// oldpath file to newpath file.
+func MvFile(oldpath, newpath string) func(string) error {
+	return func(root string) error {
+		defer Sync()
+
+		var (
+			oldpath = filepath.Join(root, filepath.FromSlash(oldpath))
+			newpath = filepath.Join(root, filepath.FromSlash(newpath))
+		)
+
+		return os.Rename(oldpath, newpath)
+	}
+}
+
+// ChmodFile creates a functor which, when invoked on provided root, will change
+// mode bits of the file specified by file argument.
+func ChmodFile(file string, mode os.FileMode) func(string) error {
+	return func(root string) error {
+		defer Sync()
+
+		return os.Chmod(filepath.Join(root, filepath.FromSlash(file)), mode)
+	}
+}

--- a/go/src/koding/klient/machine/index/indextest/indextest_unix.go
+++ b/go/src/koding/klient/machine/index/indextest/indextest_unix.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-package index_test
+package indextest
 
 import "syscall"
 

--- a/go/src/koding/klient/machine/index/indextest/indextest_windows.go
+++ b/go/src/koding/klient/machine/index/indextest/indextest_windows.go
@@ -1,6 +1,6 @@
 // +build windows
 
-package index_test
+package indextest
 
 // Sync is a no-op on Windows. This file is here only to make windows builds
 // work.


### PR DESCRIPTION
This PR moves(and adds few new) index test helpers to separate package. These functions are needed in other non-index-related packages.

## Motivation and Context
Making #10637 smaller.