### PR TITLE
klient/machine: add sync test helpers

### DIFF
--- a/go/src/koding/klient/machine/mount/sync/synctest/synctest.go
+++ b/go/src/koding/klient/machine/mount/sync/synctest/synctest.go
@@ -25,7 +25,7 @@ func SyncLocal(s msync.Syncer, rootA, rootB string, dir index.ChangeMeta) (conte
 		return nil, nil, err
 	}
 
-	var evs []*msync.Event
+	evs := make([]*msync.Event, 0, len(cs))
 	for _, c := range cs {
 		c = index.NewChange(c.Path(), c.Meta()|dir)
 		evs = append(evs, msync.NewEvent(context.Background(), nil, c))

--- a/go/src/koding/klient/machine/mount/sync/synctest/synctest.go
+++ b/go/src/koding/klient/machine/mount/sync/synctest/synctest.go
@@ -1,0 +1,82 @@
+package synctest
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"koding/klient/machine/index"
+	"koding/klient/machine/index/indextest"
+	msync "koding/klient/machine/mount/sync"
+)
+
+// SyncLocal sends all index changes between local and remote directories to
+// provided syncer. Then it calls produced Execers. Returned contex will be
+// closed when all changes are consumed and their events executed. The direction
+// of changes is marked by dir argument and it must be ChangeMetaRemote and/or
+// ChangeMetaRemote
+func SyncLocal(s msync.Syncer, rootA, rootB string, dir index.ChangeMeta) (context.Context, context.CancelFunc, error) {
+	if dir&^(index.ChangeMetaLocal|index.ChangeMetaRemote) != 0 {
+		return nil, nil, fmt.Errorf("invalid change type: %v", dir)
+	}
+
+	cs, err := indextest.Compare(rootA, rootB)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var evs []*msync.Event
+	for _, c := range cs {
+		c = index.NewChange(c.Path(), c.Meta()|dir)
+		evs = append(evs, msync.NewEvent(context.Background(), nil, c))
+	}
+
+	var (
+		evC = make(chan *msync.Event)
+		exC = s.ExecStream(evC)
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		defer cancel()
+		for i := 0; i < len(evs); {
+			select {
+			case evC <- evs[i]:
+			case ex := <-exC:
+				ex.Exec()
+				i++
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return ctx, cancel, nil
+}
+
+// ExecChange uses provided to create Execer from provided index change. Then
+// the function will execute it end return its error or timeout if such occurs.
+func ExecChange(s msync.Syncer, change *index.Change, timeout time.Duration) error {
+	var (
+		ev       = msync.NewEvent(context.Background(), nil, change)
+		evC      = make(chan *msync.Event)
+		timeoutC = time.After(timeout)
+	)
+
+	go func() {
+		select {
+		case evC <- ev:
+		case <-timeoutC:
+		}
+	}()
+
+	select {
+	case ex := <-s.ExecStream(evC):
+		if ex == nil {
+			return fmt.Errorf("nil execer received")
+		}
+		return ex.Exec()
+	case <-timeoutC:
+		return fmt.Errorf("timed out after %s", timeout)
+	}
+}


### PR DESCRIPTION
This PR adds generic test helpers for syncer interface.

Depends on: ~#10692~

## Motivation and Context
Testing mount synchronization logic.
