### PR TITLE
klient/machine: create cached ssh address builder

### DIFF
--- a/go/src/koding/klient/machine/mount/sync/sync.go
+++ b/go/src/koding/klient/machine/mount/sync/sync.go
@@ -22,8 +22,7 @@ import (
 // IndexFileName is a file name of managed directory index.
 const IndexFileName = "index"
 
-// DynamicSSHFunc is an adapter that allows to retrieve information needed to
-// make SSH connection to remote machine.
+// DynamicSSHFunc locates the remote host which ssh should connect to.
 type DynamicSSHFunc func() (host string, port int, err error)
 
 // BuildOpts represents the context that can be used by external syncers to

--- a/go/src/koding/klient/machine/mount/sync/sync.go
+++ b/go/src/koding/klient/machine/mount/sync/sync.go
@@ -22,6 +22,10 @@ import (
 // IndexFileName is a file name of managed directory index.
 const IndexFileName = "index"
 
+// DynamicSSHFunc is an adapter that allows to retrieve information needed to
+// make SSH connection to remote machine.
+type DynamicSSHFunc func() (host string, port int, err error)
+
 // BuildOpts represents the context that can be used by external syncers to
 // build their own type. Built syncer should update the index after syncing and
 // manage received events.


### PR DESCRIPTION
This PR splits `kd machine ssh` logic into reusable methods. These methods and additional cache are needed for proper work of rsync syncer.

## How Has This Been Tested?
Existing unit tests.

## Screenshots (if appropriate):

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
