### PR TITLE
klient/machine: disable autocomplete for kd machine mount command

### DIFF
--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -561,8 +561,9 @@ func run(args []string) {
 				}},
 			},
 			cli.Command{
-				Name:  "machine",
-				Usage: "Manage remote machines.",
+				Name:         "machine",
+				Usage:        "Manage remote machines.",
+				BashComplete: func(c *cli.Context) {},
 				Subcommands: []cli.Command{{
 					Name:      "list",
 					ShortName: "ls",


### PR DESCRIPTION
This PR disables autocompletion for `kd machine mount` command. Which is not implemented.

Related to: #10711

## Motivation and Context
https://asciinema.org/a/83rvcitdlibmeen8fgocttd0n

## How Has This Been Tested?
Manually.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)