### PR TITLE
Delete team: Make sure slack integration and JForeignAuth data is cleaned

### DIFF
--- a/workers/social/lib/social/models/group/index.coffee
+++ b/workers/social/lib/social/models/group/index.coffee
@@ -1705,6 +1705,12 @@ module.exports = class JGroup extends Module
         JName.one { name: slug }, (err, name) ->
           removeHelper name, err, next, 'JName'
 
+      (next) ->
+        # unlink slack if anyone in this team auth slack previously
+        JUser = require '../user'
+        JUser.update { "foreignAuth.slack.#{slug}": { $exists: true } }, { $unset: { "foreignAuth.slack.#{slug}": 1 } }, (err) ->
+          kallback 'JForeignAuth', next, err
+
       (next) =>
         Relationship.remove { sourceId : @getId() }, next
 

--- a/workers/social/lib/social/models/group/index.coffee
+++ b/workers/social/lib/social/models/group/index.coffee
@@ -1709,6 +1709,11 @@ module.exports = class JGroup extends Module
         # unlink slack if anyone in this team auth slack previously
         JUser = require '../user'
         JUser.update { "foreignAuth.slack.#{slug}": { $exists: true } }, { $unset: { "foreignAuth.slack.#{slug}": 1 } }, (err) ->
+          kallback 'JUser foreign auth', next, err
+
+      (next) ->
+        JForeignAuth = require '../foreignauth'
+        JForeignAuth.remove { group: slug }, (err) ->
           kallback 'JForeignAuth', next, err
 
       (next) =>

--- a/workers/social/lib/social/models/group/index.test.coffee
+++ b/workers/social/lib/social/models/group/index.test.coffee
@@ -326,6 +326,20 @@ runTests = -> describe 'workers.social.group.index', ->
               next()
 
           (next) ->
+            JForeignAuth = require '../foreignauth'
+            foreignData =
+              foreignId: 'test-foreignid'
+              foreignAuthType: 'test'
+              foreignAuth:
+                test: 'test-foreignAuth'
+
+            username = account.profile.nickname
+            JForeignAuth.create { foreignData, group: groupSlug, username }, (err, foreignAuth) ->
+              expect(err).to.not.exist
+              expect(foreignAuth).to.exist
+              next()
+
+          (next) ->
             # add slack integration
             slackIntegration =
               slack:
@@ -412,6 +426,13 @@ runTests = -> describe 'workers.social.group.index', ->
               JMachine.some client, {}, (err, machines) ->
                 expect(err).to.not.exist
                 expect(machines.length).to.be.equal 0
+                next()
+
+            (next) ->
+              JForeignAuth = require '../foreignauth'
+              JForeignAuth.one { group: groupSlug }, (err, foreignAuth) ->
+                expect(err).to.not.exist
+                expect(foreignAuth).to.not.exist
                 next()
 
             (next) ->


### PR DESCRIPTION
Fixes #10707

if there is any slack authentication made by any user before deleting the team, we are removing now