### PR TITLE
Machine mount prefetch

### DIFF
--- a/go/src/koding/klient/app/klient.go
+++ b/go/src/koding/klient/app/klient.go
@@ -519,6 +519,7 @@ func (k *Klient) RegisterMethods() {
 	k.kite.HandleFunc("machine.ssh", machinegroup.KiteHandlerSSH(k.machines))
 	k.kite.HandleFunc("machine.mount.head", machinegroup.KiteHandlerHeadMount(k.machines))
 	k.kite.HandleFunc("machine.mount.add", machinegroup.KiteHandlerAddMount(k.machines))
+	k.kite.HandleFunc("machine.mount.updateIndex", machinegroup.KiteHandlerUpdateIndex(k.machines))
 	k.kite.HandleFunc("machine.mount.list", machinegroup.KiteHandlerListMount(k.machines))
 	k.kite.HandleFunc("machine.umount", machinegroup.KiteHandlerUmount(k.machines))
 

--- a/go/src/koding/klient/machine/index/index.go
+++ b/go/src/koding/klient/machine/index/index.go
@@ -184,6 +184,14 @@ func (idx *Index) Lookup(name string) (*Node, bool) {
 	return idx.root.Lookup(name)
 }
 
+// LookupAll looks up a node by the given name. It doesn't ignore promised nodes.
+func (idx *Index) LookupAll(name string) (*Node, bool) {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
+	return idx.root.LookupAll(name)
+}
+
 // Merge calls MergeBranch on all nodes pointed by root path.
 func (idx *Index) Merge(root string) ChangeSlice {
 	return idx.MergeBranch(root, "")
@@ -249,6 +257,7 @@ func (idx *Index) MergeBranch(root, branch string) (cs ChangeSlice) {
 		// set to source atime. That's why this is necessary.
 		if (mtime == info.ModTime().UnixNano() || mtime == atime(info)) && entry.Size() == info.Size() && mode == info.Mode() {
 			// Files are identical. Allow different ctimes.
+			entry.SwapPromise(0, EntryPromiseVirtual)
 			return
 		}
 
@@ -259,7 +268,8 @@ func (idx *Index) MergeBranch(root, branch string) (cs ChangeSlice) {
 			return
 		}
 
-		// Files differ.
+		// Files differ. However the local file is not virtual.
+		entry.SwapPromise(EntryPromiseUpdate, EntryPromiseVirtual)
 		cs = append(cs, NewChange(
 			filepath.ToSlash(filepath.Join(branch, nameOS)),
 			ChangeMetaUpdate|markLargeMeta(info.Size()),

--- a/go/src/koding/klient/machine/machinegroup/kite.go
+++ b/go/src/koding/klient/machine/machinegroup/kite.go
@@ -129,6 +129,31 @@ func KiteHandlerAddMount(g *Group) kite.HandlerFunc {
 	}
 }
 
+// KiteHandlerUpdateIndex creates a kite handler function that, when called,
+// invokes machine group UpdateIndex method.
+func KiteHandlerUpdateIndex(g *Group) kite.HandlerFunc {
+	return func(r *kite.Request) (interface{}, error) {
+		req := &UpdateIndexRequest{}
+
+		if r.Args != nil {
+			if err := r.Args.One().Unmarshal(req); err != nil {
+				return nil, err
+			}
+		}
+
+		res, err := g.UpdateIndex(req)
+		if err != nil {
+			// TODO(ppknap): create errors file similar to kloud/stack/errors.
+			return nil, &kite.Error{
+				Type:    "machinesError",
+				Message: err.Error(),
+			}
+		}
+
+		return res, nil
+	}
+}
+
 // KiteHandlerListMount creates a kite handler function that, when called,
 // invokes machine group ListMount method.
 func KiteHandlerListMount(g *Group) kite.HandlerFunc {

--- a/go/src/koding/klient/machine/machinegroup/machinegroup.go
+++ b/go/src/koding/klient/machine/machinegroup/machinegroup.go
@@ -250,8 +250,16 @@ func (g *Group) mountSync(ids machine.IDSlice) {
 			go func() {
 				defer wg.Done()
 
-				dynSSH, dynClient := g.dynamicSSH(id), g.dynamicClient(mountID)
-				if err := g.sync.Add(mountID, m, g.nb, g.sb, dynSSH, dynClient); err != nil {
+				addReq := &syncs.AddRequest{
+					MountID:       mountID,
+					Mount:         m,
+					NotifyBuilder: g.nb,
+					SyncBuilder:   g.sb,
+					ClientFunc:    g.dynamicClient(mountID),
+					SSHFunc:       g.dynamicSSH(id),
+				}
+
+				if err := g.sync.Add(addReq); err != nil {
 					atomic.AddInt64(&errN, 1)
 					g.log.Error("Cannot start synchronization for mount %s: %s", mountID, err)
 				}

--- a/go/src/koding/klient/machine/machinegroup/mount.go
+++ b/go/src/koding/klient/machine/machinegroup/mount.go
@@ -249,6 +249,31 @@ func (g *Group) AddMount(req *AddMountRequest) (res *AddMountResponse, err error
 	}, nil
 }
 
+// UpdateIndexRequest defines index update request.
+type UpdateIndexRequest struct {
+	// MountID stores the identifier of mount which index should be updated.
+	MountID mount.ID `json:"mountID,omitempty"`
+}
+
+// UpdateIndexResponse defines index update response.
+type UpdateIndexResponse struct{}
+
+// UpdateIndex forces mount index to rescan cache directory. This will update
+// index information about files that are already synced.
+func (g *Group) UpdateIndex(req *UpdateIndexRequest) (res *UpdateIndexResponse, err error) {
+	if req == nil {
+		return nil, errors.New("invalid nil request")
+	}
+
+	sc, err := g.sync.Sync(req.MountID)
+	if err != nil {
+		return nil, errors.New("mount with ID: " + string(req.MountID) + " doesn't exist")
+	}
+	sc.UpdateIndex()
+
+	return &UpdateIndexResponse{}, nil
+}
+
 // ListMountRequest defines machine group mount list request.
 type ListMountRequest struct {
 	// ID is an optional identifier for the remote machine. If set, only

--- a/go/src/koding/klient/machine/machinegroup/syncs/syncs.go
+++ b/go/src/koding/klient/machine/machinegroup/syncs/syncs.go
@@ -241,8 +241,8 @@ func (s *Syncs) sink(exC <-chan msync.Execer) {
 	}
 }
 
-// Info returns the current state of mount synchronization with provided ID.
-func (s *Syncs) Info(mountID mount.ID) (*msync.Info, error) {
+// Sync returns mount syncer that synchronizes mount with provided ID.
+func (s *Syncs) Sync(mountID mount.ID) (*msync.Sync, error) {
 	s.mu.RLock()
 	sc, ok := s.scs[mountID]
 	s.mu.RUnlock()
@@ -251,7 +251,7 @@ func (s *Syncs) Info(mountID mount.ID) (*msync.Info, error) {
 		return nil, mount.ErrMountNotFound
 	}
 
-	return sc.Info(), nil
+	return sc, nil
 }
 
 // Drop removes the mount sync and cleans the resources it uses.

--- a/go/src/koding/klient/machine/mount/sync/sync.go
+++ b/go/src/koding/klient/machine/mount/sync/sync.go
@@ -277,7 +277,7 @@ func (s *Sync) FetchCmd() (count, diskSize int64, cmd *rsync.Command, err error)
 	}
 
 	// Look for git VCS.
-	if n, ok := s.idx.Lookup(".git/index"); ok {
+	if n, ok := s.idx.LookupAll(".git"); ok {
 		// Download only git data.
 		cmd.SourcePath += ".git/"
 		cmd.DestinationPath += ".git/"

--- a/go/src/koding/klient/machine/mount/sync/sync.go
+++ b/go/src/koding/klient/machine/mount/sync/sync.go
@@ -15,6 +15,7 @@ import (
 	"koding/klient/machine/index"
 	"koding/klient/machine/mount"
 	"koding/klient/machine/mount/notify"
+	"koding/klient/machine/transport/rsync"
 
 	"github.com/koding/logging"
 )
@@ -174,8 +175,7 @@ func NewSync(mountID mount.ID, m mount.Mount, opts Options) (*Sync, error) {
 	}
 
 	// Create directory structure if it doesn't exist.
-	cacheDir := filepath.Join(s.opts.WorkDir, "data")
-	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+	if err := os.MkdirAll(s.CacheDir(), 0755); err != nil {
 		return nil, err
 	}
 
@@ -186,7 +186,7 @@ func NewSync(mountID mount.ID, m mount.Mount, opts Options) (*Sync, error) {
 	}
 
 	// Check current state of synchronization and set promises.
-	s.idx.Merge(cacheDir)
+	s.UpdateIndex()
 
 	// Create FS event consumer queue.
 	s.a = NewAnteroom()
@@ -196,7 +196,7 @@ func NewSync(mountID mount.ID, m mount.Mount, opts Options) (*Sync, error) {
 		MountID:  mountID,
 		Mount:    m,
 		Cache:    s.a,
-		CacheDir: cacheDir,
+		CacheDir: s.CacheDir(),
 		DiskInfo: s.diskInfo(),
 		Index:    s.idx,
 	})
@@ -207,7 +207,7 @@ func NewSync(mountID mount.ID, m mount.Mount, opts Options) (*Sync, error) {
 	// Create file synchronization object.
 	s.s, err = opts.SyncBuilder.Build(&BuildOpts{
 		Mount:         m,
-		CacheDir:      cacheDir,
+		CacheDir:      s.CacheDir(),
 		ClientFunc:    s.opts.ClientFunc,
 		SSHFunc:       s.opts.SSHFunc,
 		IndexSyncFunc: s.indexSync(),
@@ -238,6 +238,58 @@ func (s *Sync) Info() *Info {
 		Queued:      items,
 		Syncing:     items - queued,
 	}
+}
+
+// CacheDir returns the name of mount cache directory.
+func (s *Sync) CacheDir() string {
+	return filepath.Join(s.opts.WorkDir, "data")
+}
+
+// UpdateIndex rescans the cache directory and sets all recorded changes to
+// managed index. This function allows to express the current state of
+// synchronized files inside index structure.
+func (s *Sync) UpdateIndex() {
+	s.idx.Merge(s.CacheDir())
+}
+
+// FetchCmd creates a strategy with prefetch command to run.
+func (s *Sync) FetchCmd() (count, diskSize int64, cmd *rsync.Command, err error) {
+	spv := client.NewSupervised(s.opts.ClientFunc, 30*time.Second)
+	// Get remote username.
+	username, err := spv.CurrentUser()
+	if err != nil {
+		return 0, 0, nil, err
+	}
+
+	// Get remote host and port.
+	host, port, err := s.opts.SSHFunc()
+	if err != nil {
+		return 0, 0, nil, err
+	}
+
+	cmd = &rsync.Command{
+		Download:        true,
+		SourcePath:      s.m.RemotePath + "/",
+		DestinationPath: s.CacheDir() + "/",
+		Username:        username,
+		Host:            host,
+		SSHPort:         port,
+	}
+
+	// Look for git VCS.
+	if n, ok := s.idx.Lookup(".git/index"); ok {
+		// Download only git data.
+		cmd.SourcePath += ".git/"
+		cmd.DestinationPath += ".git/"
+
+		count = int64(n.CountAll(-1))
+		diskSize = n.DiskSizeAll(-1)
+	} else {
+		count = int64(s.idx.CountAll(-1))
+		diskSize = s.idx.DiskSizeAll(-1)
+	}
+
+	return count, diskSize, cmd, nil
 }
 
 // Drop closes synced mount and cleans up all resources acquired by it.

--- a/go/src/koding/klient/machine/mount/sync/sync.go
+++ b/go/src/koding/klient/machine/mount/sync/sync.go
@@ -277,7 +277,7 @@ func (s *Sync) FetchCmd() (count, diskSize int64, cmd *rsync.Command, err error)
 	}
 
 	// Look for git VCS.
-	if n, ok := s.idx.LookupAll(".git"); ok {
+	if n, ok := s.idx.LookupAll(".git"); ok && n.IsDir() {
 		// Download only git data.
 		cmd.SourcePath += ".git/"
 		cmd.DestinationPath += ".git/"


### PR DESCRIPTION
This PR adds mount file prefetching. In order to reduce amount of downloaded files, prefetch can detect `.git` directory and reduce received files to `.git` folder content.

Depends on: ~#10637~

## Motivation and Context
Speed up mounting.

## How Has This Been Tested?
Manually.

## Screenshots (if appropriate):
https://asciinema.org/a/22bb04z4astfdoa4ju8r0d73u

## Types of changes
- [x] New feature (non-breaking change which adds functionality)