### PR TITLE
klient/os: add exec/kill methods

### DIFF
--- a/go/src/koding/klient/app/klient.go
+++ b/go/src/koding/klient/app/klient.go
@@ -471,6 +471,8 @@ func (k *Klient) RegisterMethods() {
 	// klient os method(s)
 	k.handleWithSub("os.home", kos.Home)
 	k.handleWithSub("os.currentUsername", kos.CurrentUsername)
+	k.handleWithSub("os.exec", kos.Exec)
+	k.handleWithSub("os.kill", kos.Kill)
 
 	// Klient Info method(s)
 	k.handleWithSub("klient.info", info.Info)

--- a/go/src/koding/klient/os/exec.go
+++ b/go/src/koding/klient/os/exec.go
@@ -1,0 +1,250 @@
+package os
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+
+	"github.com/koding/kite"
+	"github.com/koding/kite/dnode"
+)
+
+var environ = NewEnviron(os.Environ())
+
+// DefaultHandler is a handler used by Exec and Kill methods.
+var DefaultHandler = NewHandler()
+
+// ExecRequest represents a request value for the "os.exec" kite method.
+type ExecRequest struct {
+	Cmd     string            `json:"cmd"`     // a binary to execute which must be in $PATH on remote; required
+	Args    []string          `json:"args"`    // command line arguments for the command
+	Envs    map[string]string `json:"envs"`    // environmental variables that are merged with the klient ones on the remote side
+	WorkDir string            `json:"workDir"` // working directory in which
+	Stdin   []byte            `json:"stdin"`   // standard input of the command
+	Stdout  dnode.Function    `json:"stdout"`  // func(line string): if not nil, called on each stdout line produced by the command
+	Stderr  dnode.Function    `json:"stderr"`  // func(line string): if not nil, called on each stderr line produced by the command
+	Exit    dnode.Function    `json:"exit"`    // func(code int): if not nil, called upon command completion with its exit code
+}
+
+// Valid implements the stack.Validator interface.
+func (r *ExecRequest) Valid() error {
+	if r.Cmd == "" {
+		return errors.New("invalid empty command")
+	}
+	return nil
+}
+
+// ExecResponse represents a response value for the "os.exec" kite method.
+type ExecResponse struct {
+	PID int `json:"pid"` // pid of the started process
+}
+
+// KillRequest represents a request value for the "os.kill" kite method.
+type KillRequest struct {
+	PID int `json:"pid"`
+}
+
+// Valid implements the stack.Validator interface.
+func (r *KillRequest) Valid() error {
+	if r.PID == 0 {
+		return errors.New("invalid zero pid")
+	}
+	return nil
+}
+
+// KillResponse represents a response value for the "os.kill" kite method.
+type KillResponse struct{}
+
+// Handler implements kite handlers for "os.kill" and "os.exec" methods.
+type Handler struct {
+	mu   sync.Mutex
+	cmds map[int]*exec.Cmd
+}
+
+// NewHandler gives
+func NewHandler() *Handler {
+	return &Handler{
+		cmds: make(map[int]*exec.Cmd),
+	}
+}
+
+// Exec is a kite handler for "os.exec" method.
+//
+// The request value is exepected to be of *ExecRequest type.
+func (h *Handler) Exec(r *kite.Request) (interface{}, error) {
+	var req ExecRequest
+
+	if r.Args != nil {
+		if err := r.Args.One().Unmarshal(&req); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := req.Valid(); err != nil {
+		return nil, newError(err)
+	}
+
+	resp, err := h.exec(&req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func (h *Handler) exec(r *ExecRequest) (*ExecResponse, error) {
+	rcmd, err := exec.LookPath(r.Cmd)
+	if err != nil {
+		return nil, err // early fail if r.Cmd is not in $PATH
+	}
+
+	cmd := exec.Command(rcmd, r.Args...)
+	cmd.Dir = r.WorkDir
+
+	if len(r.Envs) != 0 {
+		cmd.Env = environ.Encode(r.Envs)
+	}
+
+	if len(r.Stdin) != 0 {
+		cmd.Stdin = bytes.NewReader(r.Stdin)
+	}
+
+	// wg is used to ensure eventuall Exit callback
+	// is called after streaming stdout/stderr is done
+	// server-side.
+	var wg sync.WaitGroup
+
+	if r.Stdout.IsValid() {
+		cmd.Stdout = pipe(r.Stdout, &wg)
+	}
+
+	if r.Stderr.IsValid() {
+		cmd.Stderr = pipe(r.Stderr, &wg)
+	}
+
+	if err = cmd.Start(); err != nil {
+		stop(cmd.Stdout, cmd.Stderr)
+		return nil, err
+	}
+
+	h.mu.Lock()
+	h.cmds[cmd.Process.Pid] = cmd
+	h.mu.Unlock()
+
+	go func() {
+		err := cmd.Wait()
+
+		h.mu.Lock()
+		delete(h.cmds, cmd.Process.Pid)
+		h.mu.Unlock()
+
+		stop(cmd.Stdout, cmd.Stderr)
+		wg.Wait()
+
+		if r.Exit.IsValid() {
+			code := 0
+
+			if err != nil {
+				code = -1
+			}
+
+			if e, ok := err.(*exec.ExitError); ok {
+				if ws, ok := e.Sys().(syscall.WaitStatus); ok {
+					code = ws.ExitStatus()
+				}
+			}
+
+			r.Exit.Call(code)
+		}
+	}()
+
+	return &ExecResponse{
+		PID: cmd.Process.Pid,
+	}, nil
+}
+
+// Kill is a kite handler for "os.kill" method.
+//
+// The request value is exepected to be of *KillRequest type.
+func (h *Handler) Kill(r *kite.Request) (interface{}, error) {
+	var req KillRequest
+
+	if r.Args != nil {
+		if err := r.Args.One().Unmarshal(&req); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := req.Valid(); err != nil {
+		return nil, newError(err)
+	}
+
+	resp, err := h.kill(&req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func (h *Handler) kill(r *KillRequest) (*KillResponse, error) {
+	h.mu.Lock()
+	cmd, ok := h.cmds[r.PID]
+	delete(h.cmds, r.PID)
+	h.mu.Unlock()
+
+	if !ok {
+		return nil, errors.New("pid not found")
+	}
+
+	if err := cmd.Process.Kill(); err != nil {
+		return nil, err
+	}
+
+	return &KillResponse{}, nil
+}
+
+func Exec(r *kite.Request) (interface{}, error) { return DefaultHandler.Exec(r) }
+func Kill(r *kite.Request) (interface{}, error) { return DefaultHandler.Kill(r) }
+
+func newError(err error) error {
+	if e, ok := err.(*kite.Error); ok {
+		return e
+	}
+	return &kite.Error{
+		Type:    "klient/os",
+		Message: err.Error(),
+	}
+}
+
+func pipe(cb dnode.Function, wg *sync.WaitGroup) io.Writer {
+	wg.Add(1)
+
+	r, w := io.Pipe()
+
+	go func() {
+		s := bufio.NewScanner(r)
+
+		for s.Scan() {
+			cb.Call(s.Text())
+		}
+
+		r.Close()
+		wg.Done()
+	}()
+
+	return w
+}
+
+func stop(w ...io.Writer) {
+	for _, w := range w {
+		if c, ok := w.(io.Closer); ok {
+			c.Close()
+		}
+	}
+}

--- a/go/src/koding/klient/os/exec_test.go
+++ b/go/src/koding/klient/os/exec_test.go
@@ -1,0 +1,165 @@
+package os_test
+
+import (
+	"reflect"
+	"testing"
+
+	"koding/klient/os"
+
+	"github.com/koding/kite"
+)
+
+func TestExec(t *testing.T) {
+	env := map[string]string{
+		"TESTHELPER_FOO":  "bar",
+		"TESTHELPER_HOME": "/home/rjeczalik",
+		"TESTHELPER_PATH": "/usr/bin:/bin:/sbin",
+	}
+
+	cases := map[string]struct {
+		req    *os.ExecRequest
+		stdout []string
+		stderr []string
+		exit   int
+	}{
+		"echo stdout": {
+			&os.ExecRequest{
+				Cmd:  "echo",
+				Args: []string{"-stdout", "Hello World!"},
+			},
+			[]string{"Hello World!"},
+			nil,
+			0,
+		},
+		"echo stderr": {
+			&os.ExecRequest{
+				Cmd:  "echo",
+				Args: []string{"-stderr", "-exit", "2", "Hello World!"},
+			},
+			nil,
+			[]string{"Hello World!"},
+			2,
+		},
+		"echo stdout + stderr": {
+			&os.ExecRequest{
+				Cmd:  "echo",
+				Args: []string{"-stdout", "-stderr", "-exit", "1", "Hello World!"},
+			},
+			[]string{"Hello World!"},
+			[]string{"Hello World!"},
+			1,
+		},
+		"env": {
+			&os.ExecRequest{
+				Cmd:  "env",
+				Envs: env,
+			},
+			os.Environ(env).Encode(nil),
+			nil,
+			0,
+		},
+		"tee": {
+			&os.ExecRequest{
+				Cmd:   "tee",
+				Stdin: []byte("a\nb\nc\nd"),
+			},
+			[]string{"a", "b", "c", "d"},
+			nil,
+			0,
+		},
+	}
+
+	h := os.NewHandler()
+
+	s, c, err := serve(map[string]kite.HandlerFunc{
+		"os.exec": h.Exec,
+	})
+	defer s.Close()
+
+	if err != nil {
+		t.Fatalf("serve()=%s", err)
+	}
+
+	for name, cas := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var resp os.ExecResponse
+			req := makereq(cas.req)
+			rec := record(req)
+
+			if err := call(c, "os.exec", timeout, req, &resp); err != nil {
+				t.Fatalf("call()=%s", err)
+			}
+
+			if resp.PID == 0 {
+				t.Fatal("want resp.Pid != 0")
+			}
+
+			if err := rec.wait(timeout); err != nil {
+				t.Fatalf("wait()=%s", err)
+			}
+
+			if stdout := rec.Stdout(); !reflect.DeepEqual(stdout, cas.stdout) {
+				t.Fatalf("got %v, want %v", stdout, cas.stdout)
+			}
+
+			if stderr := rec.Stderr(); !reflect.DeepEqual(stderr, cas.stderr) {
+				t.Fatalf("got %v, want %v", stderr, cas.stderr)
+			}
+
+			if exit := rec.Exit(); exit != cas.exit {
+				t.Fatalf("got %d, want %d", exit, cas.exit)
+			}
+		})
+	}
+}
+
+func TestKill(t *testing.T) {
+	h := os.NewHandler()
+
+	s, c, err := serve(map[string]kite.HandlerFunc{
+		"os.exec": h.Exec,
+		"os.kill": h.Kill,
+	})
+	defer s.Close()
+
+	if err != nil {
+		t.Fatalf("serve()=%s", err)
+	}
+
+	var resp os.ExecResponse
+	req := makereq(&os.ExecRequest{
+		Cmd:  "sleep",
+		Args: []string{"15s"},
+	})
+	rec := record(req)
+
+	if err := call(c, "os.exec", timeout, req, &resp); err != nil {
+		t.Fatalf("call()=%s", err)
+	}
+
+	if resp.PID == 0 {
+		t.Fatal("want resp.Pid != 0")
+	}
+
+	if err := call(c, "os.kill", timeout, &os.KillRequest{PID: resp.PID}, nil); err != nil {
+		t.Fatalf("call()=%s", err)
+	}
+
+	if err := rec.wait(timeout); err != nil {
+		t.Fatalf("wait()=%s", err)
+	}
+
+	if stdout := rec.Stdout(); len(stdout) != 0 {
+		t.Fatalf("got %v, want it to be empty", stdout)
+	}
+
+	if stderr := rec.Stderr(); len(stderr) != 0 {
+		t.Fatalf("got %v, want it to be empty", stderr)
+	}
+
+	if exit := rec.Exit(); exit != -1 {
+		t.Fatalf("got %d, want %d", exit, -1)
+	}
+}

--- a/go/src/koding/klient/os/home.go
+++ b/go/src/koding/klient/os/home.go
@@ -16,8 +16,10 @@ type HomeOptions struct {
 func Home(r *kite.Request) (interface{}, error) {
 	var opts HomeOptions
 
-	if err := r.Args.One().Unmarshal(&opts); err != nil {
-		return nil, err
+	if r.Args != nil {
+		if err := r.Args.One().Unmarshal(&opts); err != nil {
+			return nil, err
+		}
 	}
 
 	if opts.Username == "" {

--- a/go/src/koding/klient/os/util_test.go
+++ b/go/src/koding/klient/os/util_test.go
@@ -1,0 +1,254 @@
+package os_test
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	kos "koding/klient/os"
+
+	"github.com/koding/kite"
+	"github.com/koding/kite/dnode"
+)
+
+const timeout = 5 * time.Second
+
+func die(v ...interface{}) {
+	fmt.Fprintln(os.Stderr, v...)
+	os.Exit(1)
+}
+
+// TestCommandHelper is used by TestExec / TestKill tests to
+// execute test code as an external process.
+func TestCommandHelper(t *testing.T) {
+	if os.Getenv("GO_TEST_COMMAND_HELPER") != "1" {
+		return
+	}
+
+	cmd := ""
+	f := flag.NewFlagSet("helper", flag.ExitOnError)
+	exit := f.Int("exit", 0, "")
+	stdout := f.Bool("stdout", false, "")
+	stderr := f.Bool("stderr", false, "")
+
+	for i, arg := range os.Args {
+		if arg == "--" {
+			cmd = os.Args[i+1]
+
+			args := os.Args[i+2:]
+
+			if err := f.Parse(args); err != nil {
+				die("error: parsing flags:", err)
+			}
+
+			break
+		}
+	}
+
+	write := func(v ...interface{}) {
+		if *stderr {
+			fmt.Fprint(os.Stderr, v...)
+		}
+
+		if !*stderr || *stdout {
+			fmt.Print(v...)
+		}
+	}
+
+	defer os.Exit(*exit)
+
+	switch cmd {
+	case "sleep":
+		d, err := time.ParseDuration(f.Arg(0))
+		if err != nil {
+			die(err)
+		}
+		time.Sleep(d)
+		write("awake")
+	case "echo":
+		write(strings.Join(f.Args(), " "))
+	case "tee":
+		p, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			die(err)
+		}
+		write(string(p))
+	case "env":
+		envs := kos.NewEnviron(os.Environ())
+
+		// Print those envs only that begin with "TESTHELPER_".
+		for k := range envs {
+			if !strings.HasPrefix(k, "TESTHELPER_") {
+				delete(envs, k)
+			}
+		}
+
+		write(strings.Join(envs.Encode(nil), "\n"))
+	case "":
+		die("error: missing command")
+	default:
+		die("error: unknown command:", cmd)
+	}
+}
+
+func call(c *kite.Client, method string, timeout time.Duration, req, resp interface{}) error {
+	r, err := c.TellWithTimeout(method, timeout, req)
+	if err != nil {
+		return err
+	}
+
+	if resp != nil {
+		if err := r.Unmarshal(resp); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func serve(handlers map[string]kite.HandlerFunc) (*httptest.Server, *kite.Client, error) {
+	s := kite.New("test-server", "0.0.0")
+	s.Config.DisableAuthentication = true
+
+	for method, handler := range handlers {
+		s.HandleFunc(method, handler)
+	}
+
+	ts := httptest.NewServer(s)
+
+	c := kite.New("c", "0.0.0").NewClient(fmt.Sprintf("%s/kite", ts.URL))
+
+	if err := c.DialTimeout(timeout); err != nil {
+		return nil, nil, err
+	}
+
+	return ts, c, nil
+}
+
+// makereq enriches the Cmd and Args arguments of the given r request,
+// with a values required to run TestCommandHelper.
+func makereq(r *kos.ExecRequest) *kos.ExecRequest {
+	rCopy := *r
+
+	if rCopy.Envs != nil {
+		rCopy.Envs = make(map[string]string, len(r.Envs))
+		for k, v := range r.Envs {
+			rCopy.Envs[k] = v
+		}
+	}
+
+	if rCopy.Envs == nil {
+		rCopy.Envs = make(map[string]string)
+	}
+
+	rCopy.Envs["GO_TEST_COMMAND_HELPER"] = "1"
+	rCopy.Cmd = os.Args[0]
+	rCopy.Args = []string{"-test.run", "TestCommandHelper", "--", r.Cmd}
+
+	if r.Args != nil {
+		rCopy.Args = append(rCopy.Args, r.Args...)
+	}
+
+	return &rCopy
+}
+
+// execRecorder is a mock used to spy on stdout, stderr and exit code
+// of a command process started by a "os.exec" method.
+type execRecorder struct {
+	mu sync.Mutex
+
+	stdout []string
+	stderr []string
+	exit   int
+
+	Done chan struct{}
+}
+
+// record enriches the Stdout / Stderr / Exit callbacks of the give r request,
+// building a dnode functions the persist a streamed output and exit code
+// of a command.
+func record(r *kos.ExecRequest) *execRecorder {
+	rec := &execRecorder{
+		Done: make(chan struct{}),
+	}
+
+	r.Stdout = dnode.Callback(func(r *dnode.Partial) {
+		s := r.One().MustString()
+
+		rec.mu.Lock()
+		rec.stdout = append(rec.stdout, s)
+		rec.mu.Unlock()
+	})
+
+	r.Stderr = dnode.Callback(func(r *dnode.Partial) {
+		s := r.One().MustString()
+
+		rec.mu.Lock()
+		rec.stderr = append(rec.stderr, s)
+		rec.mu.Unlock()
+	})
+
+	r.Exit = dnode.Callback(func(r *dnode.Partial) {
+		var n int
+		r.One().MustUnmarshal(&n)
+
+		rec.mu.Lock()
+		rec.exit = n
+		rec.mu.Unlock()
+
+		close(rec.Done)
+	})
+
+	return rec
+}
+
+// Stdout gives a copy of stdout lines streamed from a command.
+func (rec *execRecorder) Stdout() []string {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+
+	if rec.stdout == nil {
+		return nil
+	}
+
+	stdout := make([]string, len(rec.stdout))
+	copy(stdout, rec.stdout)
+	return stdout
+}
+
+// Stderr gives a copy of stderr lines streamed from a command.
+func (rec *execRecorder) Stderr() []string {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+
+	if rec.stderr == nil {
+		return nil
+	}
+
+	stderr := make([]string, len(rec.stderr))
+	copy(stderr, rec.stderr)
+	return stderr
+}
+
+// Exit gives a command's exit code.
+func (rec *execRecorder) Exit() int {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+
+	return rec.exit
+}
+
+func (rec *execRecorder) wait(timeout time.Duration) error {
+	select {
+	case <-rec.Done:
+		return nil
+	case <-time.After(timeout):
+		return fmt.Errorf("wait timed out after %s", timeout)
+	}
+}


### PR DESCRIPTION
deps: https://github.com/koding/koding/pull/10726

This PR adds the following kite methods:

  - os.exec
  - os.kill

The os.exec methods is a reworked version of existing
exec method with a new API that is needed for KD. Since
the exec method is still used on client side, it's being
marked as deprecated and new version rolled out.

The os.kill method addresses shortcoming in current "kd run"
implementation - if user aborts command execution with CTRL+C,
the command won't get killed on a remote machine.

New implementation is going to call machine.kill upon exit,
which effectively will kill the user process on the remote side.

The os.kill method is limited to only those processes that
were started with os.exec.