### PR TITLE
klient/machine: umount allows to unmount non existing mount

### DIFF
--- a/go/src/koding/klient/machine/machinegroup/mount.go
+++ b/go/src/koding/klient/machine/machinegroup/mount.go
@@ -304,16 +304,17 @@ func (g *Group) Umount(req *UmountRequest) (res *UmountResponse, err error) {
 		}
 	}
 
+	// Get mount machine.
+	id, err := g.mount.MachineID(mountID)
+	if err != nil {
+		g.log.Error("Could not find mount with ID: %s", mountID)
+		return nil, err
+	}
+
 	// Stop mount synchronization routine.
 	if err := g.sync.Drop(mountID); err != nil {
 		g.log.Error("Cannot remove synced mount %s: %s", mountID, err)
 		return nil, err
-	}
-
-	// Get mount machine.
-	id, err := g.mount.MachineID(mountID)
-	if err != nil {
-		g.log.Error("Could not find machine ID for mount %s: %s", mountID, err)
 	}
 
 	var m mount.Mount

--- a/go/src/koding/klient/machine/machinegroup/mount_test.go
+++ b/go/src/koding/klient/machine/machinegroup/mount_test.go
@@ -353,11 +353,18 @@ func TestUmount(t *testing.T) {
 	shouldNotExist(mountIDs[2])
 
 	// Invalid identifier.
-	umountReq = &UmountRequest{
-		Identifier: "invalid",
+	invalidIDs := []string{
+		"invalid",
+		"00000000-0000-4000-0000-000000000000", // non -existing.
 	}
-	if umountRes, err = g.Umount(umountReq); err == nil {
-		t.Fatalf("want err != nil; got nil")
+
+	for _, invalidID := range invalidIDs {
+		umountReq = &UmountRequest{
+			Identifier: invalidID,
+		}
+		if umountRes, err = g.Umount(umountReq); err == nil {
+			t.Fatalf("want err != nil for identifier == %q; got nil", invalidID)
+		}
 	}
 }
 


### PR DESCRIPTION
This PR fixes incorrect message sent by klient. Basically changes:

https://asciinema.org/a/6r0lm6hylzsc10cbkljg7psz3
to
https://asciinema.org/a/d3x27clbfmmqig5dki86m9pk4

## Motivation and Context
Cannot successfully umount non-existing mount.

## How Has This Been Tested?
Unit tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
