### PR TITLE
machinegroup: add exec/kill methods

### DIFF
--- a/go/src/koding/klient/app/klient.go
+++ b/go/src/koding/klient/app/klient.go
@@ -524,6 +524,8 @@ func (k *Klient) RegisterMethods() {
 	k.kite.HandleFunc("machine.mount.updateIndex", machinegroup.KiteHandlerUpdateIndex(k.machines))
 	k.kite.HandleFunc("machine.mount.list", machinegroup.KiteHandlerListMount(k.machines))
 	k.kite.HandleFunc("machine.umount", machinegroup.KiteHandlerUmount(k.machines))
+	k.kite.HandleFunc("machine.exec", k.machines.HandleExec)
+	k.kite.HandleFunc("machine.kill", k.machines.HandleKill)
 
 	// Machine index handlers.
 	k.handleWithSub("machine.index.head", index.KiteHandlerHead())

--- a/go/src/koding/klient/machine/client/cached.go
+++ b/go/src/koding/klient/machine/client/cached.go
@@ -8,6 +8,7 @@ import (
 
 	"koding/klient/fs"
 	"koding/klient/machine/index"
+	"koding/klient/os"
 )
 
 // Cached allows user to cache Client method calls results. It is limited to
@@ -43,6 +44,20 @@ func NewCached(c Client, interval time.Duration) *Cached {
 // client.
 func (c *Cached) CurrentUser() (string, error) {
 	return c.currentUser()
+}
+
+// Exec calls registered Client's Exec method.
+//
+// The method does not cache the result.
+func (c *Cached) Exec(r *os.ExecRequest) (*os.ExecResponse, error) {
+	return c.c.Exec(r)
+}
+
+// Kill calls registered Client's Kill method.
+//
+// The method does not cache the result.
+func (c *Cached) Kill(r *os.KillRequest) (*os.KillResponse, error) {
+	return c.c.Kill(r)
 }
 
 func currentUser(c Client, interval time.Duration) func() (string, error) {

--- a/go/src/koding/klient/machine/client/client.go
+++ b/go/src/koding/klient/machine/client/client.go
@@ -5,6 +5,7 @@ import (
 
 	"koding/klient/fs"
 	"koding/klient/machine/index"
+	"koding/klient/os"
 )
 
 // Client describes the operations that can be made on remote machine.
@@ -25,6 +26,12 @@ type Client interface {
 
 	// DiskInfo gets basic information about volume pointed by provided path.
 	DiskInfo(string) (fs.DiskInfo, error)
+
+	// Exec runs a command on a remote machine.
+	Exec(*os.ExecRequest) (*os.ExecResponse, error)
+
+	// Kill terminates previously started command on a remote machine.
+	Kill(*os.KillRequest) (*os.KillResponse, error)
 
 	// Context returns client's Context.
 	Context() context.Context

--- a/go/src/koding/klient/machine/client/clienttest/client.go
+++ b/go/src/koding/klient/machine/client/clienttest/client.go
@@ -13,6 +13,7 @@ import (
 	"koding/klient/machine"
 	"koding/klient/machine/client"
 	"koding/klient/machine/index"
+	"koding/klient/os"
 )
 
 // Builder uses Server logic to build test clients.
@@ -146,6 +147,16 @@ func (c *Client) DiskInfo(path string) (di fs.DiskInfo, err error) {
 	}
 
 	return
+}
+
+// Exec mocks running process on a remote, always succeeds.
+func (c *Client) Exec(*os.ExecRequest) (*os.ExecResponse, error) {
+	return &os.ExecResponse{PID: 0xD}, nil
+}
+
+// Kill mocks remote process termination, always succeeds.
+func (c *Client) Kill(*os.KillRequest) (*os.KillResponse, error) {
+	return &os.KillResponse{}, nil
 }
 
 // SetContext sets provided context to test client.

--- a/go/src/koding/klient/machine/client/clienttest/counter.go
+++ b/go/src/koding/klient/machine/client/clienttest/counter.go
@@ -8,6 +8,7 @@ import (
 	"koding/klient/fs"
 	"koding/klient/machine/client"
 	"koding/klient/machine/index"
+	"koding/klient/os"
 )
 
 type invCounter int64
@@ -58,6 +59,16 @@ func (c *Counter) MountGetIndex(path string) (*index.Index, error) {
 // DiskInfo increases function call counter and returns it as an error.
 func (c *Counter) DiskInfo(path string) (fs.DiskInfo, error) {
 	return fs.DiskInfo{}, invCounter(atomic.AddInt64(&c.curr, 1))
+}
+
+// Exec increases function call counter and returns it as an error.
+func (c *Counter) Exec(*os.ExecRequest) (*os.ExecResponse, error) {
+	return nil, invCounter(atomic.AddInt64(&c.curr, 1))
+}
+
+// Kill increases function call counter and returns it as an error.
+func (c *Counter) Kill(*os.KillRequest) (*os.KillResponse, error) {
+	return nil, invCounter(atomic.AddInt64(&c.curr, 1))
 }
 
 // Context increases function call counter and returns background context.

--- a/go/src/koding/klient/machine/client/disconnected.go
+++ b/go/src/koding/klient/machine/client/disconnected.go
@@ -7,6 +7,7 @@ import (
 	"koding/klient/fs"
 	"koding/klient/machine"
 	"koding/klient/machine/index"
+	"koding/klient/os"
 )
 
 var (
@@ -70,6 +71,16 @@ func (*Disconnected) MountGetIndex(_ string) (*index.Index, error) {
 // DiskInfo always returns ErrDisconnected error.
 func (*Disconnected) DiskInfo(_ string) (fs.DiskInfo, error) {
 	return fs.DiskInfo{}, ErrDisconnected
+}
+
+// Exec always returns ErrDisconnected error.
+func (*Disconnected) Exec(*os.ExecRequest) (*os.ExecResponse, error) {
+	return nil, ErrDisconnected
+}
+
+// Kill always returns ErrDisconnected error.
+func (*Disconnected) Kill(*os.KillRequest) (*os.KillResponse, error) {
+	return nil, ErrDisconnected
 }
 
 // Context returns disconnected client's context.

--- a/go/src/koding/klient/machine/client/supervised.go
+++ b/go/src/koding/klient/machine/client/supervised.go
@@ -6,6 +6,7 @@ import (
 
 	"koding/klient/fs"
 	"koding/klient/machine/index"
+	"koding/klient/os"
 )
 
 // DynamicClientFunc is an adapter that allows to dynamically provide clients.
@@ -86,6 +87,32 @@ func (s *Supervised) MountGetIndex(path string) (idx *index.Index, err error) {
 func (s *Supervised) DiskInfo(path string) (di fs.DiskInfo, err error) {
 	fn := func(c Client) error {
 		di, err = c.DiskInfo(path)
+		return err
+	}
+
+	err = s.call(fn)
+	return
+}
+
+// Exec calls registered Client's Exec method and returns its result if
+// it's not produced by Disconnected client. If it is, this function will wait
+// until valid client is available or timeout is reached.
+func (s *Supervised) Exec(req *os.ExecRequest) (resp *os.ExecResponse, err error) {
+	fn := func(c Client) error {
+		resp, err = c.Exec(req)
+		return err
+	}
+
+	err = s.call(fn)
+	return
+}
+
+// Kill calls registered Client's Kill method and returns its result if
+// it's not produced by Disconnected client. If it is, this function will wait
+// until valid client is available or timeout is reached.
+func (s *Supervised) Kill(req *os.KillRequest) (resp *os.KillResponse, err error) {
+	fn := func(c Client) error {
+		resp, err = c.Kill(req)
 		return err
 	}
 

--- a/go/src/koding/klient/machine/machinegroup/exec.go
+++ b/go/src/koding/klient/machine/machinegroup/exec.go
@@ -1,0 +1,174 @@
+package machinegroup
+
+import (
+	"errors"
+	stdos "os"
+	"path/filepath"
+	"strings"
+
+	"koding/klient/machine"
+	"koding/klient/machine/mount"
+	"koding/klient/os"
+)
+
+// MachineRequest represents a common part of Exec and Kill
+// requests, which is used for looking up a remote machine.
+type MachineRequest struct {
+	MachineID machine.ID `json:"machineID"`
+	Path      string     `json:"path"`
+}
+
+// Valid implements the stack.Validator interface.
+func (r *MachineRequest) Valid() error {
+	if r.MachineID == "" && r.Path == "" {
+		return errors.New("both path and machine ID are empty")
+	}
+	if r.Path != "" && !filepath.IsAbs(r.Path) {
+		return errors.New("invalid relative path")
+	}
+	return nil
+}
+
+// ExecRequest is a request value of "machine.exec" kite method.
+type ExecRequest struct {
+	os.ExecRequest // request value for remote "os.exec" call
+	MachineRequest // used to look up remote
+}
+
+// Valid implements the stack.Validator interface.
+func (r *ExecRequest) Valid() error {
+	if err := r.ExecRequest.Valid(); err != nil {
+		return err
+	}
+	return r.MachineRequest.Valid()
+}
+
+// ExecResponse is a response value of "machine.exec" kite method.
+type ExecResponse struct {
+	os.ExecResponse // response value from remote "os.exec" call
+}
+
+// KillRequest is a request value of "machine.kill" kite method.
+type KillRequest struct {
+	os.KillRequest // request vaue for remote "os.kill" call
+	MachineRequest // used to look up remote
+}
+
+// Valid implements the stack.Validator interface.
+func (r *KillRequest) Valid() error {
+	if err := r.KillRequest.Valid(); err != nil {
+		return err
+	}
+	return r.MachineRequest.Valid()
+}
+
+// KillReponse is a response value of "machine.kill" kite method.
+type KillResponse struct {
+	os.KillResponse
+}
+
+// Exec is a handler implementation for "method.exec" kite method.
+func (g *Group) Exec(r *ExecRequest) (*ExecResponse, error) {
+	machineID := r.MachineID
+
+	if machineID == "" {
+		id, path, err := g.lookup(r.Path)
+		if err != nil {
+			return nil, err
+		}
+
+		machineID, err = g.mount.MachineID(id)
+		if err != nil {
+			return nil, err
+		}
+
+		if r.WorkDir == "" {
+			mounts, err := g.mount.All(machineID)
+			if err != nil {
+				return nil, err
+			}
+
+			m, ok := mounts[id]
+			if !ok {
+				return nil, mount.ErrMountNotFound
+			}
+
+			rel, err := filepath.Rel(path, r.Path)
+			if err != nil {
+				return nil, err
+			}
+
+			r.WorkDir = filepath.Join(m.RemotePath, rel)
+		}
+	}
+
+	c, err := g.client.Client(machineID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.Exec(&r.ExecRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ExecResponse{
+		ExecResponse: *resp,
+	}, nil
+}
+
+// Kill is a handler implementation for "method.kill" kite method.
+func (g *Group) Kill(r *KillRequest) (*KillResponse, error) {
+	machineID := r.MachineID
+
+	if machineID == "" {
+		id, _, err := g.lookup(r.Path)
+		if err != nil {
+			return nil, err
+		}
+
+		machineID, err = g.mount.MachineID(id)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	c, err := g.client.Client(machineID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.Kill(&r.KillRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	return &KillResponse{
+		KillResponse: *resp,
+	}, nil
+
+	return nil, nil
+}
+
+func (g *Group) lookup(path string) (mount.ID, string, error) {
+	const sep = string(stdos.PathListSeparator)
+
+	for path != "" {
+		id, err := g.mount.Path(path)
+		if err == nil {
+			return id, path, nil
+		}
+		if err == mount.ErrMountNotFound {
+			continue
+		}
+
+		if i := strings.LastIndex(path, sep); i != -1 {
+			path = path[:i]
+			continue
+		}
+
+		break
+	}
+
+	return "", "", mount.ErrMountNotFound
+}

--- a/go/src/koding/klient/machine/machinegroup/kite.go
+++ b/go/src/koding/klient/machine/machinegroup/kite.go
@@ -4,6 +4,18 @@ import (
 	"github.com/koding/kite"
 )
 
+// TODO(ppknap): create errors file similar to kloud/stack/errors.
+func newError(err error) error {
+	if e, ok := err.(*kite.Error); ok {
+		return e
+	}
+
+	return &kite.Error{
+		Type:    "machinesError",
+		Message: err.Error(),
+	}
+}
+
 // KiteHandlerCreate creates a kite handler function that, when called, invokes
 // machine group Create method.
 func KiteHandlerCreate(g *Group) kite.HandlerFunc {
@@ -18,11 +30,7 @@ func KiteHandlerCreate(g *Group) kite.HandlerFunc {
 
 		res, err := g.Create(req)
 		if err != nil {
-			// TODO(ppknap): create errors file similar to kloud/stack/errors.
-			return nil, &kite.Error{
-				Type:    "machinesError",
-				Message: err.Error(),
-			}
+			return nil, newError(err)
 		}
 
 		return res, nil
@@ -43,11 +51,7 @@ func KiteHandlerID(g *Group) kite.HandlerFunc {
 
 		res, err := g.ID(req)
 		if err != nil {
-			// TODO(ppknap): create errors file similar to kloud/stack/errors.
-			return nil, &kite.Error{
-				Type:    "machinesError",
-				Message: err.Error(),
-			}
+			return nil, newError(err)
 		}
 
 		return res, nil
@@ -68,11 +72,7 @@ func KiteHandlerSSH(g *Group) kite.HandlerFunc {
 
 		res, err := g.SSH(req)
 		if err != nil {
-			// TODO(ppknap): create errors file similar to kloud/stack/errors.
-			return nil, &kite.Error{
-				Type:    "machinesError",
-				Message: err.Error(),
-			}
+			return nil, newError(err)
 		}
 
 		return res, nil
@@ -93,11 +93,7 @@ func KiteHandlerHeadMount(g *Group) kite.HandlerFunc {
 
 		res, err := g.HeadMount(req)
 		if err != nil {
-			// TODO(ppknap): create errors file similar to kloud/stack/errors.
-			return nil, &kite.Error{
-				Type:    "machinesError",
-				Message: err.Error(),
-			}
+			return nil, newError(err)
 		}
 
 		return res, nil
@@ -118,11 +114,7 @@ func KiteHandlerAddMount(g *Group) kite.HandlerFunc {
 
 		res, err := g.AddMount(req)
 		if err != nil {
-			// TODO(ppknap): create errors file similar to kloud/stack/errors.
-			return nil, &kite.Error{
-				Type:    "machinesError",
-				Message: err.Error(),
-			}
+			return nil, newError(err)
 		}
 
 		return res, nil
@@ -168,11 +160,7 @@ func KiteHandlerListMount(g *Group) kite.HandlerFunc {
 
 		res, err := g.ListMount(req)
 		if err != nil {
-			// TODO(ppknap): create errors file similar to kloud/stack/errors.
-			return nil, &kite.Error{
-				Type:    "machinesError",
-				Message: err.Error(),
-			}
+			return nil, newError(err)
 		}
 
 		return res, nil
@@ -193,13 +181,53 @@ func KiteHandlerUmount(g *Group) kite.HandlerFunc {
 
 		res, err := g.Umount(req)
 		if err != nil {
-			// TODO(ppknap): create errors file similar to kloud/stack/errors.
-			return nil, &kite.Error{
-				Type:    "machinesError",
-				Message: err.Error(),
-			}
+			return nil, newError(err)
 		}
 
 		return res, nil
 	}
+}
+
+// HandleExec is a handler for "machine.exec" kite requests.
+func (g *Group) HandleExec(r *kite.Request) (interface{}, error) {
+	var req ExecRequest
+
+	if r.Args != nil {
+		if err := r.Args.One().Unmarshal(&req); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := req.Valid(); err != nil {
+		return nil, newError(err)
+	}
+
+	resp, err := g.Exec(&req)
+	if err != nil {
+		return nil, newError(err)
+	}
+
+	return resp, nil
+}
+
+// HandleKill is a handler for "machine.kill" kite requests.
+func (g *Group) HandleKill(r *kite.Request) (interface{}, error) {
+	var req KillRequest
+
+	if r.Args != nil {
+		if err := r.Args.One().Unmarshal(&req); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := req.Valid(); err != nil {
+		return nil, newError(err)
+	}
+
+	resp, err := g.Kill(&req)
+	if err != nil {
+		return nil, newError(err)
+	}
+
+	return resp, nil
 }


### PR DESCRIPTION
deps: ~~https://github.com/koding/koding/pull/10726 https://github.com/koding/koding/pull/10728~~

This PR adds the following kite methods:

  - machine.exec
  - machine.kill

Those methods are going to be used by KD to indirectly
call "os.exec" and "os.kill" methods on a remote machines.

Klient is responsible for maintaining kite connection pools
with remotes, thus the indirection.