### PR TITLE
kd: add "machine exec" command

### DIFF
--- a/go/src/koding/kites/kloud/machine/client.go
+++ b/go/src/koding/kites/kloud/machine/client.go
@@ -35,6 +35,7 @@ type User struct {
 
 // Filter is used for filtering machine records.
 type Filter struct {
+	ID           string // machine ID
 	Username     string // user name.
 	Owners       bool   // keep machine owners.
 	OnlyApproved bool   // only approved machines.

--- a/go/src/koding/kites/kloud/machine/modelhelper.go
+++ b/go/src/koding/kites/kloud/machine/modelhelper.go
@@ -7,6 +7,8 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
+var modelHelper modelHelperAdapter
+
 // modelHelperAdapter wraps modelhelper package with adapter interface. Thus,
 // it allows to use it as ordinal object which satisfies adapter interface.
 type modelHelperAdapter struct{}
@@ -20,4 +22,9 @@ func (modelHelperAdapter) GetParticipatedMachinesByUsername(username string) ([]
 func (modelHelperAdapter) GetStackTemplateFieldsByIds(
 	ids []bson.ObjectId, fields []string) ([]*models.StackTemplate, error) {
 	return modelhelper.GetStackTemplateFieldsByIds(ids, fields)
+}
+
+// GetMachineByID forwards fuction call to the modelhelper package.
+func (modelHelperAdapter) GetMachineByID(id string) (*models.Machine, error) {
+	return modelhelper.GetMachine(id)
 }

--- a/go/src/koding/kites/kloud/stack/machine.go
+++ b/go/src/koding/kites/kloud/stack/machine.go
@@ -7,7 +7,9 @@ import (
 )
 
 // MachineListRequest represents a request value for "machine.list" method.
-type MachineListRequest struct{}
+type MachineListRequest struct {
+	MachineID string `json:"machineID"`
+}
 
 // MachineListResponse represents a response value from "machine.list" method.
 type MachineListResponse struct {
@@ -24,6 +26,7 @@ func (k *Kloud) MachineList(r *kite.Request) (interface{}, error) {
 	// We need to keep machine owners as well as skip unapproved shared machines
 	// which shouldn't be visible until user approve them.
 	f := &machine.Filter{
+		ID:           req.MachineID,
 		Username:     r.Username,
 		Owners:       true,
 		OnlyApproved: true,

--- a/go/src/koding/klientctl/ctlcli/ctlcli.go
+++ b/go/src/koding/klientctl/ctlcli/ctlcli.go
@@ -16,6 +16,12 @@ import (
 
 var closers []io.Closer
 
+// CloseFunc wraps func to provide an implementation for the io.Closer interface.
+type CloseFunc func() error
+
+// Close implements the io.Closer interface.
+func (c CloseFunc) Close() error { return c() }
+
 // ExitFunc is called upon command exit, it sets exit code.
 //
 // It is overwritten during testing, as calling os.Exit

--- a/go/src/koding/klientctl/endpoint/kloud/kloud.go
+++ b/go/src/koding/klientctl/endpoint/kloud/kloud.go
@@ -77,6 +77,11 @@ type KiteTransport struct {
 	// If nil, global config.Konfig is going to be used instead.
 	Konfig *cfg.Konfig
 
+	// ClientURL is an remote kite endpoint to connect to.
+	//
+	// If empty, kloud's public endpoint is going to be used instead.
+	ClientURL string
+
 	// DialTimeout is a maximum time external kite is
 	// going to be dialed for.
 	//
@@ -105,7 +110,7 @@ var (
 )
 
 func (kt *KiteTransport) Call(method string, arg, reply interface{}) error {
-	k, err := kt.kloud()
+	k, err := kt.client()
 	if err != nil {
 		return err
 	}
@@ -168,17 +173,17 @@ func (kt *KiteTransport) kiteConfig() *kitecfg.Config {
 	return kt.kCfg
 }
 
-func (kt *KiteTransport) kloud() (*kite.Client, error) {
+func (kt *KiteTransport) client() (*kite.Client, error) {
 	if kt.kClient != nil {
 		return kt.kClient, nil
 	}
 
-	kloud, err := kt.newClient(kt.konfig().Endpoints.Kloud().Public.String())
+	c, err := kt.newClient(kt.clientURL())
 	if err != nil {
 		return nil, err
 	}
 
-	kt.kClient = kloud
+	kt.kClient = c
 
 	return kt.kClient, nil
 }
@@ -226,6 +231,14 @@ func (kt *KiteTransport) konfig() *cfg.Konfig {
 		return kt.Konfig
 	}
 	return config.Konfig
+}
+
+func (kt *KiteTransport) clientURL() string {
+	if kt.ClientURL != "" {
+		return kt.ClientURL
+	}
+
+	return kt.konfig().Endpoints.Kloud().Public.String()
 }
 
 func (kt *KiteTransport) Valid() error {

--- a/go/src/koding/klientctl/endpoint/kloud/kloud.go
+++ b/go/src/koding/klientctl/endpoint/kloud/kloud.go
@@ -14,6 +14,8 @@ import (
 	"github.com/koding/logging"
 )
 
+// TODO(rjeczalik): rename to kite
+
 // Transport is an interface that abstracts underlying
 // RPC round trip.
 //

--- a/go/src/koding/klientctl/endpoint/machine/client.go
+++ b/go/src/koding/klientctl/endpoint/machine/client.go
@@ -1,0 +1,147 @@
+package machine
+
+import (
+	"koding/kites/config"
+	"koding/klient/machine"
+	"koding/klient/machine/machinegroup"
+	"koding/klient/os"
+	konfig "koding/klientctl/config"
+	"koding/klientctl/endpoint/kloud"
+
+	"github.com/koding/kite/dnode"
+	"github.com/koding/logging"
+)
+
+// DefaultClient is a default client used by all machine functions.
+var DefaultClient = &Client{}
+
+// Client is responsible for machine operations like:
+//
+//   - starting, stopping and listing machines
+//   - creating, deleting and listing mounts
+//
+type Client struct {
+	Konfig *config.Konfig
+	Klient kloud.Transport
+	Kloud  *kloud.Client
+	Log    logging.Logger
+
+	k kloud.Transport
+}
+
+// ExecOptions represents available parameters for the Exec method.
+type ExecOptions struct {
+	MachineID string       // machine ID
+	Path      string       // if it resides inside existing mount, machine ID is inferred from it
+	Cmd       string       // binary to execute
+	Args      []string     // command line flags for the binary
+	Stdout    func(string) // stdout callback, called in-order if not nil
+	Stderr    func(string) // stderr callback, called in-order if not nil
+	Exit      func(int)    // process exit callback, guaranteed to get called last if not nil
+}
+
+// KillOptions represents available parameters for the Kill method.
+type KillOptions struct {
+	MachineID string // machine ID
+	Path      string // if it resides inside existing mount, machine ID is inferred from it
+	PID       int    // pid of the remote process
+}
+
+// Exec runs the given command in a remote machine.
+func (c *Client) Exec(opts *ExecOptions) (int, error) {
+	req := &machinegroup.ExecRequest{
+		ExecRequest: os.ExecRequest{
+			Cmd:  opts.Cmd,
+			Args: opts.Args,
+		},
+		MachineRequest: machinegroup.MachineRequest{
+			MachineID: machine.ID(opts.MachineID),
+			Path:      opts.Path,
+		},
+	}
+
+	if opts.Stdout != nil {
+		req.Stdout = dnode.Callback(func(r *dnode.Partial) {
+			opts.Stdout(r.One().MustString())
+		})
+	}
+
+	if opts.Stderr != nil {
+		req.Stderr = dnode.Callback(func(r *dnode.Partial) {
+			opts.Stderr(r.One().MustString())
+		})
+	}
+
+	if opts.Exit != nil {
+		req.Exit = dnode.Callback(func(r *dnode.Partial) {
+			var exit int
+			r.One().MustUnmarshal(&exit)
+			opts.Exit(exit)
+		})
+	}
+
+	var resp machinegroup.ExecResponse
+
+	if err := c.klient().Call("machine.exec", req, &resp); err != nil {
+		return 0, err
+	}
+
+	return resp.PID, nil
+}
+
+// Kill terminates a running process on a remote machine.
+func (c *Client) Kill(opts *KillOptions) error {
+	req := &machinegroup.KillRequest{
+		KillRequest: os.KillRequest{
+			PID: opts.PID,
+		},
+		MachineRequest: machinegroup.MachineRequest{
+			MachineID: machine.ID(opts.MachineID),
+			Path:      opts.Path,
+		},
+	}
+
+	return c.klient().Call("machine.kill", req, nil)
+}
+
+func (c *Client) konfig() *config.Konfig {
+	if c.Konfig != nil {
+		return c.Konfig
+	}
+	return konfig.Konfig
+}
+
+func (c *Client) klient() kloud.Transport {
+	if c.Klient != nil {
+		return c.Klient
+	}
+
+	if c.k == nil {
+		c.k = &kloud.KiteTransport{
+			ClientURL: c.konfig().Endpoints.Klient.Private.String(),
+		}
+	}
+
+	return c.k
+}
+
+func (c *Client) kloud() *kloud.Client {
+	if c.Kloud != nil {
+		return c.Kloud
+	}
+	return kloud.DefaultClient
+}
+
+func (c *Client) log() logging.Logger {
+	if c.Log != nil {
+		return c.Log
+	}
+	return kloud.DefaultLog
+}
+
+// Exec runs the given command in a remote machine using DefaultClient.
+func Exec(opts *ExecOptions) (int, error) { return DefaultClient.Exec(opts) }
+
+// Kill terminates a command looked up by the given pid on a remote machine
+// using DefaultClient.
+func Kill(opts *KillOptions) error { return DefaultClient.Kill(opts) }

--- a/go/src/koding/klientctl/endpoint/machine/list.go
+++ b/go/src/koding/klientctl/endpoint/machine/list.go
@@ -20,7 +20,8 @@ import (
 
 // ListOptions stores options for `machine list` call.
 type ListOptions struct {
-	Log logging.Logger
+	MachineID string
+	Log       logging.Logger
 }
 
 // List retrieves user's machines from kloud.
@@ -29,13 +30,13 @@ func List(options *ListOptions) ([]*Info, error) {
 		return nil, errors.New("invalid nil options")
 	}
 
-	var (
-		listReq = stack.MachineListRequest{}
-		listRes = stack.MachineListResponse{}
-	)
+	listReq := &stack.MachineListRequest{
+		MachineID: options.MachineID,
+	}
+	var listRes stack.MachineListResponse
 
 	// Get info from kloud.
-	if err := kloud.Call("machine.list", &listReq, &listRes); err != nil {
+	if err := kloud.Call("machine.list", listReq, &listRes); err != nil {
 		return nil, err
 	}
 

--- a/go/src/koding/klientctl/endpoint/machine/list.go
+++ b/go/src/koding/klientctl/endpoint/machine/list.go
@@ -2,8 +2,6 @@ package machine
 
 import (
 	"errors"
-	"fmt"
-	"os"
 	"sort"
 	"time"
 
@@ -12,8 +10,6 @@ import (
 	"koding/kites/kloud/stack"
 	kmachine "koding/klient/machine"
 	"koding/klient/machine/machinegroup"
-	"koding/klientctl/endpoint/kloud"
-	"koding/klientctl/klient"
 
 	"github.com/koding/logging"
 )
@@ -25,7 +21,7 @@ type ListOptions struct {
 }
 
 // List retrieves user's machines from kloud.
-func List(options *ListOptions) ([]*Info, error) {
+func (c *Client) List(options *ListOptions) ([]*Info, error) {
 	if options == nil {
 		return nil, errors.New("invalid nil options")
 	}
@@ -36,25 +32,16 @@ func List(options *ListOptions) ([]*Info, error) {
 	var listRes stack.MachineListResponse
 
 	// Get info from kloud.
-	if err := kloud.Call("machine.list", listReq, &listRes); err != nil {
-		return nil, err
-	}
-
-	// TODO(ppknap): this is copied from klientctl old list and will be reworked.
-	k, err := klient.CreateKlientWithDefaultOpts()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error creating klient:", err)
-		return nil, err
-	}
-
-	if err := k.Dial(); err != nil {
+	if err := c.kloud().Call("machine.list", listReq, &listRes); err != nil {
 		return nil, err
 	}
 
 	// Register machines to klient and get aliases.
-	createReq := machinegroup.CreateRequest{
+	createReq := &machinegroup.CreateRequest{
 		Addresses: make(map[kmachine.ID][]kmachine.Addr),
 	}
+	var createRes machinegroup.CreateResponse
+
 	for _, m := range listRes.Machines {
 		createReq.Addresses[kmachine.ID(m.ID)] = []kmachine.Addr{
 			{
@@ -74,12 +61,8 @@ func List(options *ListOptions) ([]*Info, error) {
 			},
 		}
 	}
-	createRaw, err := k.Tell("machine.create", createReq)
-	if err != nil {
-		return nil, err
-	}
-	createRes := machinegroup.CreateResponse{}
-	if err := createRaw.Unmarshal(&createRes); err != nil {
+
+	if err := c.klient().Call("machine.create", createReq, &createRes); err != nil {
 		return nil, err
 	}
 
@@ -160,3 +143,6 @@ var ms2State = map[machinestate.State]kmachine.State{
 func fromMachineStateString(raw string) kmachine.State {
 	return ms2State[machinestate.States[raw]]
 }
+
+// List retrieves user's machines from kloud using DefaultClient.
+func List(opts *ListOptions) ([]*Info, error) { return DefaultClient.List(opts) }

--- a/go/src/koding/klientctl/endpoint/machine/mount.go
+++ b/go/src/koding/klientctl/endpoint/machine/mount.go
@@ -161,7 +161,7 @@ func (c *Client) ListMount(options *ListMountOptions) (map[string][]sync.Info, e
 	}
 	var listMountRes machinegroup.ListMountResponse
 
-	if err := c.klient().Call("machine.mount.list", listMountReq, listMountRes); err != nil {
+	if err := c.klient().Call("machine.mount.list", listMountReq, &listMountRes); err != nil {
 		return nil, err
 	}
 

--- a/go/src/koding/klientctl/endpoint/machine/mount.go
+++ b/go/src/koding/klientctl/endpoint/machine/mount.go
@@ -14,7 +14,6 @@ import (
 	"koding/klient/machine/mount"
 	"koding/klient/machine/mount/sync"
 	"koding/klient/machine/transport/rsync"
-	"koding/klientctl/klient"
 
 	"github.com/dustin/go-humanize"
 	"github.com/koding/logging"
@@ -30,7 +29,7 @@ type MountOptions struct {
 }
 
 // Mount synchronizes directories between remote and local machines.
-func Mount(options *MountOptions) (err error) {
+func (c *Client) Mount(options *MountOptions) (err error) {
 	if options == nil {
 		return errors.New("invalid nil options")
 	}
@@ -46,27 +45,13 @@ func Mount(options *MountOptions) (err error) {
 		}
 	}()
 
-	// TODO(ppknap): this is copied from klientctl old list and will be reworked.
-	k, err := klient.CreateKlientWithDefaultOpts()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error creating klient:", err)
-		return err
-	}
-
-	if err := k.Dial(); err != nil {
-		return err
-	}
-
 	// Translate identifier to machine ID.
-	idReq := machinegroup.IDRequest{
+	idReq := &machinegroup.IDRequest{
 		Identifier: options.Identifier,
 	}
-	idRaw, err := k.Tell("machine.id", idReq)
-	if err != nil {
-		return err
-	}
-	idRes := machinegroup.IDResponse{}
-	if err := idRaw.Unmarshal(&idRes); err != nil {
+	var idRes machinegroup.IDResponse
+
+	if err := c.klient().Call("machine.id", idReq, &idRes); err != nil {
 		return err
 	}
 
@@ -76,19 +61,17 @@ func Mount(options *MountOptions) (err error) {
 		Path:       options.Path,
 		RemotePath: options.RemotePath,
 	}
+
 	// First head the remote machine directory in order to get basic mount info.
-	headMountReq := machinegroup.HeadMountRequest{
+	headMountReq := &machinegroup.HeadMountRequest{
 		MountRequest: machinegroup.MountRequest{
 			ID:    idRes.ID,
 			Mount: m,
 		},
 	}
-	headMountRaw, err := k.Tell("machine.mount.head", headMountReq)
-	if err != nil {
-		return err
-	}
-	headMountRes := machinegroup.HeadMountResponse{}
-	if err := headMountRaw.Unmarshal(&headMountRes); err != nil {
+	var headMountRes machinegroup.HeadMountResponse
+
+	if err := c.klient().Call("machine.mount.head", headMountReq, &headMountRes); err != nil {
 		return err
 	}
 
@@ -112,18 +95,15 @@ func Mount(options *MountOptions) (err error) {
 	fmt.Fprintf(os.Stdout, "Initializing mount %s...\n", m)
 
 	// Create mount.
-	addMountReq := machinegroup.AddMountRequest{
+	addMountReq := &machinegroup.AddMountRequest{
 		MountRequest: machinegroup.MountRequest{
 			ID:    idRes.ID,
 			Mount: m,
 		},
 	}
-	addMountRaw, err := k.Tell("machine.mount.add", addMountReq)
-	if err != nil {
-		return err
-	}
-	addMountRes := machinegroup.AddMountResponse{}
-	if err := addMountRaw.Unmarshal(&addMountRes); err != nil {
+	var addMountRes machinegroup.AddMountResponse
+
+	if err := c.klient().Call("machine.mount.add", addMountReq, &addMountRes); err != nil {
 		return err
 	}
 
@@ -168,34 +148,20 @@ type ListMountOptions struct {
 	Log     logging.Logger
 }
 
-// ListMount removes existing mount.
-func ListMount(options *ListMountOptions) (map[string][]sync.Info, error) {
+// ListMount lists local mounts that are known to a klient.
+func (c *Client) ListMount(options *ListMountOptions) (map[string][]sync.Info, error) {
 	if options == nil {
 		return nil, errors.New("invalid nil options")
 	}
 
-	// TODO(ppknap): this is copied from klientctl old list and will be reworked.
-	k, err := klient.CreateKlientWithDefaultOpts()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error creating klient:", err)
-		return nil, err
-	}
-
-	if err := k.Dial(); err != nil {
-		return nil, err
-	}
-
 	// List mounts.
-	listMountReq := machinegroup.ListMountRequest{
+	listMountReq := &machinegroup.ListMountRequest{
 		ID:      machine.ID(options.ID),
 		MountID: mount.ID(options.MountID),
 	}
-	listMountRaw, err := k.Tell("machine.mount.list", listMountReq)
-	if err != nil {
-		return nil, err
-	}
-	listMountRes := machinegroup.ListMountResponse{}
-	if err := listMountRaw.Unmarshal(&listMountRes); err != nil {
+	var listMountRes machinegroup.ListMountResponse
+
+	if err := c.klient().Call("machine.mount.list", listMountReq, listMountRes); err != nil {
 		return nil, err
 	}
 
@@ -209,35 +175,21 @@ type UmountOptions struct {
 }
 
 // Umount removes existing mount.
-func Umount(options *UmountOptions) (err error) {
+func (c *Client) Umount(options *UmountOptions) (err error) {
 	if options == nil {
 		return errors.New("invalid nil options")
-	}
-
-	// TODO(ppknap): this is copied from klientctl old list and will be reworked.
-	k, err := klient.CreateKlientWithDefaultOpts()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error creating klient:", err)
-		return err
-	}
-
-	if err := k.Dial(); err != nil {
-		return err
 	}
 
 	// TODO: ask user to confirm unmounting.
 	fmt.Fprintf(os.Stdout, "Unmounting %s...\n", options.Identifier)
 
 	// Remove mount.
-	umountReq := machinegroup.UmountRequest{
+	umountReq := &machinegroup.UmountRequest{
 		Identifier: options.Identifier,
 	}
-	umountRaw, err := k.Tell("machine.umount", umountReq)
-	if err != nil {
-		return err
-	}
-	umountRes := machinegroup.UmountResponse{}
-	if err := umountRaw.Unmarshal(&umountRes); err != nil {
+	var umountRes machinegroup.UmountResponse
+
+	if err := c.klient().Call("machine.umount", umountReq, &umountRes); err != nil {
 		return err
 	}
 
@@ -344,3 +296,15 @@ func drawProgress(w io.Writer, nAll, sizeAll int64) func(n, size, speed int64, e
 		}
 	}
 }
+
+// Mount synchronizes directories between remote and local machines
+// using DefaultClient.
+func Mount(opts *MountOptions) error { return DefaultClient.Mount(opts) }
+
+// ListMount lists local mounts that are known to a klient using DefaultClient.
+func ListMount(opts *ListMountOptions) (map[string][]sync.Info, error) {
+	return DefaultClient.ListMount(opts)
+}
+
+// Umount removes existing mount using DefaultClient.
+func Umount(opts *UmountOptions) error { return DefaultClient.Umount(opts) }

--- a/go/src/koding/klientctl/endpoint/machine/mount.go
+++ b/go/src/koding/klientctl/endpoint/machine/mount.go
@@ -129,10 +129,10 @@ func (c *Client) Mount(options *MountOptions) (err error) {
 		}
 
 		// Index needs to be updated after prefetching.
-		updateIndexReq := machinegroup.UpdateIndexRequest{
+		updateIndexReq := &machinegroup.UpdateIndexRequest{
 			MountID: addMountRes.MountID,
 		}
-		if _, err := k.Tell("machine.mount.updateIndex", updateIndexReq); err != nil {
+		if err := c.klient().Call("machine.mount.updateIndex", updateIndexReq, nil); err != nil {
 			fmt.Fprintf(os.Stderr, "Cannot update mount index: %s\n", err)
 		}
 	}

--- a/go/src/koding/klientctl/help.go
+++ b/go/src/koding/klientctl/help.go
@@ -29,13 +29,24 @@ var cmdDescriptions = map[string]string{
 	),
 	"mount-new": fmtDesc(
 		"(<machine-identifier>:<remote-path> <local-path> | <command>) [<options>...]",
-		fmt.Sprintf(`Mount <remote-path> from remote machine to <local-path>.
+		`Mount <remote-path> from remote machine to <local-path>.
 
    With <machine-identifier> argument, kd machine mount identifies requested machine.
    Either machine ID, machine alias or IP can be used as identifier and all of them
    can by obtained by running "kd machine list" command.
 
-   <local-path> can be relative or absolute, if the folder does not exit, it will be created.`),
+   <local-path> can be relative or absolute, if the folder does not exit, it will be created.`,
+	),
+	"exec": fmtDesc(
+		"(<local-mount-path> | @<machine-id>) <command> [<args>...]",
+		`Run <command> on a remote machine specified by either @<machine-id> or <local-mount-path>.
+
+    If <local-mount-path> is provided, kd is going to look up a remote machine
+    by reading the remote source of the mount. The mount must be active and
+    the remote end on-line.
+
+    In order to run a <command> on a remote machine that has no local mounts,
+    use @<machine-id> argument instead.`,
 	),
 	"ssh": fmtDesc(
 		"<alias>", "SSH into the machine.",

--- a/go/src/koding/klientctl/main_unix.go
+++ b/go/src/koding/klientctl/main_unix.go
@@ -2,7 +2,14 @@
 
 package main
 
-import "errors"
+import (
+	"errors"
+	"syscall"
+)
+
+func init() {
+	signals = append(signals, syscall.SIGQUIT, syscall.SIGABRT)
+}
 
 // AdminChecker is a simple interface used to determine if admin is required.
 type AdminChecker interface {


### PR DESCRIPTION
deps: ~~https://github.com/koding/koding/pull/10726 https://github.com/koding/koding/pull/10728 https://github.com/koding/koding/pull/10732~~

This PR add new implementation for `kd run` - `kd machine exec`:

```
$ kd machine exec
USAGE:
   kd machine exec (<local-mount-path> | @<machine-id>) <command> [<args>...]

DESCRIPTION
   Run <command> on a remote machine specified by either @<machine-id> or <local-mount-path>.

    If <local-mount-path> is provided, kd is going to look up a remote machine
    by reading the remote source of the mount. The mount must be active and
    the remote end on-line.

    In order to run a <command> on a remote machine that has no local mounts,
    use @<machine-id> argument instead.
```

Example usage

```
mount-dir $ kd machine exec . echo abc
```
```
~ $ kd machine exec @58a98b91a1c2df9405703226 echo abc
```