### PR TITLE
klient/mount: FUSE do not sent update change on file's Flush

### DIFF
--- a/go/src/koding/klient/machine/mount/notify/fuse/fuse.go
+++ b/go/src/koding/klient/machine/mount/notify/fuse/fuse.go
@@ -456,7 +456,10 @@ func (fs *Filesystem) FlushFile(ctx context.Context, op *fuseops.FlushFileOp) er
 		return err
 	}
 
-	return fs.update(ctx, f, nd)
+	err = f.Sync()
+	updateSize(f, nd)
+
+	return err
 }
 
 // ReleaseFileHandle releases file handle. It does not return errors even if it


### PR DESCRIPTION
`Flush` is called also on file reads which are quite frequent. Because of that, `kd machine` was always (incorrectly) informed on file updates.

## Motivation and Context
Limit synchronize operations.

## How Has This Been Tested?
Manually
