### PR TITLE
klient/machine: paths should be swapped when index change is remote

### DIFF
--- a/go/src/koding/klient/machine/transport/rsync/rsync.go
+++ b/go/src/koding/klient/machine/transport/rsync/rsync.go
@@ -113,6 +113,10 @@ func (c *Command) Run(ctx context.Context) error {
 
 		meta := c.Change.Meta()
 		c.Download = meta&index.ChangeMetaLocal == 0 && meta&index.ChangeMetaRemote != 0
+		if c.Download {
+			c.SourcePath, c.DestinationPath = c.DestinationPath, c.SourcePath
+		}
+
 		if meta&index.ChangeMetaRemove != 0 {
 			c.Cmd.Args = append(c.Cmd.Args, "--delete")
 		}

--- a/go/src/koding/klient/machine/transport/rsync/rsync_test.go
+++ b/go/src/koding/klient/machine/transport/rsync/rsync_test.go
@@ -42,27 +42,27 @@ func TestRsyncArgs(t *testing.T) {
 	}{
 		"file added locally": {
 			Meta:     index.ChangeMetaAdd | index.ChangeMetaLocal,
-			Expected: []string{"-zlptgoDd", "--include='/x.txt'", "--exclude='*'", "/src/", "usr@host:/dst/"},
+			Expected: []string{"-zlptgoDd", "--include='/x.txt'", "--exclude='*'", "/A/", "usr@host:/B/"},
 		},
 		"file updated locally": {
 			Meta:     index.ChangeMetaUpdate | index.ChangeMetaLocal,
-			Expected: []string{"-zlptgoDd", "--include='/x.txt'", "--exclude='*'", "/src/", "usr@host:/dst/"},
+			Expected: []string{"-zlptgoDd", "--include='/x.txt'", "--exclude='*'", "/A/", "usr@host:/B/"},
 		},
 		"file removed locally": {
 			Meta:     index.ChangeMetaRemove | index.ChangeMetaLocal,
-			Expected: []string{"-zlptgoDd", "--delete", "--include='/x.txt'", "--exclude='*'", "/src/", "usr@host:/dst/"},
+			Expected: []string{"-zlptgoDd", "--delete", "--include='/x.txt'", "--exclude='*'", "/A/", "usr@host:/B/"},
 		},
 		"file added remotely": {
 			Meta:     index.ChangeMetaAdd | index.ChangeMetaRemote,
-			Expected: []string{"-zlptgoDd", "--include='/x.txt'", "--exclude='*'", "usr@host:/src/", "/dst/"},
+			Expected: []string{"-zlptgoDd", "--include='/x.txt'", "--exclude='*'", "usr@host:/B/", "/A/"},
 		},
 		"file updated remotely": {
 			Meta:     index.ChangeMetaUpdate | index.ChangeMetaRemote,
-			Expected: []string{"-zlptgoDd", "--include='/x.txt'", "--exclude='*'", "usr@host:/src/", "/dst/"},
+			Expected: []string{"-zlptgoDd", "--include='/x.txt'", "--exclude='*'", "usr@host:/B/", "/A/"},
 		},
 		"file removed remotely": {
 			Meta:     index.ChangeMetaRemove | index.ChangeMetaRemote,
-			Expected: []string{"-zlptgoDd", "--delete", "--include='/x.txt'", "--exclude='*'", "usr@host:/src/", "/dst/"},
+			Expected: []string{"-zlptgoDd", "--delete", "--include='/x.txt'", "--exclude='*'", "usr@host:/B/", "/A/"},
 		},
 	}
 
@@ -74,8 +74,8 @@ func TestRsyncArgs(t *testing.T) {
 			var buf = &bytes.Buffer{}
 			cmd := &rsync.Command{
 				Cmd:             dumpArgs(buf),
-				SourcePath:      "/src",
-				DestinationPath: "/dst",
+				SourcePath:      "/A",
+				DestinationPath: "/B",
 				Username:        "usr",
 				Host:            "host",
 				Change:          index.NewChange("x.txt", test.Meta),


### PR DESCRIPTION
This PR fixes a bug in index.Change sync logic where localhost(cache) path is set to remote machine. 

## Motivation and Context
Rsync fails when trying to download a file from directory that doesn't exist on remote.

## How Has This Been Tested?
Unit tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
