### PR TITLE
klient/machine: changes should not be applied when rsync fails

### DIFF
--- a/go/src/koding/klient/machine/index/index.go
+++ b/go/src/koding/klient/machine/index/index.go
@@ -254,8 +254,9 @@ func (idx *Index) MergeBranch(root, branch string) (cs ChangeSlice) {
 
 		// Merge will not report directory updates because this means that file
 		// inside directory was added/removed and this file should be reported.
-		// Howewer we want to detect permission changes on all files.
+		// Howewer we want to detect permission changes in all files.
 		if mode.IsDir() && mode == info.Mode() {
+			entry.SwapPromise(0, EntryPromiseVirtual)
 			return
 		}
 

--- a/go/src/koding/klient/machine/mount/sync/rsync/rsync.go
+++ b/go/src/koding/klient/machine/mount/sync/rsync/rsync.go
@@ -40,6 +40,7 @@ func (e *Event) Exec() error {
 	}
 
 	var change = e.ev.Change()
+
 	err = (&rsync.Command{
 		SourcePath:      e.parent.local,
 		DestinationPath: e.parent.remote,
@@ -50,9 +51,13 @@ func (e *Event) Exec() error {
 		Change:          change,
 	}).Run(e.ev.Context())
 
+	if err != nil {
+		return err
+	}
+
 	e.parent.indexSync(change)
 
-	return err
+	return nil
 }
 
 // String implements fmt.Stringer interface. It pretty prints internal event.


### PR DESCRIPTION
This PR provides two fixes:

1) When rsync fails, it should not update index - this could remove entries from it.
2) Virtual promise was not unset from directories - this resulted in invalid index statistics.

## Motivation and Context
- invalid number of synced files after `kd machine mount list`
- disappearing files after failed rsync synchronization

## How Has This Been Tested?
Manually

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
