### PR TITLE
kd: enable new mounts

### DIFF
--- a/go/src/koding/klientctl/help.go
+++ b/go/src/koding/klientctl/help.go
@@ -14,7 +14,7 @@ var cmdDescriptions = map[string]string{
 		"<authToken>",
 		fmt.Sprintf("Install the %s. sudo is required.", config.KlientName),
 	),
-	"mount": fmtDesc(
+	"compat-mount": fmtDesc(
 		"[optional args] <alias:remote path> <local folder>",
 		fmt.Sprintf(`Mount folder from remote machine to local folder.
     Alias is the local identifer for machine in 'kd list'.
@@ -27,7 +27,7 @@ var cmdDescriptions = map[string]string{
     that does a lot of filesystem operations like git,
     use --oneway-sync.`),
 	),
-	"mount-new": fmtDesc(
+	"mount": fmtDesc(
 		"(<machine-identifier>:<remote-path> <local-path> | <command>) [<options>...]",
 		`Mount <remote-path> from remote machine to <local-path>.
 
@@ -51,11 +51,11 @@ var cmdDescriptions = map[string]string{
 	"ssh": fmtDesc(
 		"<alias>", "SSH into the machine.",
 	),
-	"unmount": fmtDesc(
+	"compat-unmount": fmtDesc(
 		"<alias>",
 		"Unmount folder which was previously mounted.",
 	),
-	"umount-new": fmtDesc(
+	"umount": fmtDesc(
 		"<mount-id>",
 		"Unmount existing mount with given ID.",
 	),

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -276,22 +276,70 @@ func run(args []string) {
 				Usage:       "Remount previously mounted machine using same settings.",
 				Description: cmdDescriptions["remount"],
 				Action:      ctlcli.ExitAction(RemountCommandFactory, log, "remount"),
-			},
 			}},
-		{
+		}, {
+			Name:  "config",
+			Usage: "Manage tool configuration.",
+			Subcommands: []cli.Command{{
+				Name:   "show",
+				Usage:  "Show configuration.",
+				Action: ctlcli.ExitErrAction(ConfigShow, log, "show"),
+				Flags: []cli.Flag{
+					cli.BoolFlag{
+						Name:  "defaults",
+						Usage: "Show also default configuration",
+					},
+					cli.BoolFlag{
+						Name:  "json",
+						Usage: "Output in JSON format.",
+					},
+				},
+			}, {
+				Name:      "list",
+				ShortName: "ls",
+				Usage:     "List all available configurations.",
+				Action:    ctlcli.ExitErrAction(ConfigList, log, "list"),
+				Flags: []cli.Flag{
+					cli.BoolFlag{
+						Name:  "json",
+						Usage: "Output in JSON format.",
+					},
+				},
+			}, {
+				Name:   "use",
+				Usage:  "Change active configuration.",
+				Action: ctlcli.ExitErrAction(ConfigUse, log, "use"),
+			}, {
+				Name:   "set",
+				Usage:  "Set a value for the given key, overwriting default one.",
+				Action: ctlcli.ExitErrAction(ConfigSet, log, "set"),
+			}, {
+				Name:   "unset",
+				Usage:  "Unset the given key, restoring the defaut value.",
+				Action: ctlcli.ExitErrAction(ConfigUnset, log, "set"),
+			}, {
+				Name:   "reset",
+				Usage:  "Resets configuration to the default value fetched from Koding.",
+				Action: ctlcli.ExitErrAction(ConfigReset, log, "reset"),
+				Flags: []cli.Flag{
+					cli.BoolFlag{
+						Name:  "force",
+						Usage: "Force retrieving configuration from Koding.",
+					},
+				},
+			}},
+		}, {
 			Name:        "version",
 			Usage:       "Display version information.",
 			HideHelp:    true,
 			Description: cmdDescriptions["version"],
 			Action:      ctlcli.ExitAction(VersionCommand, log, "version"),
-		},
-		{
+		}, {
 			Name:        "status",
 			Usage:       fmt.Sprintf("Check status of the %s.", config.KlientName),
 			Description: cmdDescriptions["status"],
 			Action:      ctlcli.ExitAction(StatusCommand, log, "status"),
-		},
-		{
+		}, {
 			Name:        "update",
 			Usage:       fmt.Sprintf("Update %s to latest version.", config.KlientName),
 			Description: cmdDescriptions["update"],
@@ -323,32 +371,27 @@ func run(args []string) {
 					Hidden: true,
 				},
 			},
-		},
-		{
+		}, {
 			Name:        "restart",
 			Usage:       fmt.Sprintf("Restart the %s.", config.KlientName),
 			Description: cmdDescriptions["restart"],
 			Action:      ctlcli.ExitAction(RestartCommand, log, "restart"),
-		},
-		{
+		}, {
 			Name:        "start",
 			Usage:       fmt.Sprintf("Start the %s.", config.KlientName),
 			Description: cmdDescriptions["start"],
 			Action:      ctlcli.ExitAction(StartCommand, log, "start"),
-		},
-		{
+		}, {
 			Name:        "stop",
 			Usage:       fmt.Sprintf("Stop the %s.", config.KlientName),
 			Description: cmdDescriptions["stop"],
 			Action:      ctlcli.ExitAction(StopCommand, log, "stop"),
-		},
-		{
+		}, {
 			Name:        "uninstall",
 			Usage:       fmt.Sprintf("Uninstall the %s.", config.KlientName),
 			Description: cmdDescriptions["uninstall"],
 			Action:      ExitWithMessage(UninstallCommand, log, "uninstall"),
-		},
-		{
+		}, {
 			Name:        "install",
 			Usage:       fmt.Sprintf("Install the %s.", config.KlientName),
 			Description: cmdDescriptions["install"],
@@ -359,14 +402,12 @@ func run(args []string) {
 				},
 			},
 			Action: ctlcli.ExitErrAction(InstallCommandFactory, log, "install"),
-		},
-		{
+		}, {
 			Name:     "metrics",
 			Usage:    fmt.Sprintf("Internal use only."),
 			HideHelp: true,
 			Action:   ctlcli.ExitAction(MetricsCommandFactory, log, "metrics"),
-		},
-		{
+		}, {
 			Name:        "autocompletion",
 			Usage:       "Enable autocompletion support for bash and fish shells",
 			Description: cmdDescriptions["autocompletion"],
@@ -390,8 +431,7 @@ func run(args []string) {
 			BashComplete: ctlcli.FactoryCompletion(
 				AutocompleteCommandFactory, log, "autocompletion",
 			),
-		},
-		{
+		}, {
 			Name:  "log",
 			Usage: "Display logs.",
 			Flags: []cli.Flag{
@@ -403,8 +443,7 @@ func run(args []string) {
 				cli.IntFlag{Name: "lines, n"},
 			},
 			Action: ctlcli.FactoryAction(LogCommandFactory, log, "log"),
-		},
-		{
+		}, {
 			Name: "open",
 			Usage: fmt.Sprintf(
 				"Open the given file(s) on the Koding UI",
@@ -450,58 +489,6 @@ func run(args []string) {
 					// command: kd auth register
 					auth.NewRegisterSubCommand(log),
 				},
-			},
-			cli.Command{
-				Name:  "config",
-				Usage: "Manage tool configuration.",
-				Subcommands: []cli.Command{{
-					Name:   "show",
-					Usage:  "Show configuration.",
-					Action: ctlcli.ExitErrAction(ConfigShow, log, "show"),
-					Flags: []cli.Flag{
-						cli.BoolFlag{
-							Name:  "defaults",
-							Usage: "Show also default configuration",
-						},
-						cli.BoolFlag{
-							Name:  "json",
-							Usage: "Output in JSON format.",
-						},
-					},
-				}, {
-					Name:      "list",
-					ShortName: "ls",
-					Usage:     "List all available configurations.",
-					Action:    ctlcli.ExitErrAction(ConfigList, log, "list"),
-					Flags: []cli.Flag{
-						cli.BoolFlag{
-							Name:  "json",
-							Usage: "Output in JSON format.",
-						},
-					},
-				}, {
-					Name:   "use",
-					Usage:  "Change active configuration.",
-					Action: ctlcli.ExitErrAction(ConfigUse, log, "use"),
-				}, {
-					Name:   "set",
-					Usage:  "Set a value for the given key, overwriting default one.",
-					Action: ctlcli.ExitErrAction(ConfigSet, log, "set"),
-				}, {
-					Name:   "unset",
-					Usage:  "Unset the given key, restoring the defaut value.",
-					Action: ctlcli.ExitErrAction(ConfigUnset, log, "set"),
-				}, {
-					Name:   "reset",
-					Usage:  "Resets configuration to the default value fetched from Koding.",
-					Action: ctlcli.ExitErrAction(ConfigReset, log, "reset"),
-					Flags: []cli.Flag{
-						cli.BoolFlag{
-							Name:  "force",
-							Usage: "Force retrieving configuration from Koding.",
-						},
-					},
-				}},
 			},
 			cli.Command{
 				Name:      "credential",

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -174,7 +174,7 @@ func run(args []string) {
 				Name:        "mount",
 				ShortName:   "m",
 				Usage:       "Mount a remote folder to a local folder.",
-				Description: cmdDescriptions["mount"],
+				Description: cmdDescriptions["compat-mount"],
 				Flags: []cli.Flag{
 					cli.StringFlag{
 						Name:  "remotepath, r",
@@ -268,7 +268,7 @@ func run(args []string) {
 				Name:        "unmount",
 				ShortName:   "u",
 				Usage:       "Unmount previously mounted machine.",
-				Description: cmdDescriptions["unmount"],
+				Description: cmdDescriptions["compat-unmount"],
 				Action:      ctlcli.FactoryAction(UnmountCommandFactory, log, "unmount"),
 			}, {
 				Name:        "remount",
@@ -453,6 +453,70 @@ func run(args []string) {
 				cli.BoolFlag{Name: "debug"},
 			},
 			Action: ctlcli.FactoryAction(OpenCommandFactory, log, "log"),
+		}, {
+			Name:         "machine",
+			Usage:        "Manage remote machines.",
+			BashComplete: func(c *cli.Context) {},
+			Subcommands: []cli.Command{{
+				Name:      "list",
+				ShortName: "ls",
+				Usage:     "List available machines.",
+				Action:    ctlcli.ExitErrAction(MachineListCommand, log, "list"),
+				Flags: []cli.Flag{
+					cli.BoolFlag{
+						Name:  "json",
+						Usage: "Output in JSON format.",
+					},
+				},
+			}, {
+				Name:      "ssh",
+				ShortName: "s",
+				Usage:     "SSH into provided remote machine.",
+				Action:    ctlcli.ExitErrAction(MachineSSHCommand, log, "ssh"),
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:  "username",
+						Usage: "Remote machine username.",
+					},
+				},
+			}, {
+				Name:        "mount",
+				Aliases:     []string{"m"},
+				Usage:       "Mount remote directory.",
+				Description: cmdDescriptions["mount"],
+				Action:      ctlcli.ExitErrAction(MachineMountCommand, log, "mount"),
+				Flags:       []cli.Flag{},
+				Subcommands: []cli.Command{{
+					Name:    "list",
+					Aliases: []string{"ls"},
+					Usage:   "List available mounts.",
+					Action:  ctlcli.ExitErrAction(MachineListMountCommand, log, "mount list"),
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "filter",
+							Usage: "Limits the output to a specific `<mount-id>`.",
+						},
+						cli.BoolFlag{
+							Name:  "json",
+							Usage: "Output in JSON format.",
+						},
+					},
+				}},
+			}, {
+				Name:        "umount",
+				ShortName:   "u",
+				Usage:       "Unmount remote directory.",
+				Description: cmdDescriptions["umount"],
+				Action:      ctlcli.ExitErrAction(MachineUmountCommand, log, "umount"),
+				Flags:       []cli.Flag{},
+			}, {
+				Name:            "exec",
+				ShortName:       "e",
+				Description:     cmdDescriptions["exec"],
+				Usage:           "Run a command in a started machine.",
+				Action:          ctlcli.ExitErrAction(MachineExecCommand, log, "exec"),
+				SkipFlagParsing: true,
+			}},
 		},
 	}
 
@@ -558,71 +622,6 @@ func run(args []string) {
 							Usage: "Specify credential provider.",
 						},
 					},
-				}},
-			},
-			cli.Command{
-				Name:         "machine",
-				Usage:        "Manage remote machines.",
-				BashComplete: func(c *cli.Context) {},
-				Subcommands: []cli.Command{{
-					Name:      "list",
-					ShortName: "ls",
-					Usage:     "List available machines.",
-					Action:    ctlcli.ExitErrAction(MachineListCommand, log, "list"),
-					Flags: []cli.Flag{
-						cli.BoolFlag{
-							Name:  "json",
-							Usage: "Output in JSON format.",
-						},
-					},
-				}, {
-					Name:      "ssh",
-					ShortName: "s",
-					Usage:     "SSH into provided remote machine.",
-					Action:    ctlcli.ExitErrAction(MachineSSHCommand, log, "ssh"),
-					Flags: []cli.Flag{
-						cli.StringFlag{
-							Name:  "username",
-							Usage: "Remote machine username.",
-						},
-					},
-				}, {
-					Name:        "mount",
-					Aliases:     []string{"m"},
-					Usage:       "",
-					Description: cmdDescriptions["mount-new"],
-					Action:      ctlcli.ExitErrAction(MachineMountCommand, log, "mount"),
-					Flags:       []cli.Flag{},
-					Subcommands: []cli.Command{{
-						Name:    "list",
-						Aliases: []string{"ls"},
-						Usage:   "List available mounts.",
-						Action:  ctlcli.ExitErrAction(MachineListMountCommand, log, "mount list"),
-						Flags: []cli.Flag{
-							cli.StringFlag{
-								Name:  "filter",
-								Usage: "Limits the output to a specific `<mount-id>`.",
-							},
-							cli.BoolFlag{
-								Name:  "json",
-								Usage: "Output in JSON format.",
-							},
-						},
-					}},
-				}, {
-					Name:        "umount",
-					ShortName:   "u",
-					Usage:       "Unmount remote directory.",
-					Description: cmdDescriptions["umount-new"],
-					Action:      ctlcli.ExitErrAction(MachineUmountCommand, log, "umount"),
-					Flags:       []cli.Flag{},
-				}, {
-					Name:            "exec",
-					ShortName:       "e",
-					Description:     cmdDescriptions["exec"],
-					Usage:           "Run a command in a started machine.",
-					Action:          ctlcli.ExitErrAction(MachineExecCommand, log, "exec"),
-					SkipFlagParsing: true,
 				}},
 			},
 			cli.Command{

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -520,6 +520,15 @@ func run(args []string) {
 		},
 	}
 
+	// Alias commands.
+	app.Commands = append(app.Commands,
+		find(app.Commands, "machine", "list"),
+		find(app.Commands, "machine", "ssh"),
+		find(app.Commands, "machine", "mount"),
+		find(app.Commands, "machine", "umount"),
+		find(app.Commands, "machine", "exec"),
+	)
+
 	if experimental {
 		app.Commands = append(app.Commands,
 			cli.Command{
@@ -765,4 +774,25 @@ func ExitWithMessage(f ExitingWithMessageCommand, log logging.Logger, cmd string
 
 		return nil
 	}
+}
+
+func find(cmds cli.Commands, names ...string) cli.Command {
+	last := len(names) - 1
+
+	for _, name := range names[:last] {
+		for _, cmd := range cmds {
+			if cmd.Name == name {
+				cmds = cmd.Subcommands
+				break
+			}
+		}
+	}
+
+	for _, cmd := range cmds {
+		if cmd.Name == names[last] {
+			return cmd
+		}
+	}
+
+	return cli.Command{}
 }


### PR DESCRIPTION
~~deps: https://github.com/koding/koding/pull/10740~~

This PR adds `kd machine` and `kd config` commands, moving `kd {ssh,ls,run,mount}` to `kd compat`.