### PR TITLE
klientctl/machine: inform user when mount synchronization didn't start due to error

### DIFF
--- a/go/src/koding/klient/machine/machinegroup/mount.go
+++ b/go/src/koding/klient/machine/machinegroup/mount.go
@@ -328,8 +328,10 @@ func (g *Group) ListMount(req *ListMountRequest) (*ListMountResponse, error) {
 		if err != nil {
 			// Add mount to the list but log not synchronized mount.
 			res.Mounts[alias] = append(res.Mounts[alias], msync.Info{
-				ID:    mountID,
-				Mount: mm.m,
+				ID:      mountID,
+				Mount:   mm.m,
+				Queued:  -1,
+				Syncing: -1,
 			})
 			g.log.Warning("Mount %s for %s is not synchronized: %s", mountID, mm.m, err)
 			continue

--- a/go/src/koding/klient/machine/mount/sync/sync.go
+++ b/go/src/koding/klient/machine/mount/sync/sync.go
@@ -278,12 +278,16 @@ func (s *Sync) FetchCmd() (count, diskSize int64, cmd *rsync.Command, err error)
 
 	// Look for git VCS.
 	if n, ok := s.idx.LookupAll(".git"); ok && n.IsDir() {
-		// Download only git data.
-		cmd.SourcePath += ".git/"
-		cmd.DestinationPath += ".git/"
+		// TODO(ppknap) Enable after https://github.com/koding/koding/issues/10750
+		// // Download only git data.
+		// cmd.SourcePath += ".git/"
+		// cmd.DestinationPath += ".git/"
 
-		count = int64(n.CountAll(-1))
-		diskSize = n.DiskSizeAll(-1)
+		// count = int64(n.CountAll(-1))
+		// diskSize = n.DiskSizeAll(-1)
+
+		count = int64(s.idx.CountAll(-1))
+		diskSize = s.idx.DiskSizeAll(-1)
 	} else {
 		count = int64(s.idx.CountAll(-1))
 		diskSize = s.idx.DiskSizeAll(-1)

--- a/go/src/koding/klientctl/machine.go
+++ b/go/src/koding/klientctl/machine.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -177,12 +178,12 @@ func getIdentifiers(c *cli.Context) (idents []string, err error) {
 	}
 
 	if len(unknown) > 0 {
-		plular := ""
+		plural := ""
 		if len(unknown) > 1 {
-			plular = "s"
+			plural = "s"
 		}
 
-		return nil, fmt.Errorf("unrecognized argument%s: %s", plular, strings.Join(unknown, ", "))
+		return nil, fmt.Errorf("unrecognized argument%s: %s", plural, strings.Join(unknown, ", "))
 	}
 
 	return idents, nil
@@ -255,20 +256,37 @@ func tabListMountFormatter(w io.Writer, mounts map[string][]sync.Info) {
 	fmt.Fprintf(tw, "ID\tMACHINE\tMOUNT\tFILES\tQUEUED\tSYNCING\tSIZE\n")
 	for alias, infos := range mounts {
 		for _, info := range infos {
-			fmt.Fprintf(tw, "%s\t%s\t%s\t%d/%d\t%d\t%d\t%s/%s\n",
+			sign := info.Syncing
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s/%s\t%s\t%s\t%s/%s\n",
 				info.ID,
 				alias,
 				info.Mount,
-				info.Count,
-				info.CountAll,
-				info.Queued,
-				info.Syncing,
-				humanize.IBytes(uint64(info.DiskSize)),
-				humanize.IBytes(uint64(info.DiskSizeAll)),
+				dashIfNegative(sign, info.Count),
+				dashIfNegative(sign, info.CountAll),
+				dashIfNegative(sign, info.Queued),
+				errorIfNegative(info.Syncing),
+				dashIfNegative(sign, humanize.IBytes(uint64(info.DiskSize))),
+				dashIfNegative(sign, humanize.IBytes(uint64(info.DiskSizeAll))),
 			)
 		}
 	}
 	tw.Flush()
+}
+
+func errorIfNegative(val int) string {
+	if val < 0 {
+		return "err"
+	}
+
+	return strconv.Itoa(val)
+}
+
+func dashIfNegative(sign int, val interface{}) string {
+	if sign < 0 {
+		return "-"
+	}
+
+	return fmt.Sprint(val)
 }
 
 func dashIfEmpty(val string) string {


### PR DESCRIPTION
If kite client fails when klient is starting, mount will not be created. This PR informs the user about the problem when he runs `kd machine mount list`


This PR also disables `.git` optimization since it needs #10750 to work properly.

## Motivation and Context
User must analyze logs to discover why mount is not visible.

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):
```sh
(archpk) {mount_sync_error} ~/koding/koding/go/src/koding/klientctl$ kdev machine mount list
ID                                    MACHINE      MOUNT                                                    FILES  QUEUED  SYNCING  SIZE
b62e1f92-bf4e-466c-bb98-f2cdf3032ce8  teal_raisin  /home/ppknap/koding -> /home/pawelknap/tmp/mount/koding  -/-    -       err      -/-
f89c0833-ce00-4c32-955a-bb45ebc322c1  teal_raisin  /home/ppknap/kite -> /home/pawelknap/tmp/mount/kite      -/-    -       err      -/-
```

## Types of changes
- [x] New feature (non-breaking change which adds functionality)