### PR TITLE
Escape dot character in regexp for subdomain requests

### DIFF
--- a/deployment/nginx.coffee
+++ b/deployment/nginx.coffee
@@ -174,7 +174,7 @@ createLocations = (KONFIG) ->
         cors = "add_header 'Access-Control-Allow-Origin' '*' always;"
       else if location.cors
         cors = """
-        if ($http_origin ~* (.*\.)*#{_.escapeRegExp KONFIG.domains.main}) {
+        if ($http_origin ~* (.*\\.)*#{_.escapeRegExp KONFIG.domains.main}) {
                 add_header Access-Control-Allow-Origin $http_origin always;
               }
         """


### PR DESCRIPTION
pcre_exec() is failing with an error with longer base domain names.

```
2017/03/13 20:19:41 [alert] 6329#6329: *76 pcre_exec() failed: -8 on "http://downtowork-szkl.koding.team" using "(.*.)*downtowork-szkl\.koding\.team", client: 212.252.164.51, server: , request: "POST /-/analytics/track HTTP/1.1", host: "downtowork-szkl.koding.team", referrer: "http://downtowork-szkl.koding.team/Team/Domain"
```

https://trac.nginx.org/nginx/browser/nginx/src/core/ngx_regex.c#L215

Line 183 in https://vcs.pcre.org/pcre/code/trunk/pcre.h.in?view=markup

```c
#define PCRE_ERROR_MATCHLIMIT       (-8)
```

Line 721-725 https://vcs.pcre.org/pcre/code/trunk/pcre_exec.c?view=markup
```c
/* First check that we haven't called match() too many times, or that we
haven't exceeded the recursive call limit. */

if (md->match_call_count++ >= md->match_limit) RRETURN(PCRE_ERROR_MATCHLIMIT);
if (rdepth >= md->match_limit_recursion) RRETURN(PCRE_ERROR_RECURSIONLIMIT);
```

Signed-off-by: Sonmez Kartal <sonmez@koding.com>