### PR TITLE
Add non-synced os-specific files to mounted volume.

### DIFF
--- a/go/src/koding/klient/machine/mount/sync/skipper.go
+++ b/go/src/koding/klient/machine/mount/sync/skipper.go
@@ -1,0 +1,109 @@
+package sync
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// DefaultSkipper contains a default set of non-synced file rules.
+var DefaultSkipper Skipper = MultiSkipper{
+	OsSkip(DirectorySkip(".Trash"), "darwin"), // OSX trash directory.
+	PathSuffixSkip(".git/index.lock"),         // git index lock file.
+}
+
+// Skipper describes a file or set of files which are not going to be synced.
+type Skipper interface {
+	// Initialize ensures object which is not going to be synced.
+	Initialize(string) error
+
+	// IsSkip tells whether Event should be skipped or not.
+	IsSkip(*Event) bool
+}
+
+// MultiSkipper is a set of rules on files that should not be synced with remote
+// machine. It contains OS specific files or entries that do not have to be sent
+// to remote machine like git index lock file etc.
+type MultiSkipper []Skipper
+
+// Initialize initializes all underlying Skippers.
+func (ms MultiSkipper) Initialize(wd string) (err error) {
+	for _, s := range ms {
+		if e := s.Initialize(wd); e != nil && err == nil {
+			err = e
+		}
+	}
+
+	return err
+}
+
+// IsSkip runs all underlying Skippers and returns true if any of them returns
+// true.
+func (ms MultiSkipper) IsSkip(ev *Event) bool {
+	for _, s := range ms {
+		if ok := s.IsSkip(ev); ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// NeverSkip implements Skipper interface. It never skips the Event.
+type NeverSkip struct{}
+
+// Initialize always returns true.
+func (NeverSkip) Initialize(_ string) error { return nil }
+
+// IsSkip never skips the evvent.
+func (NeverSkip) IsSkip(_ *Event) bool { return false }
+
+// DirectorySkip creates a directory which content will not be synced.
+type DirectorySkip string
+
+// Initialize checks if stored file exists and if it is a directory. If not
+// exist directory will be created. If not a directory, an error is returned.
+func (ds DirectorySkip) Initialize(wd string) error {
+	path := filepath.Join(wd, filepath.FromSlash(string(ds)))
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return os.MkdirAll(path, 0755)
+	}
+
+	if !info.IsDir() {
+		return errors.New("path " + path + " exists and is not a directory")
+	}
+
+	return nil
+}
+
+// IsSkip returns true for all events which are created in given path and for
+// the path itself.
+func (ds DirectorySkip) IsSkip(ev *Event) bool {
+	path := ev.Change().Path()
+	return path == string(ds) || (strings.HasPrefix(path, string(ds)) && path[len(ds):len(ds)+1] == "/")
+}
+
+// PathSuffixSkip skips all paths that end with provided suffix.
+type PathSuffixSkip string
+
+// Initialize always returns true.
+func (PathSuffixSkip) Initialize(_ string) error { return nil }
+
+// IsSkip returns true for all change paths that ends with provided suffix.
+func (pss PathSuffixSkip) IsSkip(ev *Event) bool {
+	path := ev.Change().Path()
+	return path == string(pss) || (strings.HasSuffix(path, string(pss)) && path[len(path)-len(pss)-1:len(path)-len(pss)] == "/")
+}
+
+// OsSkip returns provided skipper only when goos name matches current system. It
+// returns NeverSkip in other cases.
+func OsSkip(s Skipper, goos string) Skipper {
+	if runtime.GOOS == goos {
+		return s
+	}
+
+	return NeverSkip{}
+}

--- a/go/src/koding/klient/machine/mount/sync/skipper.go
+++ b/go/src/koding/klient/machine/mount/sync/skipper.go
@@ -83,7 +83,7 @@ func (ds DirectorySkip) Initialize(wd string) error {
 // the path itself.
 func (ds DirectorySkip) IsSkip(ev *Event) bool {
 	path := ev.Change().Path()
-	return path == string(ds) || (strings.HasPrefix(path, string(ds)) && path[len(ds):len(ds)+1] == "/")
+	return path == string(ds) || (strings.HasPrefix(path, string(ds)) && path[len(ds)] == '/')
 }
 
 // PathSuffixSkip skips all paths that end with provided suffix.
@@ -95,7 +95,7 @@ func (PathSuffixSkip) Initialize(_ string) error { return nil }
 // IsSkip returns true for all change paths that ends with provided suffix.
 func (pss PathSuffixSkip) IsSkip(ev *Event) bool {
 	path := ev.Change().Path()
-	return path == string(pss) || (strings.HasSuffix(path, string(pss)) && path[len(path)-len(pss)-1:len(path)-len(pss)] == "/")
+	return path == string(pss) || (strings.HasSuffix(path, string(pss)) && path[len(path)-len(pss)-1] == '/')
 }
 
 // OsSkip returns provided skipper only when goos name matches current system. It

--- a/go/src/koding/klient/machine/mount/sync/skipper_test.go
+++ b/go/src/koding/klient/machine/mount/sync/skipper_test.go
@@ -1,0 +1,93 @@
+package sync_test
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"koding/klient/machine/index"
+	msync "koding/klient/machine/mount/sync"
+)
+
+func TestIsSkip(t *testing.T) {
+	ctx := context.Background()
+	tests := map[string]struct {
+		Ev     *msync.Event
+		Sk     msync.Skipper
+		IsSkip bool
+	}{
+		"directory itself": {
+			Ev:     msync.NewEvent(ctx, nil, index.NewChange(".Trash", 0)),
+			Sk:     msync.DirectorySkip(".Trash"),
+			IsSkip: true,
+		},
+		"file inside directory": {
+			Ev:     msync.NewEvent(ctx, nil, index.NewChange(".Trash/file.txt", 0)),
+			Sk:     msync.DirectorySkip(".Trash"),
+			IsSkip: true,
+		},
+		"similar prefix": {
+			Ev:     msync.NewEvent(ctx, nil, index.NewChange(".Trasher/file.txt", 0)),
+			Sk:     msync.DirectorySkip(".Trash"),
+			IsSkip: false,
+		},
+		"in the middle": {
+			Ev:     msync.NewEvent(ctx, nil, index.NewChange("aa/.Trasher/file.txt", 0)),
+			Sk:     msync.DirectorySkip(".Trash"),
+			IsSkip: false,
+		},
+		"path suffix equal": {
+			Ev:     msync.NewEvent(ctx, nil, index.NewChange(".git/index.lock", 0)),
+			Sk:     msync.PathSuffixSkip(".git/index.lock"),
+			IsSkip: true,
+		},
+		"path suffix": {
+			Ev:     msync.NewEvent(ctx, nil, index.NewChange("somerepo/.git/index.lock", 0)),
+			Sk:     msync.PathSuffixSkip(".git/index.lock"),
+			IsSkip: true,
+		},
+		"path suffix part": {
+			Ev:     msync.NewEvent(ctx, nil, index.NewChange("somerepo/troll.git/index.lock", 0)),
+			Sk:     msync.PathSuffixSkip(".git/index.lock"),
+			IsSkip: false,
+		},
+		"path suffix too short": {
+			Ev:     msync.NewEvent(ctx, nil, index.NewChange("git/index.lock", 0)),
+			Sk:     msync.PathSuffixSkip(".git/index.lock"),
+			IsSkip: false,
+		},
+	}
+
+	for name, test := range tests {
+		test := test // Capture range variable.
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if isSkip := test.Sk.IsSkip(test.Ev); isSkip != test.IsSkip {
+				t.Fatalf("want isSkip = %t; got %t", test.IsSkip, isSkip)
+			}
+		})
+	}
+}
+
+func TestDirectorySkip(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "skipper")
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	var (
+		ds = msync.DirectorySkip("dir")
+	)
+
+	if err := ds.Initialize(tmpDir); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	if _, err := os.Lstat(filepath.Join(tmpDir, string(ds))); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+}

--- a/go/src/koding/klient/machine/mount/sync/skipper_test.go
+++ b/go/src/koding/klient/machine/mount/sync/skipper_test.go
@@ -19,42 +19,42 @@ func TestIsSkip(t *testing.T) {
 		IsSkip bool
 	}{
 		"directory itself": {
-			Ev:     msync.NewEvent(ctx, nil, index.NewChange(".Trash", 0)),
+			Ev:     msync.NewEvent(ctx, nil, index.NewChange(".Trash", index.PriorityMedium, 0)),
 			Sk:     msync.DirectorySkip(".Trash"),
 			IsSkip: true,
 		},
 		"file inside directory": {
-			Ev:     msync.NewEvent(ctx, nil, index.NewChange(".Trash/file.txt", 0)),
+			Ev:     msync.NewEvent(ctx, nil, index.NewChange(".Trash/file.txt", index.PriorityMedium, 0)),
 			Sk:     msync.DirectorySkip(".Trash"),
 			IsSkip: true,
 		},
 		"similar prefix": {
-			Ev:     msync.NewEvent(ctx, nil, index.NewChange(".Trasher/file.txt", 0)),
+			Ev:     msync.NewEvent(ctx, nil, index.NewChange(".Trasher/file.txt", index.PriorityMedium, 0)),
 			Sk:     msync.DirectorySkip(".Trash"),
 			IsSkip: false,
 		},
 		"in the middle": {
-			Ev:     msync.NewEvent(ctx, nil, index.NewChange("aa/.Trasher/file.txt", 0)),
+			Ev:     msync.NewEvent(ctx, nil, index.NewChange("aa/.Trasher/file.txt", index.PriorityMedium, 0)),
 			Sk:     msync.DirectorySkip(".Trash"),
 			IsSkip: false,
 		},
 		"path suffix equal": {
-			Ev:     msync.NewEvent(ctx, nil, index.NewChange(".git/index.lock", 0)),
+			Ev:     msync.NewEvent(ctx, nil, index.NewChange(".git/index.lock", index.PriorityMedium, 0)),
 			Sk:     msync.PathSuffixSkip(".git/index.lock"),
 			IsSkip: true,
 		},
 		"path suffix": {
-			Ev:     msync.NewEvent(ctx, nil, index.NewChange("somerepo/.git/index.lock", 0)),
+			Ev:     msync.NewEvent(ctx, nil, index.NewChange("somerepo/.git/index.lock", index.PriorityMedium, 0)),
 			Sk:     msync.PathSuffixSkip(".git/index.lock"),
 			IsSkip: true,
 		},
 		"path suffix part": {
-			Ev:     msync.NewEvent(ctx, nil, index.NewChange("somerepo/troll.git/index.lock", 0)),
+			Ev:     msync.NewEvent(ctx, nil, index.NewChange("somerepo/troll.git/index.lock", index.PriorityMedium, 0)),
 			Sk:     msync.PathSuffixSkip(".git/index.lock"),
 			IsSkip: false,
 		},
 		"path suffix too short": {
-			Ev:     msync.NewEvent(ctx, nil, index.NewChange("git/index.lock", 0)),
+			Ev:     msync.NewEvent(ctx, nil, index.NewChange("git/index.lock", index.PriorityMedium, 0)),
 			Sk:     msync.PathSuffixSkip(".git/index.lock"),
 			IsSkip: false,
 		},

--- a/go/src/koding/klient/machine/mount/sync/sync.go
+++ b/go/src/koding/klient/machine/mount/sync/sync.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"koding/klient/fs"
@@ -149,6 +150,10 @@ type Sync struct {
 
 	a *Anteroom // file system event consumer.
 
+	sk     Skipper       // local to remote file skippers.
+	once   sync.Once     // used for closing closeC chan.
+	closeC chan struct{} // closed when sync object is closed.
+
 	n notify.Notifier // object responsible for file system notifications.
 	s Syncer          // object responsible for actual file synchronization.
 
@@ -166,6 +171,8 @@ func NewSync(mountID mount.ID, m mount.Mount, opts Options) (*Sync, error) {
 		opts:    opts,
 		mountID: mountID,
 		m:       m,
+		sk:      DefaultSkipper,
+		closeC:  make(chan struct{}),
 	}
 
 	if opts.Log != nil {
@@ -183,6 +190,11 @@ func NewSync(mountID mount.ID, m mount.Mount, opts Options) (*Sync, error) {
 	var err error
 	if s.idx, err = s.loadIdx(IndexFileName); err != nil {
 		return nil, err
+	}
+
+	// Initialize skippers.
+	if err = s.sk.Initialize(s.CacheDir()); err != nil {
+		s.log.Warning("File local filters were not initialized: %s", err)
 	}
 
 	// Create FS event consumer queue.
@@ -218,7 +230,26 @@ func NewSync(mountID mount.ID, m mount.Mount, opts Options) (*Sync, error) {
 
 // Stream creates a stream of file synchronization jobs.
 func (s *Sync) Stream() <-chan Execer {
-	return s.s.ExecStream(s.a.Events())
+	evC := make(chan *Event)
+
+	go func() {
+		// Event loop will be closed once Anteroom is closed.
+		evSourceC := s.a.Events()
+		for ev := range evSourceC {
+			if s.sk.IsSkip(ev) {
+				ev.Done()
+				continue
+			}
+
+			select {
+			case evC <- ev:
+			case <-s.closeC:
+				return
+			}
+		}
+	}()
+
+	return s.s.ExecStream(evC)
 }
 
 // Info returns the current mount synchronization status.
@@ -305,6 +336,10 @@ func (s *Sync) Drop() error {
 
 // Close closes memory resources acquired by Sync object.
 func (s *Sync) Close() error {
+	s.once.Do(func() {
+		close(s.closeC)
+	})
+
 	return nonil(s.n.Close(), s.s.Close(), s.a.Close())
 }
 


### PR DESCRIPTION
This PR solves #10753

## Motivation and Context
Support for `.Trash` directory on OS X, skipping syncing of some files.

## How Has This Been Tested?
Unit tests

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
