### PR TITLE
klient/machine: do not try to create working dir until new mount is requested

### DIFF
--- a/go/src/koding/kites/config/cache.go
+++ b/go/src/koding/kites/config/cache.go
@@ -94,20 +94,16 @@ func KodingHome() string {
 	return home
 }
 
-// KodingCacheHome gives the path of the koding cache directory.
+// KodingMounts gives the path of the koding cache directory.
 //
-// The default value is overwritten with KODING_CACHE_HOME env,
+// The default value is overwritten with KODING_MOUNTS env,
 // if it points to a valid directory.
-func KodingCacheHome() string {
-	cache := os.Getenv("KODING_CACHE_HOME")
+func KodingMounts() string {
+	cache := os.Getenv("KODING_MOUNTS")
 
 	if fi, err := os.Stat(cache); err != nil || !fi.IsDir() {
 		cache = filepath.Join(CurrentUser.HomeDir, ".cache", "koding")
 	}
-
-	// Best-effort attempt, ignore errors.
-	_ = os.MkdirAll(cache, 0755)
-	_ = util.Chown(cache, CurrentUser.User)
 
 	return cache
 }

--- a/go/src/koding/kites/config/cache.go
+++ b/go/src/koding/kites/config/cache.go
@@ -105,6 +105,10 @@ func KodingCacheHome() string {
 		cache = filepath.Join(CurrentUser.HomeDir, ".cache", "koding")
 	}
 
+	// Best-effort attempt, ignore errors.
+	_ = os.MkdirAll(cache, 0755)
+	_ = util.Chown(cache, CurrentUser.User)
+
 	return cache
 }
 

--- a/go/src/koding/kites/config/configstore/configstore.go
+++ b/go/src/koding/kites/config/configstore/configstore.go
@@ -35,6 +35,7 @@ type Client struct {
 	Cache     *config.Cache        // if nil, a new db will be opened during each operation
 	CacheOpts *config.CacheOptions // if nil, defaultCacheOpts are going to be used
 	Home      string               // uses config.KodingHome by default
+	Mounts    string               // uses config.KodingMounts by default
 	Owner     *config.User         // uses config.CurrentUser by default
 
 	once sync.Once // for c.init()
@@ -210,6 +211,13 @@ func (c *Client) home() string {
 		return c.Home
 	}
 	return config.KodingHome()
+}
+
+func (c *Client) mounts() string {
+	if c.Mounts != "" {
+		return c.Mounts
+	}
+	return config.KodingMounts()
 }
 
 func (c *Client) owner() *config.User {

--- a/go/src/koding/kites/config/configstore/metadata.go
+++ b/go/src/koding/kites/config/configstore/metadata.go
@@ -229,7 +229,10 @@ func (c *Client) FixOwner() error {
 		return nil
 	}
 
-	return util.ChownAll(c.home(), c.owner().User)
+	return nonil(
+		util.ChownAll(c.home(), c.owner().User),
+		util.ChownAll(c.mounts(), c.owner().User),
+	)
 }
 
 func FixOwner() error                { return DefaultClient.FixOwner() }

--- a/go/src/koding/klient/app/klient.go
+++ b/go/src/koding/klient/app/klient.go
@@ -326,7 +326,7 @@ func NewKlient(conf *KlientConfig) (*Klient, error) {
 		SyncBuilder:     rsync.Builder{},
 		DynAddrInterval: 2 * time.Second,
 		PingInterval:    15 * time.Second,
-		WorkDir:         cfg.KodingCacheHome(),
+		WorkDir:         cfg.KodingMounts(),
 	}
 
 	machines, err := machinegroup.New(machinesOpts)

--- a/go/src/koding/klient/machine/machinegroup/syncs/syncs.go
+++ b/go/src/koding/klient/machine/machinegroup/syncs/syncs.go
@@ -75,10 +75,6 @@ func New(opts Options) (*Syncs, error) {
 		return nil, err
 	}
 
-	if err := os.MkdirAll(opts.WorkDir, 0755); err != nil {
-		return nil, err
-	}
-
 	s := &Syncs{
 		wd:  opts.WorkDir,
 		log: opts.Log,


### PR DESCRIPTION
This PR prevents klient from stopping on initialization phase when `.cache` directory is not accessible.

## Description
Each mount uses its own MkdirAll during initialization so the removed call is not needed anyway.

## Motivation and Context
Make klient start.

## How Has This Been Tested?
Manually
