### PR TITLE
klient/machine: get klient from pool on each machine client call

### DIFF
--- a/go/src/koding/klient/machine/client/kite.go
+++ b/go/src/koding/klient/machine/client/kite.go
@@ -5,7 +5,10 @@ import (
 	"time"
 
 	"koding/kites/kloud/klient"
+	"koding/klient/fs"
 	"koding/klient/machine"
+	"koding/klient/machine/index"
+	"koding/klient/os"
 
 	"github.com/koding/kite"
 )
@@ -43,11 +46,74 @@ func (kb *KiteBuilder) Ping(dynAddr DynamicAddrFunc) (machine.Status, machine.Ad
 // Build builds new kite client that will connect to machine using provided
 // address.
 func (kb *KiteBuilder) Build(ctx context.Context, addr machine.Addr) Client {
-	k, err := kb.pool.Get(addr.Value)
-	if err != nil {
+	if _, err := kb.pool.Get(addr.Value); err != nil {
 		return NewDisconnected(ctx)
 	}
 
-	k.SetContext(ctx)
+	return &kiteClient{
+		ctx:  ctx,
+		addr: addr.Value,
+		pool: kb.pool,
+	}
+}
+
+// kiteClient implements Client interface it uses klient from internal pool.
+type kiteClient struct {
+	ctx  context.Context
+	addr string
+	pool *klient.KlientPool
+}
+
+// CurrentUser returns remote machine current username.
+func (kc *kiteClient) CurrentUser() (string, error) {
+	return kc.get().CurrentUser()
+}
+
+// SSHAddKeys adds SSH public keys to user's authorized_keys file.
+func (kc *kiteClient) SSHAddKeys(username string, keys ...string) error {
+	return kc.get().SSHAddKeys(username, keys...)
+}
+
+// MountHeadIndex returns the number and the overall size of files in a
+// given remote directory.
+func (kc *kiteClient) MountHeadIndex(path string) (string, int, int64, error) {
+	return kc.get().MountHeadIndex(path)
+}
+
+// MountGetIndex returns an index that describes the current state of remote
+// directory.
+func (kc *kiteClient) MountGetIndex(path string) (*index.Index, error) {
+	return kc.get().MountGetIndex(path)
+}
+
+// DiskInfo gets basic information about volume pointed by provided path.
+func (kc *kiteClient) DiskInfo(path string) (fs.DiskInfo, error) {
+	return kc.get().DiskInfo(path)
+}
+
+// Exec runs a command on a remote machine.
+func (kc *kiteClient) Exec(req *os.ExecRequest) (*os.ExecResponse, error) {
+	return kc.get().Exec(req)
+}
+
+// Kill terminates previously started command on a remote machine.
+func (kc *kiteClient) Kill(req *os.KillRequest) (*os.KillResponse, error) {
+	return kc.get().Kill(req)
+}
+
+// Context returns client's Context.
+func (kc *kiteClient) Context() context.Context {
+	return kc.get().Context()
+}
+
+// Get gets klient from the pool, if an error occurs, disconnected client will
+// be returned.
+func (kc *kiteClient) get() Client {
+	k, err := kc.pool.Get(kc.addr)
+	if err != nil {
+		return NewDisconnected(kc.ctx)
+	}
+
+	k.SetContext(kc.ctx)
 	return k
 }

--- a/go/src/koding/klient/machine/client/kite.go
+++ b/go/src/koding/klient/machine/client/kite.go
@@ -46,10 +46,6 @@ func (kb *KiteBuilder) Ping(dynAddr DynamicAddrFunc) (machine.Status, machine.Ad
 // Build builds new kite client that will connect to machine using provided
 // address.
 func (kb *KiteBuilder) Build(ctx context.Context, addr machine.Addr) Client {
-	if _, err := kb.pool.Get(addr.Value); err != nil {
-		return NewDisconnected(ctx)
-	}
-
 	return &kiteClient{
 		ctx:  ctx,
 		addr: addr.Value,


### PR DESCRIPTION
This PR fixes: #10754

## Description
When klient produced by pool loses connection, it [Closes itself and removes from the pool](https://github.com/koding/koding/blob/354b39c8a7b28cf879a3e97cd9059241e331b70e/go/src/koding/kites/kloud/klient/klient.go#L96). However, machine client still reuses taken and already closed klient. Thus, producing `can't send, client is closed` error.

This PR creates a new Client wrapper that will always get klient from the pool before connection.

## Motivation and Context
Bug fix.

## How Has This Been Tested?
Manually.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
