### PR TITLE
klient/machine: remove disk info from client.

### DIFF
--- a/go/src/koding/kites/kloud/klient/klient.go
+++ b/go/src/koding/kites/kloud/klient/klient.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"koding/klient/fs"
 	"koding/klient/machine/index"
 	"koding/klient/os"
 	"koding/klient/sshkeys"
@@ -437,25 +436,6 @@ func (k *Klient) MountGetIndex(path string) (*index.Index, error) {
 	}
 
 	return resp.Index, nil
-}
-
-// DiskInfo gets basic information about volume pointed by provided path.
-func (k *Klient) DiskInfo(path string) (fs.DiskInfo, error) {
-	req := fs.GetInfoOptions{
-		Path: path,
-	}
-
-	raw, err := k.Client.TellWithTimeout("fs.getDiskInfo", k.timeout(), req)
-	if err != nil {
-		return fs.DiskInfo{}, err
-	}
-
-	resp := fs.DiskInfo{}
-	if err := raw.Unmarshal(&resp); err != nil {
-		return fs.DiskInfo{}, err
-	}
-
-	return resp, nil
 }
 
 // SetContext sets provided context to Klient.

--- a/go/src/koding/klient/machine/client/cached_test.go
+++ b/go/src/koding/klient/machine/client/cached_test.go
@@ -41,13 +41,6 @@ func TestCached(t *testing.T) {
 			},
 			Arguments: true,
 		},
-		"disk info": {
-			Method: func(i int, c client.Client) (err error) {
-				_, err = c.DiskInfo(strings.Repeat("s", i))
-				return
-			},
-			Arguments: true,
-		},
 	}
 
 	const callsN = 100

--- a/go/src/koding/klient/machine/client/client.go
+++ b/go/src/koding/klient/machine/client/client.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 
-	"koding/klient/fs"
 	"koding/klient/machine/index"
 	"koding/klient/os"
 )
@@ -23,9 +22,6 @@ type Client interface {
 	// MountGetIndex returns an index that describes the current state of remote
 	// directory.
 	MountGetIndex(string) (*index.Index, error)
-
-	// DiskInfo gets basic information about volume pointed by provided path.
-	DiskInfo(string) (fs.DiskInfo, error)
 
 	// Exec runs a command on a remote machine.
 	Exec(*os.ExecRequest) (*os.ExecResponse, error)

--- a/go/src/koding/klient/machine/client/clienttest/client.go
+++ b/go/src/koding/klient/machine/client/clienttest/client.go
@@ -9,7 +9,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"koding/klient/fs"
 	"koding/klient/machine"
 	"koding/klient/machine/client"
 	"koding/klient/machine/index"
@@ -133,20 +132,6 @@ func (c *Client) MountHeadIndex(path string) (string, int, int64, error) {
 // not cached.
 func (c *Client) MountGetIndex(path string) (*index.Index, error) {
 	return index.NewIndexFiles(path)
-}
-
-// DiskInfo gets faked information about file-system.
-func (c *Client) DiskInfo(path string) (di fs.DiskInfo, err error) {
-	// TODO(ppknap): replace with non-faked data when we have platform
-	// independent logic for disk stat operation.
-	di = fs.DiskInfo{
-		BlockSize:   512,
-		BlocksTotal: 1e9,
-		BlocksFree:  9e8,
-		BlocksUsed:  1e9 - 9e8,
-	}
-
-	return
 }
 
 // Exec mocks running process on a remote, always succeeds.

--- a/go/src/koding/klient/machine/client/disconnected.go
+++ b/go/src/koding/klient/machine/client/disconnected.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 
-	"koding/klient/fs"
 	"koding/klient/machine"
 	"koding/klient/machine/index"
 	"koding/klient/os"
@@ -66,11 +65,6 @@ func (*Disconnected) MountHeadIndex(_ string) (string, int, int64, error) {
 // MountGetIndex always returns ErrDisconnected error.
 func (*Disconnected) MountGetIndex(_ string) (*index.Index, error) {
 	return nil, ErrDisconnected
-}
-
-// DiskInfo always returns ErrDisconnected error.
-func (*Disconnected) DiskInfo(_ string) (fs.DiskInfo, error) {
-	return fs.DiskInfo{}, ErrDisconnected
 }
 
 // Exec always returns ErrDisconnected error.

--- a/go/src/koding/klient/machine/client/kite.go
+++ b/go/src/koding/klient/machine/client/kite.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"koding/kites/kloud/klient"
-	"koding/klient/fs"
 	"koding/klient/machine"
 	"koding/klient/machine/index"
 	"koding/klient/os"
@@ -80,11 +79,6 @@ func (kc *kiteClient) MountHeadIndex(path string) (string, int, int64, error) {
 // directory.
 func (kc *kiteClient) MountGetIndex(path string) (*index.Index, error) {
 	return kc.get().MountGetIndex(path)
-}
-
-// DiskInfo gets basic information about volume pointed by provided path.
-func (kc *kiteClient) DiskInfo(path string) (fs.DiskInfo, error) {
-	return kc.get().DiskInfo(path)
 }
 
 // Exec runs a command on a remote machine.

--- a/go/src/koding/klient/machine/client/supervised.go
+++ b/go/src/koding/klient/machine/client/supervised.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"koding/klient/fs"
 	"koding/klient/machine/index"
 	"koding/klient/os"
 )
@@ -74,19 +73,6 @@ func (s *Supervised) MountHeadIndex(path string) (absPath string, count int, dis
 func (s *Supervised) MountGetIndex(path string) (idx *index.Index, err error) {
 	fn := func(c Client) error {
 		idx, err = c.MountGetIndex(path)
-		return err
-	}
-
-	err = s.call(fn)
-	return
-}
-
-// DiskInfo calls registered Client's DiskInfo method and returns its result if
-// it's not produced by Disconnected client. If it is, this function will wait
-// until valid client is available or timeout is reached.
-func (s *Supervised) DiskInfo(path string) (di fs.DiskInfo, err error) {
-	fn := func(c Client) error {
-		di, err = c.DiskInfo(path)
 		return err
 	}
 

--- a/go/src/koding/klient/machine/mount/notify/notify.go
+++ b/go/src/koding/klient/machine/mount/notify/notify.go
@@ -4,13 +4,9 @@ import (
 	"context"
 	"io"
 
-	"koding/klient/fs"
 	"koding/klient/machine/index"
 	"koding/klient/machine/mount"
 )
-
-// DiskInfo retrieves information about remote directory volume.
-type DiskInfo func() (fs.DiskInfo, error)
 
 // BuildOpts represents the context that can be used by external notifiers to
 // build their own type.
@@ -20,8 +16,6 @@ type BuildOpts struct {
 
 	Cache    Cache  // index file system change consumer.
 	CacheDir string // absolute path to locally cached files.
-
-	DiskInfo DiskInfo // remote directory volume info.
 
 	Index *index.Index // known state of managed index.
 }

--- a/go/src/koding/klient/machine/mount/sync/sync.go
+++ b/go/src/koding/klient/machine/mount/sync/sync.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"koding/klient/fs"
 	"koding/klient/machine"
 	"koding/klient/machine/client"
 	"koding/klient/machine/index"
@@ -194,7 +193,6 @@ func NewSync(mountID mount.ID, m mount.Mount, opts Options) (*Sync, error) {
 		Mount:    m,
 		Cache:    s.a,
 		CacheDir: s.CacheDir(),
-		DiskInfo: s.diskInfo(),
 		Index:    s.idx,
 	})
 	if err != nil {
@@ -329,19 +327,6 @@ func (s *Sync) loadIdx(name string) (*index.Index, error) {
 
 	idx := index.NewIndex()
 	return idx, json.NewDecoder(f).Decode(idx)
-}
-
-func (s *Sync) diskInfo() notify.DiskInfo {
-	const (
-		rt = 10 * time.Second // How long client should wait for valid connection.
-		ct = 5 * time.Minute  // How long client responses will be cached.
-	)
-
-	cached := client.NewCached(client.NewSupervised(s.opts.ClientFunc, rt), ct)
-
-	return func() (fs.DiskInfo, error) {
-		return cached.DiskInfo(s.m.RemotePath)
-	}
 }
 
 func (s *Sync) indexSync() IndexSyncFunc {


### PR DESCRIPTION
`DiskInfo` method was intended to use in FUSE mounts. However, it doesn't make sense to initialize fuse with information taken from a completely different device.

Depends on: ~#10785~

## Motivation and Context
Clean up dead code.

## How Has This Been Tested?
Only removes - current unit tests pass.
