### PR TITLE
Keep mount index file updated during mount lifetime.

### DIFF
--- a/go/src/koding/klient/machine/index/entry.go
+++ b/go/src/koding/klient/machine/index/entry.go
@@ -110,10 +110,10 @@ func NewEntryFile(path string) (*Entry, error) {
 	return NewEntryFileInfo(info), nil
 }
 
-// Copy returns a deep copy of the e value.
+// Clone returns a deep copy of the e value.
 //
 // RefCount field is ignored and set to 0.
-func (e *Entry) Copy() *Entry {
+func (e *Entry) Clone() *Entry {
 	return &Entry{
 		real: realEntry{
 			CTime: e.CTime(),

--- a/go/src/koding/klient/machine/index/index.go
+++ b/go/src/koding/klient/machine/index/index.go
@@ -99,6 +99,13 @@ func (idx *Index) addEntryWorker(root string, wg *sync.WaitGroup, fC <-chan *fil
 	}
 }
 
+// Clone returns a deep copy of called index.
+func (idx *Index) Clone() *Index {
+	return &Index{
+		root: idx.root.Clone(),
+	}
+}
+
 // PromiseAdd adds a node under the given path marked as newly added.
 //
 // If mode is non-zero, the node's mode is overwritten with the value.

--- a/go/src/koding/klient/machine/index/node.go
+++ b/go/src/koding/klient/machine/index/node.go
@@ -86,6 +86,27 @@ func (nd *Node) Del(path string) {
 	}
 }
 
+// Clone creates a deep copy of node.
+func (nd *Node) Clone() *Node {
+	cpy := &Node{
+		Sub: make(map[string]*Node, len(nd.Sub)),
+	}
+
+	for sub, node := range nd.Sub {
+		if node != nil {
+			cpy.Sub[sub] = node.Clone()
+		} else {
+			cpy.Sub[sub] = nil
+		}
+	}
+
+	if nd.Entry != nil {
+		cpy.Entry = nd.Entry.Clone()
+	}
+
+	return cpy
+}
+
 // PromiseAdd adds a node under the given path marked as newly added.
 //
 // If the node already exists, it'd be only marked with EntryPromiseAdd flag.

--- a/go/src/koding/klient/machine/mount/notify/fuse/fuse.go
+++ b/go/src/koding/klient/machine/mount/notify/fuse/fuse.go
@@ -223,7 +223,7 @@ func (fs *Filesystem) Rename(ctx context.Context, op *fuseops.RenameOp) error {
 		return err
 	}
 
-	entry := oldNd.Entry.Copy()
+	entry := oldNd.Entry.Clone()
 
 	fs.mu.Lock()
 	fs.inodes[fuseops.InodeID(entry.Inode())] = newPath

--- a/go/src/koding/klient/machine/mount/sync/idxupdate.go
+++ b/go/src/koding/klient/machine/mount/sync/idxupdate.go
@@ -1,0 +1,128 @@
+package sync
+
+import (
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"koding/klient/machine"
+	"koding/klient/machine/index"
+
+	"github.com/koding/logging"
+)
+
+func init() {
+	// initialize pseudo random number generator.
+	rand.Seed(time.Now().UnixNano())
+}
+
+// IdxUpdate periodically dumps memory index to disk. Thus, it is responsible
+// for keeping memory index and locally stored one synchronized as much as
+// possible.
+//
+// Note that some changes may missing, this will not break syncing logic.
+// However, it will unnecessary trigger synchronization for these ones.
+// This type tries to minimize this effect.
+type IdxUpdate struct {
+	idx     *index.Index // synced index.
+	idxPath string       // index file path
+
+	flush time.Duration // flush interval.
+	cN    int64         // number of changes to sync.
+
+	once   sync.Once     // used for closing closeC chan.
+	closeC chan struct{} // closed when update object is closed.
+
+	log logging.Logger
+}
+
+// NewIdxUpdate creates a new index update instance.
+func NewIdxUpdate(idxPath string, idx *index.Index, flush time.Duration, log logging.Logger) *IdxUpdate {
+	iu := &IdxUpdate{
+		idx:     idx,
+		idxPath: idxPath,
+		flush:   flush,
+		closeC:  make(chan struct{}),
+		log:     log,
+	}
+
+	if iu.log == nil {
+		iu.log = machine.DefaultLogger.New("sync")
+	}
+
+	go iu.cron()
+	return iu
+}
+
+// Update synchronizes internal index and increases index synced counter.
+func (iu *IdxUpdate) Update(cacheDir string, c *index.Change) {
+	iu.idx.Sync(cacheDir, c)
+	atomic.AddInt64(&iu.cN, 1)
+}
+
+// ChangeN returns the number of changes which haven't been synchronized yet
+func (iu *IdxUpdate) ChangeN() int64 {
+	return atomic.LoadInt64(&iu.cN)
+}
+
+// Close stops index update process.
+func (iu *IdxUpdate) Close() error {
+	iu.once.Do(func() {
+		close(iu.closeC)
+	})
+
+	return nil
+}
+
+func (iu *IdxUpdate) cron() {
+	// Start cron goroutine after some portion of random time related to
+	// flush interval. This will uniformly distribute index disk flushes form
+	// many mounts.
+	select {
+	case <-time.After(iu.flush / 100 * time.Duration(rand.Intn(100))):
+	case <-iu.closeC:
+		return
+	}
+
+	var (
+		minFlush   = iu.flush / 4
+		last       = time.Now().Add(-minFlush - time.Second)
+		updateTick = time.NewTicker(iu.flush / 3)
+	)
+
+	var flush = func() {
+		cN := atomic.LoadInt64(&iu.cN)
+
+		// Nothing to update
+		if cN == 0 {
+			return
+		}
+
+		// Save index always after flush interval or when we have a lot of changes.
+		sinceUpdate := time.Since(last)
+		if (sinceUpdate < iu.flush) && !(sinceUpdate > minFlush && cN > 100) {
+			return
+		}
+
+		last = time.Now()
+		if err := index.SaveIndex(iu.idx, iu.idxPath); err != nil {
+			iu.log.Warning("Cannot update mount index file %s: %v", iu.idxPath, err)
+		} else {
+			atomic.AddInt64(&iu.cN, -cN)
+		}
+	}
+
+	for {
+		select {
+		case <-updateTick.C:
+			flush()
+		case <-iu.closeC:
+			flush()
+
+			// Stop ticker.
+			updateTick.Stop()
+			return
+		}
+	}
+}

--- a/go/src/koding/klient/machine/mount/sync/idxupdate_test.go
+++ b/go/src/koding/klient/machine/mount/sync/idxupdate_test.go
@@ -1,0 +1,63 @@
+package sync_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"koding/klient/machine/index"
+	msync "koding/klient/machine/mount/sync"
+)
+
+func TestIdxUpdateFlush(t *testing.T) {
+	path, err := createTmpFile()
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	defer os.Remove(path)
+
+	var (
+		idx = index.NewIndex()
+		iu  = msync.NewIdxUpdate(path, idx, 100*time.Millisecond, nil)
+		c   = index.NewChange("not/important", index.PriorityHigh, index.ChangeMetaAdd)
+	)
+	defer iu.Close()
+
+	iu.Update(os.TempDir(), c)
+	if err := waitForZeroChanges(iu, 2*time.Second); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+}
+
+func createTmpFile() (string, error) {
+	f, err := ioutil.TempFile("", "sync.update.index")
+	if err != nil {
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		return "", err
+	}
+
+	return f.Name(), nil
+}
+
+func waitForZeroChanges(iu *msync.IdxUpdate, timeout time.Duration) error {
+	var (
+		ticker   = time.NewTicker(5 * time.Millisecond)
+		timeoutC = time.After(timeout)
+	)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if cN := iu.ChangeN(); cN == 0 {
+				return nil
+			}
+		case <-timeoutC:
+			return fmt.Errorf("timed out after %s", timeout)
+		}
+	}
+}


### PR DESCRIPTION
Solves: #10751

## Motivation and Context
Currently, index file has only one state created during first mount process. All changes made later are not applied to it. This PR solves this problem.

## How Has This Been Tested?
Unit tests.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
