### PR TITLE
klient/machine: unsync all poped events, even these deprecated

### DIFF
--- a/go/src/koding/klient/machine/mount/sync/anteroom.go
+++ b/go/src/koding/klient/machine/mount/sync/anteroom.go
@@ -201,7 +201,12 @@ func (a *Anteroom) detach(path string, id uint64) {
 	defer a.mu.Unlock()
 
 	if ev, ok := a.evs[path]; ok && ev.ID() == id {
-		atomic.AddInt64(&a.synced, -1)
+		a.unsync()
 		delete(a.evs, path)
 	}
+}
+
+// unsync is called by event which is considered done.
+func (a *Anteroom) unsync() {
+	atomic.AddInt64(&a.synced, -1)
 }

--- a/go/src/koding/klient/machine/mount/sync/event.go
+++ b/go/src/koding/klient/machine/mount/sync/event.go
@@ -99,6 +99,8 @@ func (e *Event) Done() {
 			e.parent.detach(e.change.Path(), e.id)
 		}
 		e.cancel()
+	} else if e.parent != nil {
+		e.parent.unsync()
 	}
 }
 


### PR DESCRIPTION
Without this change `kd machine mount list` could display misleading information about
SYNCed files.

## Description
Some file synchronization events may become invalid after they are poped from the queue(changing sync directon etc). We mark these changes deprecated so they will not be run(if possible). However when we pop form the queue we increase Sync counter. Which was decreased only for non deprecated events but should be always. 

## Motivation and Context
Incorrect information about mounts.

## How Has This Been Tested?
Manually.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)


