### PR TITLE
klient/machine: disable sync(2) test calls on CI environments

### DIFF
--- a/go/src/koding/klient/machine/index/indextest/indextest_unix.go
+++ b/go/src/koding/klient/machine/index/indextest/indextest_unix.go
@@ -2,11 +2,17 @@
 
 package indextest
 
-import "syscall"
+import (
+	"os"
+	"syscall"
+)
 
 // Sync causes all buffered modifications to file metadata and data to be
 // written to the underlying file systems. This function must be called in order
 // to not receive false negative test results.
 func Sync() {
-	syscall.Sync()
+	// Disable sync(2) test calls on continuous integration environments.
+	if os.Getenv("CI") == "" {
+		syscall.Sync()
+	}
 }


### PR DESCRIPTION
for unknown reason `sync(2)` may hang on dockerized environments. We probably don't need this call there. Thus, this PR disables it.

/cc @szkl 

## Motivation and Context
Attempt to fix timeouts on CI: eg. https://circleci.com/gh/koding/koding/1271

## How Has This Been Tested?
Unit test change.
