### PR TITLE
Show is canceling step in Subscription cancel modal

### DIFF
--- a/client/component-lab/CancelSubscriptionModal/CancelSubscriptionModal.coffee
+++ b/client/component-lab/CancelSubscriptionModal/CancelSubscriptionModal.coffee
@@ -7,7 +7,7 @@ styles = require './CancelSubscriptionModal.stylus'
 
 module.exports = CancelSubscriptionModal = (props) ->
 
-  { isOpen, onConfirm, onCancel } = props
+  { isCanceling, isOpen, onConfirm, onCancel } = props
 
   modalProps =
     showAlien: no
@@ -15,6 +15,10 @@ module.exports = CancelSubscriptionModal = (props) ->
     onRequstClose: onCancel
     width: 'xlarge'
     height: 'tall'
+
+  primaryTitle = if isCanceling
+  then 'Canceling...'
+  else 'Yes, Cancel Subscription'
 
   <Modal {...modalProps}>
     <Header title='Cancel Subscription' />
@@ -24,7 +28,9 @@ module.exports = CancelSubscriptionModal = (props) ->
       </div>
       <div>
         <Label size="large" type="danger">
-          <strong style={fontWeight: 'bold'}>You are about to cancel your team’s subscription</strong>
+          <strong style={fontWeight: 'bold'}>
+            You are about to cancel your team’s subscription
+          </strong>
         </Label>
       </div>
       <div style={lineHeight: '20px'}>
@@ -36,7 +42,8 @@ module.exports = CancelSubscriptionModal = (props) ->
       </div>
     </Content>
     <Footer
-      primaryButtonTitle='Yes, Cancel Subscription'
+      disabled={isCanceling}
+      primaryButtonTitle={primaryTitle}
       primaryButtonSize='medium'
       onPrimaryButtonClick={onConfirm}
       secondaryButtonTitle='Close'

--- a/client/component-lab/Modal/Modal.coffee
+++ b/client/component-lab/Modal/Modal.coffee
@@ -67,13 +67,19 @@ exports.Footer = Modal.Footer = (props) ->
   <div className={styles.footer}>
     <div className={styles.footerContainer}>
 
-      <Button type={secondaryButtonType} size={primaryButtonSize} onClick={onSecondaryButtonClick}>
-        {secondaryButtonTitle}
-      </Button>
+      <Button
+        disabled={props.disabled}
+        type={secondaryButtonType}
+        size={primaryButtonSize}
+        onClick={onSecondaryButtonClick}
+        children={secondaryButtonTitle} />
 
-      <Button type={primaryButtonType} size={secondaryButtonSize} onClick={onPrimaryButtonClick}>
-        {primaryButtonTitle}
-      </Button>
+      <Button
+        disabled={props.disabled}
+        type={primaryButtonType}
+        size={secondaryButtonSize}
+        onClick={onPrimaryButtonClick}
+        children={primaryButtonTitle} />
 
     </div>
   </div>

--- a/client/component-lab/Modal/Modal.coffee
+++ b/client/component-lab/Modal/Modal.coffee
@@ -42,6 +42,7 @@ Modal.defaultProps =
   width: 'large'
   height: 'normal'
   showAlien: no
+  contentLabel: ''
 
 
 exports.Header = Modal.Header = ({ title }) ->

--- a/client/home/lib/billing/components/paymentsection.coffee
+++ b/client/home/lib/billing/components/paymentsection.coffee
@@ -20,6 +20,7 @@ module.exports = class PaymentSection extends React.Component
     @state =
       hasSuccessModal: no
       hasCancelSubModal: no
+      isCanceling: no
 
 
   onSubmit: -> @_form.getWrappedInstance().submit()
@@ -41,9 +42,10 @@ module.exports = class PaymentSection extends React.Component
     @setState { hasCancelSubModal: no }
 
 
-  onCancelSubSuccess: ->
-    @setState { hasCancelSubModal: no }
-    @props.onCancelSubscription()
+  onCancelSubConfirm: ->
+    @setState { isCanceling: yes }
+    @props.onCancelSubscription().catch =>
+      @setState { isCanceling: no }
 
 
   onInviteMembers: ->
@@ -63,7 +65,7 @@ module.exports = class PaymentSection extends React.Component
       onResetForm, onCancelSubscription
       onMessageClose, onPaymentHistory } = @props
 
-    { hasSuccessModal, hasCancelSubModal, formVisible } = @state
+    { hasSuccessModal, hasCancelSubModal, formVisible, isCanceling } = @state
 
     buttonTitle = switch
       when submitting then 'SAVING...'
@@ -81,15 +83,18 @@ module.exports = class PaymentSection extends React.Component
         {message and
           <PaymentSectionMessage {...message} onCloseClick={onMessageClose} />}
 
-        <SubscriptionSuccessModal
-          isOpen={hasSuccessModal}
-          onCancel={=> @onSuccessModalClose()}
-          onInviteMembersClick={=> @onInviteMembers()} />
+        {hasSuccessModal and
+          <SubscriptionSuccessModal
+            isOpen={yes}
+            onCancel={=> @onSuccessModalClose()}
+            onInviteMembersClick={=> @onInviteMembers()} /> }
 
-        <CancelSubscriptionModal
-          isOpen={hasCancelSubModal}
-          onCancel={=> @onCancelSubCancel()}
-          onConfirm={=> @onCancelSubSuccess()} />
+        {hasCancelSubModal and
+          <CancelSubscriptionModal
+            isOpen={yes}
+            isCanceling={isCanceling}
+            onCancel={=> @onCancelSubCancel()}
+            onConfirm={=> @onCancelSubConfirm()} /> }
 
         {hasCard and
           <CardInfo

--- a/client/home/lib/billing/components/paymentsection.coffee
+++ b/client/home/lib/billing/components/paymentsection.coffee
@@ -18,6 +18,7 @@ module.exports = class PaymentSection extends React.Component
     super props
 
     @state =
+      hasSuccessModal: no
       hasCancelSubModal: no
 
 

--- a/client/home/lib/billing/components/paymentsectioncontainer.coffee
+++ b/client/home/lib/billing/components/paymentsectioncontainer.coffee
@@ -82,9 +82,9 @@ mapDispatchToProps = (dispatch) ->
       dispatch(resetForm(FORM_NAME))
     onCancelSubscription: ->
       dispatch(stripe.resetLastAction())
-      dispatch(subscription.remove()).then ->
-        dispatch(creditCard.remove()).then ->
-          location.reload()
+      dispatch(subscription.remove())
+        .then -> dispatch(creditCard.remove())
+        .then -> location.reload()
     onPaymentHistory: ->
       dispatch(stripe.resetLastAction())
       kd.singletons.router.handleRoute '/Home/payment-history'


### PR DESCRIPTION
Provides a better ux by showing canceling state via changing the title of confirm button on `CancelSubscriptionModal`

## Description
Previously we were not showing any feedback to user, by simply closing the modal and not showing any info, and reloading the window while there seems to be nothing running on the screen. This PR aims to resolve this issue by not closing the modal while making the cancel request, and let it reload as before once it's successful. We basically don't allow user to do anything before cancel request is ended. If there is an error the button will return to the default state.

![ux-cancel-sub](https://cloud.githubusercontent.com/assets/1783869/24195544/d9f2a99e-0f02-11e7-98a2-6bd3198303bc.gif)
