### PR TITLE
kites: update koding/kite and revert sub check

### DIFF
--- a/go/src/glide.lock
+++ b/go/src/glide.lock
@@ -557,7 +557,7 @@ imports:
   - helpers
   - services
 - name: github.com/koding/kite
-  version: 1ed804424233a8f6d7ec9fdef092b16200101617
+  version: cdd66cedbdf88da7755d890de22d9d6a16642323
   subpackages:
   - config
   - dnode

--- a/go/src/koding/kites/config/kite.go
+++ b/go/src/koding/kites/config/kite.go
@@ -38,6 +38,7 @@ func ReadKiteConfig(debug bool) (*config.Config, error) {
 // server and client connections for use with koding kites.
 func NewKiteConfig(debug bool) *config.Config {
 	cfg := config.New()
+
 	// cfg.Websocket.EnableCompression = true
 	cfg.Client = httputil.Client(debug)
 	cfg.XHR = httputil.ClientXHR(debug)

--- a/go/src/koding/klient/app/klient.go
+++ b/go/src/koding/klient/app/klient.go
@@ -584,7 +584,9 @@ func (k *Klient) handleWithSub(method string, fn kite.HandlerFunc) {
 			return nil, err
 		}
 
-		if !team.Paid {
+		// TODO(rjeczalik): enable after rolling out kloud support first
+		// if !team.Paid {
+		if !team.IsSubActive(k.config.Environment) {
 			k.log.Error("Method %q is blocked due to unpaid subscription for %s team.", method, team.Name)
 			return nil, errors.New("method is blocked")
 		}

--- a/go/src/koding/klient/app/klient.go
+++ b/go/src/koding/klient/app/klient.go
@@ -324,6 +324,7 @@ func NewKlient(conf *KlientConfig) (*Klient, error) {
 		Type: "kiteKey",
 		Key:  k.Config.KiteKey,
 	}
+	c.Reconnect = true
 
 	kloud := &apiutil.LazyKite{
 		Client: c,

--- a/go/src/koding/klient/registration/registration.go
+++ b/go/src/koding/klient/registration/registration.go
@@ -65,6 +65,7 @@ func Register(koding *url.URL, username, token string, debug bool) error {
 	}
 
 	kontrol := k.NewClient(newKonfig.Endpoints.Kontrol().Public.String())
+
 	if err := kontrol.DialTimeout(30 * time.Second); err != nil {
 		return err
 	}

--- a/go/src/koding/klient/tunnel/vbox.go
+++ b/go/src/koding/klient/tunnel/vbox.go
@@ -283,6 +283,7 @@ func (t *Tunnel) dialHostKite(addr string) (*kite.Client, error) {
 		Type: "kiteKey",
 		Key:  t.opts.Kite.Config.KiteKey,
 	}
+	client.Reconnect = true
 
 	if err := client.DialTimeout(7 * time.Second); err != nil {
 		return nil, err

--- a/go/src/koding/klientctl/endpoint/kloud/kloud.go
+++ b/go/src/koding/klientctl/endpoint/kloud/kloud.go
@@ -190,6 +190,7 @@ func (kt *KiteTransport) client() (*kite.Client, error) {
 
 func (kt *KiteTransport) newClient(url string) (*kite.Client, error) {
 	k := kt.kite().NewClient(url)
+	k.Reconnect = true
 
 	if err := k.DialTimeout(kt.dialTimeout()); err != nil {
 		return nil, err

--- a/go/src/vendor/github.com/koding/kite/config/transport.go
+++ b/go/src/vendor/github.com/koding/kite/config/transport.go
@@ -6,6 +6,7 @@ type Transport int
 const (
 	WebSocket = iota
 	XHRPolling
+	Auto
 )
 
 func (t Transport) String() string {
@@ -14,6 +15,8 @@ func (t Transport) String() string {
 		return "WebSocket"
 	case XHRPolling:
 		return "XHRPolling"
+	case Auto:
+		return "auto"
 	default:
 		return "UnkownKiteTransport"
 	}
@@ -22,4 +25,5 @@ func (t Transport) String() string {
 var Transports = map[string]Transport{
 	"WebSocket":  WebSocket,
 	"XHRPolling": XHRPolling,
+	"auto":       Auto,
 }

--- a/go/src/vendor/github.com/koding/kite/kontrol/kontrol.go
+++ b/go/src/vendor/github.com/koding/kite/kontrol/kontrol.go
@@ -189,7 +189,8 @@ func NewWithoutHandlers(conf *config.Config, version string) *Kontrol {
 		conf.VerifyFunc = k.Verify
 	}
 
-	k.Kite = kite.NewWithConfig("kontrol", version, conf)
+	k.Kite = kite.New("kontrol", version)
+	k.Kite.Config = conf
 	k.log = k.Kite.Log
 
 	return k

--- a/go/src/vendor/github.com/koding/kite/kontrol/kontrol_test.go
+++ b/go/src/vendor/github.com/koding/kite/kontrol/kontrol_test.go
@@ -345,7 +345,7 @@ func TestTokenInvalidation(t *testing.T) {
 	}
 
 	if oldToken == token {
-		t.Errorf("want %q == %q", oldToken, token)
+		t.Errorf("want %q != %q", oldToken, token)
 	}
 
 	time.Sleep(time.Millisecond * 700)

--- a/go/src/vendor/github.com/koding/kite/sockjsclient/xhr_test.go
+++ b/go/src/vendor/github.com/koding/kite/sockjsclient/xhr_test.go
@@ -1,0 +1,93 @@
+package sockjsclient
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net"
+	"testing"
+	"time"
+)
+
+type fakeReader struct {
+	err error
+	p   chan []byte
+}
+
+func (fk *fakeReader) Read(p []byte) (int, error) {
+	q, ok := <-fk.p
+	if !ok {
+		if fk.err == nil {
+			return 0, io.EOF
+		}
+		return 0, fk.err
+	}
+	if len(q) > len(p) {
+		panic(io.ErrShortBuffer)
+	}
+	return copy(p, q), nil
+}
+
+func TestFrameReader(t *testing.T) {
+	const timeout = 100 * time.Millisecond
+
+	var (
+		doWrite = func(fk *fakeReader, p []byte, _ error) {
+			fk.p <- p
+			close(fk.p)
+		}
+		doTimeout = func(fk *fakeReader, p []byte, _ error) {
+			time.AfterFunc(2*timeout, func() {
+				fk.p <- p
+				close(fk.p)
+			})
+		}
+		doError = func(fk *fakeReader, _ []byte, err error) {
+			fk.err = err
+			close(fk.p)
+		}
+	)
+
+	cases := map[string]struct {
+		write func(*fakeReader, []byte, error)
+		p     []byte
+		err   error
+	}{
+		"session open":         {doWrite, []byte{'o'}, nil},
+		"session open timeout": {doTimeout, []byte{'o'}, ErrPollTimeout},
+		"session open error":   {doError, []byte{'o'}, &net.AddrError{}},
+		"message":              {doWrite, []byte(`m"hello world"`), nil},
+		"message timeout":      {doTimeout, []byte(`m"hello world"`), ErrPollTimeout},
+		"message error":        {doError, []byte(`m"hello world"`), &net.AddrError{}},
+	}
+
+	for name, cas := range cases {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			fk := &fakeReader{
+				p: make(chan []byte, 1),
+			}
+
+			fr := &frameReader{
+				r:       bufio.NewReader(fk),
+				timeout: timeout,
+			}
+
+			cas.write(fk, cas.p, cas.err)
+
+			p, err := ioutil.ReadAll(fr)
+			if cas.err != nil {
+				if err != cas.err {
+					t.Fatalf("got %v, want %v", err, cas.err)
+				}
+
+				return
+			}
+
+			if bytes.Compare(p, cas.p) != 0 {
+				t.Fatalf("got %q, want %q", p, cas.p)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR update koding/kite and it also reverts then Paid check, as server support (kloud) should be deployed first. And in order to deploy kloud, we need to deploy klient first. Thus the change.  