### PR TITLE
Create a Higher-order Component to connect with compute controller & storage

### DIFF
--- a/.coffeelintignore
+++ b/.coffeelintignore
@@ -11,6 +11,7 @@ client/app/lib/providers/computeeventlistener.coffee
 client/app/lib/providers/computehelpers.coffee
 client/app/lib/providers/computestatechecker.coffee
 client/app/lib/providers/environmentsmachinestatemodal.coffee
+client/app/lib/providers/connectcompute.coffee
 client/app/lib/react
 client/app/lib/routehandler.coffee
 client/app/lib/shortcuts/accounteditshortcutsrow.coffee

--- a/client/app/lib/providers/computestorage.coffee
+++ b/client/app/lib/providers/computestorage.coffee
@@ -173,9 +173,8 @@ module.exports = class ComputeStorage extends kd.Object
 
     postPush?.call this, value
 
-    @emit 'change', @storage
+    @emit 'change', { operation: 'push', type, value }
     @emit "change:#{type}", { operation: 'push', value }
-
 
     return value
 
@@ -202,7 +201,7 @@ module.exports = class ComputeStorage extends kd.Object
 
     postPop?.call this, value
 
-    @emit 'change', @storage
+    @emit 'change', { operation: 'pop', type, value }
     @emit "change:#{type}", { operation: 'pop', value }
 
     debug 'after pop', @storage

--- a/client/app/lib/providers/computestorage.coffee
+++ b/client/app/lib/providers/computestorage.coffee
@@ -23,6 +23,10 @@ module.exports = class ComputeStorage extends kd.Object
         machines.map (machine) ->
           if machine.ಠ_ಠ then machine else remote.revive machine
 
+      postPush: -> @emit 'change'
+      postPop: -> @emit 'change'
+
+
     stacks       :
       collection : 'JComputeStack'
       payload    : 'userStacks'
@@ -31,6 +35,7 @@ module.exports = class ComputeStorage extends kd.Object
           @pop 'machines', '_id', machine._id  for machine in cached.machines
 
       postPop    : (stackId) ->
+        @emit 'change'
         { reactor } = kd.singletons
         reactor.dispatch actions.REMOVE_STACK, stackId
 
@@ -38,6 +43,7 @@ module.exports = class ComputeStorage extends kd.Object
         @push 'machines', machine  for machine in stack.machines
 
       postPush   : (stack) ->
+        @emit 'change'
         { reactor } = kd.singletons
         reactor.dispatch actions.LOAD_USER_ENVIRONMENT_SUCCESS, stack.machines
         reactor.dispatch actions.LOAD_USER_STACKS_SUCCESS, [ stack ]
@@ -62,8 +68,14 @@ module.exports = class ComputeStorage extends kd.Object
       prePush    : (template) ->
         template.on 'update', kd.noop
 
+      postPush: -> @emit 'change'
+      postPop: -> @emit 'change'
+
     credentials  :
       collection : 'JCredential'
+
+      postPush: -> @emit 'change'
+      postPop: -> @emit 'change'
 
 
   constructor: ->
@@ -245,4 +257,5 @@ module.exports = class ComputeStorage extends kd.Object
     for item, index in (@get type)
       if item._id is key
         _.extend @storage[type][index], value
+        @emit 'change'
         return @storage[type][index]

--- a/client/app/lib/providers/connectcompute.coffee
+++ b/client/app/lib/providers/connectcompute.coffee
@@ -1,0 +1,65 @@
+React = require 'app/react'
+kd = require 'kd'
+
+# FIXME: so naive, but works for now.
+makeSingular = (plural) -> plural.slice 0, -1
+
+
+module.exports = connectCompute = (config) -> (WrappedComponent) ->
+
+  class ConnectedCompute extends React.Component
+
+    constructor: (props) ->
+      super props
+
+      @handlers = null
+      @events = {}
+
+      { storage } = kd.singletons.computeController
+
+      state = config.require.reduce (acc, pluralName) ->
+        singularName = makeSingular pluralName
+        # if we pass stackId, machineId or templateId our wrapped component will
+        # receive a prop named stack, machine, template.
+        if resourceId = props["#{singularName}Id"]
+          acc[singularName] = storage.get(pluralName, '_id', resourceId)
+
+        # no matter what, return the full resource just incase the component
+        # wants to use all items for some calculation.
+        acc[pluralName] = storage.get(pluralName)
+
+        return acc
+
+      , {}
+
+      @state = Object.assign(state, props)
+
+    componentDidMount: ->
+
+      { computeController } = kd.singletons
+      { controllerEvents } = config
+
+      Object.keys(controllerEvents).forEach (resource) =>
+        return  unless resourceId = @props["#{resource}Id"]
+
+        handlers = controllerEvents[resource]
+        Object.keys(handlers).forEach (eventName) =>
+          eventId = "#{eventName}-#{resourceId}"
+          return  if @events[eventId]
+
+          @events[eventId] = (event) =>
+            newState = handlers[eventName](event)
+            @setState newState
+
+          computeController.on eventId, @events[eventId]
+
+    componentWillUnmount: ->
+
+      { computeController } = kd.singletons
+
+      Object.keys(@events).forEach (eventId) =>
+        computeController.off eventId, @events[eventId]
+        delete @events[eventId]
+
+    render: ->
+      <WrappedComponent {...@state} />

--- a/client/app/lib/providers/connectcompute.coffee
+++ b/client/app/lib/providers/connectcompute.coffee
@@ -8,14 +8,14 @@ makeSingular = (plural) -> plural.slice 0, -1
 
 makeState = (config, props) ->
 
-  unless config.require
+  unless config.storage
     console.warning \
-      'You need to specify the requirements via `require` config option.'
+      'You need to specify the requirements via `storage` config option.'
     return {}
 
   { storage } = kd.singletons.computeController
 
-  state = config.require.reduce (acc, pluralName) ->
+  state = config.storage.reduce (acc, pluralName) ->
     singularName = makeSingular pluralName
     # if we pass stackId, machineId or templateId our wrapped component will
     # receive a prop named stack, machine, template.

--- a/client/app/lib/providers/connectcompute.coffee
+++ b/client/app/lib/providers/connectcompute.coffee
@@ -8,7 +8,10 @@ makeSingular = (plural) -> plural.slice 0, -1
 
 makeState = (config, props) ->
 
-  return {}  unless config.require
+  unless config.require
+    console.warning \
+      'You need to specify the requirements via `require` config option.'
+    return {}
 
   { storage } = kd.singletons.computeController
 

--- a/client/app/lib/providers/connectcompute.coffee
+++ b/client/app/lib/providers/connectcompute.coffee
@@ -9,7 +9,7 @@ makeSingular = (plural) -> plural.slice 0, -1
 makeState = (config, props) ->
 
   unless config.storage
-    console.warning \
+    console.warn \
       'You need to specify the requirements via `storage` config option.'
     return {}
 

--- a/client/app/lib/providers/connectcompute.coffee
+++ b/client/app/lib/providers/connectcompute.coffee
@@ -47,13 +47,17 @@ module.exports = connectCompute = (config) -> (WrappedComponent) ->
       return shallowCompare this, nextProps, nextState
 
 
+    onStorageUpdate: ->
+
+      @setState makeState config, @props
+
+
     componentDidMount: ->
 
       { computeController } = kd.singletons
       { controllerEvents } = config
 
-      computeController.storage.on 'change', =>
-        @setState makeState config, @props
+      computeController.storage.on 'change', @bound 'onStorageUpdate'
 
       Object.keys(controllerEvents).forEach (resource) =>
         return  unless resourceId = @props["#{resource}Id"]
@@ -73,6 +77,8 @@ module.exports = connectCompute = (config) -> (WrappedComponent) ->
     componentWillUnmount: ->
 
       { computeController } = kd.singletons
+
+      computeController.storage.off 'change', @bound 'onStorageUpdate'
 
       Object.keys(@events).forEach (eventId) =>
         computeController.off eventId, @events[eventId]

--- a/client/package.json
+++ b/client/package.json
@@ -57,6 +57,7 @@
     "pluralize": "3.1.0",
     "raf": "3.3.0",
     "react": "15.4.2",
+    "react-addons-shallow-compare": "15.4.2",
     "react-autocomplete": "1.4.0",
     "react-dom": "15.4.2",
     "react-flexbox-grid": "0.10.2",


### PR DESCRIPTION
connectCompute can be used as a component creating function
to connect compute storage as well as computeController events.

```coffee
ConnectedComponent = connectCompute { ... }, OriginalComponent
```

## Description

This function can be used to create components which uses directly the compute storage, and can bind to the events emitted by compute controller.

### Example

Following example is how i am using this component to provide info to `SidebarMachineItem`.

```coffee
connectCompute = require 'app/providers/connectcompute'

MachineItemContainer = require './container'

module.exports = SidebarMachinesListItem = connectCompute({
  storage: ['machines']
  defaultProps: {
    percentage: 0
    status: ''
  }
  controllerEvents: {
    stack: {
      apply: ({ status, percentage }) -> { status, percentage }
    }
    machine: {
      public: ({ status, percentage }) -> { status, percentage }
    }
  }
})(MachineItemContainer)
```

Simply we provide a `config` object, and our simple component to the function it returns, which will provide information as `props` to our components. There is a little bit amount of *magic* happening here to ensure without writing too much, we can easily connect storage to our components.

- In `storage` we define which collection from storage is needed by the consuming component:

```coffee
OriginalComponent = ({ machines, machine }) ->
  <div>
    <div>There are {machines.length} machines in storage.</div>
    <div>Machine label: {machine?.getLabel()}</div>
  </div>

ConnectedComponent = connectCompute({
  storage: ['machines']
})(OriginalComponent)
```
- This is gonna simply provide `computeStorage.get 'machines'` as `@props.machines` to the connected component.
- But if we provide a `machineId` (name is important) to the connected component, it will also make sure that `computeStorage.get 'machines, '_id', @props.machineId` is provided as `@props.machine` to the connected component as well.

```coffee
<ConnectedComponent />
# generated html:
#   <div>
#     <div>There are 3 machines in storage.</div>
#     <div>Machine label: undefined</div>
#  </div>

# let's assume machineId points to a machine we know it exists in storage,
# if not it's gonna simply be the same as above.
<ConnectedComponent machineId={machineId} />
# generated html:
#   <div>
#     <div>There are 3 machines in storage.</div>
#     <div>Machine label: aws-instance</div>
#  </div>
```

### Listening compute controller events

We need to provide `controllerEvents` config (the name is to make it explicit that it's coming from the compute controller):

```coffee
config = {
  storage: ['machines']
  controllerEvents: {
    machine: {
      public: ({ status, percentage }) -> { status, percentage }
    }
  }
}
```

- It's gonna bind the provided event handler to `computeController.on "public-{@props.machineId}"` event
- It's gonna provide the returned result from this handler to the connected component. 

_In the above example it's gonna provide `@props.status` and `@props.percentage` to the connected component after each time this event is emitted by compute controller._

If we extend the above example:

```coffee
# we are now accepting percentage and status as well.
OriginalComponent = ({ machines, machine, percentage, status }) ->
  <div>
    <div>There are {machines.length} machines in storage.</div>
    <div>Machine label: {machine?.getLabel()}</div>
    <div>percentage: {percentage}, status: {status}</div>
  </div>

ConnectedComponent = connectCompute({
  storage: ['machines']
  controllerEvents: {
    machine: {
      public: ({ status, percentage }) -> { status, percentage }
    }
  }
})(OriginalComponent)
```

It still doesn't support async calls, so if you are planning to do something async in the event handlers and want to pass it down, there is no way to do that. But I am planning to add `Promise` support so that if we return a promise from the handler, it will wait for promise to be resolved and pass down the resolved result to the component as long as it's an object that can be merged to the old props.

## Motivation and Context

Since `connectCompute` actually returns a function which can be used as a decorator to another component, we can use this to share functionality (eg: showing progress bar in vm section of dashboard would be possible by using the exact same configured function for `SidebarMachineItem`)

Also this Higher-order components is the widely common in the React community, which makes it easier for a person who knows how to connect a redux store to a component to use this connector function (thus `connectCompute` reflects the `connect` function of `react-redux` package)

This also eliminates the risks of not cleaning after ourselves by automatically cleaning up all the event listeners while a connected component is unmounted from DOM.

_Note that this is still in development mode since i only want to provide an easy and clean way to what i need to do, we should improve its functionality as we go on with the new requirements (async supporting, providing default props in a clean way, etc)_

/cc @koding/frontend 