### PR TITLE
Stacktemplate::clone improvements

### DIFF
--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -723,7 +723,22 @@ module.exports = class JStackTemplate extends Module
     success: (client, options, callback) ->
 
       [ options, callback ] = [ callback, options ]  unless callback
-      options          ?= {}
+      options ?= {}
+
+      { connection: { delegate }, context: { group } } = client
+
+      hasAccess = yes
+
+      if @getAt('accessLevel') is 'private'
+        if @getAt('originId') isnt delegate.getId()
+          hasAccess = no
+
+      else if @getAt('accessLevel') is 'group'
+        if @getAt('group') isnt group
+          hasAccess = no
+
+      unless hasAccess
+        return callback new KodingError 'Access denied'
 
       cloneData         =
         slug            : @getAt 'slug'

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.test.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.test.coffee
@@ -538,6 +538,171 @@ runTests = -> describe 'workers.social.models.computeproviders.stacktemplate', -
             expect(clonedTemplate.config.clonedSum)  .to.be.equal stackTemplate.template.sum
             done()
 
+
+    describe 'should support different access levels', ->
+
+      describe 'when accessLevel is private', ->
+
+        it 'should deny cloning by other users in same group', (done) ->
+
+          withConvertedUserAndStackTemplate (data) ->
+            { client, stackTemplate } = data
+            groupSlug = client.context.group
+
+            withConvertedUser { groupSlug }, (data) ->
+
+              { client } = data
+              stackTemplate.clone client, (err, clonedTemplate) ->
+                expect(err).to.exist
+                expect(clonedTemplate).to.not.exist
+                done()
+
+        it 'should deny cloning by other users in different groups', (done) ->
+
+          withConvertedUserAndStackTemplate (data) ->
+            { client, stackTemplate } = data
+            groupSlug = generateRandomString()
+
+            withConvertedUser { groupSlug }, (data) ->
+
+              { client } = data
+              stackTemplate.clone client, (err, clonedTemplate) ->
+                expect(err).to.exist
+                expect(clonedTemplate).to.not.exist
+                done()
+
+        it 'should allow cloning by owner', (done) ->
+
+          withConvertedUserAndStackTemplate (data) ->
+            { client, stackTemplate } = data
+
+            stackTemplate.clone client, (err, clonedTemplate) ->
+              expect(err)                              .to.not.exist
+              expect(clonedTemplate)                   .to.exist
+              expect(clonedTemplate.title)             .to.be.equal "#{stackTemplate.title} - clone"
+              expect(clonedTemplate.config.clonedFrom) .to.be.equal stackTemplate._id
+              expect(clonedTemplate.config.clonedSum)  .to.be.equal stackTemplate.template.sum
+              done()
+
+
+      describe 'when accessLevel is group', ->
+
+        it 'should allow cloning by other users in same group', (done) ->
+
+          withConvertedUserAndStackTemplate (data) ->
+            { client, stackTemplate } = data
+
+            stackTemplate.setAccess client, 'group', (err) ->
+              expect(err).to.not.exist
+
+              groupSlug = client.context.group
+              withConvertedUser { groupSlug }, (data) ->
+
+                { client } = data
+
+                stackTemplate.clone client, (err, clonedTemplate) ->
+                  expect(err)                              .to.not.exist
+                  expect(clonedTemplate)                   .to.exist
+                  expect(clonedTemplate.title)             .to.be.equal "#{stackTemplate.title} - clone"
+                  expect(clonedTemplate.config.clonedFrom) .to.be.equal stackTemplate._id
+                  expect(clonedTemplate.config.clonedSum)  .to.be.equal stackTemplate.template.sum
+                  done()
+
+        it 'should deny cloning by other users in different groups', (done) ->
+
+          withConvertedUserAndStackTemplate (data) ->
+            { client, stackTemplate } = data
+
+            stackTemplate.setAccess client, 'group', (err) ->
+              expect(err).to.not.exist
+
+              groupSlug = generateRandomString()
+              withConvertedUser { groupSlug }, (data) ->
+
+                { client } = data
+
+                stackTemplate.clone client, (err, clonedTemplate) ->
+                  expect(err).to.exist
+                  expect(clonedTemplate).to.not.exist
+                  done()
+
+        it 'should allow cloning by owner', (done) ->
+
+          withConvertedUserAndStackTemplate (data) ->
+            { client, stackTemplate } = data
+
+            stackTemplate.setAccess client, 'group', (err) ->
+              expect(err).to.not.exist
+
+              stackTemplate.clone client, (err, clonedTemplate) ->
+                expect(err)                              .to.not.exist
+                expect(clonedTemplate)                   .to.exist
+                expect(clonedTemplate.title)             .to.be.equal "#{stackTemplate.title} - clone"
+                expect(clonedTemplate.config.clonedFrom) .to.be.equal stackTemplate._id
+                expect(clonedTemplate.config.clonedSum)  .to.be.equal stackTemplate.template.sum
+                done()
+
+      describe 'when accessLevel is public', ->
+
+        it 'should allow cloning by other users in same group', (done) ->
+
+          withConvertedUserAndStackTemplate (data) ->
+            { client, stackTemplate } = data
+
+            stackTemplate.setAccess client, 'public', (err) ->
+              expect(err).to.not.exist
+
+              groupSlug = client.context.group
+              withConvertedUser { groupSlug }, (data) ->
+
+                { client } = data
+
+                stackTemplate.clone client, (err, clonedTemplate) ->
+                  expect(err)                              .to.not.exist
+                  expect(clonedTemplate)                   .to.exist
+                  expect(clonedTemplate.title)             .to.be.equal "#{stackTemplate.title} - clone"
+                  expect(clonedTemplate.config.clonedFrom) .to.be.equal stackTemplate._id
+                  expect(clonedTemplate.config.clonedSum)  .to.be.equal stackTemplate.template.sum
+                  done()
+
+        it 'should allow cloning by other users in different groups', (done) ->
+
+          withConvertedUserAndStackTemplate (data) ->
+            { client, stackTemplate } = data
+
+            stackTemplate.setAccess client, 'public', (err) ->
+              expect(err).to.not.exist
+
+              groupSlug = generateRandomString()
+              withConvertedUser { groupSlug, createGroup: yes }, (data) ->
+
+                { client } = data
+
+                stackTemplate.clone client, (err, clonedTemplate) ->
+                  expect(err)                              .to.not.exist
+                  expect(clonedTemplate)                   .to.exist
+                  expect(clonedTemplate.title)             .to.be.equal "#{stackTemplate.title} - clone"
+                  expect(clonedTemplate.config.clonedFrom) .to.be.equal stackTemplate._id
+                  expect(clonedTemplate.config.clonedSum)  .to.be.equal stackTemplate.template.sum
+                  done()
+
+        it 'should allow cloning by owner', (done) ->
+
+          withConvertedUserAndStackTemplate (data) ->
+            { client, stackTemplate } = data
+
+            stackTemplate.setAccess client, 'public', (err) ->
+              expect(err).to.not.exist
+
+              stackTemplate.clone client, (err, clonedTemplate) ->
+                expect(err)                              .to.not.exist
+                expect(clonedTemplate)                   .to.exist
+                expect(clonedTemplate.title)             .to.be.equal "#{stackTemplate.title} - clone"
+                expect(clonedTemplate.config.clonedFrom) .to.be.equal stackTemplate._id
+                expect(clonedTemplate.config.clonedSum)  .to.be.equal stackTemplate.template.sum
+                done()
+
+
 beforeTests()
 
 runTests()


### PR DESCRIPTION
JStackTemplate::clone should respect the `accessLevel` based on the requester session data, active group etc. related with #10906 

```
JStackTemplate::clone()
  when user doesnt have the permission
    ✓ should fail to clone a stacktemplate (121ms)
  when user has the permission
    ✓ should be able to clone a stacktemplate (153ms)
  should support different access levels
    when accessLevel is private
      ✓ should deny cloning by other users in same group (235ms)
      ✓ should deny cloning by other users in different groups (210ms)
      ✓ should allow cloning by owner (146ms)
    when accessLevel is group
      ✓ should allow cloning by other users in same group (289ms)
      ✓ should deny cloning by other users in different groups (251ms)
      ✓ should allow cloning by owner (149ms)
    when accessLevel is public
      ✓ should allow cloning by other users in same group (239ms)
      ✓ should allow cloning by other users in different groups (357ms)
      ✓ should allow cloning by owner (149ms)
```