### PR TITLE
klient/machine: adding new nodes to unmarshaled index panics with 'assignment to entry in nil map'

### DIFF
--- a/go/src/koding/klient/machine/index/node.go
+++ b/go/src/koding/klient/machine/index/node.go
@@ -398,6 +398,8 @@ func split(path string) (string, string) {
 	return path, ""
 }
 
+var _ json.Unmarshaler = (*Node)(nil)
+
 // UnmarshalJSON satisfies json.Unmarshaler interface. It initializes empty sub
 // map when it's omitted in serialized data.
 //

--- a/go/src/koding/klient/machine/index/node.go
+++ b/go/src/koding/klient/machine/index/node.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,7 +16,7 @@ import (
 // Lookup, Count methods. Deleting such nodes is a nop.
 // This is how Node implements shallow delete.
 type Node struct {
-	Sub   map[string]*Node `json:"d,omitempty"`
+	Sub   map[string]*Node `json:"d"`
 	Entry *Entry           `json:"e,omitempty"`
 }
 
@@ -395,4 +396,24 @@ func split(path string) (string, string) {
 	}
 
 	return path, ""
+}
+
+// UnmarshalJSON satisfies json.Unmarshaler interface. It initializes empty sub
+// map when it's omitted in serialized data.
+//
+// Note: this is a fixing function that was created due to `omitempty` tag
+// in Node's sub field.
+func (nd *Node) UnmarshalJSON(data []byte) error {
+	type tmp Node
+
+	tnd := tmp{}
+	if err := json.Unmarshal(data, &tnd); err != nil {
+		return err
+	}
+
+	if *nd = Node(tnd); nd.Sub == nil {
+		nd.Sub = make(map[string]*Node)
+	}
+
+	return nil
 }

--- a/go/src/koding/klient/machine/index/node_test.go
+++ b/go/src/koding/klient/machine/index/node_test.go
@@ -1,6 +1,7 @@
 package index_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"sort"
@@ -18,15 +19,19 @@ func fixture() *index.Node {
 				Sub: map[string]*index.Node{
 					"addresser.go": {
 						Entry: index.NewEntry(714, 0),
+						Sub:   map[string]*index.Node{},
 					},
 					"addresses.go": {
 						Entry: index.NewEntry(2428, 0),
+						Sub:   map[string]*index.Node{},
 					},
 					"addresses_test.go": {
 						Entry: index.NewEntry(3095, 0),
+						Sub:   map[string]*index.Node{},
 					},
 					"cached.go": {
 						Entry: index.NewEntry(2036, 0),
+						Sub:   map[string]*index.Node{},
 					},
 				},
 			},
@@ -35,15 +40,19 @@ func fixture() *index.Node {
 				Sub: map[string]*index.Node{
 					"aliaser.go": {
 						Entry: index.NewEntry(596, 0),
+						Sub:   map[string]*index.Node{},
 					},
 					"aliases.go": {
 						Entry: index.NewEntry(3218, 0),
+						Sub:   map[string]*index.Node{},
 					},
 					"aliases_test.go": {
 						Entry: index.NewEntry(1831, 0),
+						Sub:   map[string]*index.Node{},
 					},
 					"cached.go": {
 						Entry: index.NewEntry(2196, 0),
+						Sub:   map[string]*index.Node{},
 					},
 				},
 			},
@@ -52,72 +61,95 @@ func fixture() *index.Node {
 				Sub: map[string]*index.Node{
 					"clients.go": {
 						Entry: index.NewEntry(4003, 0),
+						Sub:   map[string]*index.Node{},
 					},
 					"clients_test.go": {
 						Entry: index.NewEntry(1783, 0),
+						Sub:   map[string]*index.Node{},
 					},
 				},
 			},
 			"create.go": {
 				Entry: index.NewEntry(3660, 0),
+				Sub:   map[string]*index.Node{},
 			},
 			"create_test.go": {
 				Entry: index.NewEntry(4582, 0),
+				Sub:   map[string]*index.Node{},
 			},
 			"id.go": {
 				Entry: index.NewEntry(1272, 0),
+				Sub:   map[string]*index.Node{},
 			},
 			"id_test.go": {
 				Entry: index.NewEntry(1979, 0),
+				Sub:   map[string]*index.Node{},
 			},
 			"idset": {
 				Entry: index.NewEntry(0, 0),
 				Sub: map[string]*index.Node{
 					"idset.go": {
 						Entry: index.NewEntry(1288, 0),
+						Sub:   map[string]*index.Node{},
 					},
 					"idset_test.go": {
 						Entry: index.NewEntry(4231, 0),
+						Sub:   map[string]*index.Node{},
 					},
 				},
 			},
+			"empty": {
+				Entry: index.NewEntry(0, 0),
+				Sub:   map[string]*index.Node{},
+			},
 			"kite.go": {
 				Entry: index.NewEntry(4152, 0),
+				Sub:   map[string]*index.Node{},
 			},
 			"machinegroup.go": {
 				Entry: index.NewEntry(6839, 0),
+				Sub:   map[string]*index.Node{},
 			},
 			"machinegroup_test.go": {
 				Entry: index.NewEntry(6592, 0),
+				Sub:   map[string]*index.Node{},
 			},
 			"mount.go": {
 				Entry: index.NewEntry(9346, 0),
+				Sub:   map[string]*index.Node{},
 			},
 			"mount_test.go": {
 				Entry: index.NewEntry(8824, 0),
+				Sub:   map[string]*index.Node{},
 			},
 			"mounts": {
 				Entry: index.NewEntry(0, 0),
 				Sub: map[string]*index.Node{
 					"cached.go": {
 						Entry: index.NewEntry(2465, 0),
+						Sub:   map[string]*index.Node{},
 					},
 					"mounter.go": {
 						Entry: index.NewEntry(1000, 0),
+						Sub:   map[string]*index.Node{},
 					},
 					"mounts.go": {
 						Entry: index.NewEntry(4133, 0),
+						Sub:   map[string]*index.Node{},
 					},
 					"mounts_test.go": {
 						Entry: index.NewEntry(5330, 0),
+						Sub:   map[string]*index.Node{},
 					},
 				},
 			},
 			"ssh.go": {
 				Entry: index.NewEntry(2831, 0),
+				Sub:   map[string]*index.Node{},
 			},
 			"ssh_test.go": {
 				Entry: index.NewEntry(3567, 0),
+				Sub:   map[string]*index.Node{},
 			},
 		},
 	}
@@ -154,10 +186,10 @@ func TestNodeLookup(t *testing.T) {
 
 func TestNodeCount(t *testing.T) {
 	cases := map[int64]int{
-		-1:   33,
+		-1:   34,
 		0:    0,
-		4000: 23,
-		6000: 29,
+		4000: 24,
+		6000: 30,
 	}
 
 	root := fixture()
@@ -199,14 +231,14 @@ func TestNodeAdd(t *testing.T) {
 		name  string
 		count int
 	}{
-		{"addresses/cached_test.go", 34},
-		{"notify.go", 35},
-		{"notify/notify.go", 37},
-		{"proxy/fuse/fuse.go", 40},
-		{"notify", 40},   // no-op
-		{"notify/", 40},  // no-op
-		{"/notify/", 40}, // no-op
-		{"/notify", 40},  // no-op
+		{"addresses/cached_test.go", 35},
+		{"notify.go", 36},
+		{"notify/notify.go", 38},
+		{"proxy/fuse/fuse.go", 41},
+		{"notify", 41},   // no-op
+		{"notify/", 41},  // no-op
+		{"/notify/", 41}, // no-op
+		{"/notify", 41},  // no-op
 	}
 
 	root := fixture()
@@ -239,13 +271,13 @@ func TestNodeDel(t *testing.T) {
 		name  string
 		count int
 	}{
-		{"addresses/addresser.go", 32},
-		{"addresses/", 28},
-		{"aliases", 23},
-		{"id.go", 22},
-		{"id.go", 22},          // no-op
-		{"nonexisting.go", 22}, // no-op
-		{"/kite.go", 21},
+		{"addresses/addresser.go", 33},
+		{"addresses/", 29},
+		{"aliases", 24},
+		{"id.go", 23},
+		{"id.go", 23},          // no-op
+		{"nonexisting.go", 23}, // no-op
+		{"/kite.go", 22},
 	}
 
 	root := fixture()
@@ -287,6 +319,7 @@ func TestNodeForEach(t *testing.T) {
 		"clients/clients_test.go",
 		"create.go",
 		"create_test.go",
+		"empty",
 		"id.go",
 		"id_test.go",
 		"idset",
@@ -316,5 +349,23 @@ func TestNodeForEach(t *testing.T) {
 
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestNodeMarshalJSON(t *testing.T) {
+	root := fixture()
+
+	data, err := json.Marshal(root)
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	node := &index.Node{}
+	if err := json.Unmarshal(data, node); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	if !reflect.DeepEqual(root, node) {
+		t.Fatalf("want:\n%#v\ngot\n%#v\n", root, node)
 	}
 }


### PR DESCRIPTION
All `node.Sub` entries inside index are initialized with empty maps. However when index is marshalled and unmarshalled again empty maps are skipped and replaced by `nil` ones. This is caused due to `omitempty` tag in `Node` structure.

From godoc:
```
The "omitempty" option specifies that the field should be omitted from the encoding
if the field has an empty value, defined as false, 0, a nil pointer, a nil interface
value, and any empty array, slice, map, or string.
```

Using nil maps will panic when eg. unmarshalled empty directory gets its first file:

```
panic: assignment to entry in nil map

goroutine 40 [running]:
panic(0x1219e00, 0xc420338910)
	/usr/lib/go/src/runtime/panic.go:500 +0x1a1
koding/klient/machine/index.(*Node).Add(0xc42044b0f0, 0x0, 0x0, 0xc4202b6300)
	/home/pawelknap/koding/koding/go/src/koding/klient/machine/index/node.go:51 +0x1ac
koding/klient/machine/index.(*Node).PromiseAdd(0xc42050dc20, 0xc42049d84e, 0x2e, 0xc4202b62d0)
	/home/pawelknap/koding/koding/go/src/koding/klient/machine/index/node.go:132 +0xc0
koding/klient/machine/index.(*Index).MergeBranch.func2(0xc42049d800, 0x7c, 0x1bc4600, 0xc420621a00, 0x0, 0x0, 0x0, 0x0)
	/home/pawelknap/koding/koding/go/src/koding/klient/machine/index/index.go:317 +0x205
path/filepath.walk(0xc42049d800, 0x7c, 0x1bc4600, 0xc420621a00, 0xc420409f80, 0x0, 0x0)
	/usr/lib/go/src/path/filepath/path.go:351 +0x81
path/filepath.walk(0xc42049d580, 0x77, 0x1bc4600, 0xc420621930, 0xc420409f80, 0x0, 0x0)
	/usr/lib/go/src/path/filepath/path.go:376 +0x344
path/filepath.walk(0xc4202bf810, 0x70, 0x1bc4600, 0xc420621860, 0xc420409f80, 0x0, 0x0)
	/usr/lib/go/src/path/filepath/path.go:376 +0x344
path/filepath.walk(0xc4202befc0, 0x63, 0x1bc4600, 0xc420620820, 0xc420409f80, 0x0, 0x0)
	/usr/lib/go/src/path/filepath/path.go:376 +0x344
path/filepath.walk(0xc420256a20, 0x5b, 0x1bc4600, 0xc4208372b0, 0xc420409f80, 0x0, 0x0)
	/usr/lib/go/src/path/filepath/path.go:376 +0x344
path/filepath.walk(0xc4204362a0, 0x54, 0x1bc4600, 0xc420807c70, 0xc420409f80, 0x0, 0x0)
	/usr/lib/go/src/path/filepath/path.go:376 +0x344
path/filepath.walk(0xc420178b40, 0x4d, 0x1bc4600, 0xc420807860, 0xc420409f80, 0x0, 0xc4205f9d01)
	/usr/lib/go/src/path/filepath/path.go:376 +0x344
path/filepath.Walk(0xc420178b40, 0x4d, 0xc420409f80, 0xc42064fc8f, 0xc42035d320)
	/usr/lib/go/src/path/filepath/path.go:398 +0xd5
koding/klient/machine/index.(*Index).MergeBranch(0xc4201c1620, 0xc420178aa0, 0x4d, 0x0, 0x0, 0x48, 0x141015a, 0x4)
	/home/pawelknap/koding/koding/go/src/koding/klient/machine/index/index.go:323 +0x2ae
koding/klient/machine/index.(*Index).Merge(0xc4201c1620, 0xc420178aa0, 0x4d, 0x24, 0xc42031c708, 0x1bb8401)
	/home/pawelknap/koding/koding/go/src/koding/klient/machine/index/index.go:204 +0x51
koding/klient/machine/mount/sync.(*Sync).UpdateIndex(0xc420344690)
	/home/pawelknap/koding/koding/go/src/koding/klient/machine/mount/sync/sync.go:285 +0x58
koding/klient/machine/machinegroup.(*Group).mountSync.func1(0xc42050db80, 0xc42054bf20, 0x24, 0xc42054bef0, 0x21, 0xc42050d920, 0xf, 0xc420550c00, 0xc4201c1420, 0x18, ...)
	/home/pawelknap/koding/koding/go/src/koding/klient/machine/machinegroup/machinegroup.go:272 +0x382
created by koding/klient/machine/machinegroup.(*Group).mountSync
	/home/pawelknap/koding/koding/go/src/koding/klient/machine/machinegroup/machinegroup.go:273 +0x244
```

## Motivation and Context
Bug fix

## How Has This Been Tested?
Unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
