### PR TITLE
NSE: Template title, cloned from and load improvements

### DIFF
--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -996,7 +996,10 @@ module.exports = class ComputeController extends KDController
 
     remote.api.JStackTemplate.some query, options, (err, templates) =>
       return callback err  if err
-      @storage.set 'templates', templates
+
+      for template in templates
+        @storage.templates.push template
+
       callback null, templates
 
 

--- a/client/app/lib/providers/computestorage.coffee
+++ b/client/app/lib/providers/computestorage.coffee
@@ -121,6 +121,10 @@ module.exports = class ComputeStorage extends kd.Object
     debug 'query requested', type, key, value
 
     if items = @storage[type]
+
+      [ key, value ] = [ value, key ]  unless value
+      key ?= '_id'
+
       res = items
         .map (item) ->
           return item  if item and (item.getAt?(key) ? item[key]) is value
@@ -135,6 +139,9 @@ module.exports = class ComputeStorage extends kd.Object
 
     if not key and not value
       return @storage[type] ? []
+
+    [ key, value ] = [ value, key ]  unless value
+    key ?= '_id'
 
     if items = @storage[type]
       for item in items when (item and (item.getAt?(key) ? item[key]) is value)

--- a/client/app/lib/remote-extensions/stacktemplate.coffee
+++ b/client/app/lib/remote-extensions/stacktemplate.coffee
@@ -41,12 +41,12 @@ module.exports = class JStackTemplate extends remote.api.JStackTemplate
 
 
   @one = ->
-    console.warn 'JStackTemplate.one will be deprecated!'
+    debug 'JStackTemplate.one will be deprecated!'
     super
 
 
   @some = ->
-    console.warn 'JStackTemplate.some will be deprecated!'
+    debug 'JStackTemplate.some will be deprecated!'
     super
 
 

--- a/client/new-stack-editor/lib/controllers/editor.coffee
+++ b/client/new-stack-editor/lib/controllers/editor.coffee
@@ -71,3 +71,20 @@ module.exports = class EditorController extends BaseController
     return if convertedDoc.err
     then [ 'Failed to convert YAML to JSON, fix the document and try again.' ]
     else [ null, convertedDoc ]
+
+
+  updateTitle: (title) ->
+
+    @getData().update { title }, (err, updatedTemplate) =>
+
+      if err
+        @logs.handleError err
+        options    =
+          message  : 'Failed to update title! Check logs for more information.'
+          showlogs : yes
+      else
+        options    =
+          message  : 'Template title updated successfully!'
+          autohide : 1500
+
+      @emit Events.WarnUser, options

--- a/client/new-stack-editor/lib/controllers/logs.coffee
+++ b/client/new-stack-editor/lib/controllers/logs.coffee
@@ -77,10 +77,7 @@ module.exports = class LogsController extends BaseController
 
     @emit Events.WarnUser, {
       message : 'An error ocurred please check logs.'
-      action  :
-        title : 'Show Logs'
-        event : Events.Menu.Logs
-      autohide: if @editor.isClosed() then no else 1500
+      showlogs: yes
     }
 
     if err.name is 'Internal'

--- a/client/new-stack-editor/lib/events.coffee
+++ b/client/new-stack-editor/lib/events.coffee
@@ -5,6 +5,7 @@ module.exports = do ->
   events = [
     'CredentialChangesRevertRequested'
     'CredentialChangesSaveRequested'
+    'TemplateTitleChangeRequested'
     'CredentialSelectionChanged'
     'CredentialFilterChanged'
     'SelectedProviderChanged'

--- a/client/new-stack-editor/lib/events.coffee
+++ b/client/new-stack-editor/lib/events.coffee
@@ -17,6 +17,7 @@ module.exports = do ->
     'LazyLoadFinished'
     'LazyLoadStarted'
     'ToggleSideView'
+    'LoadClonedFrom'
     'ShowSideView'
     'HideWarning'
     'WarnUser'

--- a/client/new-stack-editor/lib/index.coffee
+++ b/client/new-stack-editor/lib/index.coffee
@@ -45,7 +45,7 @@ module.exports = class StackEditorAppController extends AppController
     super options, data
 
     @templates = {}
-    @mainView.addSubView @stackEditor = new StackEditor
+    @mainView.addSubView @stackEditor = new StackEditor { cssClass: 'initial' }
 
     @stackEditor.on Events.InitializeRequested, @bound 'initializeStack'
 
@@ -59,6 +59,8 @@ module.exports = class StackEditorAppController extends AppController
       return callback { message: 'No template provided' }
 
     @fetchStackTemplate templateId, (err, template) =>
+
+      @stackEditor.unsetClass 'initial'
 
       if err
         showError err

--- a/client/new-stack-editor/lib/styl/main.styl
+++ b/client/new-stack-editor/lib/styl/main.styl
@@ -192,6 +192,13 @@ $stack-border-width         = 2px
     border-left             $stack-border-width solid $stack-border-color
     border-right            $stack-border-width solid $stack-border-color
     borderBox()
+    .toolbar, .content, .statusbar
+      opacity               1
+
+  .initial
+    .mainview
+      .toolbar, .content, .statusbar
+        opacity             0
 
   .statusbar
     background              $stack-border-color !important

--- a/client/new-stack-editor/lib/styl/main.styl
+++ b/client/new-stack-editor/lib/styl/main.styl
@@ -83,14 +83,24 @@ $stack-border-width         = 2px
     .kdbutton.expand
       abs                   13px, 120px !important
 
-    h3
+    .title-input
+      padding               0
+      width                 auto
+
+      font-size             13px
+      line-height           14px
+      background            none
+      border                none
+      color                 #eee
+
       display               inline-block
       margin-left           10px
       max-width             calc(100% - 360px)
-      text-overflow         ellipsis
-      overflow              hidden
-      white-space           nowrap
       vertical-align        middle
+
+      &:hover, &:focus
+        border              none
+        box-shadow          none
 
     cite.stack
       fa                    server

--- a/client/new-stack-editor/lib/styl/main.styl
+++ b/client/new-stack-editor/lib/styl/main.styl
@@ -125,6 +125,9 @@ $stack-border-width         = 2px
         background          #727272
         cursor              default
 
+      &.clone
+        display             none
+
     cite.credential
       fa                    cog
       margin-left           -10px
@@ -176,10 +179,13 @@ $stack-border-width         = 2px
       .tag.credential
         vendor              animation, shake .6s
 
+    &.clone
+      .tag.clone
+        display             inline-block
+
     &.has-message
       height                80px
       min-height            80px !important
-
 
   .content
     background              $stack-bg-color

--- a/client/new-stack-editor/lib/views/index.coffee
+++ b/client/new-stack-editor/lib/views/index.coffee
@@ -139,6 +139,8 @@ module.exports = class StackEditor extends kd.View
 
   handleActions: (event, rest...) ->
 
+    { router } = kd.singletons
+
     switch event
       when Events.Menu.Logs
         @logs.unsetClass 'shake'
@@ -155,6 +157,9 @@ module.exports = class StackEditor extends kd.View
         @toolbar.banner.emit Events.Banner.Close
       when Events.TemplateTitleChangeRequested
         @controllers.editor.updateTitle rest...
+      when Events.LoadClonedFrom
+        { config: { clonedFrom } } = @getData()
+        router.handleRoute "/Stack-Editor/#{clonedFrom}"
 
 
   setData: (data, reset = no) ->

--- a/client/new-stack-editor/lib/views/index.coffee
+++ b/client/new-stack-editor/lib/views/index.coffee
@@ -84,14 +84,15 @@ module.exports = class StackEditor extends kd.View
 
     @controllers = {}
 
+    @controllers.logs = new LogsController
+      shared   :
+        editor : @logs
+
     @controllers.editor = new EditorController
       shared   :
         editor : @editor
         readme : @readme
-
-    @controllers.logs = new LogsController
-      shared   :
-        editor : @logs
+        logs   : @controllers.logs
 
     @controllers.variables = new VariablesController
       shared   :
@@ -152,6 +153,8 @@ module.exports = class StackEditor extends kd.View
         @sideView.toggle rest...
       when Events.HideWarning
         @toolbar.banner.emit Events.Banner.Close
+      when Events.TemplateTitleChangeRequested
+        @controllers.editor.updateTitle rest...
 
 
   setData: (data, reset = no) ->

--- a/client/new-stack-editor/lib/views/toolbar.coffee
+++ b/client/new-stack-editor/lib/views/toolbar.coffee
@@ -46,6 +46,12 @@ module.exports = class Toolbar extends JView
 
     debug 'handling banner message', data.message, data.action
 
+    if data.showlogs
+      data.action   ?=
+        title : 'Show Logs'
+        event : Events.Menu.Logs
+      data.autohide ?= 2500
+
     @banner.setData data
     @banner.show()
     @setClass 'has-message'

--- a/client/new-stack-editor/lib/views/toolbar.coffee
+++ b/client/new-stack-editor/lib/views/toolbar.coffee
@@ -17,6 +17,16 @@ module.exports = class Toolbar extends JView
 
     super options, data
 
+    @templateTitle = new kd.HitEnterInputView
+      type         : 'text'
+      autogrow     : yes
+      cssClass     : 'title-input'
+      placeholder  : ''
+      defaultValue : ''
+      disabled     : yes
+      attributes   :
+        spellcheck : no
+
     @actionButton = new kd.ButtonView
       cssClass : 'action-button solid green compact'
       title    : 'Initialize'
@@ -40,6 +50,17 @@ module.exports = class Toolbar extends JView
       @unsetClass 'has-message'
       kd.utils.wait 500, @banner.bound 'hide'
     @forwardEvent @banner, Events.Action
+
+
+  setTitle: (data) ->
+
+    @templateTitle.setData data
+
+    { title } = data
+    @templateTitle.setPlaceholder title
+    @templateTitle.setValue title
+
+    @templateTitle.resize()
 
 
   setBanner: (data) ->
@@ -78,6 +99,9 @@ module.exports = class Toolbar extends JView
     if data._initial
       credentials = '-'
       accessLevel = '-'
+
+    else
+      @setTitle data
 
     super { _id, accessLevel, credentials, title }
 
@@ -128,7 +152,7 @@ module.exports = class Toolbar extends JView
   pistachio: ->
 
     '''
-    {cite.stack{}} {h3{#(title)}} {{> @menuIcon}}
+    {cite.stack{}} {{> @templateTitle}} {{> @menuIcon}}
     {.tag.level{#(accessLevel)}} {div.tag.credential{#(credentials)}} {cite.credential{}}
     {div.controls{> @expandButton}} {{> @actionButton}}
     {{> @banner}}

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -730,8 +730,7 @@ module.exports = class JStackTemplate extends Module
       hasAccess = yes
 
       if @getAt('accessLevel') is 'private'
-        if @getAt('originId') isnt delegate.getId()
-          hasAccess = no
+        hasAccess = delegate.getId().equals @getAt('originId')
 
       else if @getAt('accessLevel') is 'group'
         if @getAt('group') isnt group


### PR DESCRIPTION
With this PR we're now supporting template title rename over new stack editor, handling cloned from information on stack templates and also it provides better ux for the first load of editor.

# Template Title Rename
![](http://g.recordit.co/Vn0b5gept2.gif)

# Handle ClonedFrom information
![](http://g.recordit.co/oR3HFjQ5Iy.gif)

# Show Editor once it's ready on load
![](http://g.recordit.co/YfOtjlVw8f.gif)