### PR TITLE
Add hidden mount inspect command which tracks synchronization events.

### DIFF
--- a/go/src/koding/klient/app/klient.go
+++ b/go/src/koding/klient/app/klient.go
@@ -495,6 +495,7 @@ func (k *Klient) RegisterMethods() {
 	k.kite.HandleFunc("machine.mount.add", machinegroup.KiteHandlerAddMount(k.machines))
 	k.kite.HandleFunc("machine.mount.updateIndex", machinegroup.KiteHandlerUpdateIndex(k.machines))
 	k.kite.HandleFunc("machine.mount.list", machinegroup.KiteHandlerListMount(k.machines))
+	k.kite.HandleFunc("machine.mount.inspect", machinegroup.KiteHandlerInspectMount(k.machines))
 	k.kite.HandleFunc("machine.umount", machinegroup.KiteHandlerUmount(k.machines))
 	k.kite.HandleFunc("machine.cp", machinegroup.KiteHandlerCp(k.machines))
 	k.kite.HandleFunc("machine.exec", k.machines.HandleExec)

--- a/go/src/koding/klient/machine/machinegroup/kite.go
+++ b/go/src/koding/klient/machine/machinegroup/kite.go
@@ -188,6 +188,27 @@ func KiteHandlerUmount(g *Group) kite.HandlerFunc {
 	}
 }
 
+// KiteHandlerInspectMount creates a kite handler function that, when called,
+// invokes machine group InspectMount method.
+func KiteHandlerInspectMount(g *Group) kite.HandlerFunc {
+	return func(r *kite.Request) (interface{}, error) {
+		req := &InspectMountRequest{}
+
+		if r.Args != nil {
+			if err := r.Args.One().Unmarshal(req); err != nil {
+				return nil, err
+			}
+		}
+
+		res, err := g.InspectMount(req)
+		if err != nil {
+			return nil, newError(err)
+		}
+
+		return res, nil
+	}
+}
+
 // KiteHandlerCp creates a kite handler function that, when called, invokes
 // machine group Cp method.
 func KiteHandlerCp(g *Group) kite.HandlerFunc {

--- a/go/src/koding/klient/machine/mount/sync.go
+++ b/go/src/koding/klient/machine/mount/sync.go
@@ -235,7 +235,7 @@ func (s *Sync) History() ([]*history.Record, error) {
 		return h.Get(), nil
 	}
 
-	return nil, errors.New("synchronization history in unavailable")
+	return nil, errors.New("synchronization history is unavailable")
 }
 
 // CacheDir returns the name of mount cache directory.

--- a/go/src/koding/klient/machine/mount/sync/discard/discard.go
+++ b/go/src/koding/klient/machine/mount/sync/discard/discard.go
@@ -20,6 +20,11 @@ type Event struct {
 	ev *msync.Event
 }
 
+// Event returns base event which is going to be synchronized.
+func (e *Event) Event() *msync.Event {
+	return e.ev
+}
+
 // Exec satisfies msync.Execer interface. The only thing this method does is
 // closing internal sync event.
 func (e *Event) Exec() error {
@@ -30,9 +35,14 @@ func (e *Event) Exec() error {
 	return nil
 }
 
+// Debug always returns empty string for discard execer.
+func (e *Event) Debug() string {
+	return ""
+}
+
 // String implements fmt.Stringer interface. It pretty prints internal event.
 func (e *Event) String() string {
-	return e.ev.String() + " - " + "discarded"
+	return e.ev.String() + " (discarded)"
 }
 
 // Discard is a no-op synchronization object. It can be used as a stub for other

--- a/go/src/koding/klient/machine/mount/sync/event.go
+++ b/go/src/koding/klient/machine/mount/sync/event.go
@@ -24,16 +24,16 @@ const (
 func (s status) String() string {
 	switch s {
 	case statusPush:
-		return "PUSH"
+		return "push"
 	case statusPop:
-		return "POP_"
+		return "pop"
 	case statusDeprecated:
-		return "DEPR"
+		return "deprecated"
 	case statusDone:
-		return "DONE"
+		return "done"
 	}
 
-	return "UNKN"
+	return "unknown"
 }
 
 // Finalizer is an interface used by Event to clean its resources from event

--- a/go/src/koding/klient/machine/mount/sync/history/history.go
+++ b/go/src/koding/klient/machine/mount/sync/history/history.go
@@ -53,7 +53,7 @@ func (h *History) ExecStream(evC <-chan *msync.Event) <-chan msync.Execer {
 				}
 
 				h.add(&Record{
-					CreatedAt: time.Now(),
+					CreatedAt: time.Now().UTC(),
 					Message:   "received: " + ex.String(),
 				})
 
@@ -130,7 +130,7 @@ func (he *histExec) Event() *msync.Event {
 // Exec starts synchronization of stored syncing job.
 func (he *histExec) Exec() (err error) {
 	he.parent.add(&Record{
-		CreatedAt: time.Now(),
+		CreatedAt: time.Now().UTC(),
 		Message:   "started: " + he.ex.String(),
 	})
 
@@ -142,7 +142,7 @@ func (he *histExec) Exec() (err error) {
 	}
 
 	he.parent.add(&Record{
-		CreatedAt: time.Now(),
+		CreatedAt: time.Now().UTC(),
 		Message:   msg,
 		Details:   he.ex.Debug(),
 	})

--- a/go/src/koding/klient/machine/mount/sync/history/history.go
+++ b/go/src/koding/klient/machine/mount/sync/history/history.go
@@ -87,6 +87,8 @@ func (h *History) Close() error {
 
 // Get gets recorded history. Returned slice length will not exceed history
 // maximum size.
+//
+// If there's no history available, the method returns empty, non-nil slice.
 func (h *History) Get() []*Record {
 	recs := make([]*Record, 0)
 

--- a/go/src/koding/klient/machine/mount/sync/history/history.go
+++ b/go/src/koding/klient/machine/mount/sync/history/history.go
@@ -1,0 +1,161 @@
+package sync
+
+import (
+	"container/ring"
+	"fmt"
+	"sync"
+	"time"
+
+	msync "koding/klient/machine/mount/sync"
+)
+
+// Record stores a single history record.
+type Record struct {
+	CreatedAt time.Time `json:"createdAt"`        // creation time.
+	Message   string    `json:"message"`          // short summary.
+	Details   string    `json:"detail,omitempty"` // detailed description.
+}
+
+// History gathers synchronization history of results produced by stored Syncer.
+type History struct {
+	s msync.Syncer // underlying Syncer.
+
+	mu sync.Mutex
+	r  *ring.Ring
+
+	once  sync.Once
+	stopC chan struct{} // channel used to close any opened exec streams.
+}
+
+// NewHistory creates a new History instance. Provided size defines the maximum
+// length of history records.
+func NewHistory(s msync.Syncer, size int) *History {
+	return &History{
+		s:     s,
+		r:     ring.New(size),
+		stopC: make(chan struct{}),
+	}
+}
+
+// ExecStream wraps underlying execers with history gathering logic.
+func (h *History) ExecStream(evC <-chan *msync.Event) <-chan msync.Execer {
+	exhC := make(chan msync.Execer)
+
+	go func() {
+		defer close(exhC)
+
+		exC := h.s.ExecStream(evC)
+		for {
+			select {
+			case ex, ok := <-exC:
+				if !ok {
+					return
+				}
+
+				h.add(&Record{
+					CreatedAt: time.Now(),
+					Message:   "received: " + ex.String(),
+				})
+
+				exh := &histExec{
+					ex:     ex,
+					parent: h,
+				}
+
+				select {
+				case exhC <- exh:
+				case <-h.stopC:
+					return
+				}
+			case <-h.stopC:
+				return
+			}
+		}
+	}()
+
+	return exhC
+}
+
+// Close stops all created synchronization streams.
+func (h *History) Close() error {
+	h.once.Do(func() {
+		close(h.stopC)
+	})
+
+	return nil
+}
+
+// Get gets recorded history. Returned slice length will not exceed history
+// maximum size.
+func (h *History) Get() []*Record {
+	recs := make([]*Record, 0)
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.r.Do(func(val interface{}) {
+		if val == nil {
+			return
+		}
+
+		rec, ok := val.(*Record)
+		if !ok || rec == nil {
+			panic(fmt.Sprintf("unknown history record: %#v", val))
+		}
+
+		recs = append(recs, rec)
+	})
+
+	return recs
+}
+
+// add adds new record to history.
+func (h *History) add(rec *Record) {
+	h.mu.Lock()
+	h.r.Value = rec
+	h.r = h.r.Next()
+	h.mu.Unlock()
+}
+
+// histExec wraps Execer interface in order to track its invocation status.
+type histExec struct {
+	ex     msync.Execer
+	parent *History
+}
+
+// Event returns base event which is going to be synchronized.
+func (he *histExec) Event() *msync.Event {
+	return he.ex.Event()
+}
+
+// Exec starts synchronization of stored syncing job.
+func (he *histExec) Exec() (err error) {
+	he.parent.add(&Record{
+		CreatedAt: time.Now(),
+		Message:   "started: " + he.ex.String(),
+	})
+
+	var msg string
+	if err = he.ex.Exec(); err != nil {
+		msg = "failed: " + he.ex.String() + "; err: " + err.Error()
+	} else {
+		msg = "succeeded: " + he.ex.String()
+	}
+
+	he.parent.add(&Record{
+		CreatedAt: time.Now(),
+		Message:   msg,
+		Details:   he.ex.Debug(),
+	})
+
+	return
+}
+
+// Debug returns debug information about the execer.
+func (he *histExec) Debug() string {
+	return he.ex.Debug()
+}
+
+// fmt.Stringer defines human readable information about the event.
+func (he *histExec) String() string {
+	return he.ex.String()
+}

--- a/go/src/koding/klient/machine/mount/sync/history/history.go
+++ b/go/src/koding/klient/machine/mount/sync/history/history.go
@@ -1,4 +1,4 @@
-package sync
+package history
 
 import (
 	"container/ring"

--- a/go/src/koding/klient/machine/mount/sync/history/history_test.go
+++ b/go/src/koding/klient/machine/mount/sync/history/history_test.go
@@ -39,7 +39,7 @@ func TestHistory(t *testing.T) {
 	h := history.NewHistory(discard.NewDiscard(), historySize)
 
 	for i, change := range changes {
-		tLeft := time.Now()
+		tLeft := time.Now().UTC()
 
 		if change.Change != nil {
 			if err := synctest.ExecChange(h, change.Change, time.Second); err != nil {
@@ -52,8 +52,12 @@ func TestHistory(t *testing.T) {
 			t.Fatalf("want recs len = %d; got %d (i:%d)", change.RecLen, len(recs), i)
 		}
 
-		for j := len(recs) - 1; j >= 0 && (len(recs)-1-j) < 3; j-- {
-			if err := timeBetween(recs[j].CreatedAt, tLeft, time.Now()); err != nil {
+		// Check creation time of last three elements stored in returned slice.
+		// Each new event should add at least three new entries to the buffer.
+		// Here we check if they were added and if they are at the right place.
+		maxIndex := len(recs) - 1
+		for j := maxIndex; j >= 0 && maxIndex-j < 3; j-- {
+			if err := timeBetween(recs[j].CreatedAt, tLeft, time.Now().UTC()); err != nil {
 				t.Fatalf("want err = nil; got %v (i:%d,j:%d)", err, i, j)
 			}
 		}

--- a/go/src/koding/klient/machine/mount/sync/history/history_test.go
+++ b/go/src/koding/klient/machine/mount/sync/history/history_test.go
@@ -1,0 +1,74 @@
+package history_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"koding/klient/machine/index"
+	"koding/klient/machine/mount/sync/discard"
+	"koding/klient/machine/mount/sync/history"
+	"koding/klient/machine/mount/sync/synctest"
+)
+
+func TestHistory(t *testing.T) {
+	const historySize = 5
+
+	changes := []struct {
+		Change *index.Change
+		RecLen int
+	}{
+		{
+			Change: nil,
+			RecLen: 0,
+		},
+		{
+			Change: index.NewChange("a/", index.PriorityLow, 0),
+			RecLen: 3,
+		},
+		{
+			Change: index.NewChange("b/", index.PriorityMedium, 0),
+			RecLen: historySize,
+		},
+		{
+			Change: index.NewChange("c/", index.PriorityHigh, 0),
+			RecLen: historySize,
+		},
+	}
+
+	h := history.NewHistory(discard.NewDiscard(), historySize)
+
+	for i, change := range changes {
+		tLeft := time.Now()
+
+		if change.Change != nil {
+			if err := synctest.ExecChange(h, change.Change, time.Second); err != nil {
+				t.Fatalf("want err = nil; got %v (i:%d)", err, i)
+			}
+		}
+
+		recs := h.Get()
+		if len(recs) != change.RecLen {
+			t.Fatalf("want recs len = %d; got %d (i:%d)", change.RecLen, len(recs), i)
+		}
+
+		for j := len(recs) - 1; j >= 0 && (len(recs)-1-j) < 3; j-- {
+			if err := timeBetween(recs[j].CreatedAt, tLeft, time.Now()); err != nil {
+				t.Fatalf("want err = nil; got %v (i:%d,j:%d)", err, i, j)
+			}
+		}
+	}
+}
+
+// timeBetween returns error when provided time stamp is not between tLeft and
+// tRight. tRight must be greater than tLeft.
+func timeBetween(t, tLeft, tRight time.Time) error {
+	if d := t.Sub(tLeft); d < 0 {
+		return fmt.Errorf("time %v is is before time %v (%v)", t, tLeft, -d)
+	}
+	if d := t.Sub(tRight); d > 0 {
+		return fmt.Errorf("time %v is after time %v (%v)", t, tRight, d)
+	}
+
+	return nil
+}

--- a/go/src/koding/klient/machine/mount/sync/sync.go
+++ b/go/src/koding/klient/machine/mount/sync/sync.go
@@ -37,9 +37,15 @@ type Builder interface {
 // Execer represents an interface which must be implemented by sync event
 // produced by external syncer.
 type Execer interface {
+	// Event returns base event which is going to be synchronized.
+	Event() *Event
+
 	// Exec starts synchronization of stored syncing job. It should update
 	// indexes and clean up synced Event.
 	Exec() error
+
+	// Debug returns debug information about the execer.
+	Debug() string
 
 	// fmt.Stringer defines human readable information about the event.
 	fmt.Stringer

--- a/go/src/koding/klient/machine/transport/rsync/rsync_test.go
+++ b/go/src/koding/klient/machine/transport/rsync/rsync_test.go
@@ -28,10 +28,9 @@ func dumpFile(name string) *exec.Cmd {
 	return cmd
 }
 
-func dumpArgs(w io.Writer) *exec.Cmd {
+func dumpArgs() *exec.Cmd {
 	cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess", "--", "args")
 	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
-	cmd.Stdout = w
 	return cmd
 }
 
@@ -73,17 +72,19 @@ func TestRsyncArgs(t *testing.T) {
 
 			var buf = &bytes.Buffer{}
 			cmd := &rsync.Command{
-				Cmd:             dumpArgs(buf),
+				Cmd:             dumpArgs(),
 				SourcePath:      "/A",
 				DestinationPath: "/B",
 				Username:        "usr",
 				Host:            "host",
 				Change:          index.NewChange("x.txt", index.PriorityLow, test.Meta),
+				Output:          buf,
 			}
 
 			if err := cmd.Run(context.Background()); err != nil {
 				t.Fatalf("want err = nil; got %v", err)
 			}
+
 			got := strings.Split(buf.String(), "\n")
 			if !reflect.DeepEqual(got, test.Expected) {
 				t.Fatalf("want exec args = %v; got %v", test.Expected, got)

--- a/go/src/koding/klientctl/machine.go
+++ b/go/src/koding/klientctl/machine.go
@@ -256,6 +256,11 @@ func MachineCpCommand(c *cli.Context, log logging.Logger, _ string) (int, error)
 	return 0, nil
 }
 
+// MachineInspectMountCommand allows to inspect internal mount status.
+func MachineInspectMountCommand(c *cli.Context, log logging.Logger, _ string) (int, error) {
+	return 1, fmt.Errorf("not implemented")
+}
+
 // getIdentifiers extracts identifiers and validate provided arguments.
 // TODO(ppknap): other CLI libraries like Cobra have this out of the box.
 func getIdentifiers(c *cli.Context) (idents []string, err error) {

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -503,10 +503,10 @@ func run(args []string) {
 					Action: ctlcli.ExitErrAction(MachineInspectMountCommand, log, "mount inspect"),
 					Flags: []cli.Flag{
 						cli.BoolFlag{
-							Name: "sync",
+							Name:  "sync",
 							Usage: "Displays syncing history up to 100 records.",
 						},
-					}
+					},
 				}},
 			}, {
 				Name:        "umount",

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -496,6 +496,17 @@ func run(args []string) {
 							Usage: "Output in JSON format.",
 						},
 					},
+				}, {
+					Name:   "inspect",
+					Hidden: true,
+					Usage:  "Advanced utilities for mount command.",
+					Action: ctlcli.ExitErrAction(MachineInspectMountCommand, log, "mount inspect"),
+					Flags: []cli.Flag{
+						cli.BoolFlag{
+							Name: "sync",
+							Usage: "Displays syncing history up to 100 records.",
+						},
+					}
 				}},
 			}, {
 				Name:        "umount",
@@ -784,6 +795,7 @@ func createActionFunc(action cli.ActionFunc) cli.ActionFunc {
 		return err
 	}
 }
+
 // ExitWithMessage takes a ExitingWithMessageCommand type and returns a
 // codegansta/cli friendly command Action.
 func ExitWithMessage(f ExitingWithMessageCommand, log logging.Logger, cmd string) cli.ActionFunc {


### PR DESCRIPTION
This PR adds `kd machine mount inspect` command. The command is not visible for users and allows to inspect recent synchronization events.

There are up to 100 events stored inside mount's ring buffer. 

## Motivation and Context
Debug mount synchronization issues.

## How Has This Been Tested?
Unit tests, Manually.

## Screenshots (if appropriate):
https://asciinema.org/a/1qpr8xc3hlp41x2un22t0dlwe

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
