### PR TITLE
Add supervised syncer that gracefully handles client errors.

### DIFF
--- a/go/src/koding/klient/machine/mount/sync.go
+++ b/go/src/koding/klient/machine/mount/sync.go
@@ -15,6 +15,7 @@ import (
 	"koding/klient/machine/mount/prefetch"
 	msync "koding/klient/machine/mount/sync"
 	"koding/klient/machine/mount/sync/history"
+	"koding/klient/machine/mount/sync/supervised"
 
 	"github.com/koding/logging"
 )
@@ -171,8 +172,13 @@ func NewSync(mountID ID, m Mount, opts Options) (*Sync, error) {
 		return nil, nonil(err, s.a.Close(), s.iu.Close())
 	}
 
+	// Use supervised syncer to gracefully handle client disconnections.
+	sb := supervised.Builder{
+		Inner: opts.SyncBuilder,
+	}
+
 	// Create file synchronization object.
-	syncer, err := opts.SyncBuilder.Build(&msync.BuildOpts{
+	syncer, err := sb.Build(&msync.BuildOpts{
 		RemoteDir:     m.RemotePath,
 		CacheDir:      s.CacheDir(),
 		ClientFunc:    s.opts.ClientFunc,

--- a/go/src/koding/klient/machine/mount/sync/discard/discard.go
+++ b/go/src/koding/klient/machine/mount/sync/discard/discard.go
@@ -78,6 +78,9 @@ func (d *Discard) ExecStream(evC <-chan *msync.Event) <-chan msync.Execer {
 				select {
 				case exC <- ex:
 				case <-d.stopC:
+					if ex.ev.Valid() {
+						ex.ev.Done()
+					}
 					return
 				}
 			case <-d.stopC:

--- a/go/src/koding/klient/machine/mount/sync/rsync/rsync.go
+++ b/go/src/koding/klient/machine/mount/sync/rsync/rsync.go
@@ -166,6 +166,9 @@ func (r *Rsync) ExecStream(evC <-chan *msync.Event) <-chan msync.Execer {
 				select {
 				case exC <- ex:
 				case <-r.stopC:
+					if ex.ev.Valid() {
+						ex.ev.Done()
+					}
 					return
 				}
 			case <-r.stopC:

--- a/go/src/koding/klient/machine/mount/sync/supervised/supervised.go
+++ b/go/src/koding/klient/machine/mount/sync/supervised/supervised.go
@@ -1,0 +1,129 @@
+package supervised
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"koding/klient/machine/client"
+	msync "koding/klient/machine/mount/sync"
+)
+
+// Builder is a factory for Supervised synchronization objects.
+type Builder struct {
+	Inner msync.Builder
+}
+
+// Build satisfies msync.Builder interface. It creates a new Supervised
+// instance.
+func (b *Builder) Build(opts *msync.BuildOpts) (msync.Syncer, error) {
+	return NewSupervised(b.Inner, opts, 30*time.Second), nil
+}
+
+// Supervised satisfies msync.Syncer interface. It wraps other syncer and
+// handles its build errors. When inner syncer builder fails, Supervised assumes
+// that the failure is recoverable and waits for provided interval to rebuild
+// the syncer.
+type Supervised struct {
+	b        msync.Builder
+	opts     *msync.BuildOpts
+	interval time.Duration
+
+	once  sync.Once
+	stopC chan struct{} // channel used to close any opened exec streams.
+}
+
+// NewSupervised creates a new Supervised object.
+func NewSupervised(b msync.Builder, opts *msync.BuildOpts, interval time.Duration) *Supervised {
+	return &Supervised{
+		b:        b,
+		opts:     opts,
+		interval: interval,
+		stopC:    make(chan struct{}),
+	}
+}
+
+// ExecStream streams synchronization events from inner Syncers when they are
+// available.
+func (s *Supervised) ExecStream(evC <-chan *msync.Event) <-chan msync.Execer {
+	exC := make(chan msync.Execer)
+	opts := *s.opts // Shallow copy.
+
+	// First create cancalled contex which will trigger first select in loop
+	// bellow.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Wrap provided client function in order to get context that other Syncers
+	// used to initialize themselves.
+	opts.ClientFunc = func() (client.Client, error) {
+		c, err := s.opts.ClientFunc()
+		if err != nil {
+			return nil, err
+		}
+		ctx = c.Context()
+
+		return c, nil
+	}
+
+	go func() {
+		defer close(exC)
+
+		var (
+			sy     msync.Syncer
+			exDynC <-chan msync.Execer
+		)
+
+		// Rebuild can be triggered by either exDynC channel or closed context.
+		// The goal of this function is to rebuild the syncer. In case of error
+		// other than disconnected this function will be repeated after provided
+		// interval.
+		rebuild := func() {
+			var err error
+			switch sy, err = s.b.Build(s.opts); err {
+			case nil:
+				exDynC = sy.ExecStream(evC) // Consume from new syncer.
+			case client.ErrDisconnected:
+				exDynC = nil // Contex was set by ClientFunc.
+			default:
+				exDynC = nil
+				ctx, _ = context.WithTimeout(context.Background(), s.interval)
+			}
+		}
+
+		for {
+			select {
+			case ex, ok := <-exDynC:
+				if !ok {
+					rebuild()
+					break
+				}
+
+				select {
+				case exC <- ex:
+				case <-s.stopC:
+					return
+				}
+			case <-ctx.Done():
+				if sy == nil {
+					rebuild()
+				} else {
+					sy.Close()
+				}
+			case <-s.stopC:
+				return
+			}
+		}
+	}()
+
+	return exC
+}
+
+// Close stops all created synchronization streams.
+func (s *Supervised) Close() error {
+	s.once.Do(func() {
+		close(s.stopC)
+	})
+
+	return nil
+}

--- a/go/src/koding/klient/machine/mount/sync/supervised/supervised.go
+++ b/go/src/koding/klient/machine/mount/sync/supervised/supervised.go
@@ -98,6 +98,9 @@ func (s *Supervised) ExecStream(evC <-chan *msync.Event) <-chan msync.Execer {
 				select {
 				case exC <- ex:
 				case <-s.stopC:
+					if sy != nil {
+						sy.Close()
+					}
 					return
 				}
 			case <-ctx.Done():
@@ -108,6 +111,9 @@ func (s *Supervised) ExecStream(evC <-chan *msync.Event) <-chan msync.Execer {
 					sy.Close()
 				}
 			case <-s.stopC:
+				if sy != nil {
+					sy.Close()
+				}
 				return
 			}
 		}

--- a/go/src/koding/klient/machine/mount/sync/supervised/sypervised_test.go
+++ b/go/src/koding/klient/machine/mount/sync/supervised/sypervised_test.go
@@ -1,0 +1,75 @@
+package supervised_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"koding/klient/machine/client"
+	"koding/klient/machine/client/clienttest"
+	"koding/klient/machine/index"
+	msync "koding/klient/machine/mount/sync"
+	"koding/klient/machine/mount/sync/discard"
+	"koding/klient/machine/mount/sync/supervised"
+	"koding/klient/machine/mount/sync/synctest"
+)
+
+func TestSupervised(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	opts := &msync.BuildOpts{
+		ClientFunc: func() (client.Client, error) {
+			c := clienttest.NewClient()
+			c.SetContext(ctx)
+			return c, nil
+		},
+	}
+
+	change := index.NewChange("a", index.PriorityMedium, 0)
+	tb := &testBuilder{
+		buildC: make(chan struct{}, 1),
+	}
+
+	s := supervised.NewSupervised(tb, opts, time.Second)
+	defer s.Close()
+
+	if err := synctest.ExecChange(s, change, time.Second); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	if err := waitBuildC(tb.buildC, time.Second); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	cancel()
+
+	// Client closed its context. This means that it changed.
+	if err := waitBuildC(tb.buildC, time.Second); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	if err := synctest.ExecChange(s, change, 50*time.Millisecond); err == nil {
+		t.Fatalf("want err != nil; got nil")
+	}
+
+}
+
+// testBuilder triggers client function.
+type testBuilder struct {
+	buildC chan struct{}
+}
+
+func (tb *testBuilder) Build(opts *msync.BuildOpts) (msync.Syncer, error) {
+	opts.ClientFunc()
+	tb.buildC <- struct{}{}
+	return discard.NewDiscard(), nil
+}
+
+func waitBuildC(buildC <-chan struct{}, timeout time.Duration) error {
+	select {
+	case <-buildC:
+		return nil
+	case <-time.After(timeout):
+		return fmt.Errorf("timed out after %s", timeout)
+	}
+}

--- a/go/src/koding/klient/machine/mount/sync/synctest/synctest.go
+++ b/go/src/koding/klient/machine/mount/sync/synctest/synctest.go
@@ -58,15 +58,14 @@ func SyncLocal(s msync.Syncer, rootA, rootB string, dir index.ChangeMeta) (conte
 // the function will execute it end return its error or timeout if such occurs.
 func ExecChange(s msync.Syncer, change *index.Change, timeout time.Duration) error {
 	var (
-		ev       = msync.NewEvent(context.Background(), nil, change)
-		evC      = make(chan *msync.Event)
-		timeoutC = time.After(timeout)
+		ev  = msync.NewEvent(context.Background(), nil, change)
+		evC = make(chan *msync.Event)
 	)
 
 	go func() {
 		select {
 		case evC <- ev:
-		case <-timeoutC:
+		case <-time.After(timeout):
 		}
 	}()
 
@@ -76,7 +75,7 @@ func ExecChange(s msync.Syncer, change *index.Change, timeout time.Duration) err
 			return fmt.Errorf("nil execer received")
 		}
 		return ex.Exec()
-	case <-timeoutC:
+	case <-time.After(timeout):
 		return fmt.Errorf("timed out after %s", timeout)
 	}
 }


### PR DESCRIPTION
Till now when mount syncer was not able to connect remote machine it failed and the entire mounts don't start. This resulted with empty mount folder. However, user should be able to work with mounted files even if they are not synchronized with remote machine.

This PR adds supervised syncer that uses underlying one when it can build successfully. If not, produced events are not consumed and wait for running syncer.

## Motivation and Context
Temporary connection problems resulted with empty mounted folder. 

## How Has This Been Tested?
Unit tests.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)