### PR TITLE
klient/machine: add benchmarks to mount index node structure

### DIFF
--- a/go/src/koding/klient/machine/index/benchmark_test.go
+++ b/go/src/koding/klient/machine/index/benchmark_test.go
@@ -1,4 +1,4 @@
-package index
+package index_test
 
 import (
 	"bytes"
@@ -6,6 +6,8 @@ import (
 	"flag"
 	"testing"
 	"time"
+
+	"koding/klient/machine/index"
 )
 
 var repo = flag.String("repo", "", "")
@@ -16,7 +18,7 @@ func TestRepo(t *testing.T) {
 	}
 
 	start := time.Now()
-	idx, err := NewIndexFiles(*repo)
+	idx, err := index.NewIndexFiles(*repo)
 	if err != nil {
 		t.Fatalf("NewIndexFiles()=%s", err)
 	}
@@ -31,4 +33,52 @@ func TestRepo(t *testing.T) {
 	t.Logf("Index build time: %s", end.Sub(start))
 	t.Logf("Index file count: %d", idx.Count(-1))
 	t.Logf("Index size: %.4f MiB", float64(buf.Len())/1024/1024)
+}
+
+func BenchmarkNodeLookup(b *testing.B) {
+	const name = "/idset/idset_test.go"
+	root := fixture()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, ok := root.Lookup(name); !ok {
+			b.Fatalf("want %s to be present in root node", name)
+		}
+	}
+}
+
+func BenchmarkNodeAdd(b *testing.B) {
+	const name = "proxy/tmp/sync/fuse/fuse.go"
+	entry := index.NewEntry(0xB, 0)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		root := fixture()
+		b.StartTimer()
+
+		root.Add(name, entry)
+	}
+}
+
+func BenchmarkNodeDel(b *testing.B) {
+	const name = "addresses/addresser.go"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		root := fixture()
+		b.StartTimer()
+
+		root.Del(name)
+	}
+}
+
+func BenchmarkNodeForEach(b *testing.B) {
+	root := fixture()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		root.ForEach(func(name string, _ *index.Entry) {})
+	}
 }


### PR DESCRIPTION
## Description
```sh
$ go test --bench=. --benchmem
BenchmarkNodeLookup-4            5000000               268 ns/op              64 B/op          2 allocs/op
BenchmarkNodeAdd-4                500000              3383 ns/op            1397 B/op         19 allocs/op
BenchmarkNodeDel-4               3000000               418 ns/op               0 B/op          0 allocs/op
BenchmarkNodeForEach-4            200000              7286 ns/op            2984 B/op         35 allocs/op
PASS
```

## Motivation and Context
Mount index speed improvements.

## How Has This Been Tested?
Test itself

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
