### PR TITLE
klientctl: forward exit codes to the shell

### DIFF
--- a/go/src/koding/klientctl/ctlcli/ctlcli.go
+++ b/go/src/koding/klientctl/ctlcli/ctlcli.go
@@ -108,18 +108,17 @@ func ExitAction(f ExitingCommand, log logging.Logger, cmdName string) cli.Action
 // ExitErrAction implements a cli.Command's Action field for an ExitingErrCommand
 func ExitErrAction(f ExitingErrCommand, log logging.Logger, cmdName string) cli.ActionFunc {
 	return func(c *cli.Context) error {
+		defer Close()
+
 		exit, err := f(c, log, cmdName)
 		if err != nil {
 			log.Error("ExitErrAction encountered error. err:%s", err)
+
 			// Print error message to the user.
-			fmt.Fprintf(os.Stderr, "error executing %q command: %s\n", cmdName, err)
+			return cli.NewExitError(fmt.Sprintf("error executing %q command: %s", cmdName, err), exit)
 		}
 
-		Close()
-		if exit == 0 {
-			return nil
-		}
-		return fmt.Errorf("exit code: %d", exit)
+		return nil
 	}
 }
 

--- a/go/src/koding/klientctl/ctlcli/ctlcli.go
+++ b/go/src/koding/klientctl/ctlcli/ctlcli.go
@@ -8,7 +8,6 @@ package ctlcli
 import (
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/codegangsta/cli"
 	"github.com/koding/logging"
@@ -21,12 +20,6 @@ type CloseFunc func() error
 
 // Close implements the io.Closer interface.
 func (c CloseFunc) Close() error { return c() }
-
-// ExitFunc is called upon command exit, it sets exit code.
-//
-// It is overwritten during testing, as calling os.Exit
-// prevents saving coverage profile.
-var ExitFunc = os.Exit
 
 // CloseOnExit is a hack to close program-lifetime-bound resources,
 // like log file or BoltDB database.
@@ -96,13 +89,20 @@ func CommandHelper(ctx *cli.Context, cmd string) Helper {
 
 // ExitAction implements a cli.Command's Action field for an ExitingCommand type.
 func ExitAction(f ExitingCommand, log logging.Logger, cmdName string) cli.ActionFunc {
-	return func(c *cli.Context) error {
-		exit := f(c, log, cmdName)
-		Close()
-		ExitFunc(exit)
-
-		return nil
+	eec := func(c *cli.Context, log logging.Logger, cmdName string) (int, error) {
+		return f(c, log, cmdName), nil
 	}
+
+	return ExitErrAction(eec, log, cmdName)
+}
+
+// FactoryAction implements a cli.Command's Action field.
+func FactoryAction(factory CommandFactory, log logging.Logger, cmdName string) cli.ActionFunc {
+	eec := func(c *cli.Context, log logging.Logger, cmdName string) (int, error) {
+		return factory(c, log, cmdName).Run()
+	}
+
+	return ExitErrAction(eec, log, cmdName)
 }
 
 // ExitErrAction implements a cli.Command's Action field for an ExitingErrCommand
@@ -111,36 +111,12 @@ func ExitErrAction(f ExitingErrCommand, log logging.Logger, cmdName string) cli.
 		defer Close()
 
 		exit, err := f(c, log, cmdName)
-		if err != nil {
-			log.Error("ExitErrAction encountered error. err:%s", err)
+		if err != nil || exit != 0 {
+			log.Error("Command %q encountered error. Exit:%d, err:%v", cmdName, exit, err)
 
 			// Print error message to the user.
-			return cli.NewExitError(fmt.Sprintf("error executing %q command: %s", cmdName, err), exit)
+			return cli.NewExitError(fmt.Sprintf("error executing %q command: %v", cmdName, err), exit)
 		}
-
-		return nil
-	}
-}
-
-// FactoryAction implements a cli.Command's Action field.
-func FactoryAction(factory CommandFactory, log logging.Logger, cmdName string) cli.ActionFunc {
-	return func(c *cli.Context) error {
-		cmd := factory(c, log, cmdName)
-		exit, err := cmd.Run()
-
-		// For API reasons, we may return an error but a zero exit code. So we want
-		// to check and log both.
-		if exit != 0 || err != nil {
-			log.Error(
-				"Command encountered error. command:%s, exit:%d, err:%s",
-				cmdName, exit, err,
-			)
-			// Print error message to the user.
-			fmt.Fprintf(os.Stderr, "error executing %q command: %s\n", cmdName, err)
-		}
-
-		Close()
-		ExitFunc(exit)
 
 		return nil
 	}

--- a/go/src/koding/klientctl/main_test.go
+++ b/go/src/koding/klientctl/main_test.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"testing"
 
-	"koding/klientctl/ctlcli"
 	"koding/klientctl/endpoint/kloud"
 )
 
@@ -24,12 +23,6 @@ func TestMainHelper(t *testing.T) {
 	// Close stdout as soon as command finishes, so Go's testing command
 	// does not pollute it.
 	defer os.Stdout.Close()
-
-	ctlcli.ExitFunc = func(code int) {
-		if code != 0 {
-			os.Exit(code)
-		}
-	}
 
 	var args []string
 


### PR DESCRIPTION
```shell
(archpk) $ kdev machine ls
error executing "list" command: Post http://ppknap.koding.team/kloud/kite/797/9537758c82566a7796b3/xhr: dial tcp 52.73.206.132:80: i/o timeout
(archpk) $ echo $?
1
```

## How Has This Been Tested?
Manually

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
