### PR TITLE
circleci: workaround rabbitmq:3 start failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,8 @@ jobs:
       - image: koding/postgres
 
       - image: rabbitmq:3
+        env:
+            RABBITMQ_VM_MEMORY_HIGH_WATERMARK: "2048MB"
 
       - image: redis
 


### PR DESCRIPTION
Works around https://github.com/docker-library/rabbitmq/issues/148 and recent failures on ci.

FYI previous rabbitmq:3 version set the limit to:

```
=INFO REPORT==== 7-Apr-2017::08:06:00 ===
Memory limit set to 24155MB of 60387MB total.

=INFO REPORT==== 7-Apr-2017::08:06:00 ===
Disk free limit set to 50MB

=INFO REPORT==== 7-Apr-2017::08:06:00 ===
Limiting to approx 65436 file handles (58890 sockets)
```