### PR TITLE
klientctl: do not print 'is running' reason for offline state

### DIFF
--- a/go/src/koding/klientctl/endpoint/machine/info.go
+++ b/go/src/koding/klientctl/endpoint/machine/info.go
@@ -3,6 +3,7 @@ package machine
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"koding/klient/machine"
@@ -99,7 +100,10 @@ func PrettyStatus(status machine.Status, now time.Time) string {
 	}
 
 	timeReasonFmt := ShortDuration(status.Since, now)
-	if status.Reason != "" {
+	// Do not print reason when machine is offline and reported reason contains
+	// `is running` string. This is a temporary fix for potentially invalid
+	// entries in mongo DB an will be improved by dynamic client.
+	if status.Reason != "" && !(status.State == machine.StateOffline && strings.Contains(status.Reason, "is running")) {
 		timeReasonFmt += ": " + status.Reason
 	}
 


### PR DESCRIPTION
This PR prevents invalid `kd machine list` statuses from offline machines.

Apparently, the offline machine is running status is stored by mongo. This PR is a quick fix which will not affect other messages.

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
