### PR TITLE
NSE: Bootstrap requirements handled in backend

### DIFF
--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -811,6 +811,17 @@ module.exports = class JStackTemplate extends Module
           Kloud.buildStack client, { stackId, provider, variables }, callback
 
 
+  getProvider: ->
+
+    # TODO: add multiple provider support here ~GG
+    provider = @getAt 'config.requiredProviders.0'
+
+    unless provider or not PROVIDERS[provider]
+      return [ new KodingError 'Provider is not supported' ]
+
+    return [ null, provider ]
+
+
   verify$: permit
 
     advanced: [
@@ -825,10 +836,9 @@ module.exports = class JStackTemplate extends Module
   verify: (client, callback) ->
 
     stackTemplateId = @getAt '_id'
-    provider = (@getAt 'config.requiredProviders')[0]
 
-    unless provider or not PROVIDERS[provider]
-      return callback new KodingError 'Provider is not supported'
+    [ err, provider ] = @getProvider()
+    return callback err  if err
 
     noMachines = ->
       callback new KodingError \

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -857,6 +857,27 @@ module.exports = class JStackTemplate extends Module
         return callback err  if err
         callback null, this
 
+  verifyCredentials: (client, callback) ->
+
+    [ err, provider ] = @getProvider()
+    return callback err  if err
+
+    # TODO: add multiple provider support here ~GG
+    unless identifier = @getAt "credentials.#{provider}.0"
+      return callback new KodingError \
+        "No credential found for #{provider} provider"
+
+    JCredential = require './credential'
+    JCredential.one$ client, identifier, (err, credential) ->
+      if err or not credential
+        return callback new KodingError 'Credential is not accessible'
+
+      credential.isBootstrapped client, (err, bootstrapped) ->
+        return callback err   if err
+        return callback null  if bootstrapped
+
+        credential.bootstrap client, callback
+
 
   forceStacksToReinit: permit 'force stacks to reinit',
 


### PR DESCRIPTION
![](http://g.recordit.co/xBOrH4AKld.gif)

Credential Bootstrap requirements was checking and handled on client-side in old Stack Editor, in New Stack Editor (NSE) there is no such flow, instead it's handled in the backend on `JStackTemplate.verify` method. So, with this change it's possible to create a new credential and use it with a brand new stack template on NSE.