### PR TITLE
sidebar improvements -- merge fixes

### DIFF
--- a/client/app/lib/lazyrouter.coffee
+++ b/client/app/lib/lazyrouter.coffee
@@ -1,3 +1,4 @@
+debug = require('debug')('app:lazyrouter')
 Emitter = require('events').EventEmitter
 registerRoutes = require './util/registerRoutes'
 _ = require 'lodash'
@@ -6,7 +7,12 @@ emitter = new Emitter
 
 
 dispatch = (m, type, info, state, path) ->
-  emitter.emit m.name.toLowerCase(), type, info, state, path, this
+
+  name = m.name.toLowerCase()
+
+  debug 'dispatch', { name, type, info, state, path }
+
+  emitter.emit name, type, info, state, path, this
 
 
 exports.bind = (name, fn) ->

--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -1167,6 +1167,8 @@ module.exports = class ComputeController extends KDController
 
       debug 'reinitStack question answered', status
 
+      return  if status.cancelled
+
       unless status.confirmed
         callback new Error 'Stack is not reinitialized'
         return

--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -310,10 +310,10 @@ module.exports = class ComputeController extends KDController
           content  : 'A new stack generated and ready to build!'
           type     : 'success'
           duration : 3000
+        callback null, newStack
 
       @checkGroupStacks newStack.stack.getId()
 
-      callback null
 
     mainController.ready =>
 

--- a/client/app/lib/providers/computecontroller.ui.coffee
+++ b/client/app/lib/providers/computecontroller.ui.coffee
@@ -419,7 +419,7 @@ module.exports = class ComputeControllerUI
           type       : 'button'
           callback   : ->
             modal.destroy()
-            callback { confirmed: no }
+            callback { confirmed: no, cancelled: yes }
         ok           :
           title      : button ? 'Yes, remove'
           style      : 'solid medium'

--- a/client/app/lib/remote-extensions/computestack.coffee
+++ b/client/app/lib/remote-extensions/computestack.coffee
@@ -10,7 +10,7 @@ module.exports = class JComputeStack extends remote.api.JComputeStack
   getUnreadCount: -> @_revisionStatus?.status?.code or 0
 
 
-  isManaged: -> @title is 'Managed VMs'
+  isManaged: -> @getAt('title') is 'Managed VMs'
 
 
-  getOldOwner: -> @config?.oldOwner
+  getOldOwner: -> @getAt 'config.oldOwner'

--- a/client/app/lib/sidebar/components/ownedresourceheader.coffee
+++ b/client/app/lib/sidebar/components/ownedresourceheader.coffee
@@ -10,13 +10,14 @@ module.exports = class OwnedResourceHeader extends React.Component
 
   render: ->
 
-    { title, onTitleClick, unreadCount, onMenuIconClick } = @props
+    { title, onTitleClick, unreadCount, onMenuIconClick, selected } = @props
 
     className = cx ['SidebarSection-header', {
       'unread': !!unreadCount
+      'active': !!selected
     }]
 
-    <header className='SidebarSection-header'>
+    <header className={className}>
       <h4 className='SidebarSection-headerTitle'>
 
         <Link onClick={onTitleClick}>{title}</Link>

--- a/client/app/lib/sidebar/components/ownedresourceslist.coffee
+++ b/client/app/lib/sidebar/components/ownedresourceslist.coffee
@@ -254,6 +254,7 @@ module.exports = class OwnedResourcesList extends React.Component
     machine = stack.machines[rowIndex]
 
     <SidebarMachineItem
+      key={machine.getId()}
       machineId={machine.getId()}
       stackId={stack.getId()} />
 

--- a/client/app/lib/sidebar/components/ownedresourceslist.coffee
+++ b/client/app/lib/sidebar/components/ownedresourceslist.coffee
@@ -142,7 +142,6 @@ module.exports = class OwnedResourcesList extends React.Component
     menuItems = {}
     { stack, template } = resource
 
-
     if !!resource.unreadCount
       menuItems['Update'] = { callback }
 
@@ -230,6 +229,12 @@ module.exports = class OwnedResourcesList extends React.Component
     MENU.once 'KDObjectWillBeDestroyed', -> kd.utils.wait 50, -> MENU = null
 
 
+  onNewStack: (event) ->
+
+    kd.utils.stopDOMEvent event
+    kd.singletons.router.handleRoute '/Stack-Editor/New'
+
+
   renderSectionHeaderAtIndex: (sectionIndex) ->
 
     resource = @props.resources[sectionIndex]
@@ -271,7 +276,7 @@ module.exports = class OwnedResourcesList extends React.Component
   render: ->
 
     <div className='SidebarTeamSection'>
-      <SectionHeader />
+      <SectionHeader onNewStack={@bound 'onNewStack'} />
       <List
         sectionClassName='SidebarSection SidebarStackSection'
         rowClassName='SidebarSection-body'
@@ -284,8 +289,9 @@ module.exports = class OwnedResourcesList extends React.Component
     </div>
 
 
-SectionHeader = ({ children }) ->
+SectionHeader = ({ onNewStack }) ->
 
   <Link className='SidebarSection-headerTitle' href='/Home/stacks'>
     STACKS
+    <span className='SidebarSection-secondaryLink' onClick={onNewStack} />
   </Link>

--- a/client/app/lib/sidebar/components/ownedresourceslist.coffee
+++ b/client/app/lib/sidebar/components/ownedresourceslist.coffee
@@ -18,9 +18,15 @@ SidebarMachineItem = require './machineitemcontainer'
 OwnedResourceHeader = require './ownedresourceheader'
 SidebarNoStacks = require './nostacks'
 
+connectSidebar = require 'app/sidebar/connectsidebar'
+
 MENU = null
 
-module.exports = class OwnedResourcesList extends React.Component
+sidebarConnector = connectSidebar({
+  transformState: (sidebarState, props) -> { selected: sidebarState.selected }
+})
+
+module.exports = sidebarConnector class OwnedResourcesList extends React.Component
 
   constructor: (props) ->
     super props
@@ -241,7 +247,12 @@ module.exports = class OwnedResourcesList extends React.Component
 
     { template, stack, unreadCount } = resource
 
+    selected = if stack
+    then stack.getId() is @props.selected?.stackId
+    else template.getId() is @props.selected?.templateId
+
     <OwnedResourceHeader
+      selected={selected}
       ref={(header) => @headers[sectionIndex] = header}
       title={template?.title or stack?.title}
       onTitleClick={@lazyBound 'onHeaderTitleClick', resource}

--- a/client/app/lib/sidebar/styl/sidebarsection.styl
+++ b/client/app/lib/sidebar/styl/sidebarsection.styl
@@ -50,11 +50,11 @@
     .SidebarSection-secondaryLink
       visible()
 
-.SidebarSection.active
-  .SidebarSection-headerTitle a
-    color                   #e1e1e1 !important
-    &:before
-      border-color          #e1e1e1 !important
+  &.active
+    .SidebarSection-headerTitle a
+      color                   #e1e1e1 !important
+      &:before
+        border-color          #e1e1e1 !important
 
 .SidebarListItem
   antialiased()

--- a/client/app/lib/sidebarcontroller.coffee
+++ b/client/app/lib/sidebarcontroller.coffee
@@ -2,6 +2,7 @@ debug = require('debug')('sidebar:controller')
 kd = require 'kd'
 EnvironmentFlux = require 'app/flux/environment'
 remote = require 'app/remote'
+{ isObject } = require 'lodash'
 
 module.exports = class SidebarController extends kd.Controller
 
@@ -82,7 +83,10 @@ module.exports = class SidebarController extends kd.Controller
 
   setSelected: (type, id) ->
 
-    @selected[type] = id
+    if isObject type
+    then @selected = Object.assign @selected, type
+    else @selected[type] = id
+
     @emit 'change'
 
 

--- a/client/app/lib/sidebarcontroller.coffee
+++ b/client/app/lib/sidebarcontroller.coffee
@@ -19,6 +19,7 @@ module.exports = class SidebarController extends kd.Controller
     @leavingId = null
 
     @selected =
+      templateId: null
       stackId: null
       machineId: null
 

--- a/client/new-stack-editor/bant.json
+++ b/client/new-stack-editor/bant.json
@@ -4,7 +4,7 @@
   "routes": {
     "/Stack-Editor": "home",
     "/Stack-Editor/New": "new",
-    "/Stack-Editor/:stackTemplateId": "edit-stack"
+    "/Stack-Editor/:stackTemplateId/:stackId?": "edit-stack"
   },
   "sprites": [
     "./lib/sprites"

--- a/client/new-stack-editor/lib/index.coffee
+++ b/client/new-stack-editor/lib/index.coffee
@@ -50,7 +50,7 @@ module.exports = class StackEditorAppController extends AppController
     @stackEditor.on Events.InitializeRequested, @bound 'initializeStack'
 
 
-  openEditor: (templateId, options = {}, callback = kd.noop) ->
+  openEditor: (templateId, stackId, options = {}, callback = kd.noop) ->
 
     { reset = no } = options
 
@@ -67,6 +67,14 @@ module.exports = class StackEditorAppController extends AppController
         return callback err
 
       @stackEditor.setData template, reset
+
+      { sidebar } = kd.singletons
+
+      sidebar.setSelected
+        templateId: templateId
+        stackId: stackId
+        machineId: null
+
       callback null
 
     markAsLoaded templateId
@@ -78,12 +86,12 @@ module.exports = class StackEditorAppController extends AppController
     markAsLoaded()
 
 
-  reloadEditor: (templateId) ->
+  reloadEditor: (templateId, stackId) ->
 
     return  unless @templates[templateId]
 
     delete @templates[templateId]
-    @openEditor templateId, { reset: yes }
+    @openEditor templateId, stackId, { reset: yes }
 
 
   fetchStackTemplate: (templateId, callback) ->
@@ -115,7 +123,7 @@ module.exports = class StackEditorAppController extends AppController
       (next) =>
         if @stackEditor.getData()._id isnt templateId
           logs.add 'loading template first...'
-          @openEditor templateId, {}, next
+          @openEditor templateId, null, {}, next
         else
           next()
 
@@ -162,6 +170,12 @@ module.exports = class StackEditorAppController extends AppController
         logs.add 'stack template updated successfully'
         debug 'updated template instance', updatedTemplate
         debug 'generated stack', generatedStack
+        { sidebar } = kd.singletons
+
+        sidebar.setSelected
+          stackId: generatedStack.stack.getId()
+          templateId: updatedTemplate.getId()
+          machineId: null
 
 
   createStackTemplate: (provider) ->

--- a/client/new-stack-editor/lib/routehandler.coffee
+++ b/client/new-stack-editor/lib/routehandler.coffee
@@ -1,9 +1,12 @@
+debug = require('debug')('nse:routehandler')
 kd = require 'kd'
 lazyrouter = require 'app/lazyrouter'
 canCreateStacks = require 'app/util/canCreateStacks'
 isAdmin = require 'app/util/isAdmin'
 
 module.exports = -> lazyrouter.bind 'stackeditor', (type, info, state, path, ctx) ->
+
+  debug 'routing', { type, info, state, path }
 
   unless canCreateStacks() or type is 'edit-stack'
     new kd.NotificationView { title: 'You are not allowed to create/edit stacks!' }
@@ -13,4 +16,6 @@ module.exports = -> lazyrouter.bind 'stackeditor', (type, info, state, path, ctx
     kd.singletons.appManager.tell 'Stackeditor', 'openStackWizard'
   else
     kd.singletons.appManager.open 'Stackeditor', (app) ->
-      app.openEditor info.params.stackTemplateId
+      { stackTemplateId, stackId } = info.params
+      debug 'opening stack editor', { stackTemplateId, stackId }
+      app.openEditor stackTemplateId, stackId

--- a/client/stack-editor/bant.json
+++ b/client/stack-editor/bant.json
@@ -4,7 +4,7 @@
   "routes": {
     "/Stack-Editor": "home",
     "/Stack-Editor/New": "new",
-    "/Stack-Editor/:stackTemplateId": "edit-stack"
+    "/Stack-Editor/:stackTemplateId/:stackId?": "edit-stack"
   },
   "sprites": [
     "./lib/sprites"

--- a/client/stack-editor/lib/index.coffee
+++ b/client/stack-editor/lib/index.coffee
@@ -34,9 +34,8 @@ module.exports = class StackEditorAppController extends AppController
       Object.keys(@shouldReloadMap).forEach @bound 'removeEditor'
 
 
-  openEditor: (stackTemplateId = no) ->
+  openEditor: (stackTemplateId = no, stackId) ->
     { mainController, groupsController, computeController } = kd.singletons
-    { setSelectedMachineId, setSelectedTemplateId } = EnvironmentFlux.actions
 
     unless groupsController.canEditGroup()
       mainController.tellChatlioWidget 'isShown', {}, (err, isShown) ->
@@ -44,11 +43,15 @@ module.exports = class StackEditorAppController extends AppController
         return if isShown
         mainController.tellChatlioWidget 'show', { expanded: no }
 
-    setSelectedMachineId null
-
     if stackTemplateId
-      setSelectedTemplateId stackTemplateId
       if @editors[stackTemplateId]
+        { sidebar } = kd.singletons
+
+        sidebar.setSelected
+          templateId: stackTemplateId
+          stackId: stackId
+          machineId: null
+
         return  @showView { _id: stackTemplateId }
 
       computeController.fetchStackTemplate stackTemplateId, (err, stackTemplate) =>
@@ -58,6 +61,14 @@ module.exports = class StackEditorAppController extends AppController
           return showError err
 
         editor = @showView stackTemplate
+
+        { sidebar } = kd.singletons
+
+        sidebar.setSelected
+          templateId: stackTemplateId
+          stackId: stackId
+          machineId: null
+
         # If selected template is deleted, then redirect them to ide.
         # TODO: show an information modal to the user if he/she is admin. ~Umut
         stackTemplate.on 'deleteInstance', =>

--- a/client/stack-editor/lib/routehandler.coffee
+++ b/client/stack-editor/lib/routehandler.coffee
@@ -1,9 +1,12 @@
+debug = require('debug')('stack-editor:routehandler')
 kd = require 'kd'
 lazyrouter = require 'app/lazyrouter'
 canCreateStacks = require 'app/util/canCreateStacks'
 isAdmin = require 'app/util/isAdmin'
 
 module.exports = -> lazyrouter.bind 'stackeditor', (type, info, state, path, ctx) ->
+
+  debug 'routing', { type, info, state, path }
 
   unless canCreateStacks() or type is 'edit-stack'
     new kd.NotificationView { title: 'You are not allowed to create/edit stacks!' }
@@ -13,4 +16,6 @@ module.exports = -> lazyrouter.bind 'stackeditor', (type, info, state, path, ctx
     kd.singletons.appManager.tell 'Stackeditor', 'openStackWizard'
   else
     kd.singletons.appManager.open 'Stackeditor', (app) ->
-      app.openEditor info.params.stackTemplateId
+      { stackTemplateId, stackId } = info.params
+      debug 'opening stack editor', { stackTemplateId, stackId }
+      app.openEditor stackTemplateId, stackId


### PR DESCRIPTION
Fixes the problems introduced by #10907 

- Remove usages of `EnvironmentFlux` from old `Stack-Editor`
- Add functionality to pass stack id to highlight correct item on sidebar (highlighted stack/template titles) (for both old & new stack editor)

I completely missed the `stack-editor` parts with the changes i introduced in #10907, sorry for that.