### PR TITLE
New TS index node implementation.

### DIFF
--- a/go/src/koding/klient/machine/index/benchmark_test.go
+++ b/go/src/koding/klient/machine/index/benchmark_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"koding/klient/machine/index"
+	"koding/klient/machine/index/node"
 )
 
 var repo = flag.String("repo", "", "")
@@ -49,7 +50,7 @@ func BenchmarkNodeLookup(b *testing.B) {
 
 func BenchmarkNodeAdd(b *testing.B) {
 	const name = "proxy/tmp/sync/fuse/fuse.go"
-	entry := index.NewEntry(0xB, 0)
+	entry := node.NewEntry(0xB, 0)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -79,6 +80,6 @@ func BenchmarkNodeForEach(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		root.ForEach(func(name string, _ *index.Entry) {})
+		root.ForEach(func(name string, _ *node.Entry) {})
 	}
 }

--- a/go/src/koding/klient/machine/index/node.go
+++ b/go/src/koding/klient/machine/index/node.go
@@ -5,33 +5,35 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"koding/klient/machine/index/node"
 )
 
 // Node represents a file tree.
 //
 // A single node represents a file or a directory.
 //
-// Nodes marked with EntryPromiseDel flag are marked
+// Nodes marked with node.EntryPromiseDel flag are marked
 // as deleted, and are not going to be reachable via
 // Lookup, Count methods. Deleting such nodes is a nop.
 // This is how Node implements shallow delete.
 type Node struct {
 	Sub   map[string]*Node `json:"d"`
-	Entry *Entry           `json:"e,omitempty"`
+	Entry *node.Entry      `json:"e,omitempty"`
 }
 
 func newNode() *Node {
 	return &Node{
 		Sub:   make(map[string]*Node),
-		Entry: NewEntry(0, 0755|os.ModeDir),
+		Entry: node.NewEntry(0, 0755|os.ModeDir),
 	}
 }
 
 // Add adds the given entry under the given path.
 //
 // Any deleted node, encountered on the tree path that, is going to
-// be undeleted (having the EntryPromiseDel flag removed).
-func (nd *Node) Add(path string, entry *Entry) {
+// be undeleted (having the node.EntryPromiseDel flag removed).
+func (nd *Node) Add(path string, entry *node.Entry) {
 	if path == "/" || path == "" {
 		nd.Entry = entry
 		return
@@ -110,7 +112,7 @@ func (nd *Node) Clone() *Node {
 
 // PromiseAdd adds a node under the given path marked as newly added.
 //
-// If the node already exists, it'd be only marked with EntryPromiseAdd flag.
+// If the node already exists, it'd be only marked with node.EntryPromiseAdd flag.
 //
 // If the node is already marked as newly added, the method is a no-op.
 //
@@ -118,18 +120,18 @@ func (nd *Node) Clone() *Node {
 // with this value.
 //
 // Rest of entry's fields are currently ignored.
-func (nd *Node) PromiseAdd(path string, entry *Entry) {
-	var newE *Entry
+func (nd *Node) PromiseAdd(path string, entry *node.Entry) {
+	var newE *node.Entry
 
 	if nd, ok := nd.lookup(path, true); ok {
 		newE = nd.Entry
 		newE.MergeIn(entry)
 	} else {
-		newE = NewEntry(entry.Size(), entry.Mode())
+		newE = node.NewEntry(entry.Size(), entry.Mode())
 		newE.MergeIn(entry)
 	}
 
-	newE.SwapPromise(EntryPromiseAdd, EntryPromiseDel|EntryPromiseUnlink)
+	newE.SwapPromise(node.EntryPromiseAdd, node.EntryPromiseDel|node.EntryPromiseUnlink)
 	nd.Add(path, newE)
 }
 
@@ -140,16 +142,16 @@ func (nd *Node) PromiseAdd(path string, entry *Entry) {
 //
 // If node is non-nil, then it's used instead of looking it up
 // by the given path.
-func (nd *Node) PromiseDel(path string, node *Node) {
-	if node == nil {
+func (nd *Node) PromiseDel(path string, n *Node) {
+	if n == nil {
 		var ok bool
-		node, ok = nd.Lookup(path)
+		n, ok = nd.Lookup(path)
 		if !ok {
 			return
 		}
 	}
 
-	node.Entry.SwapPromise(EntryPromiseDel, EntryPromiseAdd|EntryPromiseUnlink)
+	n.Entry.SwapPromise(node.EntryPromiseDel, node.EntryPromiseAdd|node.EntryPromiseUnlink)
 }
 
 // PromiseUnlink marks a node under the given path as unlinked.
@@ -159,16 +161,16 @@ func (nd *Node) PromiseDel(path string, node *Node) {
 //
 // If node is non-nil, then it's used instead of looking it up
 // by the given path.
-func (nd *Node) PromiseUnlink(path string, node *Node) {
-	if node == nil {
+func (nd *Node) PromiseUnlink(path string, n *Node) {
+	if n == nil {
 		var ok bool
-		node, ok = nd.Lookup(path)
+		n, ok = nd.Lookup(path)
 		if !ok {
 			return
 		}
 	}
 
-	node.Entry.SwapPromise(EntryPromiseUnlink, EntryPromiseAdd)
+	n.Entry.SwapPromise(node.EntryPromiseUnlink, node.EntryPromiseAdd)
 }
 
 // Count counts nodes which Entry.Size is at most maxsize.
@@ -268,16 +270,16 @@ func (nd *Node) diskSize(maxsize int64, all bool) (size int64) {
 // ForEach traverses the tree and calls fn on every node's entry.
 //
 // It ignored nodes marked as deleted.
-func (nd *Node) ForEach(fn func(string, *Entry)) {
+func (nd *Node) ForEach(fn func(string, *node.Entry)) {
 	nd.forEach(fn, false)
 }
 
 // ForEachAll traverses the tree and calls fn on every node's entry.
-func (nd *Node) ForEachAll(fn func(string, *Entry)) {
+func (nd *Node) ForEachAll(fn func(string, *node.Entry)) {
 	nd.forEach(fn, true)
 }
 
-func (nd *Node) forEach(fn func(string, *Entry), deleted bool) {
+func (nd *Node) forEach(fn func(string, *node.Entry), deleted bool) {
 	type node struct {
 		path string
 		node *Node
@@ -358,11 +360,11 @@ func (nd *Node) Deleted() bool {
 
 // Virtual tells whether node is marked as virtual.
 func (nd *Node) Virtual() bool {
-	return nd.Entry.HasPromise(EntryPromiseVirtual)
+	return nd.Entry.HasPromise(node.EntryPromiseVirtual)
 }
 
 func (nd *Node) undelete() {
-	nd.Entry.SwapPromise(0, EntryPromiseDel|EntryPromiseUnlink)
+	nd.Entry.SwapPromise(0, node.EntryPromiseDel|node.EntryPromiseUnlink)
 }
 
 func (nd *Node) shallowCopy() *Node {

--- a/go/src/koding/klient/machine/index/node/benchmark_test.go
+++ b/go/src/koding/klient/machine/index/node/benchmark_test.go
@@ -1,0 +1,59 @@
+package node_test
+
+import (
+	"testing"
+
+	"koding/klient/machine/index/node"
+)
+
+func BenchmarkNodeLookup(b *testing.B) {
+	const name = "/idset/idset_test.go"
+	tree := testTree(fixData)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tree.Do(name, func(n *node.Node) bool {
+			if n.IsShadowed() {
+				b.Fatalf("want %s to be present in tree", name)
+			}
+
+			return true
+		})
+	}
+}
+
+func BenchmarkNodeAdd(b *testing.B) {
+	const name = "proxy/tmp/sync/fuse/fuse.go"
+	entry := node.NewEntry(0xB, 0)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		tree := testTree(fixData)
+		b.StartTimer()
+
+		tree.Do(name, node.Insert(entry))
+	}
+}
+
+func BenchmarkNodeDel(b *testing.B) {
+	const name = "addresses/addresser.go"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		tree := testTree(fixData)
+		b.StartTimer()
+
+		tree.Do(name, node.Delete())
+	}
+}
+
+func BenchmarkNodeForEach(b *testing.B) {
+	tree := testTree(fixData)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tree.Do("", node.WalkPath(func(nodePath string, _ *node.Node) {}))
+	}
+}

--- a/go/src/koding/klient/machine/index/node/entry.go
+++ b/go/src/koding/klient/machine/index/node/entry.go
@@ -1,4 +1,4 @@
-package index
+package node
 
 import (
 	"encoding/json"
@@ -6,6 +6,8 @@ import (
 	"os"
 	"sync/atomic"
 	"time"
+
+	"github.com/djherbis/times"
 )
 
 // EntryPromise describes the promised state of index entry.
@@ -61,8 +63,8 @@ type virtualEntry struct {
 }
 
 var (
-	_ json.Marshaler   = (*Index)(nil)
-	_ json.Unmarshaler = (*Index)(nil)
+	_ json.Marshaler   = (*Entry)(nil)
+	_ json.Unmarshaler = (*Entry)(nil)
 )
 
 // Entry represents a single file registered to index.
@@ -275,4 +277,21 @@ func (e *Entry) MarshalJSON() ([]byte, error) {
 // data into private entry fields.
 func (e *Entry) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &e.real)
+}
+
+func getPowerOf2(i uint64) (count int) {
+	for ; i > 1; count++ {
+		i = i >> 1
+	}
+
+	return count
+}
+
+// ctime gets file's change time in UNIX Nano format.
+func ctime(fi os.FileInfo) int64 {
+	if tspec := times.Get(fi); tspec.HasChangeTime() {
+		return tspec.ChangeTime().UnixNano()
+	}
+
+	return 0
 }

--- a/go/src/koding/klient/machine/index/node/entry_test.go
+++ b/go/src/koding/klient/machine/index/node/entry_test.go
@@ -1,30 +1,30 @@
-package index_test
+package node_test
 
 import (
 	"fmt"
 	"testing"
 
-	"koding/klient/machine/index"
+	"koding/klient/machine/index/node"
 )
 
 func TestEntryPromiseString(t *testing.T) {
 	tests := []struct {
-		EP     index.EntryPromise
+		EP     node.EntryPromise
 		Result string
 	}{
 		{
 			// 0 //
-			EP:     index.EntryPromiseVirtual,
+			EP:     node.EntryPromiseVirtual,
 			Result: "V----",
 		},
 		{
 			// 1 //
-			EP:     index.EntryPromiseVirtual | index.EntryPromiseDel | index.EntryPromiseUnlink,
+			EP:     node.EntryPromiseVirtual | node.EntryPromiseDel | node.EntryPromiseUnlink,
 			Result: "V--DN",
 		},
 		{
 			// 2 //
-			EP:     index.EntryPromiseAdd,
+			EP:     node.EntryPromiseAdd,
 			Result: "-A---",
 		},
 		{

--- a/go/src/koding/klient/machine/index/node/node.go
+++ b/go/src/koding/klient/machine/index/node/node.go
@@ -110,43 +110,6 @@ func WalkPath(f func(string, *Node)) Predicate {
 	}
 }
 
-/*
-	err := walkFn(nodePath, info, nil)
-   352		if err != nil {
-   353			if info.IsDir() && err == SkipDir {
-   354				return nil
-   355			}
-   356			return err
-   357		}
-   358
-   359		if !info.IsDir() {
-   360			return nil
-   361		}
-   362
-   363		names, err := readDirNames(nodePath)
-   364		if err != nil {
-   365			return walkFn(nodePath, info, err)
-   366		}
-   367
-   368		for _, name := range names {
-   369			filename := Join(nodePath, name)
-   370			fileInfo, err := lstat(filename)
-   371			if err != nil {
-   372				if err := walkFn(filename, fileInfo, err); err != nil && err != SkipDir {
-   373					return err
-   374				}
-   375			} else {
-   376				err = walk(filename, fileInfo, walkFn)
-   377				if err != nil {
-   378					if !fileInfo.IsDir() || err != SkipDir {
-   379						return err
-   380					}
-   381				}
-   382			}
-   383		}
-   384		return nil
-*/
-
 func Count(n *int) Predicate {
 	return Walk(func(*Node) { (*n)++ })
 }

--- a/go/src/koding/klient/machine/index/node/node.go
+++ b/go/src/koding/klient/machine/index/node/node.go
@@ -2,48 +2,46 @@ package node
 
 import (
 	"os"
+	"path"
 	"sort"
 	"strings"
 	"sync"
 )
 
-// Node
+// Node stores a single tree entity. All method calls performed on Node must
+// be synchronized.
 type Node struct {
-	name     string  // name.
-	entry    *Entry  // entry.
-	children []*Node // children.
+	Name     string  `json:"name"`
+	Entry    *Entry  `json:"entry,omitempty"`
+	Children []*Node `json:"children,omitempty"`
 }
 
-// NewNode
+// NewNode creates a new node with zero-size entry and directory mode.
 func NewNode(name string) *Node {
 	return &Node{
-		name:     name,
-		entry:    NewEntry(0, 0755|os.ModeDir),
-		children: make([]*Node, 0),
+		Name:     name,
+		Entry:    NewEntry(0, 0755|os.ModeDir),
+		Children: make([]*Node, 0),
 	}
 }
 
-// NewNodeEntry
+// NewNodeEntry creates a new node with provided entry.
 func NewNodeEntry(name string, entry *Entry) *Node {
 	return &Node{
-		name:     name,
-		entry:    entry,
-		children: make([]*Node, 0),
+		Name:  name,
+		Entry: entry,
 	}
 }
 
-// Name returns node name.
-func (n *Node) Name() string { return n.name }
-
-// Entry returns node entry data.
-func (n *Node) Entry() *Entry { return n.entry }
+// IsShadowed returns true when node is not present in tree.
+func (n *Node) IsShadowed() bool { return n.Entry == nil }
 
 // NodeSlice attaches the methods of sortInterface to []*Node, sorting in
 // asceding order.
 type NodeSlice []*Node
 
 func (ns NodeSlice) Len() int           { return len(ns) }
-func (ns NodeSlice) Less(i, j int) bool { return ns[i].name < ns[j].name }
+func (ns NodeSlice) Less(i, j int) bool { return ns[i].Name < ns[j].Name }
 func (ns NodeSlice) Swap(i, j int)      { ns[i], ns[j] = ns[j], ns[i] }
 
 // SearchNodes searches for name in a sorted slice of nodes and returns the
@@ -51,39 +49,132 @@ func (ns NodeSlice) Swap(i, j int)      { ns[i], ns[j] = ns[j], ns[i] }
 // new node if node with provided name is not present. The slice must be sorted
 // in ascending order.
 func SearchNodes(ns []*Node, name string) int {
-	return sort.Search(len(ns), func(i int) bool { return ns[i].name >= name })
+	return sort.Search(len(ns), func(i int) bool { return ns[i].Name >= name })
 }
 
+// Predicate defines the read or write operation on the node. Node passed
+// as argument can be safely modified. Any predicate function must return true
+// in order to commit the changes.
 type Predicate func(*Node) bool
 
+// Insert adds or replaces a node pointed by provided nodePath. If the node nodePath
+// doesn't exist it is created and nodes between inherit file permissions from
+// the first present node in the tree.
 func Insert(entry *Entry) Predicate {
 	return func(n *Node) bool {
-		n.entry = entry
+		n.Entry = entry
 		return true
 	}
 }
 
+// Delete removes the node and all its children from the tree.
 func Delete() Predicate {
 	return func(_ *Node) bool {
 		return false
 	}
 }
 
-// Tree todo
+func Walk(f func(*Node)) Predicate {
+	return func(n *Node) bool {
+		for stack := []*Node{n}; len(stack) != 0; {
+			f(stack[0])
+
+			stack = append(stack[1:], stack[0].Children...)
+		}
+
+		return true
+	}
+}
+
+func WalkPath(f func(string, *Node)) Predicate {
+	var subFn func(string, *Node)
+
+	subFn = func(nodePath string, n *Node) {
+		// Call on root node.
+		f(nodePath, n)
+
+		for i := range n.Children {
+			childPath := path.Join(nodePath, n.Children[i].Name)
+			// Save some function calls for regural files.
+			if len(n.Children[i].Children) == 0 {
+				f(childPath, n.Children[i])
+			} else {
+				subFn(childPath, n.Children[i])
+			}
+		}
+	}
+
+	return func(n *Node) bool {
+		subFn("", n)
+		return true
+	}
+}
+
+/*
+	err := walkFn(nodePath, info, nil)
+   352		if err != nil {
+   353			if info.IsDir() && err == SkipDir {
+   354				return nil
+   355			}
+   356			return err
+   357		}
+   358
+   359		if !info.IsDir() {
+   360			return nil
+   361		}
+   362
+   363		names, err := readDirNames(nodePath)
+   364		if err != nil {
+   365			return walkFn(nodePath, info, err)
+   366		}
+   367
+   368		for _, name := range names {
+   369			filename := Join(nodePath, name)
+   370			fileInfo, err := lstat(filename)
+   371			if err != nil {
+   372				if err := walkFn(filename, fileInfo, err); err != nil && err != SkipDir {
+   373					return err
+   374				}
+   375			} else {
+   376				err = walk(filename, fileInfo, walkFn)
+   377				if err != nil {
+   378					if !fileInfo.IsDir() || err != SkipDir {
+   379						return err
+   380					}
+   381				}
+   382			}
+   383		}
+   384		return nil
+*/
+
+func Count(n *int) Predicate {
+	return Walk(func(*Node) { (*n)++ })
+}
+
+func DiskSize(size *int64) Predicate {
+	return Walk(func(n *Node) {
+		if n.Entry != nil {
+			*size += n.Entry.Size()
+		}
+	})
+}
+
+// Tree is a wrapper on Nodes that allows safe manipulation of stored Nodes.
 type Tree struct {
 	mu   sync.Mutex
 	root *Node
 }
 
-// NewTree todo
+// NewTree creates a new Tree instance initialized with a single root node.
 func NewTree() *Tree {
 	return &Tree{
 		root: NewNode(""),
 	}
 }
 
-func (t *Tree) Do(path string, pred Predicate) {
-	names := split(path)
+// Do safely calls a given predicate on node pointed by nodePath argument.
+func (t *Tree) Do(nodePath string, pred Predicate) {
+	names := split(nodePath)
 	if len(names) == 0 {
 		t.mu.Lock()
 		// Root branch is neither a shadow branch nor can be deleted so, we can
@@ -113,33 +204,44 @@ func (t *Tree) Do(path string, pred Predicate) {
 			rmChild(p, pi, live)
 		}
 	}
+
+	t.mu.Unlock()
 }
 
 func (t *Tree) find(names []string) (pi int, p, live *Node, ci int, c, subj *Node) {
 	live, subj = t.root, t.root // Start from the root node.
 	for i := range names {
-		idx := SearchNodes(subj.children, names[i])
+		idx := SearchNodes(subj.Children, names[i])
 		// Value with a given name is not present in current node.
-		if idx >= len(subj.children) || subj.children[idx].name != names[i] {
+		if idx >= len(subj.Children) || subj.Children[idx].Name != names[i] {
 			e := &Entry{}
 			if i < len(names)-1 {
-				// This entry is a part of larger path so make it a directory.
-				e.SetMode((subj.entry.Mode() & os.ModePerm) | os.ModeDir)
+				// This entry is a part of larger nodePath so make it a directory.
+				e.SetMode((subj.Entry.Mode() & os.ModePerm) | os.ModeDir)
 			}
 
 			n := NewNodeEntry(names[i], e)
 			if c == nil {
 				// First new node.
 				ci, c = idx, n
+			} else if len(c.Children) == 0 {
+				// First branch in shadowed node.
+				c.Children = append(c.Children, n)
+			} else if len(c.Children) == 1 {
+				// Another shadowed sub-branch, move forward till empty one.
+				child := c.Children[0]
+				for len(child.Children) > 0 {
+					child = child.Children[0]
+				}
+				child.Children = append(child.Children, n)
 			} else {
-				// Another branch in new Node.
-				c.children = append(c.children, n)
+				panic("logic error: invalid number of shadowed children")
 			}
 
 			subj = n
 		} else {
 			pi, p = idx, subj
-			subj = subj.children[idx]
+			subj = subj.Children[idx]
 			live = subj
 		}
 	}
@@ -148,45 +250,45 @@ func (t *Tree) find(names []string) (pi int, p, live *Node, ci int, c, subj *Nod
 }
 
 func addChild(n *Node, pos int, child *Node) {
-	if pos >= len(n.children) {
+	if pos >= len(n.Children) {
 		// Put at the end of children slice.
-		n.children = append(n.children, child)
+		n.Children = append(n.Children, child)
 		return
 	}
 
-	if n.children[pos].name == child.name {
+	if n.Children[pos].Name == child.Name {
 		// Replace if the children already exist. This is logically impossible
 		// however do this for the sake of correctness.
-		n.children[pos] = child
+		n.Children[pos] = child
 		return
 	}
 
 	// Put child between others preserving lexicographical order.
-	n.children = append(n.children, nil)
-	copy(n.children[pos+1:], n.children[pos:])
-	n.children[pos] = child
+	n.Children = append(n.Children, nil)
+	copy(n.Children[pos+1:], n.Children[pos:])
+	n.Children[pos] = child
 }
 
 func rmChild(n *Node, pos int, child *Node) {
-	if pos >= len(n.children) {
+	if pos >= len(n.Children) {
 		// Cannot remove from position larger than number of elements in slice.
 		return
 	}
 
-	if n.children[pos].name != child.name {
+	if n.Children[pos].Name != child.Name {
 		// If node names are not equal we do nothing. As in case of add, this
 		// is not possible on correctly synchronized logic but added for the
 		// sake of correctness.
 		return
 	}
 
-	copy(n.children[pos:], n.children[pos+1:])
-	n.children[len(n.children)-1] = nil // let GC decrease refcounter.
-	n.children = n.children[:len(n.children)-1]
+	copy(n.Children[pos:], n.Children[pos+1:])
+	n.Children[len(n.Children)-1] = nil // let GC decrease refcounter.
+	n.Children = n.Children[:len(n.Children)-1]
 }
 
-func split(path string) []string {
-	names := strings.Split(path, "/")
+func split(nodePath string) []string {
+	names := strings.Split(nodePath, "/")
 
 	// Delete empty or "." sub-paths.
 	for i := 0; i < len(names); i++ {

--- a/go/src/koding/klient/machine/index/node/node.go
+++ b/go/src/koding/klient/machine/index/node/node.go
@@ -1,0 +1,80 @@
+package node
+
+import (
+	"errors"
+	"path/filepath"
+)
+
+// ErrNotFound is returned when provided node was not found during lookup.
+var ErrNotFound = errors.New("node not found")
+
+// Noder is an interface that must be implemented by entity that represents a
+// single file or directory inside directory tree.
+type Noder interface {
+	Name() string  // Name of the node/file/directory.
+	Entry() *Entry // Entry, accessing this structure is TS.
+	//Children(func(Noder)) // Node sub-nodes, always sorted.
+	//Clone Noder // Clones the node.
+}
+
+// Tree represents growable or shrinkable Noder tree.
+type Tree interface {
+	Add(path string, e *Entry)         // Adds new Entry under a given path.
+	Lookup(path string) (Noder, error) // Shearches for nodes under a given path.
+	Delete(path string)                // Removes the node under a given path.
+}
+
+// WalkFunc represents a function that can be called on each entry visited by
+// Walk function.
+type WalkFunc func(path string, entry *Entry)
+
+// Walk walks the node tree calling walkFn for each node stored by it. This
+// function assumes no cycles inside provided noder.
+func Walk(n Noder, walkFn WalkFunc) {
+	walk("", n, walkFn)
+}
+
+func walk(root string, n Noder, walkFn WalkFunc) {
+	if n == nil {
+		return
+	}
+
+	path := filepath.Join(root, n.Name())
+
+	// Call fn for noder itself.
+	walkFn(path, n.Entry())
+
+	// // Visit node children.
+	// for _, child := range n.Children() {
+	// 	walk(path, child, walkFn)
+	// }
+}
+
+// Node
+type Node struct {
+	name     string
+	entry    *Entry
+	children []*Node
+}
+
+func NewNode() *Node {
+	return nil
+}
+
+// Name
+func (n *Node) Name() string {
+	return n.name
+}
+
+// Entry
+func (n *Node) Entry() *Entry {
+	return n.entry
+}
+
+// Children
+func (n *Node) Children(f func(ndr Noder)) {
+
+}
+
+// Add
+func (n *Node) Add() {}

--- a/go/src/koding/klient/machine/index/node/node.go
+++ b/go/src/koding/klient/machine/index/node/node.go
@@ -1,80 +1,200 @@
 package node
 
 import (
-	"errors"
-	"path/filepath"
+	"os"
+	"sort"
+	"strings"
+	"sync"
 )
-
-// ErrNotFound is returned when provided node was not found during lookup.
-var ErrNotFound = errors.New("node not found")
-
-// Noder is an interface that must be implemented by entity that represents a
-// single file or directory inside directory tree.
-type Noder interface {
-	Name() string  // Name of the node/file/directory.
-	Entry() *Entry // Entry, accessing this structure is TS.
-	//Children(func(Noder)) // Node sub-nodes, always sorted.
-	//Clone Noder // Clones the node.
-}
-
-// Tree represents growable or shrinkable Noder tree.
-type Tree interface {
-	Add(path string, e *Entry)         // Adds new Entry under a given path.
-	Lookup(path string) (Noder, error) // Shearches for nodes under a given path.
-	Delete(path string)                // Removes the node under a given path.
-}
-
-// WalkFunc represents a function that can be called on each entry visited by
-// Walk function.
-type WalkFunc func(path string, entry *Entry)
-
-// Walk walks the node tree calling walkFn for each node stored by it. This
-// function assumes no cycles inside provided noder.
-func Walk(n Noder, walkFn WalkFunc) {
-	walk("", n, walkFn)
-}
-
-func walk(root string, n Noder, walkFn WalkFunc) {
-	if n == nil {
-		return
-	}
-
-	path := filepath.Join(root, n.Name())
-
-	// Call fn for noder itself.
-	walkFn(path, n.Entry())
-
-	// // Visit node children.
-	// for _, child := range n.Children() {
-	// 	walk(path, child, walkFn)
-	// }
-}
 
 // Node
 type Node struct {
-	name     string
-	entry    *Entry
-	children []*Node
+	name     string  // name.
+	entry    *Entry  // entry.
+	children []*Node // children.
 }
 
-func NewNode() *Node {
-	return nil
+// NewNode
+func NewNode(name string) *Node {
+	return &Node{
+		name:     name,
+		entry:    NewEntry(0, 0755|os.ModeDir),
+		children: make([]*Node, 0),
+	}
 }
 
-// Name
-func (n *Node) Name() string {
-	return n.name
+// NewNodeEntry
+func NewNodeEntry(name string, entry *Entry) *Node {
+	return &Node{
+		name:     name,
+		entry:    entry,
+		children: make([]*Node, 0),
+	}
 }
 
-// Entry
-func (n *Node) Entry() *Entry {
-	return n.entry
+// Name returns node name.
+func (n *Node) Name() string { return n.name }
+
+// Entry returns node entry data.
+func (n *Node) Entry() *Entry { return n.entry }
+
+// NodeSlice attaches the methods of sortInterface to []*Node, sorting in
+// asceding order.
+type NodeSlice []*Node
+
+func (ns NodeSlice) Len() int           { return len(ns) }
+func (ns NodeSlice) Less(i, j int) bool { return ns[i].name < ns[j].name }
+func (ns NodeSlice) Swap(i, j int)      { ns[i], ns[j] = ns[j], ns[i] }
+
+// SearchNodes searches for name in a sorted slice of nodes and returns the
+// index as specified by sort.Search. The return value is the index to insert
+// new node if node with provided name is not present. The slice must be sorted
+// in ascending order.
+func SearchNodes(ns []*Node, name string) int {
+	return sort.Search(len(ns), func(i int) bool { return ns[i].name >= name })
 }
 
-// Children
-func (n *Node) Children(f func(ndr Noder)) {
+type Predicate func(*Node) bool
 
+func Insert(entry *Entry) Predicate {
+	return func(n *Node) bool {
+		n.entry = entry
+		return true
+	}
 }
 
-// Add
-func (n *Node) Add() {}
+func Delete() Predicate {
+	return func(_ *Node) bool {
+		return false
+	}
+}
+
+// Tree todo
+type Tree struct {
+	mu   sync.Mutex
+	root *Node
+}
+
+// NewTree todo
+func NewTree() *Tree {
+	return &Tree{
+		root: NewNode(""),
+	}
+}
+
+func (t *Tree) Do(path string, pred Predicate) {
+	names := split(path)
+	if len(names) == 0 {
+		t.mu.Lock()
+		// Root branch is neither a shadow branch nor can be deleted so, we can
+		// only call predicate on it.
+		pred(t.root)
+		t.mu.Unlock()
+		return
+	}
+
+	t.mu.Lock()
+
+	// Find node in a tree or create a shadow branch not attached to anything.
+	pi, p, live, ci, c, subj := t.find(names)
+
+	// subj stores requested node.
+	if ok := pred(subj); ok {
+		// User wants to keep the node so, if it's a shadow branch we need to
+		// attach it to the last `live` branch.
+		if c != nil {
+			// Child for live branch is present.
+			addChild(live, ci, c)
+		}
+	} else {
+		// User wants to remove the node so, if it's a live branch we need to
+		// remove it from its parent. In this case live == subj.
+		if c == nil {
+			rmChild(p, pi, live)
+		}
+	}
+}
+
+func (t *Tree) find(names []string) (pi int, p, live *Node, ci int, c, subj *Node) {
+	live, subj = t.root, t.root // Start from the root node.
+	for i := range names {
+		idx := SearchNodes(subj.children, names[i])
+		// Value with a given name is not present in current node.
+		if idx >= len(subj.children) || subj.children[idx].name != names[i] {
+			e := &Entry{}
+			if i < len(names)-1 {
+				// This entry is a part of larger path so make it a directory.
+				e.SetMode((subj.entry.Mode() & os.ModePerm) | os.ModeDir)
+			}
+
+			n := NewNodeEntry(names[i], e)
+			if c == nil {
+				// First new node.
+				ci, c = idx, n
+			} else {
+				// Another branch in new Node.
+				c.children = append(c.children, n)
+			}
+
+			subj = n
+		} else {
+			pi, p = idx, subj
+			subj = subj.children[idx]
+			live = subj
+		}
+	}
+
+	return
+}
+
+func addChild(n *Node, pos int, child *Node) {
+	if pos >= len(n.children) {
+		// Put at the end of children slice.
+		n.children = append(n.children, child)
+		return
+	}
+
+	if n.children[pos].name == child.name {
+		// Replace if the children already exist. This is logically impossible
+		// however do this for the sake of correctness.
+		n.children[pos] = child
+		return
+	}
+
+	// Put child between others preserving lexicographical order.
+	n.children = append(n.children, nil)
+	copy(n.children[pos+1:], n.children[pos:])
+	n.children[pos] = child
+}
+
+func rmChild(n *Node, pos int, child *Node) {
+	if pos >= len(n.children) {
+		// Cannot remove from position larger than number of elements in slice.
+		return
+	}
+
+	if n.children[pos].name != child.name {
+		// If node names are not equal we do nothing. As in case of add, this
+		// is not possible on correctly synchronized logic but added for the
+		// sake of correctness.
+		return
+	}
+
+	copy(n.children[pos:], n.children[pos+1:])
+	n.children[len(n.children)-1] = nil // let GC decrease refcounter.
+	n.children = n.children[:len(n.children)-1]
+}
+
+func split(path string) []string {
+	names := strings.Split(path, "/")
+
+	// Delete empty or "." sub-paths.
+	for i := 0; i < len(names); i++ {
+		if names[i] == "" || names[i] == "." {
+			names = append(names[:i], names[i+1:]...)
+			i--
+		}
+	}
+
+	return names
+}

--- a/go/src/koding/klient/machine/index/node/node_test.go
+++ b/go/src/koding/klient/machine/index/node/node_test.go
@@ -1,6 +1,7 @@
 package node_test
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -52,7 +53,7 @@ func testTree(data map[string]int64) *node.Tree {
 	return tree
 }
 
-func TestNodeLookup(t *testing.T) {
+func TestTreeLookup(t *testing.T) {
 	cases := map[string]int64{
 		"/":                       0,
 		"addresses":               0,
@@ -87,7 +88,7 @@ func TestNodeLookup(t *testing.T) {
 	}
 }
 
-func TestNodeCount(t *testing.T) {
+func TestTreeCount(t *testing.T) {
 	cases := map[string]int{
 		"":                       34,
 		"/":                      34,
@@ -111,7 +112,7 @@ func TestNodeCount(t *testing.T) {
 	}
 }
 
-func TestNodeDiskSize(t *testing.T) {
+func TestTreeDiskSize(t *testing.T) {
 	cases := map[string]int64{
 		"":                       93991,
 		"/":                      93991,
@@ -135,7 +136,7 @@ func TestNodeDiskSize(t *testing.T) {
 	}
 }
 
-func TestNodeAdd(t *testing.T) {
+func TestTreeAdd(t *testing.T) {
 	const finalCount = 61
 
 	cases := map[string]struct{}{
@@ -183,7 +184,7 @@ func TestNodeAdd(t *testing.T) {
 	}
 }
 
-func TestNodeDel(t *testing.T) {
+func TestTreeDel(t *testing.T) {
 	const finalCount = 22
 
 	cases := map[string]struct{}{
@@ -216,7 +217,7 @@ func TestNodeDel(t *testing.T) {
 	}
 }
 
-func TestNodeForEach(t *testing.T) {
+func TestTreeForEach(t *testing.T) {
 	want := []string{
 		"",
 		"addresses",
@@ -263,5 +264,35 @@ func TestNodeForEach(t *testing.T) {
 
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestTreeMarshalJSON(t *testing.T) {
+	var treeNodes, gotNodes []string
+
+	tree := testTree(fixData)
+	tree.Do("", node.WalkPath(func(nodePath string, _ *node.Node) {
+		treeNodes = append(treeNodes, nodePath)
+	}))
+
+	data, err := json.Marshal(tree)
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+
+	got := &node.Tree{}
+	if err := json.Unmarshal(data, got); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	got.Do("", node.WalkPath(func(nodePath string, _ *node.Node) {
+		gotNodes = append(gotNodes, nodePath)
+	}))
+
+	if !reflect.DeepEqual(tree, got) {
+		t.Errorf("want:\n%#v\ngot\n%#v\n", tree, got)
+	}
+
+	if !reflect.DeepEqual(treeNodes, gotNodes) {
+		t.Errorf("want:\n%#v\ngot\n%#v\n", treeNodes, gotNodes)
 	}
 }

--- a/go/src/koding/klient/machine/index/node/node_test.go
+++ b/go/src/koding/klient/machine/index/node/node_test.go
@@ -1,12 +1,267 @@
 package node_test
 
 import (
+	"reflect"
 	"testing"
 
 	"koding/klient/machine/index/node"
 )
 
-func TestNodeSort(t *testing.T) {
-	nodes := []*node.Node{}
-	_ = nodes
+var fixData = map[string]int64{
+	"addresses":                   0,
+	"addresses/addresser.go":      714,
+	"addresses/addresses.go":      2428,
+	"addresses/addresses_test.go": 3095,
+	"addresses/cached.go":         2036,
+	"aliases":                     0,
+	"aliases/aliaser.go":          596,
+	"aliases/aliases.go":          3218,
+	"aliases/aliases_test.go":     1831,
+	"aliases/cached.go":           2196,
+	"clients":                     0,
+	"clients/clients.go":          4003,
+	"clients/clients_test.go":     1783,
+	"create.go":                   3660,
+	"create_test.go":              4582,
+	"id.go":                       1272,
+	"id_test.go":                  1979,
+	"idset":                       0,
+	"idset/idset.go":              1288,
+	"idset/idset_test.go":         4231,
+	"empty":                       0,
+	"kite.go":                     4152,
+	"machinegroup.go":             6839,
+	"machinegroup_test.go":        6592,
+	"mount.go":                    9346,
+	"mount_test.go":               8824,
+	"mounts":                      0,
+	"mounts/cached.go":            2465,
+	"mounts/mounter.go":           1000,
+	"mounts/mounts.go":            4133,
+	"mounts/mounts_test.go":       5330,
+	"ssh.go":                      2831,
+	"ssh_test.go":                 3567,
+}
+
+func testTree(data map[string]int64) *node.Tree {
+	tree := node.NewTree()
+	for path, size := range data {
+		tree.Do(path, node.Insert(node.NewEntry(size, 0)))
+	}
+
+	return tree
+}
+
+func TestNodeLookup(t *testing.T) {
+	cases := map[string]int64{
+		"/":                       0,
+		"addresses":               0,
+		"addresses/addresses.go":  2428,
+		"machinegroup.go":         6839,
+		"idset/idset_test.go":     4231,
+		"/addresses":              0,
+		"/addresses/addresses.go": 2428,
+		"/machinegroup.go":        6839,
+		"/idset/idset_test.go":    4231,
+	}
+
+	tree := testTree(fixData)
+
+	for path, size := range cases {
+		path, size := path, size // Capture range variables.
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			tree.Do(path, func(n *node.Node) bool {
+				if n.IsShadowed() {
+					t.Fatalf("Lookup(%q) failed", path)
+				}
+
+				if es := n.Entry.Size(); es != size {
+					t.Errorf("got %d, want %d", size, es)
+				}
+
+				return true
+			})
+		})
+	}
+}
+
+func TestNodeCount(t *testing.T) {
+	cases := map[string]int{
+		"":                       34,
+		"/":                      34,
+		"addresses":              5,
+		"addresses/addresses.go": 1,
+		"idset":                  3,
+	}
+
+	tree := testTree(fixData)
+
+	for path, count := range cases {
+		path, count := path, count // Capture range variables.
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			var got int
+			if tree.Do(path, node.Count(&got)); got != count {
+				t.Errorf("got %d, want %d", got, count)
+			}
+		})
+	}
+}
+
+func TestNodeDiskSize(t *testing.T) {
+	cases := map[string]int64{
+		"":                       93991,
+		"/":                      93991,
+		"/some/unknown/path":     0,
+		"addresses/addresses.go": 2428,
+		"idset":                  1288 + 4231,
+	}
+
+	tree := testTree(fixData)
+
+	for path, size := range cases {
+		path, size := path, size // Capture range variables.
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			var got int64
+			if tree.Do(path, node.DiskSize(&got)); got != size {
+				t.Errorf("got %d, want %d", got, size)
+			}
+		})
+	}
+}
+
+func TestNodeAdd(t *testing.T) {
+	const finalCount = 61
+
+	cases := map[string]struct{}{
+		"addresses/cached_test.go": {},
+		"notify.go":                {},
+		"notify/notify.go":         {},
+		"proxy/fuse/fuse.go":       {},
+		"notify":                   {},
+		"notify/":                  {},
+		"/notify/":                 {},
+		"/notify":                  {},
+		"a/b/c/d/e/f/g/h/i/j":      {},
+		"a/a/a/a/a/a/a/a/a/a/a":    {},
+	}
+
+	tree := testTree(fixData)
+
+	// Run parallel test in group test since T object uses parallel results.
+	t.Run("group", func(t *testing.T) {
+		const funnySize = 0xD
+		for path, _ := range cases {
+			path := path // Capture range variable.
+			t.Run(path, func(t *testing.T) {
+				t.Parallel()
+
+				tree.Do(path, node.Insert(node.NewEntry(funnySize, 0)))
+				tree.Do(path, func(n *node.Node) bool {
+					if n.IsShadowed() {
+						t.Fatalf("Lookup(%q) failed", path)
+					}
+
+					if size := n.Entry.Size(); size != funnySize {
+						t.Errorf("got %d, want %d", size, funnySize)
+					}
+
+					return true
+				})
+			})
+		}
+	})
+
+	var count int
+	if tree.Do("", node.Count(&count)); count != finalCount {
+		t.Fatalf("got %d, want %d", count, finalCount)
+	}
+}
+
+func TestNodeDel(t *testing.T) {
+	const finalCount = 22
+
+	cases := map[string]struct{}{
+		"addresses/addresser.go": {},
+		"addresses/":             {},
+		"aliases":                {},
+		"id.go":                  {},
+		"/id.go":                 {},
+		"nonexisting.go":         {},
+		"/kite.go":               {},
+	}
+
+	tree := testTree(fixData)
+
+	// Run parallel test in group test since T object uses parallel results.
+	t.Run("group", func(t *testing.T) {
+		for path, _ := range cases {
+			path := path // Capture range variable.
+			t.Run(path, func(t *testing.T) {
+				t.Parallel()
+
+				tree.Do(path, node.Delete())
+			})
+		}
+	})
+
+	var count int
+	if tree.Do("", node.Count(&count)); count != finalCount {
+		t.Fatalf("got %d, want %d", count, finalCount)
+	}
+}
+
+func TestNodeForEach(t *testing.T) {
+	want := []string{
+		"",
+		"addresses",
+		"addresses/addresser.go",
+		"addresses/addresses.go",
+		"addresses/addresses_test.go",
+		"addresses/cached.go",
+		"aliases",
+		"aliases/aliaser.go",
+		"aliases/aliases.go",
+		"aliases/aliases_test.go",
+		"aliases/cached.go",
+		"clients",
+		"clients/clients.go",
+		"clients/clients_test.go",
+		"create.go",
+		"create_test.go",
+		"empty",
+		"id.go",
+		"id_test.go",
+		"idset",
+		"idset/idset.go",
+		"idset/idset_test.go",
+		"kite.go",
+		"machinegroup.go",
+		"machinegroup_test.go",
+		"mount.go",
+		"mount_test.go",
+		"mounts",
+		"mounts/cached.go",
+		"mounts/mounter.go",
+		"mounts/mounts.go",
+		"mounts/mounts_test.go",
+		"ssh.go",
+		"ssh_test.go",
+	}
+
+	var got []string
+	tree := testTree(fixData)
+
+	tree.Do("", node.WalkPath(func(nodePath string, _ *node.Node) {
+		got = append(got, nodePath)
+	}))
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
 }

--- a/go/src/koding/klient/machine/index/node/node_test.go
+++ b/go/src/koding/klient/machine/index/node/node_test.go
@@ -1,0 +1,12 @@
+package node_test
+
+import (
+	"testing"
+
+	"koding/klient/machine/index/node"
+)
+
+func TestNodeSort(t *testing.T) {
+	nodes := []*node.Node{}
+	_ = nodes
+}

--- a/go/src/koding/klient/machine/index/node_test.go
+++ b/go/src/koding/klient/machine/index/node_test.go
@@ -8,147 +8,148 @@ import (
 	"testing"
 
 	"koding/klient/machine/index"
+	"koding/klient/machine/index/node"
 )
 
 func fixture() *index.Node {
 	return &index.Node{
-		Entry: index.NewEntry(0, 0),
+		Entry: node.NewEntry(0, 0),
 		Sub: map[string]*index.Node{
 			"addresses": {
-				Entry: index.NewEntry(0, 0),
+				Entry: node.NewEntry(0, 0),
 				Sub: map[string]*index.Node{
 					"addresser.go": {
-						Entry: index.NewEntry(714, 0),
+						Entry: node.NewEntry(714, 0),
 						Sub:   map[string]*index.Node{},
 					},
 					"addresses.go": {
-						Entry: index.NewEntry(2428, 0),
+						Entry: node.NewEntry(2428, 0),
 						Sub:   map[string]*index.Node{},
 					},
 					"addresses_test.go": {
-						Entry: index.NewEntry(3095, 0),
+						Entry: node.NewEntry(3095, 0),
 						Sub:   map[string]*index.Node{},
 					},
 					"cached.go": {
-						Entry: index.NewEntry(2036, 0),
+						Entry: node.NewEntry(2036, 0),
 						Sub:   map[string]*index.Node{},
 					},
 				},
 			},
 			"aliases": {
-				Entry: index.NewEntry(0, 0),
+				Entry: node.NewEntry(0, 0),
 				Sub: map[string]*index.Node{
 					"aliaser.go": {
-						Entry: index.NewEntry(596, 0),
+						Entry: node.NewEntry(596, 0),
 						Sub:   map[string]*index.Node{},
 					},
 					"aliases.go": {
-						Entry: index.NewEntry(3218, 0),
+						Entry: node.NewEntry(3218, 0),
 						Sub:   map[string]*index.Node{},
 					},
 					"aliases_test.go": {
-						Entry: index.NewEntry(1831, 0),
+						Entry: node.NewEntry(1831, 0),
 						Sub:   map[string]*index.Node{},
 					},
 					"cached.go": {
-						Entry: index.NewEntry(2196, 0),
+						Entry: node.NewEntry(2196, 0),
 						Sub:   map[string]*index.Node{},
 					},
 				},
 			},
 			"clients": {
-				Entry: index.NewEntry(0, 0),
+				Entry: node.NewEntry(0, 0),
 				Sub: map[string]*index.Node{
 					"clients.go": {
-						Entry: index.NewEntry(4003, 0),
+						Entry: node.NewEntry(4003, 0),
 						Sub:   map[string]*index.Node{},
 					},
 					"clients_test.go": {
-						Entry: index.NewEntry(1783, 0),
+						Entry: node.NewEntry(1783, 0),
 						Sub:   map[string]*index.Node{},
 					},
 				},
 			},
 			"create.go": {
-				Entry: index.NewEntry(3660, 0),
+				Entry: node.NewEntry(3660, 0),
 				Sub:   map[string]*index.Node{},
 			},
 			"create_test.go": {
-				Entry: index.NewEntry(4582, 0),
+				Entry: node.NewEntry(4582, 0),
 				Sub:   map[string]*index.Node{},
 			},
 			"id.go": {
-				Entry: index.NewEntry(1272, 0),
+				Entry: node.NewEntry(1272, 0),
 				Sub:   map[string]*index.Node{},
 			},
 			"id_test.go": {
-				Entry: index.NewEntry(1979, 0),
+				Entry: node.NewEntry(1979, 0),
 				Sub:   map[string]*index.Node{},
 			},
 			"idset": {
-				Entry: index.NewEntry(0, 0),
+				Entry: node.NewEntry(0, 0),
 				Sub: map[string]*index.Node{
 					"idset.go": {
-						Entry: index.NewEntry(1288, 0),
+						Entry: node.NewEntry(1288, 0),
 						Sub:   map[string]*index.Node{},
 					},
 					"idset_test.go": {
-						Entry: index.NewEntry(4231, 0),
+						Entry: node.NewEntry(4231, 0),
 						Sub:   map[string]*index.Node{},
 					},
 				},
 			},
 			"empty": {
-				Entry: index.NewEntry(0, 0),
+				Entry: node.NewEntry(0, 0),
 				Sub:   map[string]*index.Node{},
 			},
 			"kite.go": {
-				Entry: index.NewEntry(4152, 0),
+				Entry: node.NewEntry(4152, 0),
 				Sub:   map[string]*index.Node{},
 			},
 			"machinegroup.go": {
-				Entry: index.NewEntry(6839, 0),
+				Entry: node.NewEntry(6839, 0),
 				Sub:   map[string]*index.Node{},
 			},
 			"machinegroup_test.go": {
-				Entry: index.NewEntry(6592, 0),
+				Entry: node.NewEntry(6592, 0),
 				Sub:   map[string]*index.Node{},
 			},
 			"mount.go": {
-				Entry: index.NewEntry(9346, 0),
+				Entry: node.NewEntry(9346, 0),
 				Sub:   map[string]*index.Node{},
 			},
 			"mount_test.go": {
-				Entry: index.NewEntry(8824, 0),
+				Entry: node.NewEntry(8824, 0),
 				Sub:   map[string]*index.Node{},
 			},
 			"mounts": {
-				Entry: index.NewEntry(0, 0),
+				Entry: node.NewEntry(0, 0),
 				Sub: map[string]*index.Node{
 					"cached.go": {
-						Entry: index.NewEntry(2465, 0),
+						Entry: node.NewEntry(2465, 0),
 						Sub:   map[string]*index.Node{},
 					},
 					"mounter.go": {
-						Entry: index.NewEntry(1000, 0),
+						Entry: node.NewEntry(1000, 0),
 						Sub:   map[string]*index.Node{},
 					},
 					"mounts.go": {
-						Entry: index.NewEntry(4133, 0),
+						Entry: node.NewEntry(4133, 0),
 						Sub:   map[string]*index.Node{},
 					},
 					"mounts_test.go": {
-						Entry: index.NewEntry(5330, 0),
+						Entry: node.NewEntry(5330, 0),
 						Sub:   map[string]*index.Node{},
 					},
 				},
 			},
 			"ssh.go": {
-				Entry: index.NewEntry(2831, 0),
+				Entry: node.NewEntry(2831, 0),
 				Sub:   map[string]*index.Node{},
 			},
 			"ssh_test.go": {
-				Entry: index.NewEntry(3567, 0),
+				Entry: node.NewEntry(3567, 0),
 				Sub:   map[string]*index.Node{},
 			},
 		},
@@ -242,7 +243,7 @@ func TestNodeAdd(t *testing.T) {
 	}
 
 	root := fixture()
-	entry := index.NewEntry(0xD, 0)
+	entry := node.NewEntry(0xD, 0)
 
 	for _, cas := range cases {
 		t.Run(cas.name, func(t *testing.T) {
@@ -341,7 +342,7 @@ func TestNodeForEach(t *testing.T) {
 
 	var got []string
 
-	root.ForEach(func(name string, _ *index.Entry) {
+	root.ForEach(func(name string, _ *node.Entry) {
 		got = append(got, name)
 	})
 

--- a/go/src/koding/klient/machine/mount/notify/fuse/fuse.go
+++ b/go/src/koding/klient/machine/mount/notify/fuse/fuse.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 
 	"koding/klient/machine/index"
+	"koding/klient/machine/index/node"
 
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/fuse/fuseops"
@@ -296,7 +297,7 @@ func (fs *Filesystem) ForgetInode(ctx context.Context, op *fuseops.ForgetInodeOp
 		return nil // no-op
 	}
 
-	if nd.Entry.HasPromise(index.EntryPromiseUnlink) {
+	if nd.Entry.HasPromise(node.EntryPromiseUnlink) {
 		return fs.rm(ctx, nd, rel)
 	}
 


### PR DESCRIPTION
This PR adds new node implementation to mount's index. The old one suffers from race problems causing mounts to crash with concurrent map access panics.

Performance changes:
```
benchmark                  old ns/op     new ns/op     delta
BenchmarkNodeLookup-4      252           305           +21.03%
BenchmarkNodeAdd-4         3300          2405          -27.12%
BenchmarkNodeDel-4         352           804           +128.41%
BenchmarkNodeForEach-4     7196          3666          -49.06%

benchmark                  old allocs     new allocs     delta
BenchmarkNodeLookup-4      2              1              -50.00%
BenchmarkNodeAdd-4         19             16             -15.79%
BenchmarkNodeDel-4         0              1              +Inf%
BenchmarkNodeForEach-4     35             36             +2.86%

benchmark                  old bytes     new bytes     delta
BenchmarkNodeLookup-4      64            48            -25.00%
BenchmarkNodeAdd-4         1397          608           -56.48%
BenchmarkNodeDel-4         0             32            +Inf%
BenchmarkNodeForEach-4     2983          1000          -66.48%
```

## Motivation and Context
Prevent mounts and klient from random crashes.

## How Has This Been Tested?
Unit tests. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
