### PR TITLE
kd/template: add init command

### DIFF
--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -548,6 +548,76 @@ func run(args []string) {
 				SkipFlagParsing: true,
 				Flags:           []cli.Flag{},
 			}},
+		}, {
+			Name:  "template",
+			Usage: "Manage stack templates.",
+			Subcommands: []cli.Command{{
+				Name:      "list",
+				ShortName: "ls",
+				Usage:     "List all stack templates.",
+				Action:    ctlcli.ExitErrAction(TemplateList, log, "list"),
+				Flags: []cli.Flag{
+					cli.BoolFlag{
+						Name:  "json",
+						Usage: "Output in JSON format.",
+					},
+					cli.StringFlag{
+						Name:  "template, t",
+						Usage: "Limit to templates with the given name.",
+					},
+					cli.StringFlag{
+						Name:  "team",
+						Usage: "Limit to templates for the given team.",
+					},
+				},
+			}, {
+				Name:   "show",
+				Usage:  "Show details of a stack template.",
+				Action: ctlcli.ExitErrAction(TemplateShow, log, "show"),
+				Flags: []cli.Flag{
+					cli.BoolFlag{
+						Name:  "json",
+						Usage: "Output in JSON format.",
+					},
+					cli.StringFlag{
+						Name:  "id",
+						Usage: "Limit to a template that matches the ID.",
+					},
+					cli.BoolFlag{
+						Name:  "hcl",
+						Usage: "Output in HCL format.",
+					},
+				},
+			}, {
+				Name:   "delete",
+				Usage:  "Delete a stack template.",
+				Action: ctlcli.ExitErrAction(TemplateDelete, log, "delete"),
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:  "template, t",
+						Usage: "Show template with a given name.",
+					},
+					cli.StringFlag{
+						Name:  "id",
+						Usage: "Limit to a template that matches the ID.",
+					},
+					cli.StringFlag{
+						Name:  "force",
+						Usage: "Do not ask form confirmation.",
+					},
+				},
+			}, {
+				Name:   "init",
+				Usage:  "Generate a new stack template file.",
+				Action: ctlcli.ExitErrAction(TemplateInit, log, "init"),
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:  "output, o",
+						Usage: "Output template file.",
+						Value: "kd.yaml",
+					},
+				},
+			}},
 		},
 	}
 
@@ -714,66 +784,6 @@ func run(args []string) {
 						cli.StringFlag{
 							Name:  "team",
 							Usage: "Limit to stack for the given team.",
-						},
-					},
-				}},
-			},
-			cli.Command{
-				Name:  "template",
-				Usage: "Manage stack templates.",
-				Subcommands: []cli.Command{{
-					Name:      "list",
-					ShortName: "ls",
-					Usage:     "List all stack templates.",
-					Action:    ctlcli.ExitErrAction(TemplateList, log, "list"),
-					Flags: []cli.Flag{
-						cli.BoolFlag{
-							Name:  "json",
-							Usage: "Output in JSON format.",
-						},
-						cli.StringFlag{
-							Name:  "template, t",
-							Usage: "Limit to templates with the given name.",
-						},
-						cli.StringFlag{
-							Name:  "team",
-							Usage: "Limit to templates for the given team.",
-						},
-					},
-				}, {
-					Name:   "show",
-					Usage:  "Show details of a stack template.",
-					Action: ctlcli.ExitErrAction(TemplateShow, log, "show"),
-					Flags: []cli.Flag{
-						cli.BoolFlag{
-							Name:  "json",
-							Usage: "Output in JSON format.",
-						},
-						cli.StringFlag{
-							Name:  "id",
-							Usage: "Limit to a template that matches the ID.",
-						},
-						cli.BoolFlag{
-							Name:  "hcl",
-							Usage: "Output in HCL format.",
-						},
-					},
-				}, {
-					Name:   "delete",
-					Usage:  "Delete a stack template.",
-					Action: ctlcli.ExitErrAction(TemplateDelete, log, "delete"),
-					Flags: []cli.Flag{
-						cli.StringFlag{
-							Name:  "template, t",
-							Usage: "Show template with a given name.",
-						},
-						cli.StringFlag{
-							Name:  "id",
-							Usage: "Limit to a template that matches the ID.",
-						},
-						cli.StringFlag{
-							Name:  "force",
-							Usage: "Do not ask form confirmation.",
 						},
 					},
 				}},

--- a/go/src/koding/klientctl/main_test.go
+++ b/go/src/koding/klientctl/main_test.go
@@ -221,12 +221,3 @@ func (ft *FakeTransport) Call(method string, arg, reply interface{}) error {
 func (ft *FakeTransport) Connect(string) (kloud.Transport, error) { return ft, nil }
 
 func (*FakeTransport) Valid() (_ error) { return }
-
-func nonil(err ...error) error {
-	for _, e := range err {
-		if e != nil {
-			return e
-		}
-	}
-	return nil
-}

--- a/go/src/koding/remoteapi/client/j_stack_template/j_stack_template_samples_responses.go
+++ b/go/src/koding/remoteapi/client/j_stack_template/j_stack_template_samples_responses.go
@@ -54,7 +54,7 @@ func NewJStackTemplateSamplesOK() *JStackTemplateSamplesOK {
 stacktemplate sample in json and yaml format with default values
 */
 type JStackTemplateSamplesOK struct {
-	Payload JStackTemplateSamplesOKBody
+	Payload *models.DefaultResponse
 }
 
 func (o *JStackTemplateSamplesOK) Error() string {


### PR DESCRIPTION
This PR adds basic `kd template init` command. There's going to follow a number of improvements in next PRs, like:

- enum validation
- default values for userInput_ variables
- flag for optional expanding non-koding_ variables

Some examples:

```
$ kd template init
Provider type []: aws
Set "instance_type" to []: t2.nano

Template successfully written to kd.yaml.
```
```
$ cat kd.yaml
provider:
  aws:
    access_key: ${var.aws_access_key}
    secret_key: ${var.aws_secret_key}
resource:
  aws_instance:
    aws-instance:
      ami: ""
      instance_type: t2.nano
      tags:
        Name: ${var.koding_user_username}-${var.koding_group_slug}
      user_data: |-

        echo "hello world!" >> /helloworld.txt
```

```
$ kd template init
Provider type []: marathon
Set "image" to []: ubuntu:16.04
Set "cpus" to []: 2
Set "mem" to []: 1024

Template successfully written to kd.yaml.
```
```
$ cat kd.yaml
provider:
  marathon:
    basic_auth_password: ${var.marathon_basic_auth_password}
    basic_auth_user: ${var.marathon_basic_auth_user}
    url: ${var.marathon_url}
resource:
  marathon_app:
    app:
      container:
        docker:
        - image: ubuntu:16.04
          network: BRIDGE
      cpus: "2"
      instances: 1
      mem: "1024"
```