### PR TITLE
stack/provider: add koding_always_on attribute

### DIFF
--- a/go/src/koding/kites/kloud/stack/provider/apply.go
+++ b/go/src/koding/kites/kloud/stack/provider/apply.go
@@ -360,7 +360,7 @@ func (bs *BaseStack) applyAsync(ctx context.Context, req *stack.ApplyRequest) er
 }
 
 func (bs *BaseStack) UpdateResources(state *terraform.State) error {
-	machines, err := bs.state(state, bs.Klients)
+	machines, err := bs.state(state)
 	if err != nil {
 		return err
 	}
@@ -410,6 +410,10 @@ func (bs *BaseStack) buildUpdateObj(m *stack.Machine, s *DialState, now time.Tim
 	obj["status.modifiedAt"] = now
 	obj["status.state"] = m.State.String()
 	obj["status.reason"] = m.StateReason
+
+	for k, v := range object.MetaBuilder.Build(m.Meta) {
+		obj[k] = v
+	}
 
 	if s.KiteURL != "" {
 		obj["registerUrl"] = s.KiteURL

--- a/go/src/koding/kites/kloud/stack/provider/provider.go
+++ b/go/src/koding/kites/kloud/stack/provider/provider.go
@@ -201,6 +201,7 @@ type BaseStack struct {
 	Planner   *Planner
 	KlientIDs stack.KiteMap
 	Klients   map[string]*DialState
+	Metas     map[string]map[string]interface{}
 	TunnelURL string
 
 	Debug   bool
@@ -250,12 +251,12 @@ func (bs *BaseStack) plan() (stack.Machines, error) {
 	return bs.Plan()
 }
 
-func (bs *BaseStack) state(state *terraform.State, klients map[string]*DialState) (map[string]*stack.Machine, error) {
+func (bs *BaseStack) state(state *terraform.State) (map[string]*stack.Machine, error) {
 	if bs.StateFunc != nil {
-		return bs.StateFunc(state, klients)
+		return bs.StateFunc(state, bs.Klients)
 	}
 
-	return bs.Planner.MachinesFromState(state, klients)
+	return bs.Planner.MachinesFromState(state, bs.Klients, bs.Metas)
 }
 
 type BaseMachine struct {

--- a/go/src/koding/kites/kloud/stack/provider/stacker.go
+++ b/go/src/koding/kites/kloud/stack/provider/stacker.go
@@ -212,6 +212,7 @@ func (s *Stacker) BaseStack(ctx context.Context) (*BaseStack, error) {
 		Provider:  s.Provider,
 		KlientIDs: make(stack.KiteMap),
 		Klients:   make(map[string]*DialState),
+		Metas:     make(map[string]map[string]interface{}),
 		TunnelURL: s.TunnelURL,
 		Keys:      s.SSHKey,
 	}

--- a/go/src/koding/kites/kloud/stack/provider/stackplan.go
+++ b/go/src/koding/kites/kloud/stack/provider/stackplan.go
@@ -99,7 +99,8 @@ type Planner struct {
 //
 // It ignores any other resources than those specified by p.ResourceType
 // and p.Provider.
-func (p *Planner) MachinesFromState(state *terraform.State, klients map[string]*DialState) (map[string]*stack.Machine, error) {
+func (p *Planner) MachinesFromState(state *terraform.State, klients map[string]*DialState,
+	metas map[string]map[string]interface{}) (map[string]*stack.Machine, error) {
 	if len(state.Modules) == 0 {
 		return nil, errors.New("state modules is empty")
 	}
@@ -143,6 +144,10 @@ func (p *Planner) MachinesFromState(state *terraform.State, klients map[string]*
 				RegisterURL: state.KiteURL,
 				State:       machinestate.Running,
 				StateReason: "Created with kloud.apply",
+			}
+
+			if meta, ok := metas[label]; ok && len(meta) != 0 {
+				machine.Meta = meta
 			}
 
 			if state.Err != nil {

--- a/go/src/koding/kites/kloud/stack/provider/userdata.go
+++ b/go/src/koding/kites/kloud/stack/provider/userdata.go
@@ -56,6 +56,15 @@ func (bs *BaseStack) BuildUserdata(name string, vm map[string]interface{}) error
 		delete(vm, "koding_debug")
 	}
 
+	var meta map[string]interface{}
+
+	if b, ok := vm["koding_always_on"].(bool); ok {
+		meta = map[string]interface{}{
+			"alwaysOn": b,
+		}
+		delete(vm, "koding_always_on")
+	}
+
 	if s, ok := vm[field].(string); ok {
 		cfg.Userdata = s
 	}
@@ -78,6 +87,10 @@ func (bs *BaseStack) BuildUserdata(name string, vm map[string]interface{}) error
 		}
 
 		kiteKeys[i] = kiteKey
+
+		if len(meta) != 0 {
+			bs.Metas[label] = meta
+		}
 	}
 
 	t.Variable[kiteKeyName] = map[string]interface{}{

--- a/go/src/koding/kites/kloud/stack/stackmethods.go
+++ b/go/src/koding/kites/kloud/stack/stackmethods.go
@@ -114,10 +114,11 @@ type Machine struct {
 	Credential *Credential       `json:"-"`
 
 	// Fields set by kloud.apply:
-	QueryString string             `json:"queryString,omitempty"`
-	RegisterURL string             `json:"registerURL,omitempty"`
-	State       machinestate.State `json:"state,omitempty"`
-	StateReason string             `json:"stateReason,omitempty"`
+	QueryString string                 `json:"queryString,omitempty"`
+	RegisterURL string                 `json:"registerURL,omitempty"`
+	State       machinestate.State     `json:"state,omitempty"`
+	StateReason string                 `json:"stateReason,omitempty"`
+	Meta        map[string]interface{} `json:"meta,omitempty"`
 }
 
 // Machines represents group of machines mapped by a label.


### PR DESCRIPTION
This PR adds `koding_always_on` attribute that can be used in vm declarations in stack templates.

![demo](http://g.recordit.co/t93iCM3iTb.gif)
(http://g.recordit.co/t93iCM3iTb.gif)