### PR TITLE
kd/ssh: regenerate keypair when private key is missing

### DIFF
--- a/go/src/koding/klientctl/ssh/ssh.go
+++ b/go/src/koding/klientctl/ssh/ssh.go
@@ -109,21 +109,13 @@ func PublicKey(pubPath string) (pubKey string, err error) {
 }
 
 // PrivateKey returns a private key stored under the given path.
-//
-// The function attempts to fix permissions of the private key,
-// if they are different than 0600.
 func PrivateKey(privPath string) (privKey interface{}, err error) {
-	fi, err := os.Stat(privPath)
+	_, err = os.Stat(privPath)
 	if os.IsNotExist(err) {
 		return nil, ErrPrivateKeyNotFound
 	}
 	if err != nil {
 		return nil, err
-	}
-
-	if fi.Mode() != 0600 {
-		// Best-effort attempt at fixing private key permissions.
-		_ = os.Chmod(privPath, 0600)
 	}
 
 	p, err := ioutil.ReadFile(privPath)


### PR DESCRIPTION
Fixes:

```
$ rm ~/.ssh/kd-ssh-key
$ kd machine ssh 58ef593ccc7a51eb42c31b4b
Warning: Identity file  not accessible: No such file or directory.
Warning: Permanently added '52.59.160.233' (ECDSA) to the list of known hosts.
Permission denied (publickey).
error executing "ssh" command: exit status 255
```