### PR TITLE
kloud/provider: remove user_data interpolation

### DIFF
--- a/go/src/koding/kites/kloud/provider/azure/testdata/basic-stack-count-3.json.golden
+++ b/go/src/koding/kites/kloud/provider/azure/testdata/basic-stack-count-3.json.golden
@@ -36,14 +36,6 @@
         "username": "user",
         "virtual_network": "virtual-network"
       }
-    },
-    "null_resource": {
-      "example-instance": {
-        "depends_on": [],
-        "triggers": {
-          "custom_data": "***"
-        }
-      }
     }
   },
   "variable": {

--- a/go/src/koding/kites/kloud/provider/azure/testdata/basic-stack.json.golden
+++ b/go/src/koding/kites/kloud/provider/azure/testdata/basic-stack.json.golden
@@ -35,14 +35,6 @@
         "username": "user",
         "virtual_network": "virtual-network"
       }
-    },
-    "null_resource": {
-      "example-instance": {
-        "depends_on": [],
-        "triggers": {
-          "custom_data": "***"
-        }
-      }
     }
   },
   "variable": {

--- a/go/src/koding/kites/kloud/provider/azure/testdata/custom-endpoint.json.golden
+++ b/go/src/koding/kites/kloud/provider/azure/testdata/custom-endpoint.json.golden
@@ -41,14 +41,6 @@
         "username": "user",
         "virtual_network": "virtual-network"
       }
-    },
-    "null_resource": {
-      "example-instance": {
-        "depends_on": [],
-        "triggers": {
-          "custom_data": "***"
-        }
-      }
     }
   },
   "variable": {

--- a/go/src/koding/kites/kloud/provider/do/testdata/basic-stack-count-2.json.golden
+++ b/go/src/koding/kites/kloud/provider/do/testdata/basic-stack-count-2.json.golden
@@ -17,14 +17,6 @@
         ],
         "user_data": "..."
       }
-    },
-    "null_resource": {
-      "do-instance": {
-        "depends_on": [],
-        "triggers": {
-          "user_data": "\\necho \\\"hello world!\\\" >> /helloworld.txt\\n"
-        }
-      }
     }
   },
   "variable": {

--- a/go/src/koding/kites/kloud/provider/do/testdata/basic-stack.json.golden
+++ b/go/src/koding/kites/kloud/provider/do/testdata/basic-stack.json.golden
@@ -16,14 +16,6 @@
         ],
         "user_data": "..."
       }
-    },
-    "null_resource": {
-      "do-instance": {
-        "depends_on": [],
-        "triggers": {
-          "user_data": "\\necho \\\"hello world!\\\" >> /helloworld.txt\\n"
-        }
-      }
     }
   },
   "variable": {

--- a/go/src/koding/kites/kloud/provider/marathon/stack.go
+++ b/go/src/koding/kites/kloud/provider/marathon/stack.go
@@ -354,8 +354,6 @@ func (s *Stack) injectHealthChecks(app map[string]interface{}) {
 func (s *Stack) injectMetadata(app map[string]interface{}, name string) error {
 	envs := getObject(app["env"])
 
-	s.Builder.InterpolateField(app, name, "cmd")
-
 	cmd, ok := app["cmd"]
 	if ok {
 		delete(app, "cmd")

--- a/go/src/koding/kites/kloud/provider/marathon/testdata/multi-app.json.golden
+++ b/go/src/koding/kites/kloud/provider/marathon/testdata/multi-app.json.golden
@@ -33,7 +33,7 @@
         "count": 3,
         "cpus": 1.2,
         "env": {
-          "KODING_CMD": "${null_resource.multi-app.triggers.cmd}",
+          "KODING_CMD": "python3 -m http.server 8080",
           "KODING_KLIENT_URL": "$KLIENT_URL",
           "KODING_METADATA_1": "***",
           "KODING_METADATA_2": "***",
@@ -77,14 +77,6 @@
           0,
           0
         ]
-      }
-    },
-    "null_resource": {
-      "multi-app": {
-        "depends_on": [],
-        "triggers": {
-          "cmd": "python3 -m http.server 8080"
-        }
       }
     }
   }

--- a/go/src/koding/kites/kloud/provider/marathon/testdata/single-app.json.golden
+++ b/go/src/koding/kites/kloud/provider/marathon/testdata/single-app.json.golden
@@ -33,7 +33,7 @@
         "count": 1,
         "cpus": 1.2,
         "env": {
-          "KODING_CMD": "${null_resource.app.triggers.cmd}",
+          "KODING_CMD": "python3 -m http.server 8080",
           "KODING_KLIENT_URL": "$KLIENT_URL",
           "KODING_METADATA_1": "***"
         },
@@ -63,14 +63,6 @@
         "ports": [
           0
         ]
-      }
-    },
-    "null_resource": {
-      "app": {
-        "depends_on": [],
-        "triggers": {
-          "cmd": "python3 -m http.server 8080"
-        }
       }
     }
   }

--- a/go/src/koding/kites/kloud/provider/softlayer/testdata/single-guest.json.golden
+++ b/go/src/koding/kites/kloud/provider/softlayer/testdata/single-guest.json.golden
@@ -1,13 +1,5 @@
 {
   "resource": {
-    "null_resource": {
-      "test": {
-        "depends_on": [],
-        "triggers": {
-          "user_data": "***"
-        }
-      }
-    },
     "softlayer_virtual_guest": {
       "test": {
         "cpu": 1,

--- a/go/src/koding/kites/kloud/provider/vagrant/stack.go
+++ b/go/src/koding/kites/kloud/provider/vagrant/stack.go
@@ -184,8 +184,6 @@ func (s *Stack) ApplyTemplate(c *stack.Credential) (*stack.Template, error) {
 
 		tunnel := s.newTunnel(resourceName)
 
-		s.Builder.InterpolateField(box, resourceName, "user_data")
-
 		if b, ok := box["debug"].(bool); ok && b {
 			s.Debug = true
 		}

--- a/go/src/koding/kites/kloud/stack/provider/builder.go
+++ b/go/src/koding/kites/kloud/stack/provider/builder.go
@@ -559,61 +559,6 @@ func (b *Builder) BuildTemplate(content, contentID string) error {
 	return nil
 }
 
-// InterplateField interpolates a field that can't contain variables within it
-// with null_resource provider.
-//
-// User to interpolate content of user_data fields for kloud providers.
-func (b *Builder) InterpolateField(resource map[string]interface{}, resourceName, field string) {
-	// Build provisioning script if available - the script needs to be
-	// base64-encoded to ensure the eventual formatting and terraform
-	// interpolation won't break YAML encoding of the cloud-init
-	// script; since most likely the user_data requires terraform
-	// interpolation, let it be interpolated as variable, and base64-encode
-	// it during the interpolation.
-	//
-	// Note on implementation: since variables themselves cannot be
-	// additionally interpolated, as terraform would fail with:
-	//
-	//   * Variable 'userdata_example': cannot contain interpolations
-	//
-	// We're using special "null_resource" to have the the interpolation
-	// kick in. For more details see:
-	//
-	//   https://github.com/hashicorp/terraform/issues/4084
-	//
-	if s, ok := resource[field].(string); ok && s != "" {
-		resource[field] = fmt.Sprintf("${null_resource.%s.triggers.%s}", resourceName, field)
-
-		nullRes, ok := b.Template.Resource["null_resource"].(map[string]interface{})
-		if !ok {
-			nullRes = make(map[string]interface{})
-			b.Template.Resource["null_resource"] = nullRes
-		}
-
-		res, ok := nullRes[resourceName].(map[string]interface{})
-		if !ok {
-			res = make(map[string]interface{})
-			nullRes[resourceName] = res
-		}
-
-		triggers, ok := res["triggers"].(map[string]interface{})
-		if !ok {
-			triggers = make(map[string]interface{})
-			res["triggers"] = triggers
-
-			// This field is a nop, it works around the following terraform
-			// parsing bug:
-			//
-			//   resource must be followed by exactly two strings, a type and a name
-			//
-			// TODO(rjeczalik): report and/or fix
-			res["depends_on"] = []interface{}{}
-		}
-
-		triggers[field] = EscapeDeadVariables(s)
-	}
-}
-
 // FetchCredentials fetches credential and bootstrap data from credential store.
 //
 // If no credentials are provided, the method is a nop.

--- a/go/src/koding/kites/kloud/stack/provider/userdata.go
+++ b/go/src/koding/kites/kloud/stack/provider/userdata.go
@@ -76,8 +76,6 @@ func (bs *BaseStack) BuildUserdata(name string, vm map[string]interface{}) error
 
 	vm[field] = ci.String()
 
-	bs.Builder.InterpolateField(vm, name, field)
-
 	// create independent kiteKey for each machine and create a Terraform
 	// lookup map, which is used in conjunction with the `count.index`.
 	for i, label := range labels {


### PR DESCRIPTION
The user_data interpolation was used in previous
implementation to workaround a terraform interpolation
restriction, which caused stack build to fail when
user_data contained variables.

It is not needed anymore as user_data handling was
reworked - we merge user_data with kloud's cloud-init
and interpolate it at once.

Moreover it broke count=2+ builds, as count.index
was always 1 within the null_resource scope - so
all the instances used the same kite key.

Fixes #10967.