### PR TITLE
kd/template: print defaults for user input

### DIFF
--- a/go/src/koding/klientctl/endpoint/team/team.go
+++ b/go/src/koding/klientctl/endpoint/team/team.go
@@ -64,6 +64,18 @@ func (c *Client) List(opts *ListOptions) ([]*team.Team, error) {
 	return resp.Teams, nil
 }
 
+func (c *Client) Whoami() (*stack.WhoamiResponse, error) {
+	c.init()
+
+	var resp stack.WhoamiResponse
+
+	if err := c.kloud().Call("team.whoami", nil, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
 func (c *Client) Close() (err error) {
 	if c.used.Valid() == nil {
 		err = c.kloud().Cache().SetValue("team.used", &c.used)
@@ -95,3 +107,4 @@ func (c *Client) kloud() *kloud.Client {
 func Use(team *Team)                               { DefaultClient.Use(team) }
 func Used() *Team                                  { return DefaultClient.Used() }
 func List(opts *ListOptions) ([]*team.Team, error) { return DefaultClient.List(opts) }
+func Whoami() (*stack.WhoamiResponse, error)       { return DefaultClient.Whoami() }

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -816,6 +816,16 @@ func run(args []string) {
 							Usage: "Output in JSON format.",
 						},
 					},
+				}, {
+					Name:   "whoami",
+					Usage:  "Displays current authentication details.",
+					Action: ctlcli.ExitErrAction(TeamWhoami, log, "whoami"),
+					Flags: []cli.Flag{
+						cli.BoolFlag{
+							Name:  "json",
+							Usage: "Output in JSON format.",
+						},
+					},
 				}},
 			},
 		)

--- a/go/src/koding/klientctl/team.go
+++ b/go/src/koding/klientctl/team.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"koding/kites/kloud/stack"
 	"koding/kites/kloud/team"
+	"koding/klientctl/endpoint/kloud"
 	epteam "koding/klientctl/endpoint/team"
 
 	"github.com/codegangsta/cli"
@@ -20,7 +22,7 @@ func TeamList(c *cli.Context, log logging.Logger, _ string) (int, error) {
 
 	teams, err := epteam.List(opts)
 	if err != nil {
-		return 0, err
+		return 1, err
 	}
 
 	if len(teams) == 0 {
@@ -47,6 +49,25 @@ func TeamList(c *cli.Context, log logging.Logger, _ string) (int, error) {
 	return 0, nil
 }
 
+func TeamWhoami(c *cli.Context, _ logging.Logger, _ string) (int, error) {
+	resp, err := epteam.Whoami()
+	if err != nil {
+		return 1, err
+	}
+
+	if c.Bool("json") {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "\t")
+		enc.Encode(resp)
+
+		return 0, nil
+	}
+
+	printWhoami(resp)
+
+	return 0, nil
+}
+
 func printTeams(teams []*team.Team) {
 	w := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
 	defer w.Flush()
@@ -56,6 +77,16 @@ func printTeams(teams []*team.Team) {
 	for _, t := range teams {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", t.Name, t.Slug, t.Privacy, t.SubStatus)
 	}
+}
+
+func printWhoami(resp *stack.WhoamiResponse) {
+	t := resp.Team
+	w := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+	defer w.Flush()
+
+	fmt.Fprintln(w, "USERNAME\tTEAM\tSLUG\tPRIVACY\tSUBSCRIPTION")
+
+	fmt.Fprintln(w, "%s\t%s\t%s\t%s\t%s\n", kloud.Username(), t.Name, t.Slug, t.Privacy, t.SubStatus)
 }
 
 func TeamShow(c *cli.Context, log logging.Logger, _ string) (int, error) {


### PR DESCRIPTION
This PR improve printing of `userInput_*` variables, so the following:

```
$ kd template init
Provider type []: marathon
Set "image" to []: ubuntu:16.04
Set "cpus" to []: 2
Set "mem" to []: 1024

Template successfully written to kd.yaml.
```

becomes:

```
$ kd template init
Do you want to overwrite "kd.yaml" file? [y/N]: y

Provider type []: marathon
Set "image" to [ubuntu:14.04]:
Set "cpus" to [1]:
Set "mem" to [256]:

Template successfully written to kd.yaml.
```