### PR TITLE
kd: add init command

### DIFF
--- a/go/src/koding/kites/kloud/stack/kloud.go
+++ b/go/src/koding/kites/kloud/stack/kloud.go
@@ -3,6 +3,7 @@ package stack
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -190,4 +191,24 @@ func ReadProviders(template []byte) ([]string, error) {
 	sort.Strings(providers)
 
 	return providers, nil
+}
+
+// ReadProvider reads exact one cloud provider from the given template.
+//
+// The function returns non-nil error if none or more than one provider
+// is read.
+func ReadProvider(template []byte) (string, error) {
+	providers, err := ReadProviders(template)
+	if err != nil {
+		return "", err
+	}
+
+	switch len(providers) {
+	case 0:
+		return "", errors.New("no provider found")
+	case 1:
+		return providers[0], nil
+	default:
+		return "", fmt.Errorf("multiple providers found: %v", providers)
+	}
 }

--- a/go/src/koding/klientctl/endpoint/credential/credential.go
+++ b/go/src/koding/klientctl/endpoint/credential/credential.go
@@ -95,6 +95,10 @@ func (c *Client) Create(opts *CreateOptions) (*stack.CredentialItem, error) {
 		Provider:   opts.Provider,
 	})
 
+	if _, ok := c.used[opts.Provider]; !ok {
+		c.used[opts.Provider] = resp.Identifier
+	}
+
 	return &stack.CredentialItem{
 		Title:      resp.Title,
 		Team:       req.Team,

--- a/go/src/koding/klientctl/endpoint/kloud/kloud.go
+++ b/go/src/koding/klientctl/endpoint/kloud/kloud.go
@@ -100,10 +100,12 @@ func (c *Client) Wait(event string) <-chan *stack.EventResponse {
 		last := -1
 		defer close(ch)
 
+		id := stack.EventArgs{arg}
+
 		for {
 			var events []stack.EventResponse
 
-			if err := c.Call("event", arg, &events); err != nil {
+			if err := c.Call("event", id, &events); err != nil {
 				ch <- &stack.EventResponse{
 					EventId: arg.EventId,
 					Error:   newErr(err),
@@ -355,4 +357,7 @@ func Cache() *cfg.Cache { return DefaultClient.Cache() }
 func Username() string  { return DefaultClient.Username() }
 func Call(method string, arg, reply interface{}) error {
 	return DefaultClient.Call(method, arg, reply)
+}
+func Wait(event string) <-chan *stack.EventResponse {
+	return DefaultClient.Wait(event)
 }

--- a/go/src/koding/klientctl/init.go
+++ b/go/src/koding/klientctl/init.go
@@ -87,9 +87,13 @@ func Init(c *cli.Context, log logging.Logger, _ string) (int, error) {
 			fmt.Printf("[%d] %s\n", i+1, cred.Title)
 		}
 
-		s, err := helper.Ask("\nChoose credential to use [0]: ")
+		s, err := helper.Ask("\nChoose credential to use [1]: ")
 		if err != nil {
 			return 1, err
+		}
+
+		if s == "" {
+			s = "1"
 		}
 
 		n, err := strconv.Atoi(s)
@@ -97,7 +101,7 @@ func Init(c *cli.Context, log logging.Logger, _ string) (int, error) {
 			return 1, fmt.Errorf("unrecognized credential chosen: %s", s)
 		}
 
-		if n < 0 || n >= len(creds) {
+		if n--; n < 0 || n >= len(creds) {
 			return 1, fmt.Errorf("invalid credential chosen: %d", n)
 		}
 

--- a/go/src/koding/klientctl/init.go
+++ b/go/src/koding/klientctl/init.go
@@ -114,10 +114,15 @@ func Init(c *cli.Context, log logging.Logger, _ string) (int, error) {
 	}
 
 	fmt.Printf("Create new stack...\n\n")
+	defTitle := strings.Title(fmt.Sprintf("%s %s Stack", kstack.Pokemon(), provider))
 
-	title, err := helper.Ask("Stack name []: ")
+	title, err := helper.Ask("Stack name [%s]: ", defTitle)
 	if err != nil {
 		return 1, err
+	}
+
+	if title == "" {
+		title = defTitle
 	}
 
 	opts := &stack.CreateOptions{

--- a/go/src/koding/klientctl/init.go
+++ b/go/src/koding/klientctl/init.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+
+	yaml "gopkg.in/yaml.v2"
+
+	kstack "koding/kites/kloud/stack"
+	"koding/kites/kloud/utils/object"
+	"koding/klientctl/endpoint/credential"
+	"koding/klientctl/endpoint/stack"
+	"koding/klientctl/endpoint/team"
+	"koding/klientctl/helper"
+
+	"github.com/codegangsta/cli"
+	"github.com/koding/logging"
+)
+
+func Init(c *cli.Context, log logging.Logger, _ string) (int, error) {
+	if err := trylock(); err != nil {
+		return 1, err
+	}
+
+	switch _, err := os.Stat("kd.yaml"); {
+	case os.IsNotExist(err):
+		fmt.Printf("Initializing with new kd.yaml template file...\n\n")
+
+		if err := templateInit("kd.yaml"); err != nil {
+			return 1, err
+		}
+	case err == nil:
+	default:
+	}
+
+	p, err := readTemplate("kd.yaml")
+	if err != nil {
+		return 1, err
+	}
+
+	provider, err := kstack.ReadProvider(p)
+	if err != nil {
+		return 1, errors.New("failed to read cloud provider: " + err.Error())
+	}
+
+	ident := credential.Used()[provider]
+
+	switch {
+	case ident == "":
+		opts := &credential.ListOptions{
+			Provider: provider,
+			Team:     team.Used().Name,
+		}
+		c, err := credential.List(opts)
+		if err != nil {
+			log.Debug("credential.List failure: %s", err)
+			break
+		}
+
+		creds, ok := c[provider]
+		if !ok || len(creds) == 0 {
+			fmt.Printf("Creating new credential for %q provider...\n\n", strings.Title(provider))
+
+			opts := &credential.CreateOptions{
+				Provider: provider,
+				Team:     team.Used().Name,
+			}
+
+			if err := credentialCreate("", opts, false); err != nil {
+				return 1, err
+			}
+
+			break
+		}
+
+		if len(creds) == 1 {
+			ident = creds[0].Identifier
+		}
+
+		for i, cred := range creds {
+			fmt.Printf("[%d] %s\n", i+1, cred.Title)
+		}
+
+		s, err := helper.Ask("\nChoose credential to use [0]: ")
+		if err != nil {
+			return 1, err
+		}
+
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			return 1, fmt.Errorf("unrecognized credential chosen: %s", s)
+		}
+
+		if n < 0 || n >= len(creds) {
+			return 1, fmt.Errorf("invalid credential chosen: %d", n)
+		}
+
+		ident = creds[n].Identifier
+		credential.Use(ident)
+	}
+
+	if ident == "" {
+		ident = credential.Used()[provider]
+	}
+
+	fmt.Printf("Create new stack...\n\n")
+
+	title, err := helper.Ask("Stack name []: ")
+	if err != nil {
+		return 1, err
+	}
+
+	opts := &stack.CreateOptions{
+		Team:        team.Used().Name,
+		Title:       title,
+		Credentials: []string{ident},
+		Template:    p,
+	}
+
+	resp, err := stack.Create(opts)
+	if err != nil {
+		return 1, err
+	}
+
+	fmt.Fprintf(os.Stderr, "\nCreatad %q stack with %s ID.\n", resp.Title, resp.StackID)
+
+	// TODO(rjeczalik): wait for build
+
+	if err := writelock(resp.StackID, resp.Title); err != nil {
+		return 1, err
+	}
+
+	return 0, nil
+}
+
+type lock struct {
+	Stack struct {
+		ID    string `yaml:"id"`
+		Title string `yaml:"title"`
+	} `yaml:"stack"`
+}
+
+func trylock() error {
+	p, err := ioutil.ReadFile(".kd.lock")
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	var l lock
+
+	if err := yaml.Unmarshal(p, &l); err != nil {
+		return err
+	}
+
+	return fmt.Errorf("Project already initialized with %q stack (%s)", l.Stack.Title, l.Stack.ID)
+}
+
+func writelock(id, title string) error {
+	var l lock
+	l.Stack.ID = id
+	l.Stack.Title = title
+
+	p, err := yaml.Marshal(&l)
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(".kd.lock", p, 0644)
+}
+
+func readTemplate(file string) ([]byte, error) {
+	p, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+
+	var m map[string]interface{}
+
+	if err := yaml.Unmarshal(p, &m); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(object.FixYAML(m))
+}

--- a/go/src/koding/klientctl/init.go
+++ b/go/src/koding/klientctl/init.go
@@ -32,7 +32,7 @@ func Init(c *cli.Context, log logging.Logger, _ string) (int, error) {
 	case os.IsNotExist(err):
 		fmt.Printf("Initializing with new kd.yaml template file...\n\n")
 
-		if err := templateInit("kd.yaml"); err != nil {
+		if err := templateInit("kd.yaml", false, ""); err != nil {
 			return 1, err
 		}
 	case err == nil:

--- a/go/src/koding/klientctl/init.go
+++ b/go/src/koding/klientctl/init.go
@@ -24,19 +24,16 @@ import (
 )
 
 func Init(c *cli.Context, log logging.Logger, _ string) (int, error) {
-	if err := trylock(); err != nil {
+	if err := isLocked(); err != nil {
 		return 1, err
 	}
 
-	switch _, err := os.Stat("kd.yaml"); {
-	case os.IsNotExist(err):
+	if _, err := os.Stat("kd.yaml"); os.IsNotExist(err) {
 		fmt.Printf("Initializing with new kd.yaml template file...\n\n")
 
 		if err := templateInit("kd.yaml", false, ""); err != nil {
 			return 1, err
 		}
-	case err == nil:
-	default:
 	}
 
 	p, err := readTemplate("kd.yaml")
@@ -109,7 +106,7 @@ func Init(c *cli.Context, log logging.Logger, _ string) (int, error) {
 		ident = credential.Used()[provider]
 	}
 
-	fmt.Printf("Create new stack...\n\n")
+	fmt.Printf("Creating new stack...\n\n")
 	defTitle := strings.Title(fmt.Sprintf("%s %s Stack", kstack.Pokemon(), provider))
 
 	title, err := helper.Ask("Stack name [%s]: ", defTitle)
@@ -157,7 +154,7 @@ type lock struct {
 	} `yaml:"stack"`
 }
 
-func trylock() error {
+func isLocked() error {
 	p, err := ioutil.ReadFile(".kd.lock")
 	if os.IsNotExist(err) {
 		return nil

--- a/go/src/koding/klientctl/init.go
+++ b/go/src/koding/klientctl/init.go
@@ -79,10 +79,6 @@ func Init(c *cli.Context, log logging.Logger, _ string) (int, error) {
 			break
 		}
 
-		if len(creds) == 1 {
-			ident = creds[0].Identifier
-		}
-
 		for i, cred := range creds {
 			fmt.Printf("[%d] %s\n", i+1, cred.Title)
 		}

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -620,6 +620,14 @@ func run(args []string) {
 						Usage: "Output template file.",
 						Value: "kd.yaml",
 					},
+					cli.BoolFlag{
+						Name:  "defaults",
+						Usage: "Use default values for stack variables.",
+					},
+					cli.StringFlag{
+						Name:  "provider, p",
+						Usage: "Cloud provider to use.",
+					},
 				},
 			}},
 		},

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -411,6 +411,10 @@ func run(args []string) {
 				Action: ctlcli.ExitErrAction(DaemonStop, log, "stop"),
 			}},
 		}, {
+			Name:   "init",
+			Usage:  "Initializes KD project.",
+			Action: ctlcli.ExitErrAction(Init, log, "init"),
+		}, {
 			Name:        "version",
 			Usage:       "Display version information.",
 			HideHelp:    true,

--- a/go/src/koding/klientctl/stack.go
+++ b/go/src/koding/klientctl/stack.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"koding/klientctl/endpoint/kloud"
 	"koding/klientctl/endpoint/remoteapi"
 	"koding/klientctl/endpoint/stack"
 	"koding/klientctl/endpoint/team"
@@ -56,7 +57,15 @@ func StackCreate(c *cli.Context, log logging.Logger, _ string) (int, error) {
 		return 0, nil
 	}
 
-	fmt.Fprintf(os.Stderr, "Creatad %q stack with %s ID.\n", resp.Title, resp.StackID)
+	fmt.Fprintf(os.Stderr, "\nCreatad %q stack with %s ID.\nWaiting for the stack to finish building...\n\n", resp.Title, resp.StackID)
+
+	for e := range kloud.Wait(resp.EventID) {
+		if e.Error != nil {
+			return 1, fmt.Errorf("\nBuilding %q stack failed:\n%s\n", resp.Title, e.Error)
+		}
+
+		fmt.Printf("[%d%%] %s\n", e.Event.Percentage, e.Event.Message)
+	}
 
 	return 0, nil
 }

--- a/go/src/koding/klientctl/template.go
+++ b/go/src/koding/klientctl/template.go
@@ -203,6 +203,10 @@ func templateInit(output string) error {
 			return err
 		}
 
+		if s == "" {
+			s = def
+		}
+
 		input[v.Name] = s
 	}
 


### PR DESCRIPTION
This PR adds `kd init` command, which is responsible for creating and building a stack interactively.

Example usage:

```
$ kd init
Initializing with new kd.yaml template file...

Provider type []: aws   
Set "instance_type" to [t2.nano]:

Template successfully written to kd.yaml.
Creating new credential for "Aws" provider...

Title [rjeczalik Thu Apr 20 10:21:23 2017]: new-aws-cred
Access Key ID [***]:
Secret Access Key [***]:
Region [us-east-1]: eu-west-1
Creating credential...
Created "new-aws-cred" credential with 58f86f95877dfc7cd3e4f8f1 identifier.
Create new stack...

Stack name [Gastly Aws Stack]: New AWS Stack

Creatad "New AWS Stack" stack with 58f86fb0bccfca387d85cc81 ID.
Waiting for the stack to finish building...

[30%] Fetching and validating credentials
[55%] Building stack resources
[70%] Checking VM connections
[100%] apply finished
```
```
$ kd init
error executing "init" command: Project already initialized with "New AWS Stack" stack (58f86fb0bccfca387d85cc81)
```