### PR TITLE
Custom Permissions support

### DIFF
--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -981,10 +981,7 @@ module.exports = class ComputeController extends KDController
 
   fetchStackTemplate: (id, callback = kd.noop) ->
 
-    @storage.templates.fetch id
-      .then (template) ->
-        callback null, template
-      .catch callback
+    @storage.templates.fetch(id).nodeify callback
 
 
   fetchStackTemplates: (callback) ->

--- a/client/new-stack-editor/lib/index.coffee
+++ b/client/new-stack-editor/lib/index.coffee
@@ -2,9 +2,11 @@ debug = (require 'debug') 'nse'
 
 kd = require 'kd'
 async = require 'async'
-AppController = require 'app/appcontroller'
+
+isAdmin = require 'app/util/isAdmin'
 showError = require 'app/util/showError'
 
+AppController = require 'app/appcontroller'
 EnvironmentFlux = require 'app/flux/environment'
 
 Events = require './events'
@@ -78,6 +80,7 @@ module.exports = class StackEditorAppController extends AppController
         return callback err
 
       @stackEditor.setData template, reset
+      @stackEditor.setReadOnly not (isAdmin() or template.isMine())
 
       @showBuildFlow template, machineId  if build
 

--- a/client/new-stack-editor/lib/routehandler.coffee
+++ b/client/new-stack-editor/lib/routehandler.coffee
@@ -8,7 +8,7 @@ module.exports = -> lazyrouter.bind 'stackeditor', (type, info, state, path, ctx
 
   debug 'routing', { type, info, state, path }
 
-  unless canCreateStacks() or type is 'edit-stack'
+  unless canCreateStacks() or type in ['edit-stack', 'build']
     new kd.NotificationView { title: 'You are not allowed to create/edit stacks!' }
     return kd.singletons.router.back()
 

--- a/client/new-stack-editor/lib/views/index.coffee
+++ b/client/new-stack-editor/lib/views/index.coffee
@@ -206,6 +206,20 @@ module.exports = class StackEditor extends kd.View
       @toolbar.actionButton.hideLoader()
 
 
+  setReadOnly: (readonly = true) ->
+
+    debug 'setReadOnly', readonly
+
+    if @readonly = readonly
+      @setClass 'readonly'
+      @sideView.hide()
+    else
+      @unsetClass 'readonly'
+
+    for view in EDITORS
+      @[view].setReadOnly @readonly
+
+
   _loadSnapshot: (id) ->
 
     return no  unless id

--- a/workers/migrations/0040-allow-stacks-on-koding.js
+++ b/workers/migrations/0040-allow-stacks-on-koding.js
@@ -1,0 +1,10 @@
+
+var mongodb = require('mongodb');
+
+exports.up = function(db, next){
+    db.collection("jGroups").update({"slug":"koding"}, { $set: { "customize.membersCanCreateStacks": true } }, next);
+};
+
+exports.down = function(db, next){
+    next();
+};

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -730,7 +730,7 @@ module.exports = class JStackTemplate extends Module
 
     advanced: [
       {
-        permission   : 'update stack template',
+        permission   : 'update own stack template',
         validateWith : Validators.group.custom 'membersCanCreateStacks'
       }
       {

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -301,7 +301,14 @@ module.exports = class JStackTemplate extends Module
   #   }
   #
   @create = ->
-  @create = permit 'create stack template',
+  @create = permit
+
+    advanced: [
+      {
+        permission   : 'create stack template',
+        validateWith : Validators.group.custom 'membersCanCreateStacks'
+      }
+    ]
 
     success: revive
 
@@ -548,8 +555,14 @@ module.exports = class JStackTemplate extends Module
   generateStack: permit
 
     advanced: [
-      { permission: 'update own stack template', validateWith: Validators.own }
-      { permission: 'update stack template' }
+      {
+        permission   : 'update stack template',
+        validateWith : Validators.group.custom 'membersCanCreateStacks'
+      }
+      {
+        permission   : 'update own stack template',
+        validateWith : Validators.own
+      }
     ]
 
     success: revive
@@ -716,8 +729,14 @@ module.exports = class JStackTemplate extends Module
   clone: permit
 
     advanced: [
-      { permission: 'update own stack template' }
-      { permission: 'update stack template' }
+      {
+        permission   : 'update stack template',
+        validateWith : Validators.group.custom 'membersCanCreateStacks'
+      }
+      {
+        permission   : 'update own stack template',
+        validateWith : Validators.own
+      }
     ]
 
     success: (client, options, callback) ->

--- a/workers/social/lib/social/models/group/index.coffee
+++ b/workers/social/lib/social/models/group/index.coffee
@@ -16,7 +16,7 @@ module.exports = class JGroup extends Module
   { Inflector, ObjectId, ObjectRef, secure, signature } = require 'bongo'
 
   JPermissionSet = require './permissionset'
-  { permit }     = JPermissionSet
+  { permit, expireCache } = JPermissionSet
 
   JAccount       = require '../account'
   KodingError    = require '../../error'
@@ -1077,6 +1077,10 @@ module.exports = class JGroup extends Module
         return callback err  if err
         return callback new KodingError 'No such group!'  unless group
 
+        kallback = (rest...) ->
+          expireCache group.getAt 'slug'
+          callback rest...
+
         # we need to make sure if given stack template is
         # valid for the current group limit ~ GG
         templates = data.stackTemplates
@@ -1084,9 +1088,9 @@ module.exports = class JGroup extends Module
           ComputeProvider = require '../computeproviders/computeprovider'
           ComputeProvider.validateTemplates client, templates, group, (err) =>
             return callback err  if err
-            @updateAndNotify notifyOptions, { $set: data }, callback
+            @updateAndNotify notifyOptions, { $set: data }, kallback
         else
-          @updateAndNotify notifyOptions, { $set: data }, callback
+          @updateAndNotify notifyOptions, { $set: data }, kallback
 
 
   setLimit    : permit

--- a/workers/social/lib/social/models/group/permissionset.coffee
+++ b/workers/social/lib/social/models/group/permissionset.coffee
@@ -60,11 +60,12 @@ module.exports = class JPermissionSet extends Module
     [{ permission, validateWith: require('./validators').any }]
 
 
-  fetchGroupAndPermissionSet = do (queue = {}) ->
+  memCache = cacheManager.caching
+    store  : 'memory'
+    ttl    : 60 # seconds
 
-    memCache = cacheManager.caching
-      store  : 'memory'
-      ttl    : 60 # seconds
+
+  fetchGroupAndPermissionSet = do (queue = {}) ->
 
     fetcher = (groupName, callback) ->
       JGroup = require '../group'
@@ -94,6 +95,9 @@ module.exports = class JPermissionSet extends Module
             cb null, data  for cb in queue[groupName]
 
           queue[groupName] = []
+
+
+  @expireCache = (group) -> memCache.del group
 
 
   getGroupnameFrom = (target, client) ->

--- a/workers/social/lib/social/models/group/permissionset.test.coffee
+++ b/workers/social/lib/social/models/group/permissionset.test.coffee
@@ -1,0 +1,119 @@
+{
+  expect
+  withDummyClient
+  withConvertedUser
+  checkBongoConnectivity
+} = require '../../../../testhelper'
+JPermissionSet = require './permissionset'
+
+beforeTests = -> before (done) ->
+
+  checkBongoConnectivity done
+
+runTests = -> describe 'workers.social.models.group.permissionset', ->
+
+  describe 'JPermissionSet', ->
+
+    it 'should exist', ->
+      expect(JPermissionSet).to.be.a 'function'
+      expect(JPermissionSet.set).to.be.a 'function'
+      expect(JPermissionSet.permit).to.be.a 'function'
+      expect(JPermissionSet.checkPermission).to.be.a 'function'
+
+    describe 'permit()', ->
+
+      describe 'should support simple permissions', ->
+
+        it 'should deny for guests', (done) ->
+          withDummyClient ({ client }) ->
+            (JPermissionSet.permit \
+              'open group', { failure: -> done() }) client
+
+        it 'should allow for members', (done) ->
+          withConvertedUser ({ client }) ->
+            (JPermissionSet.permit \
+              'open group', { success: -> done() }) client
+
+
+      describe 'should support advanced permissions', ->
+
+        it 'should deny for guests', (done) ->
+          withDummyClient ({ client }) ->
+            (JPermissionSet.permit {
+              advanced : [ { permission: 'open group' } ]
+              failure  : -> done()
+            }) client
+
+        it 'should allow for members', (done) ->
+          withConvertedUser ({ client }) ->
+            (JPermissionSet.permit {
+              advanced : [ { permission: 'open group' } ]
+              success  : -> done()
+            }) client
+
+
+      describe 'should support multiple permissions', ->
+
+        it 'should deny for guests', (done) ->
+          withDummyClient ({ client }) ->
+            (JPermissionSet.permit {
+              advanced : [
+                { permission: 'grant access' }
+                { permission: 'open group' }
+              ]
+              failure  : -> done()
+            }) client
+
+        it 'should allow for members', (done) ->
+          withConvertedUser ({ client }) ->
+            (JPermissionSet.permit {
+              advanced : [
+                { permission: 'grant access' }
+                { permission: 'open group' }
+              ]
+              success  : -> done()
+            }) client
+
+
+      describe 'should support validators', ->
+
+        it 'should deny for guests when validator returned no', (done) ->
+          withDummyClient ({ client }) ->
+            (JPermissionSet.permit {
+              advanced : [
+                { permission: 'open group', validateWith: (..., cb) -> cb null, no }
+              ]
+              failure  : -> done()
+            }) client
+
+        it 'should allow for guests when validator returned yes', (done) ->
+          withDummyClient ({ client }) ->
+            (JPermissionSet.permit {
+              advanced : [
+                { permission: 'open group', validateWith: (..., cb) -> cb null, yes }
+              ]
+              success  : -> done()
+            }) client
+
+        it 'should deny for members when validator returned no', (done) ->
+          withConvertedUser ({ client }) ->
+            (JPermissionSet.permit {
+              advanced : [
+                { permission: 'open group', validateWith: (..., cb) -> cb null, no }
+              ]
+              failure  : -> done()
+            }) client
+
+        it 'should allow for guests when validator returned yes', (done) ->
+          withConvertedUser ({ client }) ->
+            (JPermissionSet.permit {
+              advanced : [
+                { permission: 'open group', validateWith: (..., cb) -> cb null, yes }
+              ]
+              success  : -> done()
+            }) client
+
+
+beforeTests()
+
+runTests()

--- a/workers/social/lib/social/models/group/validators.coffee
+++ b/workers/social/lib/social/models/group/validators.coffee
@@ -108,6 +108,11 @@ module.exports = Validators =
 
       (client, group, rest..., callback) ->
 
-        Validators.group.admin client, group, rest..., (err, isAdmin) ->
-          callback null, yes  if isAdmin
-          callback null, !!group.getAt "customize.#{customPermission}"
+        Validators.any client, group, rest..., (err, allow) ->
+          if err or not allow
+            return callback err, no
+
+          Validators.group.admin client, group, rest..., (err, isAdmin) ->
+            callback null, if isAdmin
+            then yes
+            else !!group.getAt "customize.#{customPermission}"

--- a/workers/social/lib/social/models/group/validators.coffee
+++ b/workers/social/lib/social/models/group/validators.coffee
@@ -103,3 +103,11 @@ module.exports = Validators =
         as         : { $in: [ 'owner', 'admin' ] }
 
       Relationship.count relSelector, createExistenceCallback callback
+
+    custom: (customPermission) ->
+
+      (client, group, rest..., callback) ->
+
+        Validators.group.admin client, group, rest..., (err, isAdmin) ->
+          callback null, yes  if isAdmin
+          callback null, !!group.getAt "customize.#{customPermission}"

--- a/workers/social/testhelper/index.coffee
+++ b/workers/social/testhelper/index.coffee
@@ -252,6 +252,7 @@ fetchOrCreateGroup = (client, opts, callback) ->
     groupData = _.extend
       slug           : slug
       title          : slug
+      customize      : { membersCanCreateStacks: yes }
       visibility     : 'visible'
       allowedDomains : [ 'koding.com' ]
     , opts.groupData

--- a/workers/social/testhelper/models/computeproviders/computeproviderhelper.coffee
+++ b/workers/social/testhelper/models/computeproviders/computeproviderhelper.coffee
@@ -44,6 +44,7 @@ withConvertedUserAnd = (models, options, callback) ->
       groupData =
         slug           : groupSlug
         title          : generateRandomString()
+        customize      : { membersCanCreateStacks: yes }
         visibility     : 'visible'
         allowedDomains : ['koding.com']
 


### PR DESCRIPTION
This PR introduces custom permission support into existing Bongo models over JPermissionSet with custom validators. Existing implementation of "customization" feature was only checking specific flags defined in client-side on client-side. There were custom flags defined under `JGroup.customize.*` which was not taken into account for the backend calls. This was causing issues with `memberCanCreateStack` customization which was only checking in the client-side and were allowing api calls.

Along with that, this PR also introduces read-only stack support to NSE and clone improvements on existing Stack Editor.