### PR TITLE
Machine address and alias local cache improvements.

### DIFF
--- a/go/src/koding/klient/machine/addr.go
+++ b/go/src/koding/klient/machine/addr.go
@@ -33,7 +33,7 @@ func (a Addr) String() string { return a.Network + " address " + a.Value }
 // can change its end point address over time. This can store all of these
 // addresses which allows to bind old resources with new address.
 type AddrBook struct {
-	MaxSize int // The max size of each stored address types, 0 means unlimited.
+	MaxSize int // Max size of each stored address types, 0 means unlimited.
 
 	mu    sync.RWMutex
 	addrs []Addr
@@ -94,7 +94,6 @@ func (ab *AddrBook) add(a Addr) {
 		}
 
 		if ab.addrs[i].UpdatedAt.Before(a.UpdatedAt) {
-			// New adress is the same and is newer.
 			ab.addrs[i].UpdatedAt = a.UpdatedAt
 		}
 

--- a/go/src/koding/klient/machine/addr.go
+++ b/go/src/koding/klient/machine/addr.go
@@ -87,9 +87,16 @@ func (ab *AddrBook) add(a Addr) {
 
 	// If Addr already exists, update only its Updated field.
 	for i := range ab.addrs {
-		if ab.addrs[i].Network == a.Network && ab.addrs[i].Value == a.Value && ab.addrs[i].UpdatedAt.Before(a.UpdatedAt) {
+		if ab.addrs[i].Network != a.Network || ab.addrs[i].Value != a.Value {
+			continue
+		}
+
+		if ab.addrs[i].UpdatedAt.Before(a.UpdatedAt) {
+			// New adress is the same and is newer.
 			ab.addrs[i].UpdatedAt = a.UpdatedAt
 		}
+
+		return
 	}
 
 	ab.addrs = append(ab.addrs, a)

--- a/go/src/koding/klient/machine/addr.go
+++ b/go/src/koding/klient/machine/addr.go
@@ -33,6 +33,8 @@ func (a Addr) String() string { return a.Network + " address " + a.Value }
 // can change its end point address over time. This can store all of these
 // addresses which allows to bind old resources with new address.
 type AddrBook struct {
+	MaxSize int // The max size of each stored address types, 0 means unlimited.
+
 	mu    sync.RWMutex
 	addrs []Addr
 }
@@ -100,6 +102,33 @@ func (ab *AddrBook) add(a Addr) {
 	}
 
 	ab.addrs = append(ab.addrs, a)
+	ab.keepMaxSize(a)
+}
+
+func (ab *AddrBook) keepMaxSize(a Addr) {
+	if ab.MaxSize <= 0 || len(ab.addrs) <= ab.MaxSize || len(ab.addrs) == 0 {
+		return
+	}
+
+	size := 0
+	for i := range ab.addrs {
+		if a.Network == ab.addrs[i].Network {
+			size++
+		}
+	}
+
+	for ab.MaxSize < size {
+		// Remove oldest entry.
+		t, i := ab.addrs[0].UpdatedAt, 0
+		for j := range ab.addrs {
+			if a.Network == ab.addrs[j].Network && t.After(ab.addrs[j].UpdatedAt) {
+				t, i = ab.addrs[j].UpdatedAt, j
+			}
+		}
+
+		ab.addrs = append(ab.addrs[:i], ab.addrs[i+1:]...)
+		size--
+	}
 }
 
 // Updated reports when provided address was updated. It returns ErrAddrNotFound

--- a/go/src/koding/klient/machine/addr_test.go
+++ b/go/src/koding/klient/machine/addr_test.go
@@ -2,6 +2,7 @@ package machine
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -237,6 +238,85 @@ func TestAddrLatest(t *testing.T) {
 				t.Fatalf("want updated = %v; got %v", test.UpdatedAt, addr.UpdatedAt)
 			}
 		})
+	}
+}
+
+func TestAddrMaxSize(t *testing.T) {
+	addrs := []Addr{
+		{
+			Network:   "ip",
+			Value:     "127.0.0.0",
+			UpdatedAt: time.Time{},
+		},
+		{
+			Network:   "ip",
+			Value:     "127.0.0.1",
+			UpdatedAt: time.Date(2012, time.May, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Network:   "ip",
+			Value:     "127.0.0.2",
+			UpdatedAt: time.Date(2011, time.May, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Network:   "ip",
+			Value:     "127.0.0.4",
+			UpdatedAt: time.Date(2009, time.May, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Network:   "tunnel",
+			Value:     "urjn784c4563.aaaaaa.1d54476f2.dev.koding.me",
+			UpdatedAt: time.Date(1997, time.May, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Network:   "tunnel",
+			Value:     "urjn784c4563.bbbbb.1d54476f2.dev.koding.me",
+			UpdatedAt: time.Date(2000, time.May, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Network:   "tunnel",
+			Value:     "urjn784c4563.ccccc.1d54476f2.dev.koding.me",
+			UpdatedAt: time.Date(1900, time.May, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	want := []Addr{
+		{
+			Network:   "ip",
+			Value:     "127.0.0.1",
+			UpdatedAt: time.Date(2012, time.May, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Network:   "ip",
+			Value:     "127.0.0.2",
+			UpdatedAt: time.Date(2011, time.May, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Network:   "tunnel",
+			Value:     "urjn784c4563.aaaaaa.1d54476f2.dev.koding.me",
+			UpdatedAt: time.Date(1997, time.May, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Network:   "tunnel",
+			Value:     "urjn784c4563.bbbbb.1d54476f2.dev.koding.me",
+			UpdatedAt: time.Date(2000, time.May, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	ab := &AddrBook{
+		MaxSize: 2,
+	}
+
+	for _, addr := range addrs {
+		ab.Add(addr)
+	}
+
+	if l := len(ab.All()); l != 4 {
+		t.Fatalf("want addresses count = 4; got %d", l)
+	}
+
+	if got := ab.All(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("want addrs = %#v\n; got\n%#v", want, got)
 	}
 }
 

--- a/go/src/koding/klient/machine/addr_test.go
+++ b/go/src/koding/klient/machine/addr_test.go
@@ -185,7 +185,7 @@ func TestAddrLatest(t *testing.T) {
 		{
 			Network:   "ip",
 			Value:     "127.0.0.1",
-			UpdatedAt: time.Time{},
+			UpdatedAt: time.Date(2011, time.May, 1, 0, 0, 0, 0, time.UTC),
 		},
 		{
 			Network:   "tcp",
@@ -218,6 +218,10 @@ func TestAddrLatest(t *testing.T) {
 
 	for _, addr := range addrs {
 		ab.Add(addr)
+	}
+
+	if l := len(ab.All()); l != 2 {
+		t.Fatalf("want addresses count = 2; got %d", l)
 	}
 
 	for name, test := range tests {

--- a/go/src/koding/klient/machine/machine.go
+++ b/go/src/koding/klient/machine/machine.go
@@ -18,6 +18,11 @@ var (
 // a fallback logger when Log option is not provided.
 var DefaultLogger = logging.NewCustom("machine", config.Konfig.Debug)
 
+// Cacher defines objects that can be cached.
+type Cacher interface {
+	Cache() error // Commit underlying data to external cache.
+}
+
 // ID is a unique identifier of the machine.
 type ID string
 

--- a/go/src/koding/klient/machine/machinegroup/addresses/addresses.go
+++ b/go/src/koding/klient/machine/machinegroup/addresses/addresses.go
@@ -27,7 +27,9 @@ func (a *Addresses) Add(id machine.ID, addr machine.Addr) error {
 
 	ab, ok := a.m[id]
 	if !ok {
-		ab = &machine.AddrBook{}
+		ab = &machine.AddrBook{
+			MaxSize: 4, // maximum 4 records per address type.
+		}
 	}
 
 	ab.Add(addr)
@@ -45,7 +47,7 @@ func (a *Addresses) Drop(id machine.ID) error {
 	return nil
 }
 
-// Latests returns the latest known address for a given machine and network.
+// Latest returns the latest known address for a given machine and network.
 func (a *Addresses) Latest(id machine.ID, network string) (machine.Addr, error) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()

--- a/go/src/koding/klient/machine/machinegroup/addresses/cached.go
+++ b/go/src/koding/klient/machine/machinegroup/addresses/cached.go
@@ -41,30 +41,16 @@ func NewCached(st storage.ValueInterface) (*Cached, error) {
 
 // Add adds provided address to a given machine and updates the cache.
 func (c *Cached) Add(id machine.ID, addr machine.Addr) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if err := c.addresses.Add(id, addr); err != nil {
-		return err
-	}
-
-	return c.st.SetValue(storageKey, c.addresses.all())
+	return c.addresses.Add(id, addr)
 }
 
 // Drop removes addresses which are binded to provided machine ID and updates
 // the cache.
 func (c *Cached) Drop(id machine.ID) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if err := c.addresses.Drop(id); err != nil {
-		return err
-	}
-
-	return c.st.SetValue(storageKey, c.addresses.all())
+	return c.addresses.Drop(id)
 }
 
-// Latests returns the latest known address for a given machine and network.
+// Latest returns the latest known address for a given machine and network.
 func (c *Cached) Latest(id machine.ID, network string) (machine.Addr, error) {
 	return c.addresses.Latest(id, network)
 }
@@ -79,4 +65,12 @@ func (c *Cached) MachineID(addr machine.Addr) (machine.ID, error) {
 // Registered returns all machines that are stored in this object.
 func (c *Cached) Registered() machine.IDSlice {
 	return c.addresses.Registered()
+}
+
+// Cache saves addresses data to underlying storage.
+func (c *Cached) Cache() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.st.SetValue(storageKey, c.addresses.all())
 }

--- a/go/src/koding/klient/machine/machinegroup/aliases/cached.go
+++ b/go/src/koding/klient/machine/machinegroup/aliases/cached.go
@@ -41,45 +41,19 @@ func NewCached(st storage.ValueInterface) (*Cached, error) {
 
 // Add binds custom alias to provided machine and updates the cache.
 func (c *Cached) Add(id machine.ID, alias string) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if err := c.aliases.Add(id, alias); err != nil {
-		return err
-	}
-
-	return c.st.SetValue(storageKey, c.aliases.all())
+	return c.aliases.Add(id, alias)
 }
 
 // Create generates a new alias for provided machine ID and updates the cache.
 // If alias already exists, it will not be regenerated nor cached.
 func (c *Cached) Create(id machine.ID) (string, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	alias, err := c.aliases.Create(id)
-	if err != nil {
-		return "", err
-	}
-
-	if err = c.st.SetValue(storageKey, c.aliases.all()); err != nil {
-		return "", err
-	}
-
-	return alias, nil
+	return c.aliases.Create(id)
 }
 
 // Drop removes alias which is binded to provided machine ID and updates
 // the cache.
 func (c *Cached) Drop(id machine.ID) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if err := c.aliases.Drop(id); err != nil {
-		return err
-	}
-
-	return c.st.SetValue(storageKey, c.aliases.all())
+	return c.aliases.Drop(id)
 }
 
 // MachineID checks if there is a machine ID that is binded to provided alias.
@@ -92,4 +66,12 @@ func (c *Cached) MachineID(alias string) (machine.ID, error) {
 // Registered returns all machines that are stored in this object.
 func (c *Cached) Registered() machine.IDSlice {
 	return c.aliases.Registered()
+}
+
+// Cache saves aliases data to underlying storage.
+func (c *Cached) Cache() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.st.SetValue(storageKey, c.aliases.all())
 }

--- a/go/src/koding/klient/machine/machinegroup/machinegroup.go
+++ b/go/src/koding/klient/machine/machinegroup/machinegroup.go
@@ -214,6 +214,15 @@ func (g *Group) bootstrap() {
 		g.log.Info("Created alias for %s, %s", id, alias)
 	}
 
+	// Save newly generated aliases.
+	if len(noAliases) != 0 {
+		if cache, ok := g.alias.(machine.Cacher); ok {
+			if err := cache.Cache(); err != nil {
+				g.log.Warning("Regenerated aliases were not cached: %v", err)
+			}
+		}
+	}
+
 	// Start clients for all available addresses and for mounts even if they
 	// may have no address, they will need disconnected client.
 	for _, id := range idset.Union(addressIDs, mountsIDs) {

--- a/go/src/koding/klient/machine/machinegroup/machinegroup_test.go
+++ b/go/src/koding/klient/machine/machinegroup/machinegroup_test.go
@@ -86,6 +86,9 @@ func TestMachineGroupNoAliases(t *testing.T) {
 	if err := address.Add(id, clienttest.TurnOnAddr()); err != nil {
 		t.Fatalf("want err = nil; got %v", err)
 	}
+	if err := address.Cache(); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
 	if len(address.Registered()) != 1 {
 		t.Errorf("want one registered machine; got %v", address.Registered())
 	}
@@ -142,6 +145,9 @@ func TestMachineGroupMount(t *testing.T) {
 		t.Fatalf("want err = nil; got %v", err)
 	}
 	if err := address.Add(id, clienttest.TurnOnAddr()); err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	if err := address.Cache(); err != nil {
 		t.Fatalf("want err = nil; got %v", err)
 	}
 


### PR DESCRIPTION
This PR makes bolt.db machine records update logic asynchronous. It also fixes a bug where we were adding addresses to db always after `kd machine list` even if they didn't change. 

## Motivation and Context
Make `kd list` fast again.

## How Has This Been Tested?
Unit tests, Manually

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
