### PR TITLE
klient: use exports for remote paths

### DIFF
--- a/go/src/koding/kites/config/konfig.go
+++ b/go/src/koding/kites/config/konfig.go
@@ -63,16 +63,16 @@ type Local struct {
 	// Mount is a default home path of mounted directories.
 	//
 	// If empty, defaults to ~/koding/mnt/.
-	Mount string `json:"mount,omitempty"`
+	MountHome string `json:"mountHome,omitempty"`
 
-	// Exports maps named mounts to local paths.
+	// Mounts maps named mounts to local paths.
 	//
-	// The Exports["default"] export is used as
+	// The Mounts["default"] export is used as
 	// a default one when caller does not specify
 	// a mount path.
 	//
-	// The Exports["default"] defaults to $HOME.
-	Exports map[string]string `json:"exports,omitempty"`
+	// The Mounts["default"] defaults to $HOME.
+	Mounts map[string]string `json:"mounts,omitempty"`
 }
 
 type Konfig struct {
@@ -272,8 +272,8 @@ func NewKonfig(e *Environments) *Konfig {
 			},
 		},
 		Local: &Local{
-			Mount: filepath.Join(CurrentUser.HomeDir, "koding", "mnt"),
-			Exports: map[string]string{
+			MountHome: filepath.Join(CurrentUser.HomeDir, "koding", "mnt"),
+			Mounts: map[string]string{
 				"default": CurrentUser.HomeDir,
 			},
 		},

--- a/go/src/koding/kites/config/konfig.go
+++ b/go/src/koding/kites/config/konfig.go
@@ -58,6 +58,23 @@ func (e *Endpoints) Social() *Endpoint {
 	return e.Koding.WithPath("/api/social")
 }
 
+// Local describes configuration of local paths.
+type Local struct {
+	// Mount is a default home path of mounted directories.
+	//
+	// If empty, defaults to ~/koding/mnt/.
+	Mount string `json:"mount,omitempty"`
+
+	// Exports maps named mounts to local paths.
+	//
+	// The Exports["default"] export is used as
+	// a default one when caller does not specify
+	// a mount path.
+	//
+	// The Exports["default"] defaults to $HOME.
+	Exports map[string]string `json:"exports,omitempty"`
+}
+
 type Konfig struct {
 	Endpoints *Endpoints `json:"endpoints,omitempty"`
 
@@ -68,6 +85,9 @@ type Konfig struct {
 	Environment string `json:"environment,omitempty"`
 	KiteKeyFile string `json:"kiteKeyFile,omitempty"`
 	KiteKey     string `json:"kiteKey,omitempty"`
+
+	// Local describes configuration of local paths.
+	Local *Local `json:"local,omitempty"`
 
 	// Koding networking configuration.
 	//
@@ -80,9 +100,6 @@ type Konfig struct {
 	PublicBucketRegion string `json:"publicBucketRegion,omitempty"`
 
 	Debug bool `json:"debug,string,omitempty"`
-
-	// Metadata keeps per-app configuration.
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }
 
 func (k *Konfig) KiteHome() string {
@@ -252,6 +269,12 @@ func NewKonfig(e *Environments) *Konfig {
 					Host:   "127.0.0.1:56789",
 					Path:   "/kite",
 				}},
+			},
+		},
+		Local: &Local{
+			Mount: filepath.Join(CurrentUser.HomeDir, "koding", "mnt"),
+			Exports: map[string]string{
+				"default": CurrentUser.HomeDir,
 			},
 		},
 		PublicBucketName:   Builtin.Buckets.PublicLogs.Name,

--- a/go/src/koding/kites/kloud/metadata/metadata.go
+++ b/go/src/koding/kites/kloud/metadata/metadata.go
@@ -35,10 +35,11 @@ func mustAsset(file string) []byte {
 // in order to install klient service on a remote vm
 // and authenticate and connect to Koding.
 type Config struct {
-	Konfig   *config.Konfig // Koding endpoints configuration
-	KiteKey  string         // KiteKey used by klient to authenticate with Koding
-	Userdata string         // User script to run after provisioning, if any
-	Debug    bool           // Whether klient should be started in debug mode; configurable by debug field in stack template
+	Konfig   *config.Konfig    // Koding endpoints configuration
+	KiteKey  string            // KiteKey used by klient to authenticate with Koding
+	Userdata string            // User script to run after provisioning, if any
+	Mounts   map[string]string // Maps names with mount paths, for use with kd mount.
+	Debug    bool              // Whether klient should be started in debug mode; configurable by debug field in stack template
 }
 
 // New builds new cloud-init for the given configuration.
@@ -84,7 +85,10 @@ func newMetadata(cfg *Config) ([]byte, error) {
 	konfig := &config.Konfig{
 		Endpoints: cfg.Konfig.Endpoints,
 		KiteKey:   cfg.KiteKey,
-		Debug:     cfg.Debug,
+		Local: &config.Local{
+			Mounts: cfg.Mounts,
+		},
+		Debug: cfg.Debug,
 	}
 
 	m := map[string]interface{}{

--- a/go/src/koding/klient/machine/index/handler.go
+++ b/go/src/koding/klient/machine/index/handler.go
@@ -92,10 +92,8 @@ func replaceWithExport(path string) string {
 		path = "default"
 	}
 
-	if config.Konfig.Local != nil {
-		if export, ok := config.Konfig.Local.Mounts[path]; ok {
-			return export
-		}
+	if dir, ok := config.Konfig.Local.MountPath(path); ok {
+		return dir
 	}
 
 	return path

--- a/go/src/koding/klient/machine/index/handler.go
+++ b/go/src/koding/klient/machine/index/handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"koding/klient/config"
 	"koding/klient/fs"
 )
 
@@ -72,7 +73,7 @@ func Get(req *Request) (*GetResponse, error) {
 }
 
 func preparePath(path string) (string, error) {
-	absPath, isDir, exist, err := fs.DefaultFS.Abs(path)
+	absPath, isDir, exist, err := fs.DefaultFS.Abs(replaceWithExport(path))
 	if err != nil {
 		return "", err
 	}
@@ -84,4 +85,18 @@ func preparePath(path string) (string, error) {
 	}
 
 	return absPath, nil
+}
+
+func replaceWithExport(path string) string {
+	if path == "" {
+		path = "default"
+	}
+
+	if config.Konfig.Local != nil {
+		if export, ok := config.Konfig.Local.Exports[path]; ok {
+			return export
+		}
+	}
+
+	return path
 }

--- a/go/src/koding/klient/machine/index/handler.go
+++ b/go/src/koding/klient/machine/index/handler.go
@@ -93,7 +93,7 @@ func replaceWithExport(path string) string {
 	}
 
 	if config.Konfig.Local != nil {
-		if export, ok := config.Konfig.Local.Exports[path]; ok {
+		if export, ok := config.Konfig.Local.Mounts[path]; ok {
 			return export
 		}
 	}

--- a/go/src/koding/klientctl/daemon/daemon.go
+++ b/go/src/koding/klientctl/daemon/daemon.go
@@ -59,8 +59,8 @@ func newDetails() *Details {
 		KodingHome: config.KodingHome(),
 		KlientHome: klientHome,
 		Osxfuse: &Package{
-			URL:     mustURL("https://s3.amazonaws.com/koding-dl/osxfuse-3.5.2.dmg"),
-			Version: "3.5.2",
+			URL:     mustURL("https://s3.amazonaws.com/koding-dl/osxfuse-3.5.8.dmg"),
+			Version: "3.5.8",
 		},
 		Virtualbox: map[string]*Package{
 			"darwin": {

--- a/go/src/koding/klientctl/daemon/daemon.go
+++ b/go/src/koding/klientctl/daemon/daemon.go
@@ -59,7 +59,7 @@ func newDetails() *Details {
 		KodingHome: config.KodingHome(),
 		KlientHome: klientHome,
 		Osxfuse: &Package{
-			URL:     mustURL("https://s3.amazonaws.com/koding-dl/osxfuse-3.5.8.dmg"),
+			URL:     mustURL("https://koding.com/d/osxfuse-3.5.8.dmg"),
 			Version: "3.5.8",
 		},
 		Virtualbox: map[string]*Package{

--- a/go/src/koding/klientctl/daemon/install.go
+++ b/go/src/koding/klientctl/daemon/install.go
@@ -507,7 +507,7 @@ var Script = []InstallStep{{
 		Name: "osxfuse",
 		Install: func(c *Client, _ *Opts) (string, error) {
 			const volume = "/Volumes/FUSE for macOS"
-			const pkg = volume + "/Extras/FUSE for macOS 3.5.2.pkg"
+			const pkg = volume + "/Extras/FUSE for macOS 3.5.8.pkg"
 
 			if _, err := os.Stat("/Library/Filesystems/osxfuse.fs"); err == nil {
 				return "", ErrSkipInstall

--- a/go/src/koding/klientctl/daemon/install.go
+++ b/go/src/koding/klientctl/daemon/install.go
@@ -533,11 +533,11 @@ var Script = []InstallStep{{
 })[runtime.GOOS], (map[string]InstallStep{
 	"darwin": {
 		Name: "VirtualBox",
-		Install: func(c *Client, _ *Opts) (string, error) {
+		Install: func(c *Client, opts *Opts) (string, error) {
 			const volume = "/Volumes/VirtualBox"
 			const pkg = volume + "/VirtualBox.pkg"
 
-			if hasVirtualBox() {
+			if hasVirtualBox() || !c.needVagrant(opts) {
 				return "", ErrSkipInstall
 			}
 
@@ -552,8 +552,8 @@ var Script = []InstallStep{{
 	},
 	"linux": {
 		Name: "VirtualBox",
-		Install: func(c *Client, _ *Opts) (string, error) {
-			if hasVirtualBox() {
+		Install: func(c *Client, opts *Opts) (string, error) {
+			if hasVirtualBox() || !c.needVagrant(opts) {
 				return "", ErrSkipInstall
 			}
 

--- a/go/src/koding/klientctl/endpoint/machine/mount.go
+++ b/go/src/koding/klientctl/endpoint/machine/mount.go
@@ -25,10 +25,27 @@ type MountOptions struct {
 	Log        logging.Logger
 }
 
+func (c *Client) mountPoint(ident string) (string, error) {
+	m, err := c.machine(ident)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(c.konfig().Local.Mount, m.Label), nil
+}
+
 // Mount synchronizes directories between remote and local machines.
 func (c *Client) Mount(options *MountOptions) (err error) {
+	c.init()
+
 	if options == nil {
 		return errors.New("invalid nil options")
+	}
+
+	if options.Path == "" {
+		if options.Path, err = c.mountPoint(options.Identifier); err != nil {
+			return err
+		}
 	}
 
 	// Create and check mount point directory.

--- a/go/src/koding/klientctl/endpoint/machine/mount.go
+++ b/go/src/koding/klientctl/endpoint/machine/mount.go
@@ -31,7 +31,7 @@ func (c *Client) mountPoint(ident string) (string, error) {
 		return "", err
 	}
 
-	return filepath.Join(c.konfig().Local.Mount, m.Label), nil
+	return filepath.Join(c.konfig().Local.MountHome, m.Label), nil
 }
 
 // Mount synchronizes directories between remote and local machines.


### PR DESCRIPTION
This PR adds support for default paths in `kd mount`.

It makes the following command:

```
$ kd mount black_kiwi:~/ ~/koding/mnt/aws-instance-1
```

Equivalent to:

```
$ kd mount black_kiwi
```

The default mount home is `~/koding/mnt/<label>` and default mount export is `~/`.

These can be configured via `kd config`:

1) the default mount can be overwritten by executing the following command locally:

```
$ kd config set local.mountHome ~/custom/mounts/
```

2) the default mount export can be overwritten by executing the following command on a remote vm:

```
$ kd config set local.mounts.default ~/github.com/me/project
```

3) or via the stack template:

```
provider:
  aws:
    access_key: '${var.aws_access_key}'
    secret_key: '${var.aws_secret_key}'
resource:
  aws_instance:
    aws-instance:

      koding_mounts:
        default: ~/github.com/me/project

      instance_type: t2.xlarge
      tags:
        Name: '${var.koding_user_username}-${var.koding_group_slug}'
```

Bonus

Using mount export points it is possible to define a named mount, e.g.

```
$ # on a remote
$ kd config set local.mounts.mysql /var/lib/mysql/data
```
```
$ # locally
$ kd mount black_kiwi:mysql ~/mysqldata
```