### PR TITLE
Set team stack over remote.api

### DIFF
--- a/website/swagger.json
+++ b/website/swagger.json
@@ -3649,6 +3649,42 @@
         }
       }
     },
+    "/ComputeProvider.setGroupStack": {
+      "post": {
+        "tags": [
+          "ComputeProvider"
+        ],
+        "consumes": [
+          "application/json"
+        ],
+        "operationId": "setGroupStack",
+        "parameters": [
+          {
+            "$ref": "#/parameters/bodyParam"
+          }
+        ],
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "description": "Method ComputeProvider.setGroupStack",
+        "responses": {
+          "200": {
+            "description": "Request processed successfully",
+            "schema": {
+              "$ref": "#/definitions/DefaultResponse"
+            }
+          },
+          "401": {
+            "description": "Unauthorized request",
+            "schema": {
+              "$ref": "#/definitions/UnauthorizedRequest"
+            }
+          }
+        }
+      }
+    },
     "/JCredential.one": {
       "post": {
         "tags": [

--- a/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
+++ b/workers/social/lib/social/models/computeproviders/stacktemplate.coffee
@@ -885,6 +885,18 @@ module.exports = class JStackTemplate extends Module
 
   verifyCredentials: (client, callback) ->
 
+    @fetchProviderCredential client, (err, credential) ->
+      return callback err  if err
+
+      credential.isBootstrapped client, (err, bootstrapped) ->
+        return callback err   if err
+        return callback null  if bootstrapped
+
+        credential.bootstrap client, callback
+
+
+  fetchProviderCredential: (client, callback) ->
+
     [ err, provider ] = @getProvider()
     return callback err  if err
 
@@ -898,11 +910,7 @@ module.exports = class JStackTemplate extends Module
       if err or not credential
         return callback new KodingError 'Credential is not accessible'
 
-      credential.isBootstrapped client, (err, bootstrapped) ->
-        return callback err   if err
-        return callback null  if bootstrapped
-
-        credential.bootstrap client, callback
+      callback null, credential
 
 
   forceStacksToReinit: permit 'force stacks to reinit',

--- a/workers/social/testhelper/models/computeproviders/stacktemplatehelper.coffee
+++ b/workers/social/testhelper/models/computeproviders/stacktemplatehelper.coffee
@@ -74,7 +74,7 @@ generateStackTemplateData = (client, data) ->
     rawContent      : rawContent
     description     : 'test stack template'
     accessLevel     : 'private'
-    credentials     : 'credentials'
+    credentials     : data.credentials ? { aws: [] }
     templateDetails : details
 
   stackTemplate = _.extend stackTemplate, data


### PR DESCRIPTION
Currently we are providing this flow in client-side and it's not possible to handle this flow in one call. This will simply allow an admin to set a default stack template for the active team. Once merged New Stack Editor will use this one instead of implementing the flow in client side like in old Stack Editor.