### PR TITLE
kd: add template.file setting

### DIFF
--- a/go/src/koding/kites/config/konfig.go
+++ b/go/src/koding/kites/config/konfig.go
@@ -54,12 +54,12 @@ func (e *Endpoints) Kloud() *Endpoint {
 	return e.Koding.WithPath("/kloud/kite")
 }
 
-// Kontrl gives an endpoint for Kontrol kite.
+// Kontrol gives an endpoint for Kontrol kite.
 func (e *Endpoints) Kontrol() *Endpoint {
 	return e.Koding.WithPath("/kontrol/kite")
 }
 
-// Remtoe gives an endpoint for remote.api.
+// Remote gives an endpoint for remote.api.
 func (e *Endpoints) Remote() *Endpoint {
 	return e.Koding.WithPath("/remote.api")
 }
@@ -184,13 +184,15 @@ func (k *Konfig) Valid() error {
 
 // ID gives an identifier of the Konfig value.
 //
-// The konfig.bolt stores multiple configuration, one for each
-// baseurl. The ID is unique per baseurl.
+// The konfig.bolt stores multiple configurations, one for each
+// baseurl.
+//
+// The ID is unique per baseurl.
 func (k *Konfig) ID() string {
 	return ID(k.KodingPublic().String())
 }
 
-// ID create an identifier for the given Koding base URL.
+// ID creates an identifier for the given Koding base URL.
 func ID(kodingURL string) string {
 	if kodingURL == "" {
 		return ""

--- a/go/src/koding/kites/config/konfig.go
+++ b/go/src/koding/kites/config/konfig.go
@@ -104,6 +104,11 @@ func (l *Local) MountPath(name string) (string, bool) {
 	return "", false
 }
 
+// Template represents a KD template configuration.
+type Template struct {
+	File string `json:"file,omitempty"`
+}
+
 // Konfig represents a single configuration stored
 // in a konfig.bolt database.
 type Konfig struct {
@@ -119,6 +124,9 @@ type Konfig struct {
 
 	// Local describes configuration of local paths.
 	Local *Local `json:"local,omitempty"`
+
+	// Template describes configuration of KD template.
+	Template *Template `json:"template,omitempty"`
 
 	// Koding networking configuration.
 	//
@@ -324,6 +332,9 @@ func NewKonfig(e *Environments) *Konfig {
 			Mounts: map[string]string{
 				"default": CurrentUser.HomeDir,
 			},
+		},
+		Template: &Template{
+			File: "kd.yaml",
 		},
 		PublicBucketName:   Builtin.Buckets.PublicLogs.Name,
 		PublicBucketRegion: Builtin.Buckets.PublicLogs.Region,

--- a/go/src/koding/klientctl/init.go
+++ b/go/src/koding/klientctl/init.go
@@ -9,10 +9,9 @@ import (
 	"strconv"
 	"strings"
 
-	yaml "gopkg.in/yaml.v2"
-
 	kstack "koding/kites/kloud/stack"
 	"koding/kites/kloud/utils/object"
+	"koding/klientctl/config"
 	"koding/klientctl/endpoint/credential"
 	"koding/klientctl/endpoint/kloud"
 	"koding/klientctl/endpoint/stack"
@@ -21,6 +20,7 @@ import (
 
 	"github.com/codegangsta/cli"
 	"github.com/koding/logging"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func Init(c *cli.Context, log logging.Logger, _ string) (int, error) {
@@ -28,15 +28,15 @@ func Init(c *cli.Context, log logging.Logger, _ string) (int, error) {
 		return 1, err
 	}
 
-	if _, err := os.Stat("kd.yaml"); os.IsNotExist(err) {
-		fmt.Printf("Initializing with new kd.yaml template file...\n\n")
+	if _, err := os.Stat(config.Konfig.Template.File); os.IsNotExist(err) {
+		fmt.Printf("Initializing with new %s template file...\n\n", config.Konfig.Template.File)
 
-		if err := templateInit("kd.yaml", false, ""); err != nil {
+		if err := templateInit(config.Konfig.Template.File, false, ""); err != nil {
 			return 1, err
 		}
 	}
 
-	p, err := readTemplate("kd.yaml")
+	p, err := readTemplate(config.Konfig.Template.File)
 	if err != nil {
 		return 1, err
 	}

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -711,7 +711,7 @@ func run(args []string) {
 					},
 					cli.StringFlag{
 						Name:  "file, f",
-						Value: "kd.yml",
+						Value: config.Konfig.Template.File,
 						Usage: "Read stack template from a file.",
 					},
 					cli.BoolFlag{
@@ -840,7 +840,7 @@ func run(args []string) {
 					cli.StringFlag{
 						Name:  "output, o",
 						Usage: "Output template file.",
-						Value: "kd.yaml",
+						Value: config.Konfig.Template.File,
 					},
 					cli.BoolFlag{
 						Name:  "defaults",


### PR DESCRIPTION
Fix for https://github.com/koding/koding/issues/11055.

It makes also the default template file name configurable via `kd config`:

```
$ kd config set template.file custom.yaml
```
```
$ kd init
Initializing with new custom.yaml template file...

Provider type []: aws
Set "instance_type" to [t2.nano]: t2.nano

Template successfully written to custom.yaml.

...
```