### PR TITLE
Fixes around Updated Stack Template widget on sidebar

### DIFF
--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -70,7 +70,15 @@ module.exports = class ComputeController extends KDController
 
       @on 'StackAdminMessageDeleted', @bound 'handleStackAdminMessageDeleted'
 
-      groupsController.on 'StackTemplateChanged', (event) => @checkGroupStacks event?.contents
+      groupsController.on 'StackTemplateChanged', (event) =>
+        return  unless templateId = event?.contents
+
+        @once 'StackRevisionChecked', (stack, oldRevision) =>
+          if stack.baseStackId is templateId
+            @emit 'StackRevisionUpdated', stack, oldRevision
+
+        @checkGroupStacks event?.contents
+
       groupsController.on 'StackAdminMessageCreated', @bound 'handleStackAdminMessageCreated'
       groupsController.on 'SharedStackTemplateAccessLevel', @bound 'sharedStackTemplateAccessLevel'
 
@@ -746,7 +754,7 @@ module.exports = class ComputeController extends KDController
         if not _revisionStatus or _revisionStatus.status isnt status
           debug 'checkStackRevisions stack changed!', stack
           @storage.stacks.push stack
-          @emit 'StackRevisionChecked', stack
+          @emit 'StackRevisionChecked', stack, _revisionStatus
 
     if stackTemplateId and not found
       @createDefaultStack()

--- a/client/app/lib/sidebar/components/stackupdatedwidget.coffee
+++ b/client/app/lib/sidebar/components/stackupdatedwidget.coffee
@@ -21,9 +21,15 @@ module.exports = class StackUpdatedWidget extends React.Component
       appManager.tell 'Stackeditor', 'reloadEditor', templateId
 
 
+  onClose: ->
+
+    { sidebar } = kd.singletons
+    sidebar.setUpdatedStack null
+
+
   render: ->
 
-    <SidebarWidget {...@props} onClose={@props.onClose}>
+    <SidebarWidget {...@props} onClose={@bound 'onClose'}>
       <span>STACK UPDATED</span>
       <p className='SidebarWidget-Title'>
         You need to reinitialize your machines before booting.

--- a/client/app/lib/sidebarcontroller.coffee
+++ b/client/app/lib/sidebarcontroller.coffee
@@ -1,6 +1,6 @@
 debug = require('debug')('sidebar:controller')
 kd = require 'kd'
-EnvironmentFlux = require 'app/flux/environment'
+ComputeStack = require 'app/remote-extensions/computestack'
 remote = require 'app/remote'
 { isObject } = require 'lodash'
 
@@ -59,6 +59,9 @@ module.exports = class SidebarController extends kd.Controller
 
       computeController.on 'GroupStacksConsistent', =>
         @setDefaultStackUpdated updated = no
+
+      computeController.on 'StackRevisionUpdated', (stack) =>
+        @setUpdatedStack stack.getId()
 
 
   setStateFromStorage: ->


### PR DESCRIPTION
I created a new event called `StackRevisionUpdated` on `computeController` to make it happen **ONLY IF** `StackRevisionChecked` event occurs **after** receiving a `StackTemplateChanged` event. 

Since `StackTemplateChanged` event only happens after initial load on realtime, `sidebarController` can hook into this event, and set its state to make `UpdatedStackWidget`  visible.

All other approaches i tried resulted in writing a state transition code inside a component, which was pretty ugly. 