### PR TITLE
Fixes around cloning templates

### DIFF
--- a/client/app/lib/providers/computecontroller.coffee
+++ b/client/app/lib/providers/computecontroller.coffee
@@ -784,6 +784,7 @@ module.exports = class ComputeController extends KDController
         @checkRevisionFromOriginalStackTemplate stackTemplate
       else
         @removeRevisionFromUnSharedStackTemplate _id, stackTemplate
+        @storage.templates.pop stackTemplate  unless stackTemplate.isMine()
         new kd.NotificationView { title : 'Stack Template is Unshared With Team' }
 
 

--- a/client/app/lib/sidebar/components/sharingwidget.coffee
+++ b/client/app/lib/sidebar/components/sharingwidget.coffee
@@ -38,7 +38,7 @@ Buttons = ({ children }) ->
 Button = ({ type, children, onClick }) ->
 
   <button onClick={onClick} className={cx 'kdbutton', 'GenericButton', type}>
-    <span children={type.toUpperCase()} />
+    <span className='button-title' children={type.toUpperCase()} />
   </button>
 
 

--- a/client/app/lib/sidebar/components/widgetuser.coffee
+++ b/client/app/lib/sidebar/components/widgetuser.coffee
@@ -5,7 +5,7 @@ ProfileLinkContainer = require 'app/components/profile/profilelinkcontainer'
 
 module.exports = SidebarWidgetUser = ({ size = {}, owner }) ->
 
-  { width, height } = size
+  { width = 36, height = 36 } = size
 
   <div className='SidebarWidget-UserView'>
     <ProfileLinkContainer origin={owner}>

--- a/client/app/lib/sidebar/view.coffee
+++ b/client/app/lib/sidebar/view.coffee
@@ -20,6 +20,7 @@ sidebarConnector = connectSidebar({
     { sidebar } = kd.singletons
 
     ownedResources = calculateOwnedResources(props)
+      .filter ({ stack, template }) -> stack or template?.isMine()
       .map (resource) ->
         isVisible = if resource.stack
         then sidebar.isVisible 'stack', resource.stack.getId()

--- a/client/home/lib/stacks/components/draftslist/container.coffee
+++ b/client/home/lib/stacks/components/draftslist/container.coffee
@@ -1,12 +1,9 @@
 kd = require 'kd'
 React = require 'app/react'
-EnvironmentFlux = require 'app/flux/environment'
-KDReactorMixin = require 'app/flux/base/reactormixin'
-remote = require 'app/remote'
 View = require './view'
-SidebarFlux = require 'app/flux/sidebar'
 
 calculateOwnedResources = require 'app/util/calculateOwnedResources'
+canCreateStacks = require 'app/util/canCreateStacks'
 
 module.exports = class DraftsListContainer extends React.Component
 
@@ -39,6 +36,7 @@ module.exports = class DraftsListContainer extends React.Component
   render: ->
     <View
       resources={@props.resources}
+      canCreateStacks={canCreateStacks()}
       onOpenItem={@props.onOpenItem}
       onAddToSidebar={@bound 'onAddToSidebar'}
       onRemoveFromSidebar={@bound 'onRemoveFromSidebar'}

--- a/client/home/lib/stacks/components/draftslist/view.coffee
+++ b/client/home/lib/stacks/components/draftslist/view.coffee
@@ -28,6 +28,7 @@ module.exports = class DraftsListView extends React.Component
     <StackTemplateItem
       isVisibleOnSidebar={isVisible}
       template={template}
+      canCreateStacks={@props.canCreateStacks}
       onOpen={@props.onOpenItem}
       onAddToSidebar={@props.onAddToSidebar.bind null, resource}
       onRemoveFromSidebar={@props.onRemoveFromSidebar.bind null, resource}

--- a/client/home/lib/stacks/components/stacktemplateitem/index.coffee
+++ b/client/home/lib/stacks/components/stacktemplateitem/index.coffee
@@ -77,6 +77,24 @@ module.exports = class StackTemplateItem extends React.Component
         title='ADD TO SIDEBAR' />
 
 
+  canClone: ->
+    { canCreateStacks, template, onCloneFromDashboard } = @props
+
+    return not onCloneFromDashboard or template.isMine() or canCreateStacks
+
+
+  renderCloningDisabledMessage: ->
+
+    { canCreateStacks, template, onCloneFromDashboard } = @props
+
+    return null  if @canClone()
+
+    <div className='cloning-disabled-msg'>
+      Cloning is disabled for members.
+      Please ask one of your admins to enable stack creation permission.
+    </div>
+
+
   renderUnreadCount: ->
 
     return null  unless count = @props.stack?.getUnreadCount()
@@ -162,6 +180,7 @@ module.exports = class StackTemplateItem extends React.Component
       </div>
       <div className='HomeAppViewListItem-SecondaryContainer'>
         {@renderButton()}
+        {@renderCloningDisabledMessage()}
       </div>
     </div>
 

--- a/client/home/lib/stacks/components/stacktemplateitem/index.coffee
+++ b/client/home/lib/stacks/components/stacktemplateitem/index.coffee
@@ -129,7 +129,13 @@ module.exports = class StackTemplateItem extends React.Component
     { template, stack, onOpen } = @props
 
     if stack?.getOldOwner()
-      return <DisabledStack stack={stack} onOpen={onOpen} />
+      return (
+        <DisabledStack
+          template={template}
+          stack={stack}
+          onOpen={onOpen}
+        />
+      )
 
     if not template
       return null
@@ -158,12 +164,12 @@ module.exports = class StackTemplateItem extends React.Component
     </div>
 
 
-DisabledStack = ({ stack, onOpen }) ->
+DisabledStack = ({ template, stack, onOpen }) ->
   <div className='HomeAppViewListItem StackTemplateItem'>
     <a
       className='HomeAppViewListItem-label disabled'
       onClick={onOpen}
-      children={makeTitle({ stack })} />
+      children={makeTitle({ stack, template })} />
 
     <div className='HomeAppViewListItem-description disabled'>
       Last Updated <TimeAgo from={stack.meta.modifiedAt} />

--- a/client/home/lib/stacks/components/stacktemplateitem/index.coffee
+++ b/client/home/lib/stacks/components/stacktemplateitem/index.coffee
@@ -2,6 +2,7 @@ _ = require 'lodash'
 $ = require 'jquery'
 kd = require 'kd'
 React = require 'app/react'
+cx = require 'classnames'
 
 isAdmin = require 'app/util/isAdmin'
 whoami = require 'app/util/whoami'
@@ -57,11 +58,12 @@ module.exports = class StackTemplateItem extends React.Component
 
   renderButton: ->
 
-    { onAddToSidebar, onRemoveFromSidebar,
+    { onAddToSidebar, onRemoveFromSidebar, canCreateStacks
       isVisibleOnSidebar, onCloneFromDashboard, template } = @props
 
     if onCloneFromDashboard and not template.isMine()
       <ItemLink
+        disabled={not canCreateStacks}
         onClick={onCloneFromDashboard}
         title='CLONE STACK' />
 
@@ -189,9 +191,15 @@ makeTitle = ({ template, stack }) ->
   return title
 
 
-ItemLink = ({ onClick, title }) ->
+ItemLink = ({ onClick, title, disabled }) ->
+  className = cx 'HomeAppView--button',
+    'primary': not disabled
+    'inactive': disabled
+
+  onClick = kd.noop  if disabled
+
   <a
     href="#"
-    className="HomeAppView--button primary"
+    className={className}
     onClick={onClick}
     children={title} />

--- a/client/home/lib/styl/home.styl
+++ b/client/home/lib/styl/home.styl
@@ -191,15 +191,27 @@ $subtleColor                = #A59999
 
 .HomeAppViewListItem-SecondaryContainer
   width                     50%
-  abs                       13px 0px
+  height                    100%
+  abs                       0px 0px
   text-align                right
+  display                   flex
+  flex-direction            column
+  justify-content           center
 
   .HomeAppView--button
     line-height             20px
     display                 inline-block
 
+    &.inactive
+      cursor                not-allowed
+      color                 $subtleColor
+
   .SecondaryContainerItem
     margin-left             40px
+
+.HomeAppViewListItem .cloning-disabled-msg
+  font-size                 12px
+  color                     $subtleColor
 
 
 .HomeAppView--button


### PR DESCRIPTION
Fixes #11080 
Fixes #11079 
Fixes #11023 
Fixes #10906 

Instead of not showing a shared draft, i added a message under `Clone` button to show stack creating is disabled for members:

![image](https://cloud.githubusercontent.com/assets/1783869/25486974/836c8e98-2b6b-11e7-9491-20031f2da757.png)
