### PR TITLE
kd/auth: add show command

### DIFF
--- a/go/src/koding/klientctl/auth.go
+++ b/go/src/koding/klientctl/auth.go
@@ -58,9 +58,9 @@ func AuthLogin(c *cli.Context, log logging.Logger, _ string) (int, error) {
 	}
 
 	if resp.GroupName != "" {
-		fmt.Fprintln(os.Stdout, "Successfully logged in to the following team:", resp.GroupName)
+		fmt.Println("Successfully logged in to the following team:", resp.GroupName)
 	} else {
-		fmt.Fprintf(os.Stdout, "Successfully authenticated to Koding.\n\nPlease run \"kd auth login "+
+		fmt.Printf("Successfully authenticated to Koding.\n\nPlease run \"kd auth login " +
 			"[--team myteam]\" in order to login to your team.\n")
 	}
 

--- a/go/src/koding/klientctl/auth.go
+++ b/go/src/koding/klientctl/auth.go
@@ -68,3 +68,7 @@ func AuthLogin(c *cli.Context, log logging.Logger, _ string) (int, error) {
 
 	return 0, nil
 }
+
+func AuthShow(c *cli.Context, _ logging.Logger, _ string) (int, error) {
+	return 0, nil
+}

--- a/go/src/koding/klientctl/auth.go
+++ b/go/src/koding/klientctl/auth.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
+	"text/tabwriter"
 
 	"koding/klientctl/ctlcli"
 	"koding/klientctl/endpoint/auth"
@@ -50,9 +50,7 @@ func AuthLogin(c *cli.Context, log logging.Logger, _ string) (int, error) {
 	}
 
 	if c.Bool("json") {
-		enc := json.NewEncoder(os.Stdout)
-		enc.SetIndent("", "\t")
-		enc.Encode(resp)
+		printJSON(resp)
 
 		return 0, nil
 	}
@@ -70,5 +68,26 @@ func AuthLogin(c *cli.Context, log logging.Logger, _ string) (int, error) {
 }
 
 func AuthShow(c *cli.Context, _ logging.Logger, _ string) (int, error) {
+	info := auth.Used()
+
+	if c.Bool("json") {
+		printJSON(info)
+	} else {
+		printInfo(info)
+	}
+
 	return 0, nil
+}
+
+func printInfo(info *auth.Info) {
+	w := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
+	defer w.Flush()
+
+	team := "-"
+	if info.Session != nil && info.Session.Team != "" {
+		team = info.Session.Team
+	}
+
+	fmt.Fprintln(w, "USERNAME\tTEAM\tBASEURL")
+	fmt.Fprintf(w, "%s\t%s\t%s\n", info.Username, team, info.BaseURL)
 }

--- a/go/src/koding/klientctl/endpoint/auth/auth.go
+++ b/go/src/koding/klientctl/endpoint/auth/auth.go
@@ -16,19 +16,25 @@ import (
 	"github.com/koding/kite"
 )
 
+// DefaultClient is the default client used by Login, Use and Show.
 var DefaultClient = &Client{}
 
 func init() {
 	ctlcli.CloseOnExit(DefaultClient)
 }
 
+// Session represents user session details required
+// for authentication with SocialAPI and remote.api
+// endpoints.
 type Session struct {
-	ClientID string `json:"clientID"`
-	Team     string `json:"team"`
+	ClientID string `json:"clientID"` // authentication token
+	Team     string `json:"team"`     // authenticated scope
 }
 
+// Sessions stores session details for multiple teams.
 type Sessions map[string]*Session
 
+// Slice converts the map to a sorted slice.
 func (s Sessions) Slice() []*Session {
 	keys := make([]string, 0, len(s))
 
@@ -47,15 +53,17 @@ func (s Sessions) Slice() []*Session {
 	return slice
 }
 
+// LoginOptions represents arguments for the Login method.
 type LoginOptions struct {
-	Team     string
-	Token    string
-	Username string
-	Password string
-	Prefix   string
-	Force    bool
+	Team     string // team to authenticate to
+	Token    string // optional; use token-based authentication
+	Username string // username for password-based authentication
+	Password string // password for password-based authentication
+	Prefix   string // optional; prefix for interactive mode
+	Force    bool   // whether to force new session
 }
 
+// AskUserPass asks user for Username and Password in an interactive mode.
 func (opts *LoginOptions) AskUserPass() (err error) {
 	opts.Username, err = helper.Ask("%sUsername [%s]: ", opts.Prefix, config.CurrentUser.Username)
 	if err != nil {
@@ -79,15 +87,25 @@ func (opts *LoginOptions) AskUserPass() (err error) {
 	return nil
 }
 
+// Client is responsible for authentication by communicating
+// with Kloud and Kontrol kites.
 type Client struct {
-	Kloud   *kloud.Client
-	Kontrol *kontrol.Client
-	Team    *team.Client
+	Kloud   *kloud.Client   // optional; if nil, kloud.DefaultClient is used
+	Kontrol *kontrol.Client // optional; if nil, kontrol.DefaultClient is used
+	Team    *team.Client    // optional; if nil, team.DefaultClient is used
 
 	once     sync.Once // for c.init()
 	sessions Sessions
 }
 
+// Login authenticates to Koding.
+//
+// If opts.Token is no empty, token-based authentication is used.
+//
+// If both opts.Username and opts.Password are not empty, password-based
+// authentication is used.
+//
+// Otherwise Login uses kite-based authentication.
 func (c *Client) Login(opts *LoginOptions) (*stack.PasswordLoginResponse, error) {
 	c.init()
 
@@ -144,18 +162,23 @@ func (c *Client) Login(opts *LoginOptions) (*stack.PasswordLoginResponse, error)
 	return &resp, nil
 }
 
+// Sessions gives all the authenticated sessions.
 func (c *Client) Sessions() Sessions {
 	c.init()
 
 	return c.sessions
 }
 
+// Use caches new user session.
 func (c *Client) Use(s *Session) {
 	c.init()
 
 	c.sessions[s.Team] = s
 }
 
+// Close implements the io.Closer interface.
+//
+// It closes any resources used by the Client.
 func (c *Client) Close() (err error) {
 	if len(c.sessions) != 0 {
 		err = c.kloud().Cache().SetValue("auth.sessions", c.sessions)
@@ -206,5 +229,26 @@ func nonil(err ...error) error {
 	return nil
 }
 
-func Login(opts *LoginOptions) (*stack.PasswordLoginResponse, error) { return DefaultClient.Login(opts) }
-func Use(s *Session)                                                 { DefaultClient.Use(s) }
+// Login authenticates to Koding.
+//
+// If opts.Token is no empty, token-based authentication is used.
+//
+// If both opts.Username and opts.Password are not empty, password-based
+// authentication is used.
+//
+// Otherwise Login uses kite-based authentication.
+//
+// The function forwards call to the DefaultClient.
+func Login(opts *LoginOptions) (*stack.PasswordLoginResponse, error) {
+	return DefaultClient.Login(opts)
+}
+
+// Use caches new user session.
+//
+// The function forwards call to the DefaultClient.
+func Use(s *Session) { DefaultClient.Use(s) }
+
+// Sessions gives all the authenticated sessions.
+//
+// The function forwards call to the DefaultClient.
+func Sessions() Sessions { return DefaultClient.Sessions() }

--- a/go/src/koding/klientctl/endpoint/kloud/kloud.go
+++ b/go/src/koding/klientctl/endpoint/kloud/kloud.go
@@ -23,7 +23,7 @@ import (
 // RPC round trip.
 //
 // Default implementation used in this package is
-// a kiteTransport, but plain net/rpc can also be
+// a KiteTransport, but plain net/rpc can also be
 // used.
 type Transport interface {
 	Connect(url string) (Transport, error)
@@ -33,8 +33,8 @@ type Transport interface {
 // DefaultLog is a logger used by Client with nil Log.
 var DefaultLog logging.Logger = logging.NewCustom("endpoint-kloud", false)
 
-// DefaultClient is a default client used by Cache, Kite,
-// KiteConfig and Kloud functions.
+// DefaultClient is a default client used by Cache, Username,
+// Call and Wait functions.
 var DefaultClient = &Client{
 	Transport: &KiteTransport{},
 }
@@ -58,6 +58,7 @@ type Client struct {
 	cache *cfg.Cache
 }
 
+// Cache gives new kd.bolt cache.
 func (c *Client) Cache() *cfg.Cache {
 	if c.cache != nil {
 		return c.cache
@@ -68,6 +69,11 @@ func (c *Client) Cache() *cfg.Cache {
 	return c.cache
 }
 
+// Username gives the username by:
+//
+//   - reading username from kite.key if available
+//   - giving current system username otherwise
+//
 func (c *Client) Username() string {
 	if kt, ok := c.Transport.(*KiteTransport); ok {
 		return kt.kiteConfig().Username
@@ -75,10 +81,18 @@ func (c *Client) Username() string {
 	return cfg.CurrentUser.Username
 }
 
+// Call calls the given method with provided arguments
+// on the underlying transport.
+//
+// If reply argument is non-nil, it will contain response
+// value.
 func (c *Client) Call(method string, arg, reply interface{}) error {
 	return c.Transport.Call(method, arg, reply)
 }
 
+// Close implements the io.Closer interface.
+//
+// It closes any resources used by the client.
 func (c *Client) Close() (err error) {
 	if c.cache != nil {
 		err = c.cache.Close()
@@ -86,6 +100,13 @@ func (c *Client) Close() (err error) {
 	return err
 }
 
+// Wait polls on even stream identified by the given event string.
+//
+// If the event string is invalid or receiving the events fails,
+// the returned chan will receive an event with non-nil error.
+//
+// The returned channel will be closed as soon as the operation
+// finishes or error occurs.
 func (c *Client) Wait(event string) <-chan *stack.EventResponse {
 	ch := make(chan *stack.EventResponse, 1)
 
@@ -171,16 +192,6 @@ func (c *Client) waitInterval() time.Duration {
 	return 10 * time.Second
 }
 
-func newErr(err error) *kite.Error {
-	if e, ok := err.(*kite.Error); ok {
-		return e
-	}
-	return &kite.Error{
-		Type:    "endpoint/kloud",
-		Message: err.Error(),
-	}
-}
-
 // KiteTransport is a default transport that uses github.com/koding/kite
 // for underlying communication.
 //
@@ -224,6 +235,10 @@ var (
 	_ stack.Validator = (*KiteTransport)(nil)
 )
 
+// Call calls the given method with provided arguments.
+//
+// If reply argument is non-nil, it will contain response
+// value.
 func (kt *KiteTransport) Call(method string, arg, reply interface{}) error {
 	k, err := kt.client()
 	if err != nil {
@@ -242,6 +257,8 @@ func (kt *KiteTransport) Call(method string, arg, reply interface{}) error {
 	return nil
 }
 
+// Connect creates new kite transport by connecting
+// to kite given by the url.
 func (kt *KiteTransport) Connect(url string) (Transport, error) {
 	k, err := kt.newClient(url)
 	if err != nil {
@@ -254,6 +271,8 @@ func (kt *KiteTransport) Connect(url string) (Transport, error) {
 	return &ktCopy, nil
 }
 
+// SetKiteKey sets or replaces kite.key value used for
+// kiteKey-authentication.
 func (kt *KiteTransport) SetKiteKey(kiteKey string) {
 	if kt.kCfg != nil {
 		kt.kCfg.KiteKey = kiteKey
@@ -359,6 +378,18 @@ func (kt *KiteTransport) clientURL() string {
 	return kt.konfig().Endpoints.Kloud().Public.String()
 }
 
+func newErr(err error) *kite.Error {
+	if e, ok := err.(*kite.Error); ok {
+		return e
+	}
+	return &kite.Error{
+		Type:    "endpoint/kloud",
+		Message: err.Error(),
+	}
+}
+
+// Valid is used to test whether the transport is authenticated
+// and authorized to call methods on a remote kite.
 func (kt *KiteTransport) Valid() error {
 	// In order to test whether we're able to authenticate with kloud
 	// we need to call some kite method. For that purpose we
@@ -367,11 +398,39 @@ func (kt *KiteTransport) Valid() error {
 	return kt.Call("kite.print", "", nil)
 }
 
+// Cache gives new kd.bolt cache.
+//
+// The function forwards the call to the DefaultClient.
 func Cache() *cfg.Cache { return DefaultClient.Cache() }
-func Username() string  { return DefaultClient.Username() }
+
+// Username gives the username by:
+//
+//   - reading username from kite.key if available
+//   - giving current system username otherwise
+//
+// The function forwards the call to the DefaultClient.
+func Username() string { return DefaultClient.Username() }
+
+// Call calls the given method with provided arguments
+// on the underlying transport.
+//
+// If reply argument is non-nil, it will contain response
+// value.
+//
+// The function forwards the call to the DefaultClient.
 func Call(method string, arg, reply interface{}) error {
 	return DefaultClient.Call(method, arg, reply)
 }
+
+// Wait polls on even stream identified by the given event string.
+//
+// If the event string is invalid or receiving the events fails,
+// the returned chan will receive an event with non-nil error.
+//
+// The returned channel will be closed as soon as the operation
+// finishes or error occurs.
+//
+// The function forwards the call to the DefaultClient.
 func Wait(event string) <-chan *stack.EventResponse {
 	return DefaultClient.Wait(event)
 }


### PR DESCRIPTION
This PR adds `kd auth show` command.

Example usage:

```
$ kd auth show
USERNAME   TEAM    BASEURL
rjeczalik  foobar  http://rjeczalik.koding.team
```
```
$ kd auth show --json
{
        "clientID": "aha5c639-1f1b-0014-b232-2d3999a80aa6",
        "team": "foobar",
        "username": "rjeczalik",
        "baseurl": "http://rjeczalik.koding.team"
}
```