### PR TITLE
machine/mount/fuse: filesystem improvements

### DIFF
--- a/go/src/koding/klient/machine/index/index.go
+++ b/go/src/koding/klient/machine/index/index.go
@@ -64,6 +64,11 @@ func NewIndexFiles(root string) (*Index, error) {
 			return nil
 		}
 
+		// Don't include OSX trashes to scanned files.
+		if info.Name() == ".Trash" && info.Mode().IsDir() && runtime.GOOS == "darwin" {
+			return filepath.SkipDir
+		}
+
 		fC <- &fileDesc{path: path, info: info}
 		return nil
 	}
@@ -197,6 +202,11 @@ func (idx *Index) MergeBranch(root, branch string) (cs ChangeSlice) {
 
 		if _, ok := visited[path]; ok {
 			return nil
+		}
+
+		// Don't include OSX trashes to scanned files.
+		if info.Name() == ".Trash" && info.Mode().IsDir() && runtime.GOOS == "darwin" {
+			return filepath.SkipDir
 		}
 
 		// File exists in local but not in remote.

--- a/go/src/koding/klient/machine/index/node/node.go
+++ b/go/src/koding/klient/machine/index/node/node.go
@@ -55,7 +55,8 @@ func (n *Node) Exist() bool {
 // Clone returns a deep copy of called node.
 func (n *Node) Clone() *Node {
 	c := &Node{
-		Name: n.Name,
+		Name:     n.Name,
+		children: make([]*Node, 0, len(n.children)),
 	}
 
 	if n.Entry != nil {

--- a/go/src/koding/klient/machine/index/node/tree.go
+++ b/go/src/koding/klient/machine/index/node/tree.go
@@ -17,8 +17,8 @@ func defaultInodeIDGenerator() func() uint64 {
 	var current uint64 = RootInodeID
 	return func() uint64 {
 		inodeID := atomic.AddUint64(&current, 1)
-		if inodeID <= RootInodeID {
-			return atomic.AddUint64(&current, 1)
+		for inodeID <= RootInodeID {
+			inodeID = atomic.AddUint64(&current, 1)
 		}
 
 		return inodeID

--- a/go/src/koding/klient/machine/index/node/tree.go
+++ b/go/src/koding/klient/machine/index/node/tree.go
@@ -327,6 +327,11 @@ func (g Guard) RmChild(n *Node, name string) {
 	g.t.rmChild(n, pos, child)
 }
 
+// Repudiate makes child with given name an orphan.
+func (g Guard) Repudiate(n *Node, name string) {
+	n.RmChild(name)
+}
+
 // RmOrphan removes orphan nodes.
 func (g Guard) RmOrphan(orphan *Node) {
 	orphan.Walk(func(_, n *Node) {

--- a/go/src/koding/klient/machine/mount/notify/fuse/filesystem.go
+++ b/go/src/koding/klient/machine/mount/notify/fuse/filesystem.go
@@ -17,7 +17,6 @@ import (
 	"koding/klient/machine/mount/notify"
 
 	"github.com/jacobsa/fuse"
-	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/fuse/fuseutil"
 	"golang.org/x/net/context"
 )
@@ -130,9 +129,6 @@ type Filesystem struct {
 	// Dynamic filesystem state.
 	dirHandles  *DirHandleGroup
 	fileHandles *FileHandleGroup
-
-	// Index node of mount parrent.
-	mDirParentInode fuseops.InodeID
 }
 
 // FSWrapFunc allows to attach middlerares to underling filesystems.
@@ -155,11 +151,10 @@ func NewFilesystem(opts *Options, wraps ...FSWrapFunc) (*Filesystem, error) {
 
 	gen := generator(MinHandleID)
 	fs := &Filesystem{
-		Options:         *opts,
-		cancel:          cancel,
-		dirHandles:      NewDirHandleGroup(gen),
-		fileHandles:     NewFileHandleGroup(gen),
-		mDirParentInode: getMountPointParentInode(opts.MountDir),
+		Options:     *opts,
+		cancel:      cancel,
+		dirHandles:  NewDirHandleGroup(opts.MountDir, gen),
+		fileHandles: NewFileHandleGroup(gen),
 	}
 
 	// Attach additional filesystem wrappers if any.

--- a/go/src/koding/klient/machine/mount/notify/fuse/fuse.go
+++ b/go/src/koding/klient/machine/mount/notify/fuse/fuse.go
@@ -466,13 +466,10 @@ func (fs *Filesystem) ReadDir(_ context.Context, op *fuseops.ReadDirOp) (err err
 		return err
 	}
 
-	if op.Offset == 0 && dh.Offset() > 0 {
+	if op.Offset != dh.Offset() {
 		fs.Index.Tree().DoInode(uint64(op.Inode), func(_ node.Guard, n *node.Node) {
 			dh.Rewind(n)
-			return
 		})
-
-		return
 	}
 
 	op.BytesRead, err = dh.ReadDir(op.Offset, op.Dst)

--- a/go/src/koding/klient/machine/mount/notify/fuse/fuse.go
+++ b/go/src/koding/klient/machine/mount/notify/fuse/fuse.go
@@ -235,7 +235,14 @@ func (fs *Filesystem) CreateFile(_ context.Context, op *fuseops.CreateFileOp) (e
 		// Increase reference counter for entry - fuse_reply_create.
 		incCountNoRoot(child)
 
-		fs.commit(child.Path(), index.ChangeMetaLocal|index.ChangeMetaAdd)
+		// Set created file as written but not commmit any events. They will be
+		// sent anyway by filesystem's flush operation.
+		fh, err := fs.fileHandles.Get(op.Handle)
+		if err != nil {
+			// Panic here since we added handle few lines above.
+			return panic("created file handle not found")
+		}
+		fh.Write()
 	})
 
 	return

--- a/go/src/koding/klient/machine/mount/notify/fuse/fuse.go
+++ b/go/src/koding/klient/machine/mount/notify/fuse/fuse.go
@@ -240,7 +240,7 @@ func (fs *Filesystem) CreateFile(_ context.Context, op *fuseops.CreateFileOp) (e
 		fh, err := fs.fileHandles.Get(op.Handle)
 		if err != nil {
 			// Panic here since we added handle few lines above.
-			return panic("created file handle not found")
+			panic("created file handle not found")
 		}
 		fh.Write()
 	})

--- a/go/src/koding/klient/machine/mount/notify/fuse/handle.go
+++ b/go/src/koding/klient/machine/mount/notify/fuse/handle.go
@@ -246,7 +246,7 @@ func (dh *DirHandle) ReadDir(offset fuseops.DirOffset, dst []byte) (n int, err e
 }
 
 // Rewind behaves like rewinddir(), it resets directory steram.
-func (dh *DirHandle) Rewind(n *node.Node) {
+func (dh *DirHandle) Rewind(offset fuseops.DirOffset, n *node.Node) {
 	// Sanity check. There is a logic error when we rewinding different inodes.
 	if dh.InodeID != fuseops.InodeID(n.Entry.Virtual.Inode) {
 		panic("called rewind on invalid node")
@@ -254,7 +254,7 @@ func (dh *DirHandle) Rewind(n *node.Node) {
 
 	dh.mu.Lock()
 	dh.stream = dh.readDirents(n)
-	dh.offset = 0
+	dh.offset = offset
 	dh.mu.Unlock()
 }
 

--- a/go/src/koding/klient/machine/mount/skipper.go
+++ b/go/src/koding/klient/machine/mount/skipper.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 
@@ -12,8 +13,13 @@ import (
 
 // DefaultSkipper contains a default set of non-synced file rules.
 var DefaultSkipper Skipper = MultiSkipper{
-	OsSkip(DirectorySkip(".Trash"), "darwin"), // OSX trash directory.
-	PathSuffixSkip(".git/index.lock"),         // git index lock file.
+	OsSkip(DirectorySkip(".Trash"), "darwin"),      // OSX trash directory.
+	PathSuffixSkip(".git/index.lock"),              // git index lock file.
+	PathSuffixSkip(".git/refs/stash.lock"),         // git stash lock file.
+	PathSuffixSkip(".git/HEAD.lock"),               // git HEAD lock.
+	PathSuffixSkip(".git/ORIG_HEAD.lock"),          // git ORIG_HEAD lock.
+	NewRegexSkip(`\.git/refs/heads/[^\s]+\.lock$`), // git branch lock.
+	NewRegexSkip(`\.git/index\.stash\.\d+\.lock$`), // git stash ref. lock.
 }
 
 // Skipper describes a file or set of files which are not going to be synced.
@@ -108,4 +114,25 @@ func OsSkip(s Skipper, goos string) Skipper {
 	}
 
 	return NeverSkip{}
+}
+
+// RegexSkip skips all paths that matches stored regural expression.
+type RegexSkip struct {
+	re *regexp.Regexp
+}
+
+// NewRegexSkip creates a new RegexSkip object or panics if provided expression
+// cannot be compilled.
+func NewRegexSkip(expr string) *RegexSkip {
+	return &RegexSkip{
+		re: regexp.MustCompile(expr),
+	}
+}
+
+// Initialize always returns true.
+func (rs *RegexSkip) Initialize(_ string) error { return nil }
+
+// IsSkip returns true when provided event's path matches stored regexp.
+func (rs *RegexSkip) IsSkip(ev *msync.Event) bool {
+	return rs.re.MatchString(ev.Change().Path())
 }

--- a/go/src/koding/klient/machine/mount/skipper_test.go
+++ b/go/src/koding/klient/machine/mount/skipper_test.go
@@ -59,6 +59,16 @@ func TestIsSkip(t *testing.T) {
 			Sk:     mount.PathSuffixSkip(".git/index.lock"),
 			IsSkip: false,
 		},
+		"git branch lock": {
+			Ev:     msync.NewEvent(ctx, nil, index.NewChange("notify/.git/refs/heads/master.lock", index.PriorityMedium, 0)),
+			Sk:     mount.NewRegexSkip(`\.git/refs/heads/[^\s]+\.lock$`),
+			IsSkip: true,
+		},
+		"git stash reference lock": {
+			Ev:     msync.NewEvent(ctx, nil, index.NewChange("notify/.git/index.stash.31012.lock", index.PriorityMedium, 0)),
+			Sk:     mount.NewRegexSkip(`\.git/index\.stash\.\d+\.lock$`),
+			IsSkip: true,
+		},
 	}
 
 	for name, test := range tests {

--- a/go/src/koding/klient/machine/mount/sync.go
+++ b/go/src/koding/klient/machine/mount/sync.go
@@ -113,6 +113,10 @@ type Sync struct {
 	iu  *IdxUpdate   // local index updater.
 }
 
+func (s *Sync) Idx() *index.Index {
+	return s.idx
+}
+
 // NewSync creates a new sync instance for a given mount. It ensures basic mount
 // directory structure. This function is blocking.
 func NewSync(mountID ID, m Mount, opts Options) (*Sync, error) {

--- a/go/src/koding/klient/machine/mount/sync_test.go
+++ b/go/src/koding/klient/machine/mount/sync_test.go
@@ -50,11 +50,11 @@ func TestSyncNew(t *testing.T) {
 	expected := &mount.Info{
 		ID:          mountID,
 		Mount:       m,
-		Count:       1,
-		CountAll:    2,
+		Count:       2,
+		CountAll:    3,
 		DiskSize:    info.DiskSize,
 		DiskSizeAll: info.DiskSizeAll,
-		Queued:      2,
+		Queued:      3,
 		Syncing:     info.Syncing,
 	}
 
@@ -85,11 +85,11 @@ func TestSyncNew(t *testing.T) {
 	expected = &mount.Info{
 		ID:          mountID,
 		Mount:       m,
-		Count:       2,
-		CountAll:    3,
+		Count:       3,
+		CountAll:    4,
 		DiskSize:    info.DiskSize,
 		DiskSizeAll: info.DiskSizeAll,
-		Queued:      3,
+		Queued:      4,
 		Syncing:     info.Syncing,
 	}
 

--- a/go/src/koding/klient/machine/mount/sync_test.go
+++ b/go/src/koding/klient/machine/mount/sync_test.go
@@ -50,11 +50,11 @@ func TestSyncNew(t *testing.T) {
 	expected := &mount.Info{
 		ID:          mountID,
 		Mount:       m,
-		Count:       2,
-		CountAll:    3,
+		Count:       1,
+		CountAll:    2,
 		DiskSize:    info.DiskSize,
 		DiskSizeAll: info.DiskSizeAll,
-		Queued:      3,
+		Queued:      2,
 		Syncing:     info.Syncing,
 	}
 
@@ -85,11 +85,11 @@ func TestSyncNew(t *testing.T) {
 	expected = &mount.Info{
 		ID:          mountID,
 		Mount:       m,
-		Count:       3,
-		CountAll:    4,
+		Count:       2,
+		CountAll:    3,
 		DiskSize:    info.DiskSize,
 		DiskSizeAll: info.DiskSizeAll,
-		Queued:      4,
+		Queued:      3,
 		Syncing:     info.Syncing,
 	}
 

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -609,10 +609,11 @@ func run(args []string) {
 		Usage:        "Manage remote machines.",
 		BashComplete: func(c *cli.Context) {},
 		Subcommands: []cli.Command{{
-			Name:      "list",
-			ShortName: "ls",
-			Usage:     "List available machines.",
-			Action:    ctlcli.ExitErrAction(MachineListCommand, log, "list"),
+			Name:         "list",
+			ShortName:    "ls",
+			Usage:        "List available machines.",
+			Action:       ctlcli.ExitErrAction(MachineListCommand, log, "list"),
+			BashComplete: func(c *cli.Context) {},
 			Flags: []cli.Flag{
 				cli.BoolFlag{
 					Name:  "json",
@@ -620,10 +621,11 @@ func run(args []string) {
 				},
 			},
 		}, {
-			Name:      "ssh",
-			ShortName: "s",
-			Usage:     "SSH into provided remote machine.",
-			Action:    ctlcli.ExitErrAction(MachineSSHCommand, log, "ssh"),
+			Name:         "ssh",
+			ShortName:    "s",
+			Usage:        "SSH into provided remote machine.",
+			Action:       ctlcli.ExitErrAction(MachineSSHCommand, log, "ssh"),
+			BashComplete: func(c *cli.Context) {},
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "username",
@@ -649,12 +651,13 @@ func run(args []string) {
 				},
 			}},
 		}, {
-			Name:        "mount",
-			Aliases:     []string{"m"},
-			Usage:       "Mount remote directory.",
-			Description: cmdDescriptions["mount"],
-			Action:      ctlcli.ExitErrAction(MachineMountCommand, log, "mount"),
-			Flags:       []cli.Flag{},
+			Name:         "mount",
+			Aliases:      []string{"m"},
+			Usage:        "Mount remote directory.",
+			Description:  cmdDescriptions["mount"],
+			Action:       ctlcli.ExitErrAction(MachineMountCommand, log, "mount"),
+			BashComplete: func(c *cli.Context) {},
+			Flags:        []cli.Flag{},
 			Subcommands: []cli.Command{{
 				Name:    "list",
 				Aliases: []string{"ls"},
@@ -683,11 +686,12 @@ func run(args []string) {
 				},
 			}},
 		}, {
-			Name:        "umount",
-			ShortName:   "u",
-			Usage:       "Unmount remote directory.",
-			Description: cmdDescriptions["umount"],
-			Action:      ctlcli.ExitErrAction(MachineUmountCommand, log, "umount"),
+			Name:         "umount",
+			ShortName:    "u",
+			Usage:        "Unmount remote directory.",
+			Description:  cmdDescriptions["umount"],
+			Action:       ctlcli.ExitErrAction(MachineUmountCommand, log, "umount"),
+			BashComplete: func(c *cli.Context) {},
 			Flags: []cli.Flag{
 				cli.BoolFlag{
 					Name:  "force, f",
@@ -704,6 +708,7 @@ func run(args []string) {
 			Description:     cmdDescriptions["exec"],
 			Usage:           "Run a command in a started machine.",
 			Action:          ctlcli.ExitErrAction(MachineExecCommand, log, "exec"),
+			BashComplete:    func(c *cli.Context) {},
 			SkipFlagParsing: true,
 		}, {
 			Name:            "cp",
@@ -711,6 +716,7 @@ func run(args []string) {
 			Usage:           "Copies a file between hosts on a network.",
 			Action:          ctlcli.ExitErrAction(MachineCpCommand, log, "cp"),
 			SkipFlagParsing: true,
+			BashComplete:    func(c *cli.Context) {},
 			Flags:           []cli.Flag{},
 		}, {
 			Name:   "start",


### PR DESCRIPTION
This PR reworks readdir fuse method to seek directory position when requested and stored offsets mismatch. It also adds synchronisation filters for some git files that should not be sent to remote.