### PR TITLE
kd/machine: add config show / set commands

### DIFF
--- a/go/src/koding/klientctl/config.go
+++ b/go/src/koding/klientctl/config.go
@@ -90,7 +90,7 @@ func ConfigShow(c *cli.Context, log logging.Logger, _ string) (int, error) {
 		return 0, nil
 	}
 
-	printKonfig(used)
+	printKeyVal(used, ignoredFields...)
 
 	return 0, nil
 }
@@ -210,17 +210,17 @@ var ignoredFields = []string{
 	"tunnelID",
 }
 
-func printKonfig(konfig *konfig.Konfig) {
+func printKeyVal(v interface{}, ignoredFields ...string) {
 	w := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
 	defer w.Flush()
 
 	fmt.Fprintln(w, "KEY\tVALUE")
 
-	obj := b.Build(konfig, ignoredFields...)
+	obj := b.Build(v, ignoredFields...)
 
 	for _, key := range obj.Keys() {
 		value := obj[key]
-		if value == nil || fmt.Sprintf("%v", value) == "" {
+		if s := fmt.Sprintf("%v", value); value == nil || s == "" || s == "0" {
 			value = "-"
 		}
 		fmt.Fprintf(w, "%s\t%v\n", key, value)

--- a/go/src/koding/klientctl/endpoint/remoteapi/machine.go
+++ b/go/src/koding/klientctl/endpoint/remoteapi/machine.go
@@ -4,6 +4,7 @@ import (
 	"koding/remoteapi"
 	"koding/remoteapi/models"
 
+	computeprovider "koding/remoteapi/client/compute_provider"
 	machine "koding/remoteapi/client/j_machine"
 )
 
@@ -39,4 +40,27 @@ func (c *Client) ListMachines(f *Filter) ([]*models.JMachine, error) {
 	}
 
 	return machines, nil
+}
+
+// UpdateMachineAlwaysOn updates JMachine.meta.alwaysOn using ComputeProvider.
+func (c *Client) UpdateMachineAlwaysOn(m *models.JMachine, on bool) error {
+	c.init()
+
+	params := &computeprovider.ComputeProviderUpdateParams{
+		Body: map[string]interface{}{
+			"machineId":  m.ID,
+			"provider":   *m.Provider,
+			"credential": m.Credential,
+			"alwaysOn":   on,
+		},
+	}
+
+	params.SetTimeout(c.timeout())
+
+	resp, err := c.client().ComputeProvider.ComputeProviderUpdate(params, nil)
+	if err != nil {
+		return err
+	}
+
+	return remoteapi.Unmarshal(resp.Payload, nil)
 }

--- a/go/src/koding/klientctl/machine.go
+++ b/go/src/koding/klientctl/machine.go
@@ -287,6 +287,7 @@ func MachineInspectMountCommand(c *cli.Context, log logging.Logger, _ string) (i
 	return 0, nil
 }
 
+// MachineStart turns a vm on.
 func MachineStart(c *cli.Context, _ logging.Logger, _ string) (int, error) {
 	if err := machineCommand(c, machine.Start); err != nil {
 		return 1, err
@@ -295,9 +296,55 @@ func MachineStart(c *cli.Context, _ logging.Logger, _ string) (int, error) {
 	return 0, nil
 }
 
+// MachineStop turns a vm off.
 func MachineStop(c *cli.Context, _ logging.Logger, _ string) (int, error) {
 	if err := machineCommand(c, machine.Stop); err != nil {
 		return 1, err
+	}
+
+	return 0, nil
+}
+
+// MachineConfigSet sets key=value pair for a machine.
+func MachineConfigSet(c *cli.Context, _ logging.Logger, _ string) (int, error) {
+	ident := c.Args().Get(0)
+	key := c.Args().Get(1)
+	value := c.Args().Get(2)
+
+	switch {
+	case ident == "":
+		return 1, errors.New("machine identifier is empty or missing")
+	case key == "":
+		return 1, errors.New("configuration key is empty or missing")
+	case value == "":
+		return 1, errors.New("configuration value is empty or missing")
+	}
+
+	if err := machine.Set(ident, key, value); err != nil {
+		return 1, err
+	}
+
+	return 0, nil
+}
+
+// MachineCondifShow displays machine's key=value pairs.
+func MachineConfigShow(c *cli.Context, _ logging.Logger, _ string) (int, error) {
+	ident := c.Args().Get(0)
+	json := c.Bool("json")
+
+	if ident == "" {
+		return 1, errors.New("machine identifier is empty or missing")
+	}
+
+	conf, err := machine.Show(ident)
+	if err != nil {
+		return 1, err
+	}
+
+	if json {
+		printJSON(conf)
+	} else {
+		printKeyVal(conf)
 	}
 
 	return 0, nil

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -625,6 +625,24 @@ func run(args []string) {
 				},
 			},
 		}, {
+			Name:  "config",
+			Usage: "Manage remote machine configuration.",
+			Subcommands: []cli.Command{{
+				Name:   "set",
+				Usage:  "Set a value for a given key.",
+				Action: ctlcli.ExitErrAction(MachineConfigSet, log, "set"),
+			}, {
+				Name:   "show",
+				Usage:  "Show configuration.",
+				Action: ctlcli.ExitErrAction(MachineConfigShow, log, "show"),
+				Flags: []cli.Flag{
+					cli.BoolFlag{
+						Name:  "json",
+						Usage: "Output in JSON format.",
+					},
+				},
+			}},
+		}, {
 			Name:        "mount",
 			Aliases:     []string{"m"},
 			Usage:       "Mount remote directory.",


### PR DESCRIPTION
This PR adds `kd machine config set` command that can be used to flip `alwaysOn` value for a machine.

Example usage:

```
$ kd machine config show white_coconut
KEY               VALUE
alwaysOn          true
assignedLabel     aws-instance
availabilityZone  eu-west-1b
image             ami-7cdd0a0b
instanceId        i-01c0daf43ac9343a
instance_type     t2.xlarge
placementGroup    -
region            eu-west-1
storage_size      -
type              aws
```
```
$ kd machine config show white_coconut --json | jq -r .alwaysOn
true
```
```
$ kd machine config set white_coconut alwaysOn true
```
```
$ kd machine config set white_coconut alwaysOn false
```