### PR TITLE
kd: add --json flag for version command

### DIFF
--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -141,7 +141,7 @@ func run(args []string) {
 
 	app := cli.NewApp()
 	app.Name = config.Name
-	app.Version = getReadableVersion(config.Version)
+	app.Version = getReadableVersion(config.VersionNum())
 	app.EnableBashCompletion = true
 
 	app.Commands = []cli.Command{{
@@ -547,6 +547,12 @@ func run(args []string) {
 		HideHelp:    true,
 		Description: cmdDescriptions["version"],
 		Action:      ctlcli.ExitAction(VersionCommand, log, "version"),
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "json",
+				Usage: "Output in JSON format.",
+			},
+		},
 	}, {
 		Name:        "status",
 		Usage:       fmt.Sprintf("Check status of the %s.", config.KlientName),

--- a/go/src/koding/klientctl/version.go
+++ b/go/src/koding/klientctl/version.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"strconv"
 
 	"koding/klientctl/config"
 
@@ -10,22 +9,38 @@ import (
 	"github.com/koding/logging"
 )
 
+type version struct {
+	Installed   int    `json:"installed"`
+	Latest      int    `json:"latest"`
+	Environment string `json:"environment"`
+	KiteID      string `json:"kiteID"`
+}
+
 // VersionCommand displays version information like Environment or Kite Query ID.
 func VersionCommand(c *cli.Context, log logging.Logger, _ string) int {
-	latest, err := latestVersion(config.Konfig.Endpoints.KDLatest.Public.String())
-
-	fmt.Printf("Installed Version: %s\n", getReadableVersion(config.Version))
-
-	if err == nil && latest != 0 {
-		fmt.Printf("Latest Version: %s\n", getReadableVersion(strconv.Itoa(latest)))
+	v := &version{
+		Installed:   config.VersionNum(),
+		Environment: config.Environment,
+		KiteID:      config.Konfig.KiteConfig().Id,
 	}
 
-	fmt.Println("Environment:", config.Environment)
-	fmt.Println("Kite Query ID:", config.Konfig.KiteConfig().Id)
+	v.Latest, _ = latestVersion(config.Konfig.Endpoints.KDLatest.Public.String())
+
+	if c.Bool("json") {
+		printJSON(v)
+	} else {
+		fmt.Printf("Installed Version: %s\n", getReadableVersion(v.Installed))
+		fmt.Printf("Latest Version: %s\n", getReadableVersion(v.Latest))
+		fmt.Println("Environment:", v.Environment)
+		fmt.Println("Kite Query ID:", v.KiteID)
+	}
 
 	return 0
 }
 
-func getReadableVersion(version string) string {
-	return fmt.Sprintf("0.1.%s", version)
+func getReadableVersion(version int) string {
+	if version == 0 {
+		return "-"
+	}
+	return fmt.Sprintf("0.1.%d", version)
 }


### PR DESCRIPTION
This PR adds a --json flag for version command, that produces machine-readable version information which can be used for detecting eventual updates.

Since kd / klient does not use symver yet, the versions are simplified to be just simple numbers.

Example output:

```
$ kd version
Installed Version: 0.1.231
Latest Version: 0.1.230
Environment: development
Kite Query ID: 3bd879ec-ede0-46e4-9d35-20fe16857c35
```
```
$ kd version --json
{
        "installed": 231,
        "latest": 230,
        "environment": "development",
        "kiteID": "3bd879ec-ede0-46e4-9d35-20fe16857c35"
}
```