### PR TITLE
kd/machine: workaround for empty entries of non-existing nodes

### DIFF
--- a/go/src/koding/klient/machine/index/node/entry.go
+++ b/go/src/koding/klient/machine/index/node/entry.go
@@ -120,6 +120,8 @@ var (
 	_ json.Unmarshaler = (*Entry)(nil)
 )
 
+var emptyEntry Entry
+
 // Entry represents a single file registered to index.
 type Entry struct {
 	File    File

--- a/go/src/koding/klient/machine/index/node/node.go
+++ b/go/src/koding/klient/machine/index/node/node.go
@@ -44,7 +44,7 @@ func NewNodeEntry(name string, entry *Entry) *Node {
 }
 
 // IsShadowed returns true when node is not present in tree.
-func (n *Node) IsShadowed() bool { return n.Entry == nil }
+func (n *Node) IsShadowed() bool { return n.Entry == nil || *n.Entry == emptyEntry }
 
 // Exist returns true for nodes that are considered as existing files. This
 // method can be called on nil nodes.


### PR DESCRIPTION
Fixes #11107.