### PR TITLE
klientctl: add mount inspect tree option that displays current index state

### DIFF
--- a/go/src/koding/klient/machine/index/index.go
+++ b/go/src/koding/klient/machine/index/index.go
@@ -314,8 +314,14 @@ func (idx *Index) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// DebugString dumps content of the index as a string, suitable for debugging.
-func (idx *Index) DebugString() string {
+// Debug contains information about internal state of single index node.
+type Debug struct {
+	Path string `json:"path"`
+	Info string `json:"info"`
+}
+
+// Debug returns the debug information about index.
+func (idx *Index) Debug() (dbg []Debug) {
 	m := make(map[string]*node.Entry)
 	idx.t.DoPath("", node.WalkPath(func(nodePath string, n *node.Node) {
 		m[nodePath] = n.Entry
@@ -327,10 +333,22 @@ func (idx *Index) DebugString() string {
 	}
 	sort.Strings(paths)
 
+	for _, path := range paths {
+		dbg = append(dbg, Debug{
+			Path: path,
+			Info: m[path].String(),
+		})
+	}
+
+	return dbg
+}
+
+// DebugString dumps content of the index as a string, suitable for debugging.
+func (idx *Index) DebugString() string {
 	var buf bytes.Buffer
 	tw := tabwriter.NewWriter(&buf, 0, 0, 1, ' ', 0)
-	for i, path := range paths {
-		fmt.Fprintf(tw, "%5d %s\t%v\n", i+1, path, m[path])
+	for i, d := range idx.Debug() {
+		fmt.Fprintf(tw, "%5d %s\t%s\n", i+1, d.Path, d.Info)
 	}
 	tw.Flush()
 

--- a/go/src/koding/klient/machine/mount/sync.go
+++ b/go/src/koding/klient/machine/mount/sync.go
@@ -244,6 +244,11 @@ func (s *Sync) History() ([]*history.Record, error) {
 	return nil, errors.New("synchronization history is unavailable")
 }
 
+// IndexDebug gets current index tree debug information.
+func (s *Sync) IndexDebug() []index.Debug {
+	return s.idx.Debug()
+}
+
 // CacheDir returns the name of mount cache directory.
 func (s *Sync) CacheDir() string {
 	return filepath.Join(s.opts.WorkDir, "data")

--- a/go/src/koding/klientctl/endpoint/machine/mount.go
+++ b/go/src/koding/klientctl/endpoint/machine/mount.go
@@ -13,7 +13,6 @@ import (
 	"koding/klient/machine/machinegroup"
 	"koding/klient/machine/mount"
 	"koding/klient/machine/mount/prefetch"
-	"koding/klient/machine/mount/sync/history"
 	"koding/klientctl/helper"
 
 	humanize "github.com/dustin/go-humanize"
@@ -169,27 +168,26 @@ func (c *Client) ListMount(options *ListMountOptions) (map[string][]mount.Info, 
 type InspectMountOptions struct {
 	Identifier string // Mount identifier.
 	Sync       bool   // Get syncing history.
+	Tree       bool   // Show index tree.
 	Log        logging.Logger
 }
 
 // InspectMount inspects provided mount.
-func (c *Client) InspectMount(options *InspectMountOptions) ([]*history.Record, error) {
+func (c *Client) InspectMount(options *InspectMountOptions) (machinegroup.InspectMountResponse, error) {
+	var inspectMountRes machinegroup.InspectMountResponse
 	if options == nil {
-		return nil, errors.New("invalid nil options")
+		return inspectMountRes, errors.New("invalid nil options")
 	}
 
 	// Inspect mount.
 	inspectMountReq := &machinegroup.InspectMountRequest{
 		Identifier: options.Identifier,
 		Sync:       options.Sync,
-	}
-	var inspectMountRes machinegroup.InspectMountResponse
-
-	if err := c.klient().Call("machine.mount.inspect", inspectMountReq, &inspectMountRes); err != nil {
-		return nil, err
+		Tree:       options.Tree,
 	}
 
-	return inspectMountRes.History, nil
+	err := c.klient().Call("machine.mount.inspect", inspectMountReq, &inspectMountRes)
+	return inspectMountRes, err
 }
 
 // UmountOptions stores options for `machine umount` call.
@@ -354,7 +352,7 @@ func ListMount(opts *ListMountOptions) (map[string][]mount.Info, error) {
 }
 
 // InspectMount inspects existing mount using DefaultClient.
-func InspectMount(opts *InspectMountOptions) ([]*history.Record, error) {
+func InspectMount(opts *InspectMountOptions) (machinegroup.InspectMountResponse, error) {
 	return DefaultClient.InspectMount(opts)
 }
 

--- a/go/src/koding/klientctl/machine.go
+++ b/go/src/koding/klientctl/machine.go
@@ -269,15 +269,17 @@ func MachineInspectMountCommand(c *cli.Context, log logging.Logger, _ string) (i
 		return 1, err
 	}
 
-	// Enable all options when none of them are set.
-	isSync := c.Bool("sync")
-	if !isSync {
+	// Enable sync option when there is none set explicitly. Tree may be too
+	// large to show it implicitly.
+	isSync, isTree := c.Bool("sync"), c.Bool("tree")
+	if !isSync && !isTree {
 		isSync = true
 	}
 
 	opts := &machine.InspectMountOptions{
 		Identifier: idents[0],
 		Sync:       isSync,
+		Tree:       isTree,
 		Log:        log.New("machine:inspect"),
 	}
 

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -680,6 +680,10 @@ func run(args []string) {
 						Name:  "sync",
 						Usage: "Displays syncing history up to 100 records.",
 					},
+					cli.BoolFlag{
+						Name:  "tree",
+						Usage: "Displays the entire mount index tree.",
+					},
 				},
 			}},
 		}, {


### PR DESCRIPTION
Adds `--tree` option to `kd mount inspect <mount-id>` subcommand. This displays index state just like DebugString did but in JSON format:

```sh
$ kd mount inspect --tree  65dd7b61-d7cd-4d58-95ca-8703596be38f
{
	"tree": [
		{
			"path": "",
			"info": "[INODE 1, COUNT 0, NLINK 1, PROMISE ----][CTIME May  1 21:40:56.833, MTIME May  1 21:40:56.833, SIZE 0, MODE drwxr-xr-x]"
		},
		{
			"path": ".Trash",
			"info": "[INODE 117, COUNT 0, NLINK 1, PROMISE ----][CTIME May  2 01:09:21.000, MTIME May  2 01:09:21.000, SIZE 0, MODE drwxr-xr-x]"
		},
		{
			"path": ".bash_history",
...
```

## Motivation and Context
Better debugging.

## How Has This Been Tested?
Manually.

## Screenshots (if appropriate):

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

