### PR TITLE
kd: list only machines belonging to current team

### DIFF
--- a/go/src/koding/klientctl/machine.go
+++ b/go/src/koding/klientctl/machine.go
@@ -15,6 +15,7 @@ import (
 	"koding/klient/machine/mount"
 	"koding/klientctl/ctlcli"
 	"koding/klientctl/endpoint/machine"
+	"koding/klientctl/endpoint/team"
 
 	"github.com/codegangsta/cli"
 	humanize "github.com/dustin/go-humanize"
@@ -40,6 +41,17 @@ func MachineListCommand(c *cli.Context, log logging.Logger, _ string) (int, erro
 	infos, err := machine.List(opts)
 	if err != nil {
 		return 1, err
+	}
+
+	if t := team.Used(); t.Valid() == nil {
+		all := infos
+		infos = infos[:0]
+
+		for _, i := range all {
+			if i.Team == t.Name {
+				infos = append(infos, i)
+			}
+		}
 	}
 
 	if c.Bool("json") {


### PR DESCRIPTION
This PR filters out machines from a listing that do no belong to current team.

The filtering is done client-side, as the current backend will go away when https://github.com/koding/koding/issues/10867 is implemented.

Before

```
$ kd ls
ID                        ALIAS             TEAM           STACK                PROVIDER  LABEL        OWNER   AGE      IP              STATUS
58a98b91a1b7df9405703266  aqua_squash       team           koding               aws       development          73d1h    34.198.216.53   connected (2h41m)
574754f8b9d070f045980f08  aqua_grape        banana-test01  IFTTT demo           aws       ifttt_1              341d17h                  offline (341d17h)
5776926466d768eb783c03fa  black_orange      test23473      Rjeczalik's Stack    aws       example              305d21h                  offline (305d20h: Machine is stopped)
57a59bd80d47554916ba7369  black_squash      mashape-kong   Mashapekong's Stack  aws       kong-1               270d5h                   offline (270d1h: Machine is stopped)
578d585eaddd0c27064f3b13  navy_fig          -              -                    aws       example_1            288d14h                  offline (288d13h: Machine is stopped)
58e29d82121dc44d784d94c8  navy_tomato       team           koding               aws       development  gokmen  29d18h   34.203.135.158  offline (6h10m: Machine is Stopped)
574f30b9d18604e15df3fe99  olive_watermelon  rrccgg         Gokmen's Stack       aws       testvm               335d18h                  offline (335d18h)
574754f8b9d070f045980f0a  silver_peach      banana-test01  IFTTT demo           aws       ifttt_2              341d17h                  offline (341d17h)
578d216d8645d7ba109613ec  white_quince      barbar555555   Rjeczalik's Stack    aws       example_1            288d18h                  offline (288d17h: Machine is stopped)
```

After

```
$ ./kd ls
ID                        ALIAS        TEAM  STACK   PROVIDER  LABEL        OWNER   AGE     IP              STATUS
58a98b91a1b7df9405703266  aqua_squash  team  koding  aws       development          73d1h   34.198.216.53   connected (2h41m)
58e29d82121dc44d784d94c8  navy_tomato  team  koding  aws       development  gokmen  29d18h  34.203.135.158  offline (6h9m: Machine is Stopped)
```

Closes #11074.