### PR TITLE
klient/mount: set mounted volume as local one

### DIFF
--- a/go/src/koding/klient/machine/mount/notify/fuse/filesystem.go
+++ b/go/src/koding/klient/machine/mount/notify/fuse/filesystem.go
@@ -186,9 +186,13 @@ func (fs *Filesystem) Config() *fuse.MountConfig {
 		VolumeName:              filepath.Base(fs.MountDir),
 		DisableWritebackCaching: true,
 		EnableVnodeCaching:      false,
-		Options:                 map[string]string{"allow_other": ""},
-		DebugLogger:             logger,
-		ErrorLogger:             logger,
+		Options: map[string]string{
+			"allow_other": "",
+			"local":       "",
+			"auto_xattr":  "",
+		},
+		DebugLogger: logger,
+		ErrorLogger: logger,
 	}
 }
 

--- a/go/src/koding/klient/machine/mount/skipper.go
+++ b/go/src/koding/klient/machine/mount/skipper.go
@@ -1,9 +1,6 @@
 package mount
 
 import (
-	"errors"
-	"os"
-	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -14,6 +11,7 @@ import (
 // DefaultSkipper contains a default set of non-synced file rules.
 var DefaultSkipper Skipper = MultiSkipper{
 	OsSkip(DirectorySkip(".Trash"), "darwin"),      // OSX trash directory.
+	OsSkip(DirectorySkip(".Trashes"), "darwin"),    // OSX trash directory.
 	PathSuffixSkip(".git/index.lock"),              // git index lock file.
 	PathSuffixSkip(".git/refs/stash.lock"),         // git stash lock file.
 	PathSuffixSkip(".git/HEAD.lock"),               // git HEAD lock.
@@ -74,16 +72,6 @@ type DirectorySkip string
 // Initialize checks if stored file exists and if it is a directory. If not
 // exist directory will be created. If not a directory, an error is returned.
 func (ds DirectorySkip) Initialize(wd string) error {
-	path := filepath.Join(wd, filepath.FromSlash(string(ds)))
-	info, err := os.Lstat(path)
-	if os.IsNotExist(err) {
-		return os.MkdirAll(path, 0755)
-	}
-
-	if !info.IsDir() {
-		return errors.New("path " + path + " exists and is not a directory")
-	}
-
 	return nil
 }
 

--- a/go/src/koding/klient/machine/mount/skipper_test.go
+++ b/go/src/koding/klient/machine/mount/skipper_test.go
@@ -2,9 +2,6 @@ package mount_test
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"koding/klient/machine/index"
@@ -80,25 +77,5 @@ func TestIsSkip(t *testing.T) {
 				t.Fatalf("want isSkip = %t; got %t", test.IsSkip, isSkip)
 			}
 		})
-	}
-}
-
-func TestDirectorySkip(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "skipper")
-	if err != nil {
-		t.Fatalf("want err = nil; got %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	var (
-		ds = mount.DirectorySkip("dir")
-	)
-
-	if err := ds.Initialize(tmpDir); err != nil {
-		t.Fatalf("want err = nil; got %v", err)
-	}
-
-	if _, err := os.Lstat(filepath.Join(tmpDir, string(ds))); err != nil {
-		t.Fatalf("want err = nil; got %v", err)
 	}
 }

--- a/go/src/koding/logrotate/logrotate.go
+++ b/go/src/koding/logrotate/logrotate.go
@@ -163,8 +163,6 @@ func (l *Uploader) Upload(key string, content io.ReadSeeker) (*url.URL, error) {
 
 	uniqKey = fmt.Sprintf("%s.%d", uniqKey, len(meta.Parts))
 
-	fmt.Println(gzip, key, uniqKey)
-
 	if !gzip {
 		content, err = l.gzip(uniqKey, content, &part.CompressedSize)
 		if err != nil {


### PR DESCRIPTION
When mounted volume is set to "local", OSX enables `.Trash` on its content. 

(partially) Fixes: #11109

This PR makes "Move to Trash" to work on Finder (http://recordit.co/NHcFJMCUcm). However, I was not able to make "Delete" works on atom /cc @usirin @sinan . There are some open issues related to this bug: 
https://github.com/atom/atom/issues/5439
https://github.com/atom/tree-view/issues/1046

Note that since this PR, mounts will not be considered as ["network"](https://github.com/osxfuse/osxfuse/wiki/Mount-options#local).

Now, Atom creates correct directory structure(/.Trashes/<user-id>) on `delete` call, but is still not able to move file there. Even if I set `0777` permissions in `.Trashes` directory.
