### PR TITLE
kd/mount: fix performance problems when accessing large git repositories

### DIFF
--- a/go/src/koding/klient/machine/index/benchmark_test.go
+++ b/go/src/koding/klient/machine/index/benchmark_test.go
@@ -50,7 +50,7 @@ func BenchmarkNodeLookup(b *testing.B) {
 
 func BenchmarkNodeAdd(b *testing.B) {
 	const name = "proxy/tmp/sync/fuse/fuse.go"
-	entry := node.NewEntry(0xB, 0)
+	entry := node.NewEntry(0xB, 0, node.RootInodeID)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/go/src/koding/klient/machine/index/index.go
+++ b/go/src/koding/klient/machine/index/index.go
@@ -129,7 +129,7 @@ func (idx *Index) MergeBranch(root, branch string, f filter.Filter) (cs ChangeSl
 		f = filter.NeverSkip{}
 	}
 
-	idx.t.DoPath(branch, node.WalkPath(func(name string, n *node.Node) {
+	idx.t.DoPath(branch, node.WalkPath(func(name string, g node.Guard, n *node.Node) {
 		if n.IsShadowed() || n.Entry.File.Mode == 0 {
 			return
 		}
@@ -152,8 +152,10 @@ func (idx *Index) MergeBranch(root, branch string, f filter.Filter) (cs ChangeSl
 			return
 		}
 
-		// Set entry inode.
-		n.Entry.File.Inode = node.Inode(info)
+		// Set entry inode but not for root inode.
+		if n.Entry.File.Inode != node.RootInodeID {
+			g.ChangeInode(n, node.Inode(info))
+		}
 
 		mode, size, mtime := n.Entry.File.Mode, n.Entry.File.Size, n.Entry.File.MTime
 		// File exists in both remote and local. We compare entry mtime with
@@ -232,7 +234,7 @@ func (idx *Index) Sync(root string, c *Change) {
 	}
 
 	info, err := os.Lstat(filepath.Join(root, filepath.FromSlash(c.Path())))
-	idx.t.DoPath(c.Path(), func(n *node.Node) bool {
+	idx.t.DoPath(c.Path(), func(g node.Guard, n *node.Node) bool {
 		if os.IsNotExist(err) {
 			// File doesn't exist. Return false to remove it from tree.
 			return false
@@ -247,6 +249,11 @@ func (idx *Index) Sync(root string, c *Change) {
 		} else {
 			n.Entry.MergeIn(node.NewEntryFileInfo(info))
 			n.UnsetPromises()
+		}
+
+		// Inodes may have changed. Update tree.
+		if n.Entry.File.Inode != node.RootInodeID {
+			g.ChangeInode(n, node.Inode(info))
 		}
 
 		return true
@@ -324,7 +331,7 @@ type Debug struct {
 // Debug returns the debug information about index.
 func (idx *Index) Debug() (dbg []Debug) {
 	m := make(map[string]*node.Entry)
-	idx.t.DoPath("", node.WalkPath(func(nodePath string, n *node.Node) {
+	idx.t.DoPath("", node.WalkPath(func(nodePath string, _ node.Guard, n *node.Node) {
 		m[nodePath] = n.Entry
 	}))
 

--- a/go/src/koding/klient/machine/index/node.go
+++ b/go/src/koding/klient/machine/index/node.go
@@ -25,7 +25,7 @@ type Node struct {
 func newNode() *Node {
 	return &Node{
 		Sub:   make(map[string]*Node),
-		Entry: node.NewEntry(0, 0755|os.ModeDir),
+		Entry: node.NewEntry(0, 0755|os.ModeDir, node.RootInodeID),
 	}
 }
 
@@ -127,7 +127,7 @@ func (nd *Node) PromiseAdd(path string, entry *node.Entry) {
 		newE = nd.Entry
 		newE.MergeIn(entry)
 	} else {
-		newE = node.NewEntry(entry.File.Size, entry.File.Mode)
+		newE = node.NewEntry(entry.File.Size, entry.File.Mode, 0)
 		newE.MergeIn(entry)
 	}
 

--- a/go/src/koding/klient/machine/index/node/benchmark_test.go
+++ b/go/src/koding/klient/machine/index/node/benchmark_test.go
@@ -24,7 +24,7 @@ func BenchmarkNodeLookup(b *testing.B) {
 
 func BenchmarkNodeAdd(b *testing.B) {
 	const name = "proxy/tmp/sync/fuse/fuse.go"
-	entry := node.NewEntry(0xB, 0)
+	entry := node.NewEntry(0xB, 0, node.RootInodeID)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/go/src/koding/klient/machine/index/node/benchmark_test.go
+++ b/go/src/koding/klient/machine/index/node/benchmark_test.go
@@ -12,7 +12,7 @@ func BenchmarkNodeLookup(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		tree.DoPath(name, func(n *node.Node) bool {
+		tree.DoPath(name, func(_ node.Guard, n *node.Node) bool {
 			if n.IsShadowed() {
 				b.Fatalf("want %s to be present in tree", name)
 			}
@@ -54,6 +54,6 @@ func BenchmarkNodeForEach(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		tree.DoPath("", node.WalkPath(func(nodePath string, _ *node.Node) {}))
+		tree.DoPath("", node.WalkPath(func(nodePath string, _ node.Guard, _ *node.Node) {}))
 	}
 }

--- a/go/src/koding/klient/machine/index/node/entry_notunix.go
+++ b/go/src/koding/klient/machine/index/node/entry_notunix.go
@@ -1,0 +1,15 @@
+// +build !darwin
+// +build !dragonfly
+// +build !freebsd
+// +build !linux
+// +build !nacl
+// +build !netbsd
+// +build !openbsd
+// +build !solaris
+
+package node
+
+import "os"
+
+// Inode always returns zero.
+func Inode(_ os.FileInfo) uint64 { return 0 }

--- a/go/src/koding/klient/machine/index/node/entry_unix.go
+++ b/go/src/koding/klient/machine/index/node/entry_unix.go
@@ -1,0 +1,17 @@
+// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
+
+package node
+
+import (
+	"os"
+	"syscall"
+)
+
+// Inode gets file inode number.
+func Inode(info os.FileInfo) uint64 {
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok && stat != nil {
+		return uint64(stat.Ino)
+	}
+
+	panic("file inode does not exist: " + info.Name())
+}

--- a/go/src/koding/klient/machine/index/node/node.go
+++ b/go/src/koding/klient/machine/index/node/node.go
@@ -24,10 +24,10 @@ type Node struct {
 }
 
 // NewNode creates a new node with zero-size entry and directory mode.
-func NewNode(name string) *Node {
+func NewNode(name string, inode uint64) *Node {
 	return &Node{
 		Name:     name,
-		Entry:    NewEntry(0, 0755|os.ModeDir),
+		Entry:    NewEntry(0, 0755|os.ModeDir, inode),
 		children: make([]*Node, 0),
 		parent:   nil,
 	}

--- a/go/src/koding/klient/machine/index/node/tree.go
+++ b/go/src/koding/klient/machine/index/node/tree.go
@@ -211,6 +211,10 @@ func (t *Tree) reset() {
 			n.Entry.File.Inode = RootInodeID
 		}
 
+		if n.Entry.File.Inode == 0 {
+			n.Entry.File.Inode = t.inGen()
+		}
+
 		for {
 			if _, ok := t.inodes[n.Entry.File.Inode]; !ok {
 				break

--- a/go/src/koding/klient/machine/index/node/tree.go
+++ b/go/src/koding/klient/machine/index/node/tree.go
@@ -35,7 +35,7 @@ type Tree struct {
 	// InodeGen is a function used to generate INodes for Tree entries. If nil,
 	// the default one will be used.
 	inGen func() uint64
-	mu    sync.Mutex
+	mu    sync.RWMutex
 	root  *Node
 
 	guard  Guard
@@ -90,6 +90,14 @@ func (t *Tree) DoInode(inode uint64, fn func(Guard, *Node)) {
 	t.mu.Lock()
 	fn(t.guard, t.inodes[inode])
 	t.mu.Unlock()
+}
+
+// DoInodeR behaves like DoInode but the provided function can not modify node
+// argument in any way.
+func (t *Tree) DoInodeR(inode uint64, fn func(*Node)) {
+	t.mu.RLock()
+	fn(t.inodes[inode])
+	t.mu.RUnlock()
 }
 
 // DoInode2 behaves like DoInode but for two inodes.

--- a/go/src/koding/klient/machine/index/node/tree.go
+++ b/go/src/koding/klient/machine/index/node/tree.go
@@ -394,7 +394,7 @@ func (g Guard) RmOrphan(orphan *Node) {
 	})
 }
 
-// ChangeInode replaces inode value inside provided Node. It's not guaranted
+// ChangeInode replaces inode value inside provided Node. It's not guaranteed
 // that provided inode will be set. The attached inode will be returned.
 func (g Guard) ChangeInode(n *Node, inode uint64) uint64 {
 	return g.t.changeInode(n, inode)

--- a/go/src/koding/klient/machine/index/node/tree_test.go
+++ b/go/src/koding/klient/machine/index/node/tree_test.go
@@ -82,7 +82,7 @@ func TestTreeLookup(t *testing.T) {
 		t.Run(path, func(t *testing.T) {
 			t.Parallel()
 
-			tree.DoPath(path, func(n *node.Node) bool {
+			tree.DoPath(path, func(_ node.Guard, n *node.Node) bool {
 				if n.IsShadowed() {
 					t.Fatalf("Lookup(%q) failed", path)
 				}
@@ -172,7 +172,7 @@ func TestTreeAdd(t *testing.T) {
 				t.Parallel()
 
 				tree.DoPath(path, node.Insert(node.NewEntry(funnySize, 0, 0)))
-				tree.DoPath(path, func(n *node.Node) bool {
+				tree.DoPath(path, func(_ node.Guard, n *node.Node) bool {
 					if n.IsShadowed() {
 						t.Fatalf("Lookup(%q) failed", path)
 					}
@@ -265,7 +265,7 @@ func TestTreeForEach(t *testing.T) {
 	var got []string
 	tree := testTree(fixData)
 
-	tree.DoPath("", node.WalkPath(func(nodePath string, _ *node.Node) {
+	tree.DoPath("", node.WalkPath(func(nodePath string, _ node.Guard, _ *node.Node) {
 		got = append(got, nodePath)
 	}))
 
@@ -281,7 +281,7 @@ func TestTreeMarshalJSON(t *testing.T) {
 	)
 
 	tree := testTree(fixData)
-	tree.DoPath("", node.WalkPath(func(nodePath string, n *node.Node) {
+	tree.DoPath("", node.WalkPath(func(nodePath string, _ node.Guard, n *node.Node) {
 		treePaths = append(treePaths, nodePath)
 		treeEntries = append(treeEntries, n.Entry)
 	}))
@@ -295,7 +295,7 @@ func TestTreeMarshalJSON(t *testing.T) {
 	if err := json.Unmarshal(data, got); err != nil {
 		t.Fatalf("want err = nil; got %v", err)
 	}
-	got.DoPath("", node.WalkPath(func(nodePath string, n *node.Node) {
+	got.DoPath("", node.WalkPath(func(nodePath string, _ node.Guard, n *node.Node) {
 		gotPaths = append(gotPaths, nodePath)
 		gotEntries = append(gotEntries, n.Entry)
 	}))

--- a/go/src/koding/klient/machine/index/node/tree_test.go
+++ b/go/src/koding/klient/machine/index/node/tree_test.go
@@ -56,7 +56,7 @@ func testTree(data map[string]int64) *node.Tree {
 	tree := node.NewTree()
 	for _, path := range paths {
 		size := data[path]
-		tree.DoPath(path, node.Insert(node.NewEntry(size, 0)))
+		tree.DoPath(path, node.Insert(node.NewEntry(size, 0, 0)))
 	}
 
 	return tree
@@ -171,7 +171,7 @@ func TestTreeAdd(t *testing.T) {
 			t.Run(path, func(t *testing.T) {
 				t.Parallel()
 
-				tree.DoPath(path, node.Insert(node.NewEntry(funnySize, 0)))
+				tree.DoPath(path, node.Insert(node.NewEntry(funnySize, 0, 0)))
 				tree.DoPath(path, func(n *node.Node) bool {
 					if n.IsShadowed() {
 						t.Fatalf("Lookup(%q) failed", path)

--- a/go/src/koding/klient/machine/index/node_test.go
+++ b/go/src/koding/klient/machine/index/node_test.go
@@ -382,7 +382,7 @@ func TestNodeToTree(t *testing.T) {
 	sort.Strings(gotNode)
 
 	tree := root.ToTree()
-	tree.DoPath("", node.WalkPath(func(nodePath string, _ *node.Node) {
+	tree.DoPath("", node.WalkPath(func(nodePath string, _ node.Guard, _ *node.Node) {
 		gotTree = append(gotTree, nodePath)
 	}))
 

--- a/go/src/koding/klient/machine/index/node_test.go
+++ b/go/src/koding/klient/machine/index/node_test.go
@@ -13,143 +13,143 @@ import (
 
 func fixture() *index.Node {
 	return &index.Node{
-		Entry: node.NewEntry(0, 0),
+		Entry: node.NewEntry(0, 0, 0),
 		Sub: map[string]*index.Node{
 			"addresses": {
-				Entry: node.NewEntry(0, 0),
+				Entry: node.NewEntry(0, 0, 0),
 				Sub: map[string]*index.Node{
 					"addresser.go": {
-						Entry: node.NewEntry(714, 0),
+						Entry: node.NewEntry(714, 0, 0),
 						Sub:   map[string]*index.Node{},
 					},
 					"addresses.go": {
-						Entry: node.NewEntry(2428, 0),
+						Entry: node.NewEntry(2428, 0, 0),
 						Sub:   map[string]*index.Node{},
 					},
 					"addresses_test.go": {
-						Entry: node.NewEntry(3095, 0),
+						Entry: node.NewEntry(3095, 0, 0),
 						Sub:   map[string]*index.Node{},
 					},
 					"cached.go": {
-						Entry: node.NewEntry(2036, 0),
+						Entry: node.NewEntry(2036, 0, 0),
 						Sub:   map[string]*index.Node{},
 					},
 				},
 			},
 			"aliases": {
-				Entry: node.NewEntry(0, 0),
+				Entry: node.NewEntry(0, 0, 0),
 				Sub: map[string]*index.Node{
 					"aliaser.go": {
-						Entry: node.NewEntry(596, 0),
+						Entry: node.NewEntry(596, 0, 0),
 						Sub:   map[string]*index.Node{},
 					},
 					"aliases.go": {
-						Entry: node.NewEntry(3218, 0),
+						Entry: node.NewEntry(3218, 0, 0),
 						Sub:   map[string]*index.Node{},
 					},
 					"aliases_test.go": {
-						Entry: node.NewEntry(1831, 0),
+						Entry: node.NewEntry(1831, 0, 0),
 						Sub:   map[string]*index.Node{},
 					},
 					"cached.go": {
-						Entry: node.NewEntry(2196, 0),
+						Entry: node.NewEntry(2196, 0, 0),
 						Sub:   map[string]*index.Node{},
 					},
 				},
 			},
 			"clients": {
-				Entry: node.NewEntry(0, 0),
+				Entry: node.NewEntry(0, 0, 0),
 				Sub: map[string]*index.Node{
 					"clients.go": {
-						Entry: node.NewEntry(4003, 0),
+						Entry: node.NewEntry(4003, 0, 0),
 						Sub:   map[string]*index.Node{},
 					},
 					"clients_test.go": {
-						Entry: node.NewEntry(1783, 0),
+						Entry: node.NewEntry(1783, 0, 0),
 						Sub:   map[string]*index.Node{},
 					},
 				},
 			},
 			"create.go": {
-				Entry: node.NewEntry(3660, 0),
+				Entry: node.NewEntry(3660, 0, 0),
 				Sub:   map[string]*index.Node{},
 			},
 			"create_test.go": {
-				Entry: node.NewEntry(4582, 0),
+				Entry: node.NewEntry(4582, 0, 0),
 				Sub:   map[string]*index.Node{},
 			},
 			"id.go": {
-				Entry: node.NewEntry(1272, 0),
+				Entry: node.NewEntry(1272, 0, 0),
 				Sub:   map[string]*index.Node{},
 			},
 			"id_test.go": {
-				Entry: node.NewEntry(1979, 0),
+				Entry: node.NewEntry(1979, 0, 0),
 				Sub:   map[string]*index.Node{},
 			},
 			"idset": {
-				Entry: node.NewEntry(0, 0),
+				Entry: node.NewEntry(0, 0, 0),
 				Sub: map[string]*index.Node{
 					"idset.go": {
-						Entry: node.NewEntry(1288, 0),
+						Entry: node.NewEntry(1288, 0, 0),
 						Sub:   map[string]*index.Node{},
 					},
 					"idset_test.go": {
-						Entry: node.NewEntry(4231, 0),
+						Entry: node.NewEntry(4231, 0, 0),
 						Sub:   map[string]*index.Node{},
 					},
 				},
 			},
 			"empty": {
-				Entry: node.NewEntry(0, 0),
+				Entry: node.NewEntry(0, 0, 0),
 				Sub:   map[string]*index.Node{},
 			},
 			"kite.go": {
-				Entry: node.NewEntry(4152, 0),
+				Entry: node.NewEntry(4152, 0, 0),
 				Sub:   map[string]*index.Node{},
 			},
 			"machinegroup.go": {
-				Entry: node.NewEntry(6839, 0),
+				Entry: node.NewEntry(6839, 0, 0),
 				Sub:   map[string]*index.Node{},
 			},
 			"machinegroup_test.go": {
-				Entry: node.NewEntry(6592, 0),
+				Entry: node.NewEntry(6592, 0, 0),
 				Sub:   map[string]*index.Node{},
 			},
 			"mount.go": {
-				Entry: node.NewEntry(9346, 0),
+				Entry: node.NewEntry(9346, 0, 0),
 				Sub:   map[string]*index.Node{},
 			},
 			"mount_test.go": {
-				Entry: node.NewEntry(8824, 0),
+				Entry: node.NewEntry(8824, 0, 0),
 				Sub:   map[string]*index.Node{},
 			},
 			"mounts": {
-				Entry: node.NewEntry(0, 0),
+				Entry: node.NewEntry(0, 0, 0),
 				Sub: map[string]*index.Node{
 					"cached.go": {
-						Entry: node.NewEntry(2465, 0),
+						Entry: node.NewEntry(2465, 0, 0),
 						Sub:   map[string]*index.Node{},
 					},
 					"mounter.go": {
-						Entry: node.NewEntry(1000, 0),
+						Entry: node.NewEntry(1000, 0, 0),
 						Sub:   map[string]*index.Node{},
 					},
 					"mounts.go": {
-						Entry: node.NewEntry(4133, 0),
+						Entry: node.NewEntry(4133, 0, 0),
 						Sub:   map[string]*index.Node{},
 					},
 					"mounts_test.go": {
-						Entry: node.NewEntry(5330, 0),
+						Entry: node.NewEntry(5330, 0, 0),
 						Sub:   map[string]*index.Node{},
 					},
 				},
 			},
 			"ssh.go": {
-				Entry: node.NewEntry(2831, 0),
+				Entry: node.NewEntry(2831, 0, 0),
 				Sub:   map[string]*index.Node{},
 			},
 			"ssh_test.go": {
-				Entry: node.NewEntry(3567, 0),
+				Entry: node.NewEntry(3567, 0, 0),
 				Sub:   map[string]*index.Node{},
 			},
 		},
@@ -243,7 +243,7 @@ func TestNodeAdd(t *testing.T) {
 	}
 
 	root := fixture()
-	entry := node.NewEntry(0xD, 0)
+	entry := node.NewEntry(0xD, 0, node.RootInodeID)
 
 	for _, cas := range cases {
 		t.Run(cas.name, func(t *testing.T) {

--- a/go/src/koding/klient/machine/mount/notify/fuse/counter/counter.go
+++ b/go/src/koding/klient/machine/mount/notify/fuse/counter/counter.go
@@ -278,7 +278,7 @@ func (c *counterFS) loop() {
 		fmt.Fprintln(os.Stderr, "Printing method execution statuses:")
 
 		w := tabwriter.NewWriter(os.Stderr, 2, 0, 2, ' ', 0)
-		fmt.Fprintf(w, "METHOD\tCALLS\tAVERAGE_TIME\n")
+		fmt.Fprintf(w, "METHOD\tCALLS\tAVERAGE_TIME\tTOTAL_CPU_TIME\n")
 
 		c.mu.Lock()
 		names := make([]string, 0, len(c.methods))
@@ -291,7 +291,7 @@ func (c *counterFS) loop() {
 			m := c.methods[name]
 
 			count, averageTime := m.Status()
-			fmt.Fprintf(w, "%s\t%d\t%v\n", name, count, averageTime)
+			fmt.Fprintf(w, "%s\t%d\t%v\t%v\n", name, count, averageTime, time.Duration(count)*averageTime)
 		}
 		c.mu.Unlock()
 

--- a/go/src/koding/klient/machine/mount/notify/fuse/fuse.go
+++ b/go/src/koding/klient/machine/mount/notify/fuse/fuse.go
@@ -372,7 +372,14 @@ func (fs *Filesystem) Unlink(_ context.Context, op *fuseops.UnlinkOp) (err error
 
 		// Remove name from the
 		if !n.Orphan() || n.Entry.File.Inode == node.RootInodeID {
-			if e := syscall.Unlink(filepath.Join(fs.CacheDir, child.Path())); e != nil {
+			var e error
+			if child.Entry.File.Mode.IsDir() {
+				e = syscall.Rmdir(filepath.Join(fs.CacheDir, child.Path()))
+			} else {
+				e = syscall.Unlink(filepath.Join(fs.CacheDir, child.Path()))
+			}
+
+			if e != nil {
 				err = toErrno(e)
 				return
 			}

--- a/go/src/koding/klient/machine/mount/prefetch/git.go
+++ b/go/src/koding/klient/machine/mount/prefetch/git.go
@@ -32,7 +32,7 @@ func (Git) Weight() int { return 100 }
 // Scan gets size and number of prefetched files.
 func (Git) Scan(idx *index.Index) (string, int64, int64, error) {
 	var isGit bool
-	idx.Tree().DoPath(".git", func(n *node.Node) bool {
+	idx.Tree().DoPath(".git", func(_ node.Guard, n *node.Node) bool {
 		isGit = !n.IsShadowed() && n.Entry.File.Mode.IsDir()
 
 		return !n.IsShadowed()

--- a/go/src/koding/klientctl/endpoint/machine/mount.go
+++ b/go/src/koding/klientctl/endpoint/machine/mount.go
@@ -120,7 +120,6 @@ func (c *Client) Mount(options *MountOptions) (err error) {
 		Strategies: prefetch.DefaultStrategy.Available(),
 	}
 	var addMountRes machinegroup.AddMountResponse
-
 	if err := c.klient().Call("machine.mount.add", addMountReq, &addMountRes); err != nil {
 		return err
 	}
@@ -136,6 +135,15 @@ func (c *Client) Mount(options *MountOptions) (err error) {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			options.Log.Error("Output: %q", exitErr.Stderr)
 		}
+	}
+
+	// Rescan cache folder in order to update index.
+	upIdxMountReq := &machinegroup.UpdateIndexRequest{
+		MountID: addMountRes.MountID,
+	}
+	var upIdxMountRes machinegroup.UpdateIndexResponse
+	if err := c.klient().Call("machine.mount.updateIndex", upIdxMountReq, &upIdxMountRes); err != nil {
+		return err
 	}
 
 	fmt.Fprintf(os.Stdout, "Created mount with ID: %s\n", addMountRes.MountID)


### PR DESCRIPTION
Fixes: #11064, #11124, also it will likely fix problems with disappearing files on remote.

Note, that this will still require initial SHA-1 computation. I'm going to solve this with #11135 by introducing a function which will run `git status` on each git repository inside cache - this will set index to proper state.

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

