### PR TITLE
kites/config: add more configuration settings for mounts

### DIFF
--- a/go/src/koding/kites/config/konfig.go
+++ b/go/src/koding/kites/config/konfig.go
@@ -69,35 +69,35 @@ func (e *Endpoints) Social() *Endpoint {
 	return e.Koding.WithPath("/api/social")
 }
 
-// Local describes configuration of local paths.
-type Local struct {
+// Mount describes configuration of mounts.
+type Mount struct {
 	// Mount is a default home path of mounted directories.
 	//
 	// If empty, defaults to ~/koding/mnt/.
-	MountHome string `json:"mountHome,omitempty"`
+	Home string `json:"home,omitempty"`
 
-	// Mounts maps named mounts to local paths.
+	// Exports maps named mounts to local paths.
 	//
-	// The Mounts["default"] export is used as
+	// The Exports["default"] export is used as
 	// a default one when caller does not specify
 	// a mount path.
 	//
-	// The Mounts["default"] defaults to $HOME.
-	Mounts map[string]string `json:"mounts,omitempty"`
+	// The Exports["default"] defaults to $HOME.
+	Exports map[string]string `json:"exports,omitempty"`
 }
 
-// MountPath gives a path for the named mount.
+// Export gives a path for the named mount.
 //
 // If the named mount does not exist, it returns false.
 //
 // If the path contains '~' - it is expended to
 // a home directory of a current user.
-func (l *Local) MountPath(name string) (string, bool) {
-	if l == nil {
+func (m *Mount) Export(name string) (string, bool) {
+	if m == nil {
 		return "", false
 	}
 
-	if dir, ok := l.Mounts[name]; ok {
+	if dir, ok := m.Exports[name]; ok {
 		return expandHome(dir), true
 	}
 
@@ -122,8 +122,8 @@ type Konfig struct {
 	KiteKeyFile string `json:"kiteKeyFile,omitempty"`
 	KiteKey     string `json:"kiteKey,omitempty"`
 
-	// Local describes configuration of local paths.
-	Local *Local `json:"local,omitempty"`
+	// Mount describes configuration of mounts.
+	Mount *Mount `json:"local,omitempty"`
 
 	// Template describes configuration of KD template.
 	Template *Template `json:"template,omitempty"`
@@ -335,9 +335,9 @@ func NewKonfig(e *Environments) *Konfig {
 				}},
 			},
 		},
-		Local: &Local{
-			MountHome: filepath.Join(CurrentUser.HomeDir, "koding", "mnt"),
-			Mounts: map[string]string{
+		Mount: &Mount{
+			Home: filepath.Join(CurrentUser.HomeDir, "koding", "mnt"),
+			Exports: map[string]string{
 				"default": CurrentUser.HomeDir,
 			},
 		},

--- a/go/src/koding/kites/config/konfig.go
+++ b/go/src/koding/kites/config/konfig.go
@@ -84,6 +84,16 @@ type Mount struct {
 	//
 	// The Exports["default"] defaults to $HOME.
 	Exports map[string]string `json:"exports,omitempty"`
+
+	// Inspect configures behavior of mount inspect command.
+	Inspect *MountInspect `json:"inspect,omitempty"`
+}
+
+// MountInspect describes configuration of mount inspect command.
+type MountInspect struct {
+	// History configures the size of inspect history,
+	// which is 100 by default.
+	History int `json:"history,omitempty"`
 }
 
 // Export gives a path for the named mount.
@@ -339,6 +349,9 @@ func NewKonfig(e *Environments) *Konfig {
 			Home: filepath.Join(CurrentUser.HomeDir, "koding", "mnt"),
 			Exports: map[string]string{
 				"default": CurrentUser.HomeDir,
+			},
+			Inspect: &MountInspect{
+				History: 100,
 			},
 		},
 		Template: &Template{

--- a/go/src/koding/kites/config/konfig.go
+++ b/go/src/koding/kites/config/konfig.go
@@ -91,6 +91,16 @@ type Mount struct {
 
 	// Sync configures behavior of synchronization goroutines.
 	Sync *MountSync `json:"sync,omitempty"`
+
+	// Debug is a debug level used for logging within
+	// mounts.
+	//
+	//   <=0  - turns off debug logging
+	//   1    - turns on debug logging for syncer events
+	//   2-8  - reserved for future use
+	//   >=9  - turns on debug logging for fuse events
+	//
+	Debug int `json:"debug,omitempty"`
 }
 
 // MountInspect describes configuration of mount inspect command.

--- a/go/src/koding/kites/config/konfig.go
+++ b/go/src/koding/kites/config/konfig.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -87,13 +88,23 @@ type Mount struct {
 
 	// Inspect configures behavior of mount inspect command.
 	Inspect *MountInspect `json:"inspect,omitempty"`
+
+	// Sync configures behavior of synchronization goroutines.
+	Sync *MountSync `json:"sync,omitempty"`
 }
 
 // MountInspect describes configuration of mount inspect command.
 type MountInspect struct {
-	// History configures the size of inspect history,
+	// History configures the length of inspect history,
 	// which is 100 by default.
 	History int `json:"history,omitempty"`
+}
+
+// MountSync describes configuration of synchronization goroutines.
+type MountSync struct {
+	// Workers configures number of concurrent rsync processes,
+	// which is 2 * cpu by default.
+	Workers int `json:"workers,omitempty"`
 }
 
 // Export gives a path for the named mount.
@@ -352,6 +363,9 @@ func NewKonfig(e *Environments) *Konfig {
 			},
 			Inspect: &MountInspect{
 				History: 100,
+			},
+			Sync: &MountSync{
+				Workers: 2 * runtime.NumCPU(),
 			},
 		},
 		Template: &Template{

--- a/go/src/koding/kites/kloud/metadata/metadata.go
+++ b/go/src/koding/kites/kloud/metadata/metadata.go
@@ -38,7 +38,7 @@ type Config struct {
 	Konfig   *config.Konfig    // Koding endpoints configuration
 	KiteKey  string            // KiteKey used by klient to authenticate with Koding
 	Userdata string            // User script to run after provisioning, if any
-	Mounts   map[string]string // Maps names with mount paths, for use with kd mount.
+	Exports  map[string]string // Maps names with mount paths, for use with kd mount.
 	Debug    bool              // Whether klient should be started in debug mode; configurable by debug field in stack template
 }
 
@@ -85,8 +85,8 @@ func newMetadata(cfg *Config) ([]byte, error) {
 	konfig := &config.Konfig{
 		Endpoints: cfg.Konfig.Endpoints,
 		KiteKey:   cfg.KiteKey,
-		Local: &config.Local{
-			Mounts: cfg.Mounts,
+		Mount: &config.Mount{
+			Exports: cfg.Exports,
 		},
 		Debug: cfg.Debug,
 	}

--- a/go/src/koding/kites/kloud/stack/provider/userdata.go
+++ b/go/src/koding/kites/kloud/stack/provider/userdata.go
@@ -57,7 +57,7 @@ func (bs *BaseStack) BuildUserdata(name string, vm map[string]interface{}) error
 	}
 
 	if v, ok := vm["koding_mounts"]; ok {
-		cfg.Mounts = tomap(v)
+		cfg.Exports = tomap(v)
 		delete(vm, "koding_mounts")
 	}
 

--- a/go/src/koding/klient/machine/index/handler.go
+++ b/go/src/koding/klient/machine/index/handler.go
@@ -92,7 +92,7 @@ func replaceWithExport(path string) string {
 		path = "default"
 	}
 
-	if dir, ok := config.Konfig.Local.MountPath(path); ok {
+	if dir, ok := config.Konfig.Mount.Export(path); ok {
 		return dir
 	}
 

--- a/go/src/koding/klient/machine/machinegroup/syncs/syncs.go
+++ b/go/src/koding/klient/machine/machinegroup/syncs/syncs.go
@@ -20,7 +20,7 @@ import (
 // debugAll must be set in order to debug print all synced events. Worker
 // events may produce a lot of events so we keep logging disabled even in
 // "normal" debug mode.
-var debugAll = os.Getenv("KD_DEBUG_MOUNT") != ""
+var debugAll = os.Getenv("KD_DEBUG_MOUNT") != "" || config.Konfig.Mount.Debug >= 1
 
 // Options are the options used to configure Syncs object.
 type Options struct {

--- a/go/src/koding/klient/machine/machinegroup/syncs/syncs.go
+++ b/go/src/koding/klient/machine/machinegroup/syncs/syncs.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sync"
 
+	"koding/klient/config"
 	"koding/klient/machine"
 	"koding/klient/machine/client"
 	"koding/klient/machine/mount"
@@ -90,7 +90,7 @@ func New(opts Options) (*Syncs, error) {
 	}
 
 	// Start synchronization workers.
-	for i := 0; i < 2*runtime.NumCPU(); i++ {
+	for i := 0; i < config.Konfig.Mount.Sync.Workers; i++ {
 		s.wg.Add(1)
 		go s.worker()
 	}

--- a/go/src/koding/klient/machine/mount/notify/fuse/filesystem.go
+++ b/go/src/koding/klient/machine/mount/notify/fuse/filesystem.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"koding/kites/config"
+	konfig "koding/klient/config"
 	"koding/klient/fs"
 	"koding/klient/machine/index"
 	"koding/klient/machine/mount/notify"
@@ -48,7 +49,7 @@ func (builder) Build(opts *notify.BuildOpts) (notify.Notifier, error) {
 		MountDir: opts.Path,
 		// intentionally separate env to not enable fuse logging
 		// for regular kd debug
-		Debug: os.Getenv("KD_MOUNT_DEBUG") == "1",
+		Debug: konfig.Konfig.Mount.Debug >= 9,
 	}
 
 	if err := o.Valid(); err != nil {

--- a/go/src/koding/klient/machine/mount/sync.go
+++ b/go/src/koding/klient/machine/mount/sync.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"koding/klient/config"
 	"koding/klient/machine"
 	"koding/klient/machine/client"
 	"koding/klient/machine/index"
@@ -213,7 +214,7 @@ func NewSync(mountID ID, m Mount, opts Options) (*Sync, error) {
 	}
 
 	// Enable syncing history for all mounts.
-	s.s = history.NewHistory(syncer, 100)
+	s.s = history.NewHistory(syncer, config.Konfig.Mount.Inspect.History)
 
 	return s, nil
 }

--- a/go/src/koding/klientctl/endpoint/machine/mount.go
+++ b/go/src/koding/klientctl/endpoint/machine/mount.go
@@ -34,7 +34,7 @@ func (c *Client) mountPoint(ident string) (string, error) {
 		return "", err
 	}
 
-	return filepath.Join(c.konfig().Local.MountHome, m.Label), nil
+	return filepath.Join(c.konfig().Mount.Home, m.Label), nil
 }
 
 // Mount synchronizes directories between remote and local machines.


### PR DESCRIPTION
This PR renames configuration from local to mount. The purpose
is to enable for mount configuration settings and not have
two places where mounts are configured.

So the following:

    $ kd config set local.mountHome ~/mount

Changes to:

    $ kd config set mount.home ~/mount

And the following:

    $ kd config set local.mounts.default ~/mount

Changes to:

    $ kd config set mount.exports.default ~/mount

It also makes it possible to change the default history length
produced by mount inspect command.

It can be overridden by the following command:

    $ kd config set mount.inspect.history 500

WARN: Do not set the history above 1e7 - the history uses container/ring
as its underlying implementation, and ring.New(1e7) can take
around 10s to complete, ring.New(1e8) takes more than 60s, which
makes the mount command to time out.

Also it is possible to change the default number of
synchronization goroutines, which are started for each
mount.

It can be overridden by the following command:

    $ kd config set mount.sync.workers 100

Last but not least, it is also possible to change the debug level
used in mount subsystem.

Currently available debug levels:

    <=0  - turns off debug logging
    1    - turns on debug logging for syncer events
    2-8  - reserved for future use
    >=9  - turns on debug logging for fuse events

It can be overridden by the following command:

    $ kd config set mount.debug 1