### PR TITLE
Show updated stack only when stack template changed event occurs

### DIFF
--- a/client/app/lib/sidebar/components/ownedresourceheader.coffee
+++ b/client/app/lib/sidebar/components/ownedresourceheader.coffee
@@ -20,24 +20,25 @@ module.exports = class OwnedResourceHeader extends React.Component
     @_header = null
 
 
+  setWidgetCoordinates: ->
+
+    kd.utils.defer =>
+      rect = findDOMNode(@_header).getBoundingClientRect()
+
+      @setState
+        coordinates: { top: rect.top, left: rect.width + rect.left }
+
+
   componentDidMount: ->
 
     if @_header and @props.hasWidget
-      kd.utils.defer =>
-        rect = findDOMNode(@_header).getBoundingClientRect()
-
-        @setState
-          coordinates: { top: rect.top, left: rect.width + rect.left }
+      @setWidgetCoordinates()
 
 
   componentWillReceiveProps: (nextProps) ->
 
     if @_header and nextProps.hasWidget
-      kd.utils.defer =>
-        rect = findDOMNode(@_header).getBoundingClientRect()
-
-        @setState
-          coordinates: { top: rect.top, left: rect.width + rect.left }
+      @setWidgetCoordinates()
 
 
   render: ->

--- a/client/app/lib/sidebar/components/stackupdatedwidget.coffee
+++ b/client/app/lib/sidebar/components/stackupdatedwidget.coffee
@@ -21,9 +21,15 @@ module.exports = class StackUpdatedWidget extends React.Component
       appManager.tell 'Stackeditor', 'reloadEditor', templateId
 
 
+  onClose: ->
+
+    { sidebar } = kd.singletons
+    sidebar.setUpdatedStack null
+
+
   render: ->
 
-    <SidebarWidget {...@props} onClose={@props.onClose}>
+    <SidebarWidget {...@props} onClose={@bound 'onClose'}>
       <span>STACK UPDATED</span>
       <p className='SidebarWidget-Title'>
         You need to reinitialize your machines before booting.

--- a/client/app/lib/sidebarcontroller.coffee
+++ b/client/app/lib/sidebarcontroller.coffee
@@ -51,7 +51,18 @@ module.exports = class SidebarController extends kd.Controller
 
   bindComputeHandlers: ->
 
-    { computeController } = kd.singletons
+    { computeController, groupsController } = kd.singletons
+
+    groupsController.ready =>
+      groupsController.on 'StackTemplateChanged', (event) =>
+        return  unless templateId = event?.contents
+
+        stacks = computeController.storage.stacks.get().filter (stack) ->
+          stack.baseStackId is templateId
+
+        return  unless stacks.length
+
+        @setUpdatedStack stacks[0].getId()
 
     computeController.ready =>
       computeController.on 'GroupStacksInconsistent', =>


### PR DESCRIPTION
Cont'd: #11063 
Fixes: #11001

@gokmen i know this is still not listening the individual updates of `JStackTemplate` events, this is because there is no access to templates from `SidebarController` and i didn't want to simply loop through all the template items and bind events onto them. Not sure if this does what you want, but i feel like this can be considered as a clean solution without complicating the flow too much. If not, we can talk about it. 