### PR TITLE
klient/mount: add --filesystem option to mount inspect that diagnose tree state

### DIFF
--- a/go/src/koding/klient/machine/index/index.go
+++ b/go/src/koding/klient/machine/index/index.go
@@ -363,6 +363,13 @@ func (idx *Index) DebugString() string {
 	return buf.String()
 }
 
+// Diagnose runs full diagnostic on current index tree state.
+//
+// TODO: Run diagnostic on underlying cache.
+func (idx *Index) Diagnose(_ string) []string {
+	return idx.t.Diagnose()
+}
+
 // atime gets file's access time in UNIX Nano format.
 func atime(fi os.FileInfo) int64 {
 	return times.Get(fi).AccessTime().UnixNano()

--- a/go/src/koding/klient/machine/index/node/diagnose.go
+++ b/go/src/koding/klient/machine/index/node/diagnose.go
@@ -1,0 +1,8 @@
+package node
+
+// Diagnose checks tree looking for broken filesystem invariants. It returns
+// a list of found problems. Each of them should be considered critical since
+// they indicate broken logic.
+func (t *Tree) Diagnose() []string {
+	return nil
+}

--- a/go/src/koding/klient/machine/index/node/diagnose.go
+++ b/go/src/koding/klient/machine/index/node/diagnose.go
@@ -71,7 +71,7 @@ func (t *Tree) diagNilVal(live map[*Node]int) (s []string) {
 	for i, n := range t.inodes {
 		visited[n] = struct{}{}
 		if n == nil {
-			s = append(s, fmt.Sprintln("nil node under %d inode value", i))
+			s = append(s, fmt.Sprintf("nil node under %d inode value", i))
 		}
 	}
 
@@ -214,24 +214,24 @@ func (t *Tree) diagOrphans(live map[*Node]int) (s []string) {
 // actual number of children node have.
 func (t *Tree) diagNChild(live map[*Node]int) (s []string) {
 	for n, cn := range live {
-		if n.parent != nil {
+		if n.parent != nil || n == t.root {
 			cn-- // Remove parent reference.
 		}
 
 		if cn != n.ChildN() {
-			s = append(s, fmt.Sprintf("node %s is referenced by too many nodes", n.Name))
+			s = append(s, fmt.Sprintf("node %s is referenced by too many nodes(%d)", n.Name, cn))
 		}
 	}
 
 	return s
 }
 
-// diagTimes checks if times are set correctly and if creation time was before
+// diagTimes checks if times are set correctly and if change time was before
 // or during modification time.
 func (t *Tree) diagTimes(_ map[*Node]int) (s []string) {
 	for _, n := range t.inodes {
 		if n.Entry.File.CTime == 0 {
-			s = append(s, fmt.Sprintf("creation time of node %s is not set", n.Name))
+			s = append(s, fmt.Sprintf("change time of node %s is not set", n.Name))
 			continue
 		}
 
@@ -240,8 +240,8 @@ func (t *Tree) diagTimes(_ map[*Node]int) (s []string) {
 			continue
 		}
 
-		if n.Entry.File.MTime < n.Entry.File.CTime {
-			s = append(s, fmt.Sprintf("node %s modification time is lower than creation one", n.Name))
+		if n.Entry.File.MTime > n.Entry.File.CTime {
+			s = append(s, fmt.Sprintf("node %s modification time is greater than change one", n.Name))
 		}
 	}
 
@@ -251,8 +251,8 @@ func (t *Tree) diagTimes(_ map[*Node]int) (s []string) {
 // diagNoDirNoChild checks if nodes with non directory mode have no children.
 func (t *Tree) diagNoDirNoChild(_ map[*Node]int) (s []string) {
 	for _, n := range t.inodes {
-		if n.Entry.File.Mode.IsDir() && n.ChildN() > 0 {
-			s = append(s, fmt.Sprintf("node %s is not a directory but has %d children", n.ChildN()))
+		if !n.Entry.File.Mode.IsDir() && n.ChildN() > 0 {
+			s = append(s, fmt.Sprintf("node %s is not a directory but has %d children", n.Name, n.ChildN()))
 		}
 	}
 

--- a/go/src/koding/klient/machine/index/node/diagnose.go
+++ b/go/src/koding/klient/machine/index/node/diagnose.go
@@ -7,7 +7,9 @@ import (
 // Diagnose checks tree looking for broken filesystem invariants. It returns
 // a list of found problems. Each of them should be considered critical since
 // they indicate broken logic.
-func (t *Tree) Diagnose() (s []string) {
+func (t *Tree) Diagnose() []string {
+	var s []string
+
 	// Find all Nodes that are present in the tree.
 	live := t.dft()
 
@@ -34,7 +36,7 @@ func (t *Tree) Diagnose() (s []string) {
 	return s
 }
 
-// dft uses deep first traversal algorithm to visit all nodes inside the tree
+// dft uses depth first traversal algorithm to visit all nodes inside the tree
 // the returned map will contain all found items with the number of child nodes
 // pointing to them.
 func (t *Tree) dft() map[*Node]int {

--- a/go/src/koding/klient/machine/index/node/diagnose.go
+++ b/go/src/koding/klient/machine/index/node/diagnose.go
@@ -1,8 +1,260 @@
 package node
 
+import (
+	"fmt"
+)
+
 // Diagnose checks tree looking for broken filesystem invariants. It returns
 // a list of found problems. Each of them should be considered critical since
 // they indicate broken logic.
-func (t *Tree) Diagnose() []string {
-	return nil
+func (t *Tree) Diagnose() (s []string) {
+	// Find all Nodes that are present in the tree.
+	live := t.dft()
+
+	// Special case where we handle nil values.
+	if s = t.diagNilVal(live); len(s) > 0 {
+		return s
+	}
+
+	diags := []func(map[*Node]int) []string{
+		t.diagZeroMode,
+		t.diagRoot,
+		t.diagNonReg,
+		t.diagMinRootID,
+		t.diagInodeMatch,
+		t.diagOrphans,
+		t.diagNChild,
+		t.diagTimes,
+		t.diagNoDirNoChild,
+	}
+	for _, diag := range diags {
+		s = append(s, diag(live)...)
+	}
+
+	return s
+}
+
+// dft uses deep first traversal algorithm to visit all nodes inside the tree
+// the returned map will contain all found items with the number of child nodes
+// pointing to them.
+func (t *Tree) dft() map[*Node]int {
+	visited := make(map[*Node]int)
+
+	var dft func(*Node)
+	dft = func(n *Node) {
+		if n == nil {
+			return
+		}
+
+		// Mark node as visited.
+		if count, ok := visited[n]; ok {
+			visited[n] = count + 1
+			return
+		}
+		visited[n] = 1
+
+		family := append([]*Node{n.parent}, n.children...)
+		for _, sub := range family {
+			dft(sub)
+		}
+	}
+
+	// Run recursively for all nodes.
+	dft(t.root)
+
+	return visited
+}
+
+// dialNilVal checks if all Nodes in tree are initialized.
+func (t *Tree) diagNilVal(live map[*Node]int) (s []string) {
+	visited := make(map[*Node]struct{})
+	for i, n := range t.inodes {
+		visited[n] = struct{}{}
+		if n == nil {
+			s = append(s, fmt.Sprintln("nil node under %d inode value", i))
+		}
+	}
+
+	if len(s) > 0 {
+		return s
+	}
+
+	for n, p := range live {
+		visited[n] = struct{}{}
+		if n == nil {
+			s = append(s, fmt.Sprintf("nil node inside the tree referenced by %d nodes", p))
+		}
+	}
+
+	if len(s) > 0 {
+		return s
+	}
+
+	for n := range visited {
+		if n.Entry == nil {
+			s = append(s, fmt.Sprintf("nil entry inside node %s", n.Name))
+		}
+	}
+
+	return s
+}
+
+// diagZeroVal looks for invalid zero file modes present in the tree.
+func (t *Tree) diagZeroMode(_ map[*Node]int) (s []string) {
+	for _, n := range t.inodes {
+		if n.Entry.File.Mode == 0 {
+			s = append(s, fmt.Sprintf("zero value mode of node %s", n.Name))
+		}
+	}
+
+	return s
+}
+
+// diagRoot checks if `root` Node is set properly.
+func (t *Tree) diagRoot(_ map[*Node]int) (s []string) {
+	if in := t.root.Entry.File.Inode; in != RootInodeID {
+		s = append(s, fmt.Sprintf("root node has invalid inode number %d", in))
+	}
+
+	if !t.root.Entry.File.Mode.IsDir() {
+		s = append(s, "root node is not a directory")
+	}
+
+	return s
+}
+
+// diagNonReg checks if all Nodes present in the tree are registered to inodes map.
+func (t *Tree) diagNonReg(live map[*Node]int) (s []string) {
+	for n := range live {
+		in := n.Entry.File.Inode
+		if _, ok := t.inodes[in]; !ok {
+			s = append(s, fmt.Sprintf("node %s with inode %d is not indexed", n.Name, in))
+		}
+	}
+
+	return s
+}
+
+// diagMinRootID checks if all registered nodes have their inodes greater or
+// equal to RootInodeID.
+func (t *Tree) diagMinRootID(_ map[*Node]int) (s []string) {
+	for i, n := range t.inodes {
+		if i < RootInodeID {
+			s = append(s, fmt.Sprintf("node %s has invalid inode value %d", n.Name, i))
+		}
+	}
+
+	return s
+}
+
+// diagInodeMatch checks if inode key stored in map matches inode field stored
+// in map's value Node.
+func (t *Tree) diagInodeMatch(_ map[*Node]int) (s []string) {
+	for i, n := range t.inodes {
+		in := n.Entry.File.Inode
+		if i != in {
+			s = append(s, fmt.Sprintf(
+				"indexed inode(%d) and stored one(%d) does not match for node %s", i, in, n.Name))
+		}
+	}
+
+	return s
+}
+
+// diagOrphans checks if all Nodes not present in `live` tree are orphans that
+// have non `root` parent. Also, they all have to be marked as deleted.
+func (t *Tree) diagOrphans(live map[*Node]int) (s []string) {
+	isOrphan := func(n *Node) bool {
+		visited := make(map[*Node]struct{})
+
+		for n != t.root {
+			if _, ok := visited[n]; ok {
+				s = append(s, fmt.Sprintf("loop detected in %s node", n.Name))
+				return false
+			}
+			visited[n] = struct{}{}
+
+			if n.parent == nil {
+				return true
+			}
+
+			n = n.parent
+		}
+
+		return false
+	}
+
+	for _, n := range t.inodes {
+		orphan := isOrphan(n)
+
+		switch _, ok := live[n]; {
+		case ok && orphan:
+			// File is an orphan but is present in the tree. This would be
+			// possible if tree supported hard links.
+			s = append(s, fmt.Sprintf("orphan node %s present in the tree", n.Name))
+		case !ok && orphan:
+			// File is not present in the tree and it's an orphan so it must be
+			// marked as deleted.
+			if !n.Entry.Virtual.Promise.Deleted() {
+				s = append(s, fmt.Sprintf("orphan node %s is not marked as deleted", n.Name))
+			}
+		case ok && !orphan:
+			// File is present in the tree. OK.
+		case !ok && !orphan:
+			// File is not preset in the tree but it claims it is connected to
+			// root inode. Which should be impossible.
+			s = append(s, fmt.Sprintf("node %s is not marked as an orphan", n.Name))
+		}
+	}
+
+	return s
+}
+
+// diagNChild checks if number of children created by DFT algorithm matches the
+// actual number of children node have.
+func (t *Tree) diagNChild(live map[*Node]int) (s []string) {
+	for n, cn := range live {
+		if n.parent != nil {
+			cn-- // Remove parent reference.
+		}
+
+		if cn != n.ChildN() {
+			s = append(s, fmt.Sprintf("node %s is referenced by too many nodes", n.Name))
+		}
+	}
+
+	return s
+}
+
+// diagTimes checks if times are set correctly and if creation time was before
+// or during modification time.
+func (t *Tree) diagTimes(_ map[*Node]int) (s []string) {
+	for _, n := range t.inodes {
+		if n.Entry.File.CTime == 0 {
+			s = append(s, fmt.Sprintf("creation time of node %s is not set", n.Name))
+			continue
+		}
+
+		if n.Entry.File.MTime == 0 {
+			s = append(s, fmt.Sprintf("modification time of node %s is not set", n.Name))
+			continue
+		}
+
+		if n.Entry.File.MTime < n.Entry.File.CTime {
+			s = append(s, fmt.Sprintf("node %s modification time is lower than creation one", n.Name))
+		}
+	}
+
+	return s
+}
+
+// diagNoDirNoChild checks if nodes with non directory mode have no children.
+func (t *Tree) diagNoDirNoChild(_ map[*Node]int) (s []string) {
+	for _, n := range t.inodes {
+		if n.Entry.File.Mode.IsDir() && n.ChildN() > 0 {
+			s = append(s, fmt.Sprintf("node %s is not a directory but has %d children", n.ChildN()))
+		}
+	}
+
+	return s
 }

--- a/go/src/koding/klient/machine/machinegroup/mount.go
+++ b/go/src/koding/klient/machine/machinegroup/mount.go
@@ -426,7 +426,7 @@ type InspectMountResponse struct {
 	Tree []index.Debug `json:"tree,omitempty"`
 
 	// Filesystem contains issues found by filesystem diagnostic.
-	Filesystem []string `json:"filesystem, omitempty"`
+	Filesystem []string `json:"filesystem,omitempty"`
 }
 
 // InspectMount gets detailed information about mount current state.

--- a/go/src/koding/klient/machine/machinegroup/mount.go
+++ b/go/src/koding/klient/machine/machinegroup/mount.go
@@ -412,6 +412,9 @@ type InspectMountRequest struct {
 
 	// Tree indicates whether inspect should attach index tree or not.
 	Tree bool `json:"tree"`
+
+	// Filesystem indicates whether inspect should run filesystem diagnostic.
+	Filesystem bool `json:"filesystem"`
 }
 
 // InspectMountResponse defines machine group mount inspect response.
@@ -421,6 +424,9 @@ type InspectMountResponse struct {
 
 	// Tree contains the entire index tree with its current state.
 	Tree []index.Debug `json:"tree,omitempty"`
+
+	// Filesystem contains issues found by filesystem diagnostic.
+	Filesystem []string `json:"filesystem, omitempty"`
 }
 
 // InspectMount gets detailed information about mount current state.
@@ -452,6 +458,11 @@ func (g *Group) InspectMount(req *InspectMountRequest) (*InspectMountResponse, e
 	// Get tree if requested.
 	if req.Tree {
 		res.Tree = sc.IndexDebug()
+	}
+
+	// Run syncer diagnostic if required.
+	if req.Filesystem {
+		res.Filesystem = sc.Diagnostic()
 	}
 
 	return res, nil

--- a/go/src/koding/klient/machine/machinegroup/mount.go
+++ b/go/src/koding/klient/machine/machinegroup/mount.go
@@ -462,7 +462,7 @@ func (g *Group) InspectMount(req *InspectMountRequest) (*InspectMountResponse, e
 
 	// Run syncer diagnostic if required.
 	if req.Filesystem {
-		res.Filesystem = sc.Diagnostic()
+		res.Filesystem = sc.Diagnose()
 	}
 
 	return res, nil

--- a/go/src/koding/klient/machine/mount/sync.go
+++ b/go/src/koding/klient/machine/mount/sync.go
@@ -276,6 +276,11 @@ func (s *Sync) IndexDebug() []index.Debug {
 	return s.idx.Debug()
 }
 
+// Diagnose diagnoses the mount looking for inconsistent or invalid states.
+func (s *Sync) Diagnose() []string {
+	return s.idx.Diagnose(s.CacheDir)
+}
+
 // CacheDir returns the name of mount cache directory.
 func (s *Sync) CacheDir() string {
 	return filepath.Join(s.opts.WorkDir, "data")

--- a/go/src/koding/klient/machine/mount/sync.go
+++ b/go/src/koding/klient/machine/mount/sync.go
@@ -278,7 +278,7 @@ func (s *Sync) IndexDebug() []index.Debug {
 
 // Diagnose diagnoses the mount looking for inconsistent or invalid states.
 func (s *Sync) Diagnose() []string {
-	return s.idx.Diagnose(s.CacheDir)
+	return s.idx.Diagnose(s.CacheDir())
 }
 
 // CacheDir returns the name of mount cache directory.

--- a/go/src/koding/klient/machine/mount/sync/history/history.go
+++ b/go/src/koding/klient/machine/mount/sync/history/history.go
@@ -90,7 +90,7 @@ func (h *History) Close() error {
 //
 // If there's no history available, the method returns empty, non-nil slice.
 func (h *History) Get() []*Record {
-	recs := make([]*Record, 0)
+	var recs []*Record
 
 	h.mu.Lock()
 	defer h.mu.Unlock()

--- a/go/src/koding/klientctl/bug.go
+++ b/go/src/koding/klientctl/bug.go
@@ -60,6 +60,7 @@ func Bug(_ *cli.Context, log logging.Logger, _ string) (int, error) {
 			opts := &machine.InspectMountOptions{
 				Identifier: string(m.ID),
 				Sync:       true,
+				Filesystem: true,
 				Log:        log.New("bug"),
 			}
 
@@ -76,6 +77,18 @@ func Bug(_ *cli.Context, log logging.Logger, _ string) (int, error) {
 
 				meta.Files = append(meta.Files, &machine.UploadedFile{
 					File:    "sync/" + id + "/" + string(m.ID) + ".json",
+					Content: p,
+				})
+			}
+
+			if len(records.Filesystem) > 0 {
+				p, err := json.Marshal(records.Filesystem)
+				if err != nil {
+					return 1, err
+				}
+
+				meta.Files = append(meta.Files, &machine.UploadedFile{
+					File:    "filesystem/" + id + "/" + string(m.ID) + ".json",
 					Content: p,
 				})
 			}

--- a/go/src/koding/klientctl/endpoint/machine/mount.go
+++ b/go/src/koding/klientctl/endpoint/machine/mount.go
@@ -184,6 +184,7 @@ type InspectMountOptions struct {
 	Identifier string // Mount identifier.
 	Sync       bool   // Get syncing history.
 	Tree       bool   // Show index tree.
+	Filesystem bool   // Check and report filesystem consistency.
 	Log        logging.Logger
 }
 
@@ -199,6 +200,7 @@ func (c *Client) InspectMount(options *InspectMountOptions) (machinegroup.Inspec
 		Identifier: options.Identifier,
 		Sync:       options.Sync,
 		Tree:       options.Tree,
+		Filesystem: options.Filesystem,
 	}
 
 	err := c.klient().Call("machine.mount.inspect", inspectMountReq, &inspectMountRes)

--- a/go/src/koding/klientctl/machine.go
+++ b/go/src/koding/klientctl/machine.go
@@ -287,8 +287,8 @@ func MachineInspectMountCommand(c *cli.Context, log logging.Logger, _ string) (i
 
 	// Enable sync option when there is none set explicitly. Tree may be too
 	// large to show it implicitly.
-	isSync, isTree := c.Bool("sync"), c.Bool("tree")
-	if !isSync && !isTree {
+	isSync, isTree, isFilesystem := c.Bool("sync"), c.Bool("tree"), c.Bool("filesystem")
+	if !isSync && !isTree && !isFilesystem {
 		isSync = true
 	}
 
@@ -296,6 +296,7 @@ func MachineInspectMountCommand(c *cli.Context, log logging.Logger, _ string) (i
 		Identifier: idents[0],
 		Sync:       isSync,
 		Tree:       isTree,
+		Filesystem: isFilesystem,
 		Log:        log.New("machine:inspect"),
 	}
 

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -696,6 +696,10 @@ func run(args []string) {
 						Name:  "tree",
 						Usage: "Displays the entire mount index tree.",
 					},
+					cli.BoolFlag{
+						Name:  "filesystem",
+						Usage: "Mount filesystem diagnostic.",
+					},
 				},
 			}},
 		}, {


### PR DESCRIPTION
This PR adds a set of checkers to mount inspect subcommand. The result of these checks will be sent with `kd bug` report.

Each of returned diagnose errors should be considered critical since they indicate invalid state of mount and can be caused only by a bug in index logic.

## Motivation and Context
Improve diagnostic of mounts.

## How Has This Been Tested?
Manually

## Types of changes
- [x] New feature (non-breaking change which adds functionality)