### PR TITLE
Show update stack widget on mismatched template/stack revisions

### DIFF
--- a/client/app/lib/remote-extensions/stacktemplate.coffee
+++ b/client/app/lib/remote-extensions/stacktemplate.coffee
@@ -6,6 +6,9 @@ remote = require('../remote')
 module.exports = class JStackTemplate extends remote.api.JStackTemplate
 
 
+  getRevisionStatus: -> @template.sum
+
+
   getCredentialIdentifiers: (exclude = ['custom']) ->
 
     ids = []

--- a/client/app/lib/remote-extensions/stacktemplate.coffee
+++ b/client/app/lib/remote-extensions/stacktemplate.coffee
@@ -6,7 +6,7 @@ remote = require('../remote')
 module.exports = class JStackTemplate extends remote.api.JStackTemplate
 
 
-  getRevisionStatus: -> @template.sum
+  getRevisionStatus: -> @getAt 'template.sum'
 
 
   getCredentialIdentifiers: (exclude = ['custom']) ->

--- a/client/app/lib/sidebar/components/ownedresourceheader.coffee
+++ b/client/app/lib/sidebar/components/ownedresourceheader.coffee
@@ -20,24 +20,25 @@ module.exports = class OwnedResourceHeader extends React.Component
     @_header = null
 
 
+  setWidgetCoordinates: ->
+
+    kd.utils.defer =>
+      rect = findDOMNode(@_header).getBoundingClientRect()
+
+      @setState
+        coordinates: { top: rect.top, left: rect.width + rect.left }
+
+
   componentDidMount: ->
 
     if @_header and @props.hasWidget
-      kd.utils.defer =>
-        rect = findDOMNode(@_header).getBoundingClientRect()
-
-        @setState
-          coordinates: { top: rect.top, left: rect.width + rect.left }
+      @setWidgetCoordinates()
 
 
   componentWillReceiveProps: (nextProps) ->
 
     if @_header and nextProps.hasWidget
-      kd.utils.defer =>
-        rect = findDOMNode(@_header).getBoundingClientRect()
-
-        @setState
-          coordinates: { top: rect.top, left: rect.width + rect.left }
+      @setWidgetCoordinates()
 
 
   render: ->

--- a/client/app/lib/sidebar/components/stackupdatedwidget.coffee
+++ b/client/app/lib/sidebar/components/stackupdatedwidget.coffee
@@ -21,9 +21,15 @@ module.exports = class StackUpdatedWidget extends React.Component
       appManager.tell 'Stackeditor', 'reloadEditor', templateId
 
 
+  onClose: ->
+
+    { sidebar } = kd.singletons
+    sidebar.setUpdatedStack null
+
+
   render: ->
 
-    <SidebarWidget {...@props} onClose={@props.onClose}>
+    <SidebarWidget {...@props} onClose={@bound 'onClose'}>
       <span>STACK UPDATED</span>
       <p className='SidebarWidget-Title'>
         You need to reinitialize your machines before booting.

--- a/client/app/lib/sidebarcontroller.coffee
+++ b/client/app/lib/sidebarcontroller.coffee
@@ -73,7 +73,7 @@ module.exports = class SidebarController extends kd.Controller
             debug 'template has an update event', template
             stacks = storage.stacks.query 'baseStackId', template.getId()
 
-            for stack in stacks when stack.revisionStatus isnt template.getRevisionStatus()
+            for stack in stacks when stack.stackRevision isnt template.getRevisionStatus()
               debug 'a stack generated from template has update', { template, stack }
               @_templateEventCache[template.getId()] = yes
               return @setUpdatedStack stack.getId()

--- a/client/app/lib/sidebarcontroller.coffee
+++ b/client/app/lib/sidebarcontroller.coffee
@@ -54,6 +54,7 @@ module.exports = class SidebarController extends kd.Controller
   bindComputeHandlers: ->
 
     { computeController } = kd.singletons
+    { storage } = computeController
 
     computeController.ready =>
       computeController.on 'GroupStacksInconsistent', =>
@@ -62,7 +63,7 @@ module.exports = class SidebarController extends kd.Controller
       computeController.on 'GroupStacksConsistent', =>
         @setDefaultStackUpdated updated = no
 
-      computeController.storage.on 'change:templates', (event) =>
+      storage.on 'change:templates', (event) =>
         { operation, value: template } = event
 
         # add a handler for each template push
@@ -70,20 +71,16 @@ module.exports = class SidebarController extends kd.Controller
           debug 'binding template events', template
           template.on 'update', =>
             debug 'template has an update event', template
-            stacks = computeController.storage.stacks.get().filter (stack) =>
-              stack.baseStackId is template.getId()
+            stacks = storage.stacks.query 'baseStackId', template.getId()
 
             for stack in stacks when stack.revisionStatus isnt template.getRevisionStatus()
               debug 'a stack generated from template has update', { template, stack }
               @_templateEventCache[template.getId()] = yes
               return @setUpdatedStack stack.getId()
 
-
         # clean up handler if the template is removed from storage
         if operation is 'pop' and @_templateEventCache[template.getId()]
           delete @_templateEventCache[template.getId()]
-
-
 
 
   setStateFromStorage: ->

--- a/client/app/lib/sidebarcontroller.coffee
+++ b/client/app/lib/sidebarcontroller.coffee
@@ -78,6 +78,11 @@ module.exports = class SidebarController extends kd.Controller
               @_templateEventCache[template.getId()] = yes
               return @setUpdatedStack stack.getId()
 
+            # no matter what emit a change event to make sidebar re-render with
+            # updated stack. this is required for template updates without sum
+            # change.
+            @emit 'change'
+
         # clean up handler if the template is removed from storage
         if operation is 'pop' and @_templateEventCache[template.getId()]
           delete @_templateEventCache[template.getId()]


### PR DESCRIPTION
This has one issue that unread count update comes after from stack template update and there is no way to wait for that event to happen without listening changes on `computeController`