### PR TITLE
klientctl/mount: clean up resources when mount prefetching or index update fail

### DIFF
--- a/go/src/koding/klientctl/endpoint/machine/mount.go
+++ b/go/src/koding/klientctl/endpoint/machine/mount.go
@@ -70,7 +70,7 @@ func (c *Client) Mount(options *MountOptions) (err error) {
 	}
 	var idRes machinegroup.IDResponse
 
-	if err := c.klient().Call("machine.id", idReq, &idRes); err != nil {
+	if err = c.klient().Call("machine.id", idReq, &idRes); err != nil {
 		return err
 	}
 
@@ -90,7 +90,7 @@ func (c *Client) Mount(options *MountOptions) (err error) {
 	}
 	var headMountRes machinegroup.HeadMountResponse
 
-	if err := c.klient().Call("machine.mount.head", headMountReq, &headMountRes); err != nil {
+	if err = c.klient().Call("machine.mount.head", headMountReq, &headMountRes); err != nil {
 		return err
 	}
 
@@ -122,9 +122,18 @@ func (c *Client) Mount(options *MountOptions) (err error) {
 		Strategies: prefetch.DefaultStrategy.Available(),
 	}
 	var addMountRes machinegroup.AddMountResponse
-	if err := c.klient().Call("machine.mount.add", addMountReq, &addMountRes); err != nil {
+	if err = c.klient().Call("machine.mount.add", addMountReq, &addMountRes); err != nil {
 		return err
 	}
+	defer func() {
+		// Remove mount when post mount operations fail.
+		if err != nil {
+			umountReq := &machinegroup.UmountRequest{
+				Identifier: string(addMountRes.MountID),
+			}
+			_ = c.klient().Call("machine.umount", umountReq, nil)
+		}
+	}()
 
 	// Prefetch files.
 	_, _, privPath, err := sshGetKeyPath()
@@ -137,6 +146,8 @@ func (c *Client) Mount(options *MountOptions) (err error) {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			options.Log.Error("Output: %q", exitErr.Stderr)
 		}
+
+		return err
 	}
 
 	// Rescan cache folder in order to update index.
@@ -144,7 +155,7 @@ func (c *Client) Mount(options *MountOptions) (err error) {
 		MountID: addMountRes.MountID,
 	}
 	var upIdxMountRes machinegroup.UpdateIndexResponse
-	if err := c.klient().Call("machine.mount.updateIndex", upIdxMountReq, &upIdxMountRes); err != nil {
+	if err = c.klient().Call("machine.mount.updateIndex", upIdxMountReq, &upIdxMountRes); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR unmount filesystem when prefetching or index update fail. This ensures more consistent state after mount.

Fixes: #11124

## How Has This Been Tested?
Manually

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
