### PR TITLE
klient/mount/rsync: nil interface value causes panics during context close.

### DIFF
--- a/go/src/koding/klient/machine/mount/sync/supervised/supervised.go
+++ b/go/src/koding/klient/machine/mount/sync/supervised/supervised.go
@@ -81,7 +81,7 @@ func (s *Supervised) ExecStream(evC <-chan *msync.Event) <-chan msync.Execer {
 		rebuild := func() {
 			var err error
 			if sy, err = s.b.Build(&opts); err != nil {
-				exDynC = nil
+				sy, exDynC = nil, nil
 				return
 			}
 			exDynC = sy.ExecStream(evC) // Consume from new syncer.


### PR DESCRIPTION
Fixes: #11138

Caused by nil value inside non nil interface: https://play.golang.org/p/zr4qizfApd
