### PR TITLE
kd: rework bolt handling

### DIFF
--- a/go/src/koding/kites/config/cache.go
+++ b/go/src/koding/kites/config/cache.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"log"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -47,7 +46,11 @@ type Cache struct {
 func NewCache(options *CacheOptions) *Cache {
 	db, err := newBoltDB(options)
 	if err != nil {
-		log.Println(err)
+		return &Cache{
+			EncodingStorage: &storage.EncodingStorage{
+				Interface: &storage.ErrStorage{Err: err},
+			},
+		}
 	}
 
 	return &Cache{

--- a/go/src/koding/kites/config/cache.go
+++ b/go/src/koding/kites/config/cache.go
@@ -85,11 +85,12 @@ func newBoltDB(o *CacheOptions) (*bolt.DB, error) {
 	_ = util.Chown(dir, o.owner().User)
 
 	db, err := bolt.Open(o.File, 0644, o.BoltDB)
+
+	_ = util.Chown(o.File, o.owner().User)
+
 	if err != nil {
 		return nil, err
 	}
-
-	_ = util.Chown(o.File, o.owner().User)
 
 	return db, nil
 }

--- a/go/src/koding/kites/config/configstore/configstore.go
+++ b/go/src/koding/kites/config/configstore/configstore.go
@@ -134,7 +134,7 @@ func (c *Client) CacheOptions(app string) *config.CacheOptions {
 	return &config.CacheOptions{
 		File: file,
 		BoltDB: &bolt.Options{
-			Timeout: 5 * time.Second,
+			Timeout: 3 * time.Second,
 		},
 		Bucket: []byte(app),
 	}
@@ -208,7 +208,11 @@ func (c *Client) commit(fn func(*config.Cache) error) error {
 		return fn(c.Cache)
 	}
 
-	cache := config.NewCache(c.cacheOpts())
+	cache, err := config.NewBoltCache(c.cacheOpts())
+	if err != nil {
+		return err
+	}
+
 	return nonil(fn(cache), cache.Close())
 }
 

--- a/go/src/koding/kites/config/konfig.go
+++ b/go/src/koding/kites/config/konfig.go
@@ -100,21 +100,21 @@ type Mount struct {
 	//   2-8  - reserved for future use
 	//   >=9  - turns on debug logging for fuse events
 	//
-	Debug int `json:"debug,omitempty"`
+	Debug int `json:"debug,omitempty,string"`
 }
 
 // MountInspect describes configuration of mount inspect command.
 type MountInspect struct {
 	// History configures the length of inspect history,
 	// which is 100 by default.
-	History int `json:"history,omitempty"`
+	History int `json:"history,omitempty,string"`
 }
 
 // MountSync describes configuration of synchronization goroutines.
 type MountSync struct {
 	// Workers configures number of concurrent rsync processes,
 	// which is 2 * cpu by default.
-	Workers int `json:"workers,omitempty"`
+	Workers int `json:"workers,omitempty,string"`
 }
 
 // Export gives a path for the named mount.

--- a/go/src/koding/kites/config/konfig.go
+++ b/go/src/koding/kites/config/konfig.go
@@ -169,7 +169,8 @@ type Konfig struct {
 	PublicBucketName   string `json:"publicBucketName,omitempty"`
 	PublicBucketRegion string `json:"publicBucketRegion,omitempty"`
 
-	Debug bool `json:"debug,string,omitempty"`
+	LockTimeout time.Duration `json:"lockTimeout,omitempty"`
+	Debug       bool          `json:"debug,string,omitempty"`
 }
 
 // KiteHome gives directory of the kite.key file.
@@ -383,6 +384,7 @@ func NewKonfig(e *Environments) *Konfig {
 		},
 		PublicBucketName:   Builtin.Buckets.PublicLogs.Name,
 		PublicBucketRegion: Builtin.Buckets.PublicLogs.Region,
+		LockTimeout:        3 * time.Second,
 		Debug:              false,
 	}
 }

--- a/go/src/koding/klient/storage/bolt.go
+++ b/go/src/koding/klient/storage/bolt.go
@@ -30,14 +30,16 @@ func NewBoltStorageBucket(db *bolt.DB, bucketName []byte) (*boltdb, error) {
 		DB:         db,
 	}
 
-	if err := b.Update(func(tx *bolt.Tx) error {
-		_, err := tx.CreateBucketIfNotExists(b.bucket())
-		if err != nil {
-			return err
+	if !db.IsReadOnly() {
+		if err := b.Update(func(tx *bolt.Tx) error {
+			_, err := tx.CreateBucketIfNotExists(b.bucket())
+			if err != nil {
+				return err
+			}
+			return nil
+		}); err != nil {
+			return nil, err
 		}
-		return nil
-	}); err != nil {
-		return nil, err
 	}
 
 	return b, nil

--- a/go/src/koding/klient/storage/bolt.go
+++ b/go/src/koding/klient/storage/bolt.go
@@ -33,10 +33,7 @@ func NewBoltStorageBucket(db *bolt.DB, bucketName []byte) (*boltdb, error) {
 	if !db.IsReadOnly() {
 		if err := b.Update(func(tx *bolt.Tx) error {
 			_, err := tx.CreateBucketIfNotExists(b.bucket())
-			if err != nil {
-				return err
-			}
-			return nil
+			return err
 		}); err != nil {
 			return nil, err
 		}

--- a/go/src/koding/klient/storage/storage.go
+++ b/go/src/koding/klient/storage/storage.go
@@ -104,6 +104,17 @@ func (s *Storage) DeleteValue(r *kite.Request) (interface{}, error) {
 	return true, nil
 }
 
+type ErrStorage struct {
+	Err error
+}
+
+var _ Interface = ErrStorage{}
+
+func (es ErrStorage) Get(key string) (string, error) { return "", es.Err }
+func (es ErrStorage) Set(key, value string) error    { return es.Err }
+func (es ErrStorage) Delete(key string) error        { return es.Err }
+func (es ErrStorage) Close() error                   { return es.Err }
+
 type EncodingStorage struct {
 	Interface
 

--- a/go/src/koding/klientctl/config.go
+++ b/go/src/koding/klientctl/config.go
@@ -102,7 +102,6 @@ func ConfigSet(c *cli.Context, log logging.Logger, _ string) (int, error) {
 	}
 
 	if err := configstore.Set(c.Args().Get(0), c.Args().Get(1)); err != nil {
-		fmt.Fprintln(os.Stderr, err)
 		return 1, err
 	}
 
@@ -118,7 +117,6 @@ func ConfigUnset(c *cli.Context, log logging.Logger, _ string) (int, error) {
 	}
 
 	if err := configstore.Set(c.Args().Get(0), ""); err != nil {
-		fmt.Fprintln(os.Stderr, err)
 		return 1, err
 	}
 

--- a/go/src/koding/klientctl/config/cache.go
+++ b/go/src/koding/klientctl/config/cache.go
@@ -29,6 +29,7 @@ type Cache struct {
 // Open tries to open new kd storage file.
 func Open() (*Cache, error) {
 	opts := configstore.CacheOptions("kd")
+	opts.BoltDB.Timeout = Konfig.LockTimeout
 
 	// Ensure the database file exists.
 	if _, err := os.Stat(opts.File); os.IsNotExist(err) {
@@ -62,6 +63,7 @@ func (c *Cache) ReadOnly() *config.Cache {
 
 	if c.ro == nil {
 		opts := configstore.CacheOptions("kd")
+		opts.BoltDB.Timeout = Konfig.LockTimeout
 		opts.BoltDB.ReadOnly = true
 
 		c.ro = config.NewCache(opts)
@@ -77,7 +79,11 @@ func (c *Cache) ReadOnly() *config.Cache {
 func (c *Cache) ReadWrite() *config.Cache {
 	if c.rw == nil {
 		_ = c.CloseRead()
-		c.rw = config.NewCache(configstore.CacheOptions("kd"))
+
+		opts := configstore.CacheOptions("kd")
+		opts.BoltDB.Timeout = Konfig.LockTimeout
+
+		c.rw = config.NewCache(opts)
 	}
 
 	return c.rw

--- a/go/src/koding/klientctl/config/cache.go
+++ b/go/src/koding/klientctl/config/cache.go
@@ -16,7 +16,7 @@ var DefaultCache = &Cache{}
 // to a kd.*.bolt storage file.
 //
 // Upon init kd uses for read-only access, thus
-// multiple kd can be run simultanously.
+// multiple kd can be run simultaneously.
 //
 // Upon exit, kd tries to acquire write access,
 // queueing multiple kd processes with a 3s

--- a/go/src/koding/klientctl/config/cache.go
+++ b/go/src/koding/klientctl/config/cache.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"os"
+
+	"koding/kites/config"
+	"koding/kites/config/configstore"
+)
+
+// DefaultCache is a kd.*.bolt database
+// for a koding endpoint configured
+// in a konfig.bolt database.
+var DefaultCache = &Cache{}
+
+// Cacheprovides a read/write access
+// to a kd.*.bolt storage file.
+//
+// Upon init kd uses for read-only access, thus
+// multiple kd can be run simultanously.
+//
+// Upon exit, kd tries to acquire write access,
+// queueing multiple kd processes with a 3s
+// timeout.
+type Cache struct {
+	ro *config.Cache
+	rw *config.Cache
+}
+
+// Open tries to open new kd storage file.
+func Open() (*Cache, error) {
+	opts := configstore.CacheOptions("kd")
+
+	// Ensure the database file exists.
+	if _, err := os.Stat(opts.File); os.IsNotExist(err) {
+		db, err := config.NewBoltCache(opts)
+		if err != nil {
+			return nil, err
+		}
+		if err := db.Close(); err != nil {
+			return nil, err
+		}
+	}
+
+	opts.BoltDB.ReadOnly = true
+
+	ro, err := config.NewBoltCache(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Cache{ro: ro}, nil
+}
+
+// ReadOnly gives a cache with read-only access.
+//
+// Such cache can be use simultaneously by multiple
+// processes.
+func (c *Cache) ReadOnly() *config.Cache {
+	if c.rw != nil {
+		return c.rw
+	}
+
+	if c.ro == nil {
+		opts := configstore.CacheOptions("kd")
+		opts.BoltDB.ReadOnly = true
+
+		c.ro = config.NewCache(opts)
+	}
+
+	return c.ro
+}
+
+// ReadWrite gives a cache with read-write access.
+//
+// If prior to calling this method a read-only
+// access was acquired, it will be released.
+func (c *Cache) ReadWrite() *config.Cache {
+	if c.rw == nil {
+		_ = c.CloseRead()
+		c.rw = config.NewCache(configstore.CacheOptions("kd"))
+	}
+
+	return c.rw
+}
+
+// CloseRead releases read-only access to a storage file.
+func (c *Cache) CloseRead() (err error) {
+	if c.ro != nil {
+		err = c.ro.Close()
+		c.ro = nil
+	}
+	return err
+}
+
+// CloseWrite releases read-write access to a storage file.
+func (c *Cache) CloseWrite() (err error) {
+	if c.rw != nil {
+		err = c.rw.Close()
+		c.rw = nil
+	}
+	return err
+}
+
+// Close releases any of the read-only or read-write accesses,
+// if acquired.
+func (c *Cache) Close() (err error) {
+	return nonil(c.CloseWrite(), c.CloseRead())
+}

--- a/go/src/koding/klientctl/config/config.go
+++ b/go/src/koding/klientctl/config/config.go
@@ -82,6 +82,15 @@ func init() {
 	Konfig = configstore.Read(Environments)
 }
 
+func nonil(err ...error) error {
+	for _, e := range err {
+		if e != nil {
+			return e
+		}
+	}
+	return nil
+}
+
 func dirURL(s, env string) string {
 	u, err := url.Parse(s)
 	if err != nil {

--- a/go/src/koding/klientctl/endpoint/auth/auth.go
+++ b/go/src/koding/klientctl/endpoint/auth/auth.go
@@ -119,6 +119,8 @@ var _ api.Storage = (*Client)(nil)
 // (once one logged in with kd auth all commands like
 //  kd stack list etc. are going to use the same user).
 func (c *Client) Get(u *api.User) (*api.Session, error) {
+	c.init()
+
 	s, ok := c.sessions[u.Team]
 	if !ok {
 		return nil, api.ErrSessionNotFound
@@ -137,6 +139,8 @@ func (c *Client) Get(u *api.User) (*api.Session, error) {
 //
 // It sets or updates session given by the s.
 func (c *Client) Set(s *api.Session) error {
+	c.init()
+
 	c.sessions[s.User.Team] = &Session{
 		ClientID: s.ClientID,
 		Team:     s.User.Team,
@@ -148,6 +152,8 @@ func (c *Client) Set(s *api.Session) error {
 //
 // It removes, possibly invalidated, session.
 func (c *Client) Delete(s *api.Session) error {
+	c.init()
+
 	delete(c.sessions, s.User.Team)
 	return nil
 }

--- a/go/src/koding/klientctl/endpoint/auth/auth.go
+++ b/go/src/koding/klientctl/endpoint/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"sync"
 
+	"koding/api"
 	conf "koding/kites/config"
 	"koding/kites/kloud/stack"
 	"koding/klientctl/config"
@@ -108,6 +109,49 @@ type Client struct {
 	sessions Sessions
 }
 
+var _ api.Storage = (*Client)(nil)
+
+// Get implements the api.Storage interface.
+//
+// It gives a session for the given team.
+//
+// All operations on a single Client assume the same user
+// (once one logged in with kd auth all commands like
+//  kd stack list etc. are going to use the same user).
+func (c *Client) Get(u *api.User) (*api.Session, error) {
+	s, ok := c.sessions[u.Team]
+	if !ok {
+		return nil, api.ErrSessionNotFound
+	}
+
+	return &api.Session{
+		ClientID: s.ClientID,
+		User: &api.User{
+			Username: c.kloud().Username(),
+			Team:     s.Team,
+		},
+	}, nil
+}
+
+// Set implements the api.Storage interface.
+//
+// It sets or updates session given by the s.
+func (c *Client) Set(s *api.Session) error {
+	c.sessions[s.User.Team] = &Session{
+		ClientID: s.ClientID,
+		Team:     s.User.Team,
+	}
+	return nil
+}
+
+// Delete implements the api.Storage interface.
+//
+// It removes, possibly invalidated, session.
+func (c *Client) Delete(s *api.Session) error {
+	delete(c.sessions, s.User.Team)
+	return nil
+}
+
 // Login authenticates to Koding.
 //
 // If opts.Token is no empty, token-based authentication is used.
@@ -209,7 +253,7 @@ func (c *Client) Used() *Info {
 // It closes any resources used by the Client.
 func (c *Client) Close() (err error) {
 	if len(c.sessions) != 0 {
-		err = c.kloud().Cache().SetValue("auth.sessions", c.sessions)
+		err = c.kloud().Cache().ReadWrite().SetValue("auth.sessions", c.sessions)
 	}
 
 	return err
@@ -224,7 +268,7 @@ func (c *Client) readCache() {
 
 	// Ignoring read error, if it's non-nil then empty cache is going to
 	// be used instead.
-	_ = c.kloud().Cache().GetValue("auth.sessions", &c.sessions)
+	_ = c.kloud().Cache().ReadOnly().GetValue("auth.sessions", &c.sessions)
 }
 
 func (c *Client) kloud() *kloud.Client {

--- a/go/src/koding/klientctl/endpoint/credential/credential.go
+++ b/go/src/koding/klientctl/endpoint/credential/credential.go
@@ -167,15 +167,15 @@ func (c *Client) Describe() (stack.Descriptions, error) {
 
 func (c *Client) Close() (err error) {
 	if len(c.cached) != 0 {
-		err = c.kloud().Cache().SetValue("credential", c.cached)
+		err = c.kloud().Cache().ReadWrite().SetValue("credential", c.cached)
 	}
 
 	if len(c.used) != 0 {
-		err = nonil(err, c.kloud().Cache().SetValue("credential.used", c.used))
+		err = nonil(err, c.kloud().Cache().ReadWrite().SetValue("credential.used", c.used))
 	}
 
 	if len(c.describe) != 0 {
-		err = nonil(err, c.kloud().Cache().SetValue("credential.describe", c.describe))
+		err = nonil(err, c.kloud().Cache().ReadWrite().SetValue("credential.describe", c.describe))
 	}
 
 	return err
@@ -219,9 +219,9 @@ func (c *Client) readCache() {
 
 	// Ignoring read error, if it's non-nil then empty cache is going to
 	// be used instead.
-	_ = c.kloud().Cache().GetValue("credential", &c.cached)
-	_ = c.kloud().Cache().GetValue("credential.used", &c.used)
-	_ = c.kloud().Cache().GetValue("credential.describe", &c.describe)
+	_ = c.kloud().Cache().ReadOnly().GetValue("credential", &c.cached)
+	_ = c.kloud().Cache().ReadOnly().GetValue("credential.used", &c.used)
+	_ = c.kloud().Cache().ReadOnly().GetValue("credential.describe", &c.describe)
 }
 
 func (c *Client) kloud() *kloud.Client {

--- a/go/src/koding/klientctl/endpoint/kloud/kloud.go
+++ b/go/src/koding/klientctl/endpoint/kloud/kloud.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	cfg "koding/kites/config"
-	"koding/kites/config/configstore"
 	"koding/kites/kloud/stack"
 	"koding/klientctl/config"
 	"koding/klientctl/ctlcli"
@@ -54,19 +53,11 @@ type Client struct {
 	//
 	// If zero, 10s is used by default.
 	WaitInterval time.Duration
-
-	cache *cfg.Cache
 }
 
 // Cache gives new kd.bolt cache.
-func (c *Client) Cache() *cfg.Cache {
-	if c.cache != nil {
-		return c.cache
-	}
-
-	c.cache = cfg.NewCache(configstore.CacheOptions("kd"))
-
-	return c.cache
+func (c *Client) Cache() *config.Cache {
+	return config.DefaultCache
 }
 
 // Username gives the username by:
@@ -93,11 +84,8 @@ func (c *Client) Call(method string, arg, reply interface{}) error {
 // Close implements the io.Closer interface.
 //
 // It closes any resources used by the client.
-func (c *Client) Close() (err error) {
-	if c.cache != nil {
-		err = c.cache.Close()
-	}
-	return err
+func (c *Client) Close() error {
+	return nil
 }
 
 // Wait polls on even stream identified by the given event string.
@@ -401,7 +389,7 @@ func (kt *KiteTransport) Valid() error {
 // Cache gives new kd.bolt cache.
 //
 // The function forwards the call to the DefaultClient.
-func Cache() *cfg.Cache { return DefaultClient.Cache() }
+func Cache() *config.Cache { return DefaultClient.Cache() }
 
 // Username gives the username by:
 //

--- a/go/src/koding/klientctl/endpoint/kloud/kloud.go
+++ b/go/src/koding/klientctl/endpoint/kloud/kloud.go
@@ -115,6 +115,9 @@ func (c *Client) Wait(event string) <-chan *stack.EventResponse {
 		return ch
 	}
 
+	// Release read-only access before long-running operation.
+	_ = c.Cache().CloseRead()
+
 	go func() {
 		last := -1
 		defer close(ch)

--- a/go/src/koding/klientctl/endpoint/machine/client.go
+++ b/go/src/koding/klientctl/endpoint/machine/client.go
@@ -247,7 +247,7 @@ func (c *Client) machine(ident string) (*models.JMachine, error) {
 
 func (c *Client) Close() (err error) {
 	if len(c.machines) != 0 {
-		err = c.kloud().Cache().SetValue("machine", c.machines)
+		err = c.kloud().Cache().ReadWrite().SetValue("machine", c.machines)
 	}
 	return err
 }
@@ -261,7 +261,7 @@ func (c *Client) readCache() {
 
 	// Ignoring read error, if it's non-nil then empty cache is going to
 	// be used instead.
-	_ = c.kloud().Cache().GetValue("machine", &c.machines)
+	_ = c.kloud().Cache().ReadOnly().GetValue("machine", &c.machines)
 
 	c.idents = make(map[string]machine.ID, len(c.machines))
 

--- a/go/src/koding/klientctl/endpoint/machine/mount.go
+++ b/go/src/koding/klientctl/endpoint/machine/mount.go
@@ -310,6 +310,9 @@ func (c *Client) WaitIdle(opts *WaitIdleOptions) error {
 		return err
 	}
 
+	// Release read-only access before long-running operation.
+	_ = c.kloud().Cache().CloseRead()
+
 	if !<-ch {
 		if req.Timeout != 0 {
 			return fmt.Errorf("waiting for mount to synchronize has timed out after %s", req.Timeout)

--- a/go/src/koding/klientctl/endpoint/team/team.go
+++ b/go/src/koding/klientctl/endpoint/team/team.go
@@ -82,7 +82,7 @@ func (c *Client) Whoami() (*stack.WhoamiResponse, error) {
 
 func (c *Client) Close() (err error) {
 	if c.used.Valid() == nil {
-		err = c.kloud().Cache().SetValue("team.used", &c.used)
+		err = c.kloud().Cache().ReadWrite().SetValue("team.used", &c.used)
 	}
 
 	return err
@@ -95,7 +95,7 @@ func (c *Client) init() {
 func (c *Client) readCache() {
 	// Ignoring read error, if it's non-nil then empty cache is going to
 	// be used instead.
-	_ = c.kloud().Cache().GetValue("team.used", &c.used)
+	_ = c.kloud().Cache().ReadOnly().GetValue("team.used", &c.used)
 }
 
 func (c *Client) kloud() *kloud.Client {

--- a/go/src/koding/klientctl/endpoint/transport.go
+++ b/go/src/koding/klientctl/endpoint/transport.go
@@ -4,6 +4,7 @@ import (
 	"koding/api"
 	"koding/api/apiutil"
 	"koding/klientctl/config"
+	"koding/klientctl/endpoint/auth"
 	"koding/klientctl/endpoint/kloud"
 )
 
@@ -11,17 +12,11 @@ import (
 // as an authorization endpoint.
 //
 // If client is nil, kloud.DefaultClient is used instead.
-func Transport(client *kloud.Client) *api.Transport {
-	if client == nil {
-		client = kloud.DefaultClient
-	}
-
+func Transport(client *kloud.Client, auth *auth.Client) *api.Transport {
 	return &api.Transport{
 		AuthFunc: (&apiutil.KloudAuth{
-			Kite: client.Transport,
-			Storage: &apiutil.Storage{
-				Cache: client.Cache(),
-			},
+			Kite:    client.Transport,
+			Storage: auth,
 		}).Auth,
 		Debug: config.Konfig.Debug,
 		Log:   kloud.DefaultLog,

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -129,6 +129,25 @@ func run(args []string) {
 		os.Exit(1)
 	}
 
+	cache, err := config.Open()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, `It seems that another kd process is currently running and doing write
+operations that prevented me from starting up.
+
+Usually it is enough to retry. If that happens again, please verify
+you have no hanging kd processes. Alternatively if you are executing
+a lot of kd processes concurrently and a number of them are failing,
+you may want to increate lock timeout with:
+
+	kd config lockTimeout 10s
+
+error opening: %s
+`, err)
+		os.Exit(3)
+	}
+
+	config.DefaultCache = cache
+
 	sig := make(chan os.Signal, 1)
 
 	go func() {


### PR DESCRIPTION
Closes  #11154.

This PR reworks bolt handling in kd so it's possible to run short-running kd process alongside a long-running one:

[![screencast](https://asciinema.org/a/amywiu289157qp871qf380p5s.png)](https://asciinema.org/a/amywiu289157qp871qf380p5s)

This PR also makes failure to obtain a bolt access a hard failure, instead of a silent one, so instead of unreadable errors kd will display:

```
$ kd mount ls
It seems that another kd process is currently running and doing write
operations that prevented me from starting up.

Usually it is enough to retry. If that happens again, please verify
you have no hanging kd processes. Alternatively if you are executing
a lot of kd processes concurrently and a number of them are failing,
you may want to increate lock timeout with:

	kd config lockTimeout 10s

error opening: timeout
$ echo $?
3
```