### PR TITLE
kloud: set environment / logging bucket via metadata

### DIFF
--- a/go/src/koding/kites/config/config.go
+++ b/go/src/koding/kites/config/config.go
@@ -297,6 +297,7 @@ var defaultAliases = aliases{
 	"managed":     {},
 	"development": {"sandbox", "default", "dev"},
 	"devmanaged":  {},
+	"default":     {},
 }
 
 type aliases map[string][]string

--- a/go/src/koding/kites/kloud/kloud/kloud.go
+++ b/go/src/koding/kites/kloud/kloud/kloud.go
@@ -428,7 +428,7 @@ func newSession(conf *Config, k *kite.Kite) (*session.Session, error) {
 
 	kontrolPrivateKey, kontrolPublicKey := kontrolKeys(conf)
 
-	klientFolder := "development/latest"
+	klientFolder := conf.Environment + "/latest"
 	if conf.ProdMode {
 		k.Log.Info("Prod mode enabled")
 		klientFolder = "production/latest"

--- a/go/src/koding/kites/kloud/metadata/metadata.go
+++ b/go/src/koding/kites/kloud/metadata/metadata.go
@@ -83,12 +83,15 @@ func New(cfg *Config) (CloudInit, error) {
 // and use in marathon as well.
 func newMetadata(cfg *Config) ([]byte, error) {
 	konfig := &config.Konfig{
-		Endpoints: cfg.Konfig.Endpoints,
-		KiteKey:   cfg.KiteKey,
+		Endpoints:   cfg.Konfig.Endpoints,
+		Environment: cfg.Konfig.Environment,
+		KiteKey:     cfg.KiteKey,
 		Mount: &config.Mount{
 			Exports: cfg.Exports,
 		},
-		Debug: cfg.Debug,
+		PublicBucketName:   cfg.Konfig.PublicBucketName,
+		PublicBucketRegion: cfg.Konfig.PublicBucketRegion,
+		Debug:              cfg.Debug,
 	}
 
 	m := map[string]interface{}{


### PR DESCRIPTION
This PR makes kloud set .Environment and .PublicBucket* fields during building metadata for klient deployment on a remove vm.