### PR TITLE
kloud/stack: add userdata to provider schema

### DIFF
--- a/go/src/koding/kites/kloud/provider/google/google.go
+++ b/go/src/koding/kites/kloud/provider/google/google.go
@@ -19,6 +19,7 @@ var p = &provider.Provider{
 	Name:         "google",
 	ResourceName: "compute_instance",
 	Userdata:     "user-data",
+	UserdataPath: []string{"google_compute_instance", "*", "metadata", "user-data"},
 	Machine:      newMachine,
 	Stack:        newStack,
 	Schema: &provider.Schema{

--- a/go/src/koding/kites/kloud/provider/marathon/marathon.go
+++ b/go/src/koding/kites/kloud/provider/marathon/marathon.go
@@ -18,6 +18,8 @@ func init() {
 	provider.Register(&provider.Provider{
 		Name:         "marathon",
 		ResourceName: "app",
+		NoCloudInit:  true,
+		Userdata:     "cmd",
 		Machine:      newMachine,
 		Stack:        newStack,
 		Schema:       schema,

--- a/go/src/koding/kites/kloud/provider/vagrant/vagrant.go
+++ b/go/src/koding/kites/kloud/provider/vagrant/vagrant.go
@@ -15,6 +15,7 @@ var p = &provider.Provider{
 	ResourceName: "instance",
 	Machine:      newMachine,
 	Stack:        newStack,
+	NoCloudInit:  true,
 	Schema: &provider.Schema{
 		NewCredential: newCredential,
 		NewBootstrap:  nil,

--- a/go/src/koding/kites/kloud/stack/credential.go
+++ b/go/src/koding/kites/kloud/stack/credential.go
@@ -28,9 +28,11 @@ type CredentialDescribeResponse struct {
 // Description describes Credential and Bootstrap
 // types used by a given provider.
 type Description struct {
-	Provider   string  `json:"provider,omitempty"`
-	Credential []Value `json:"credential"`
-	Bootstrap  []Value `json:"bootstrap,omitempty"`
+	Provider   string   `json:"provider,omitempty"`
+	Credential []Value  `json:"credential"`
+	Bootstrap  []Value  `json:"bootstrap,omitempty"`
+	UserData   []string `json:"userData,omitempty"`
+	CloudInit  bool     `json:"cloudInit"`
 }
 
 // Descriptions maps credential description per provider.


### PR DESCRIPTION
A "userdata" is a JSONPath which allows for locating
a user_data (cloud-init) key within a stack template tree.

Locating cloud-init in the tree is going to allow for
provider-agnostic manipulation of stack template content,
like creating new and custom templates on-the-fly (as oppose
to dummy templates received from JTemplate.Sample).

The templates are meant to be manipulated client-side (e.g. kd),
before sending them over to koding.