### PR TITLE
kd/mount: prevent from syncing two changes of the same file concurrently

### DIFF
--- a/go/src/koding/klient/machine/mount/anteroom.go
+++ b/go/src/koding/klient/machine/mount/anteroom.go
@@ -191,7 +191,7 @@ func (a *Anteroom) dequeue() {
 
 	// Pop event from the queue. If received event is present in current
 	// processed map, the event must be stopped until already sent one is
-	// executed. This prevents situations where two paraller workers executes
+	// executed. This prevents situations where two parallel workers executes
 	// different changes on the same file.
 	pop := func() *msync.Event {
 		a.cursMu.Lock()

--- a/go/src/koding/klient/machine/mount/anteroom_test.go
+++ b/go/src/koding/klient/machine/mount/anteroom_test.go
@@ -1,9 +1,11 @@
 package mount_test
 
 import (
+	"math/rand"
 	"reflect"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -194,5 +196,71 @@ func TestAnteroomMultiEvents(t *testing.T) {
 
 	if !reflect.DeepEqual(sent, got) {
 		t.Fatalf("sent event paths are not equal to received ones")
+	}
+}
+
+func TestSequentialSync(t *testing.T) {
+	a := mount.NewAnteroom()
+
+	var wg sync.WaitGroup
+	startC := make(chan struct{})
+
+	// We need to use different changes since identical will be coalesced to no-op.
+	changeMetas := []index.ChangeMeta{
+		index.ChangeMetaAdd,
+		index.ChangeMetaRemove,
+		index.ChangeMetaUpdate,
+		index.ChangeMetaAdd | index.ChangeMetaRemote,
+		index.ChangeMetaRemove | index.ChangeMetaRemote,
+		index.ChangeMetaUpdate | index.ChangeMetaRemote,
+	}
+
+	const eventsN = 10000
+	// Feed anteroom with events some of them will be coleased.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-startC
+
+		for i := 0; i < eventsN; i++ {
+			changeMeta := changeMetas[rand.Intn(len(changeMetas))]
+			a.Commit(index.NewChange("path.txt", index.PriorityLow, changeMeta))
+			time.Sleep(100 * time.Millisecond / eventsN)
+		}
+
+		// Close anteroom which will close `Events` channel.
+		a.Close()
+	}()
+
+	var want, got int64
+
+	const workersN = 16
+	// Add workers.
+	wg.Add(workersN)
+	for i := 0; i < workersN; i++ {
+		go func() {
+			defer wg.Done()
+			<-startC
+
+			for ev := range a.Events() {
+				atomic.AddInt64(&want, 1) // How many events were processed.
+				old := atomic.LoadInt64(&got)
+
+				// Simulate event processing and then CAS with old value. If
+				// there are other workers processing the event, CAS will fail.
+				time.Sleep(100 * time.Millisecond * time.Duration(rand.Intn(workersN)+1) / eventsN)
+				atomic.CompareAndSwapInt64(&got, old, old+1)
+
+				ev.Done()
+			}
+		}()
+	}
+
+	// Start processing.
+	close(startC)
+	wg.Wait()
+
+	if want != got {
+		t.Errorf("changes not processed sequentially: (%d != %d)", want, got)
 	}
 }

--- a/go/src/koding/klient/machine/mount/anteroom_test.go
+++ b/go/src/koding/klient/machine/mount/anteroom_test.go
@@ -138,6 +138,10 @@ func TestAnteroomPopChange(t *testing.T) {
 		t.Fatalf("want invalid valid event; got valid")
 	}
 
+	// All events either valid or not valid must went trough workers. They
+	// will execute only valid ones but mark all of them as done.
+	ev.Done()
+
 	select {
 	case <-a.Events(): // pop pending event.
 	case <-time.After(time.Second):
@@ -148,8 +152,8 @@ func TestAnteroomPopChange(t *testing.T) {
 	if items != 1 {
 		t.Errorf("want 1 items; got %d", items)
 	}
-	if synced != 2 {
-		t.Errorf("want 2 synced events; got %d", synced)
+	if synced != 1 {
+		t.Errorf("want 1 synced event; got %d", synced)
 	}
 }
 

--- a/go/src/koding/klient/machine/mount/sync/event.go
+++ b/go/src/koding/klient/machine/mount/sync/event.go
@@ -43,7 +43,7 @@ type Finalizer interface {
 	Detach(path string, id uint64)
 
 	// Unsync is called by deprecated events.
-	Unsync()
+	Unsync(path string)
 }
 
 // Event wraps index change with context.Context.
@@ -109,7 +109,7 @@ func (e *Event) Done() {
 		}
 		e.cancel()
 	} else if e.fin != nil {
-		e.fin.Unsync()
+		e.fin.Unsync(e.change.Path())
 	}
 }
 


### PR DESCRIPTION
This PR solves synchronization races caused by more than one event producer. Eg:

 - FUSE produces edit change `C1` on file `F`
 - `C1` is added to anteroom and sent to worker `X`
 - Worker `X` runs rsync on `C1`
 - FUSE produces delete change `C2` on file `F`
 - `C2` is added to anteroom
 - Anteroom deprecates `C1` however, `C1` is already being processed
 - `C2` is sent to worker `Y`
 - Worker `Y` runs rsync on `C2`

With previous logic, we could not guess which change will be finished first.

## Motivation and Context
Remote changes support prerequirement.

## How Has This Been Tested?
Unit tests.
