### PR TITLE
klientctl/cp: inform user when destination path has no write permissions

### DIFF
--- a/go/src/koding/klientctl/endpoint/machine/cp.go
+++ b/go/src/koding/klientctl/endpoint/machine/cp.go
@@ -65,6 +65,7 @@ func (c *Client) Cp(options *CpOptions) (err error) {
 	fmt.Fprintf(os.Stdout, "Checking transfer size...\n")
 
 	if n, size, err := cmd.DryRun(ctx); err != nil {
+		c.log().Warning("Cannot obtain transfer size: %v", err)
 		fmt.Fprintf(os.Stdout, "Copying files: remaining time is unknown\n")
 	} else {
 		cpRes.Command.Progress = rsync.Progress(os.Stdout, n, size)


### PR DESCRIPTION
Fixes: #11203

Actually, this is not a fix since the copying is rejected because of lack of write permissions to the destination directory. 

This PR adds a proper error message when such situation occurs.

## Motivation and Context
Bug fix.

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):
```sh
$ ./klientctl cp . lime_quince:/var/lib/koding/app
Checking transfer size...
Copying files: 0.0% (0/5), 0 B/2.9 MiB | 0 B/s
error executing "cp" command: cannot upload files to /var/lib/koding/app, you may not have write permissions to this path
```
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
