### PR TITLE
klient/machine/mount: do not send pending event when the first one is not done

### DIFF
--- a/go/src/koding/klient/machine/mount/anteroom_test.go
+++ b/go/src/koding/klient/machine/mount/anteroom_test.go
@@ -135,7 +135,7 @@ func TestAnteroomPopChange(t *testing.T) {
 	a.Commit(cB)
 
 	if ev.Valid() {
-		t.Fatalf("want invalid valid event; got valid")
+		t.Fatalf("want invalid event; got valid")
 	}
 
 	// All events either valid or not valid must went trough workers. They


### PR DESCRIPTION
Fixes:
```
=== RUN   TestAnteroomPopChange
--- FAIL: TestAnteroomPopChange (1.00s)
	anteroom_test.go:148: timed out after 1s
```

https://circleci.com/gh/koding/koding/2585?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

## Motivation and Context
Bug fix

## How Has This Been Tested?
Unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

