### PR TITLE
klientctl: move sync start/stop options to separate subcommands

### DIFF
--- a/go/src/koding/klientctl/help.go
+++ b/go/src/koding/klientctl/help.go
@@ -38,13 +38,13 @@ var cmdDescriptions = map[string]string{
    <local-path> can be relative or absolute, if the folder does not exit, it will be created.`,
 	),
 	"mount-sync": fmtDesc(
-		"[<mount-id> | <path>] [<options>...]",
+		"[<mount-id> | <path> | <command>] [<options>...]",
 		`Wait or disable mount synchronization for a given mount.
 
    If neither <mount-id> nor <path> is provided, the <path> will be assumed as current
    working directory.
 
-   Pause does not stop currently running synchronization jobs.`,
+   Pause command does not stop currently running synchronization jobs.`,
 	),
 	"exec": fmtDesc(
 		"(<local-mount-path> | @<machine-id>) <command> [<args>...]",

--- a/go/src/koding/klientctl/machine.go
+++ b/go/src/koding/klientctl/machine.go
@@ -377,10 +377,27 @@ func MachineConfigShow(c *cli.Context, _ logging.Logger, _ string) (int, error) 
 	return 0, nil
 }
 
-// MachineSyncMount manages mount synchronization.
+// MachineSyncMount waits until all mount events are synced.
 func MachineSyncMount(c *cli.Context, log logging.Logger, _ string) (int, error) {
-	ident := c.Args().Get(0)
+	return machineSyncMount(c, &machine.SyncMountOptions{})
+}
 
+// MachinePauseSyncMount pauses synchronization for a given mount.
+func MachinePauseSyncMount(c *cli.Context, log logging.Logger, _ string) (int, error) {
+	return machineSyncMount(c, &machine.SyncMountOptions{
+		Pause: true,
+	})
+}
+
+// MachineResumeSyncMount resumes paused synchronization for a given mount.
+func MachineResumeSyncMount(c *cli.Context, log logging.Logger, _ string) (int, error) {
+	return machineSyncMount(c, &machine.SyncMountOptions{
+		Resume: true,
+	})
+}
+
+func machineSyncMount(c *cli.Context, opts *machine.SyncMountOptions) (int, error) {
+	ident := c.Args().Get(0)
 	if ident == "" {
 		var err error
 		if ident, err = os.Getwd(); err != nil {
@@ -388,12 +405,8 @@ func MachineSyncMount(c *cli.Context, log logging.Logger, _ string) (int, error)
 		}
 	}
 
-	opts := &machine.SyncMountOptions{
-		Identifier: ident,
-		Pause:      c.Bool("pause"),
-		Resume:     c.Bool("resume"),
-		Timeout:    c.Duration("timeout"),
-	}
+	opts.Identifier = ident
+	opts.Timeout = c.Duration("timeout")
 
 	if err := machine.SyncMount(opts); err != nil {
 		return 1, err

--- a/go/src/koding/klientctl/main.go
+++ b/go/src/koding/klientctl/main.go
@@ -754,15 +754,16 @@ error opening: %s
 						Usage: "Maximum time to wait.",
 						Value: time.Minute,
 					},
-					cli.BoolFlag{
-						Name:  "pause",
-						Usage: "Pause synchronization.",
-					},
-					cli.BoolFlag{
-						Name:  "resume",
-						Usage: "Resume synchronization.",
-					},
 				},
+				Subcommands: []cli.Command{{
+					Name:   "pause",
+					Usage:  "Pause synchronization.",
+					Action: ctlcli.ExitErrAction(MachinePauseSyncMount, log, "set"),
+				}, {
+					Name:   "resume",
+					Usage:  "Resume synchronization.",
+					Action: ctlcli.ExitErrAction(MachineResumeSyncMount, log, "show"),
+				}},
 			}, {
 				Name:   "inspect",
 				Hidden: true,


### PR DESCRIPTION
As requested, this PR changes `kd sync` interface for `--pause` and `-resume` options that are separate subcommands now.