### PR TITLE
provider: shadow expression variables

### DIFF
--- a/go/src/koding/kites/kloud/stack/provider/template_test.go
+++ b/go/src/koding/kites/kloud/stack/provider/template_test.go
@@ -224,7 +224,7 @@ func TestTerraformTemplate_ShadowVariables(t *testing.T) {
             "example": {
 				"bar": "${var.aws_access_key}",
                 "instance_type": "t2.micro",
-                "user_data": "Echo ${var.aws_secret_key}"
+                "user_data": "echo ${var.aws_secret_key} ${base64encode(var.aws_secret_key)} >> /tmp/keys.txt"
             }
         }
     }

--- a/go/src/koding/kites/kloud/stack/provider/variable.go
+++ b/go/src/koding/kites/kloud/stack/provider/variable.go
@@ -82,6 +82,8 @@ func ReadVariables(s string) []Variable {
 				match = 0
 			case r == rune(prefix[match]):
 				match++
+			default:
+				match = 0
 			}
 		}
 

--- a/go/src/koding/kites/kloud/stack/provider/variable.go
+++ b/go/src/koding/kites/kloud/stack/provider/variable.go
@@ -5,6 +5,10 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+
+	"github.com/hashicorp/hcl"
+	"github.com/hashicorp/hcl/hcl/ast"
+	"github.com/kr/pretty"
 )
 
 // Variable represents a Terraform variable
@@ -117,4 +121,19 @@ func EscapeDeadVariables(userdata string) string {
 	}
 
 	return strings.TrimRight(buf.String(), "\r\n")
+}
+
+func MapVariables(s string, fn func()) string {
+	root, err := hcl.Parse(s)
+	if err != nil {
+		fmt.Println(err)
+		return s
+	}
+
+	ast.Walk(root, func(n ast.Node) (ast.Node, bool) {
+		pretty.Println(n)
+		return n, true
+	})
+
+	return s
 }

--- a/go/src/koding/kites/kloud/stack/provider/variable.go
+++ b/go/src/koding/kites/kloud/stack/provider/variable.go
@@ -67,9 +67,13 @@ func ReadVariables(s string) []Variable {
 		for l, r := range name {
 			switch {
 			case match >= len(prefix):
-				if isVarChar(r) && l != len(name)-1 {
+				if isVarChar(r) {
 					match++
-					break
+					if l != len(name)-1 {
+						break
+					} else {
+						l++
+					}
 				}
 
 				vars = append(vars, Variable{

--- a/go/src/koding/kites/kloud/stack/provider/variable_test.go
+++ b/go/src/koding/kites/kloud/stack/provider/variable_test.go
@@ -1,27 +1,11 @@
 package provider_test
 
 import (
-	"koding/kites/kloud/stack/provider"
 	"reflect"
-
 	"testing"
+
+	"koding/kites/kloud/stack/provider"
 )
-
-func TestMapVariables(t *testing.T) {
-	cases := map[string]struct {
-		s string
-	}{
-		"single variable": {
-			`resource "abc" "cde" { test = "${base64encode(var.foo)}" }`,
-		},
-	}
-
-	for name, cas := range cases {
-		t.Run(name, func(t *testing.T) {
-			provider.MapVariables(cas.s, func() {})
-		})
-	}
-}
 
 func TestVariables(t *testing.T) {
 	const blank = "***"
@@ -82,6 +66,69 @@ func TestVariables(t *testing.T) {
 				To:   44,
 			}},
 			"bar******foo***foo",
+		},
+		"single expression variable": {
+			"${base64encode(var.foo)}",
+			[]provider.Variable{{
+				Name:       "foo",
+				From:       15,
+				To:         22,
+				Expression: true,
+			}},
+			"${base64encode(***)}",
+		},
+		"multiple expression variables": {
+			"${func(var.foo123, var.bar-bar, var.baz_baz)}",
+			[]provider.Variable{{
+				Name:       "foo123",
+				From:       7,
+				To:         17,
+				Expression: true,
+			}, {
+				Name:       "bar-bar",
+				From:       19,
+				To:         30,
+				Expression: true,
+			}, {
+				Name:       "baz_baz",
+				From:       32,
+				To:         43,
+				Expression: true,
+			}},
+			"${func(***, ***, ***)}",
+		},
+		"variables mix": {
+			"abc ${func(var.foo, var.bar)} ${ var.baz}${var.qux} ${g(var.a, var.b)} def",
+			[]provider.Variable{{
+				Name:       "foo",
+				From:       11,
+				To:         18,
+				Expression: true,
+			}, {
+				Name:       "bar",
+				From:       20,
+				To:         27,
+				Expression: true,
+			}, {
+				Name: "baz",
+				From: 30,
+				To:   41,
+			}, {
+				Name: "qux",
+				From: 41,
+				To:   51,
+			}, {
+				Name:       "a",
+				From:       56,
+				To:         61,
+				Expression: true,
+			}, {
+				Name:       "b",
+				From:       63,
+				To:         68,
+				Expression: true,
+			}},
+			"abc ${func(***, ***)} ****** ${g(***, ***)} def",
 		},
 	}
 

--- a/go/src/koding/kites/kloud/stack/provider/variable_test.go
+++ b/go/src/koding/kites/kloud/stack/provider/variable_test.go
@@ -7,6 +7,22 @@ import (
 	"testing"
 )
 
+func TestMapVariables(t *testing.T) {
+	cases := map[string]struct {
+		s string
+	}{
+		"single variable": {
+			`resource "abc" "cde" { test = "${base64encode(var.foo)}" }`,
+		},
+	}
+
+	for name, cas := range cases {
+		t.Run(name, func(t *testing.T) {
+			provider.MapVariables(cas.s, func() {})
+		})
+	}
+}
+
 func TestVariables(t *testing.T) {
 	const blank = "***"
 

--- a/go/src/koding/kites/kloud/stack/provider/variable_test.go
+++ b/go/src/koding/kites/kloud/stack/provider/variable_test.go
@@ -145,6 +145,21 @@ func TestVariables(t *testing.T) {
 			}},
 			`${func(***, "var", ".cde", ***)}`,
 		},
+		"ternary operator expression": {
+			`${terraform.env == "devel" ? var.foo : var.bar}`,
+			[]provider.Variable{{
+				Name:       "foo",
+				From:       29,
+				To:         36,
+				Expression: true,
+			}, {
+				Name:       "bar",
+				From:       39,
+				To:         46,
+				Expression: true,
+			}},
+			`${terraform.env == "devel" ? *** : ***}`,
+		},
 	}
 
 	for name, cas := range cases {

--- a/go/src/koding/kites/kloud/stack/provider/variable_test.go
+++ b/go/src/koding/kites/kloud/stack/provider/variable_test.go
@@ -130,6 +130,21 @@ func TestVariables(t *testing.T) {
 			}},
 			"abc ${func(***, ***)} ****** ${g(***, ***)} def",
 		},
+		"reset after partial match": {
+			`${func(var.foo, "var", ".cde", var.bar)}`,
+			[]provider.Variable{{
+				Name:       "foo",
+				From:       7,
+				To:         14,
+				Expression: true,
+			}, {
+				Name:       "bar",
+				From:       31,
+				To:         38,
+				Expression: true,
+			}},
+			`${func(***, "var", ".cde", ***)}`,
+		},
 	}
 
 	for name, cas := range cases {


### PR DESCRIPTION
This PR makes kloud shadow correctly expression variables (like `${base64encode(var.aws_secret_key)}`, which is complementary to shadowing regular variables (`${var.aws_secret_key}`).