### PR TITLE
klientctl: enable metrics for all kd commands

### DIFF
--- a/go/src/koding/klientctl/commands/auth/cmd.go
+++ b/go/src/koding/klientctl/commands/auth/cmd.go
@@ -18,7 +18,9 @@ func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 	cmd.AddCommand(
 		NewLoginCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
 		NewShowCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewRegisterCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
+
+		// Register command is disabled due to: #11027
+		// NewRegisterCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
 	)
 
 	// Middlewares.

--- a/go/src/koding/klientctl/commands/auth/cmd.go
+++ b/go/src/koding/klientctl/commands/auth/cmd.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NewCommand creates a command that manages authentication process.
-func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewCommand(c *cli.CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
 		Short: "User authorization",
@@ -16,11 +16,11 @@ func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Subcommands.
 	cmd.AddCommand(
-		NewLoginCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewShowCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
+		NewLoginCommand(c),
+		NewShowCommand(c),
 
 		// Register command is disabled due to: #11027
-		// NewRegisterCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
+		// NewRegisterCommand(c),
 	)
 
 	// Middlewares.

--- a/go/src/koding/klientctl/commands/auth/login.go
+++ b/go/src/koding/klientctl/commands/auth/login.go
@@ -21,7 +21,7 @@ type loginOptions struct {
 }
 
 // NewLoginCommand creates a command that allows to log into Koding account.
-func NewLoginCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewLoginCommand(c *cli.CLI) *cobra.Command {
 	opts := &loginOptions{}
 
 	cmd := &cobra.Command{
@@ -40,8 +40,7 @@ func NewLoginCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.NoArgs, // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/auth/register.go
+++ b/go/src/koding/klientctl/commands/auth/register.go
@@ -31,7 +31,7 @@ type registerOptions struct {
 
 // NewRegisterCommand creates a command that displays remote machines which belong
 // to the user or that can be accessed by their.
-func NewRegisterCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewRegisterCommand(c *cli.CLI) *cobra.Command {
 	opts := &registerOptions{}
 
 	cmd := &cobra.Command{
@@ -54,8 +54,7 @@ func NewRegisterCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.NoArgs, // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/auth/show.go
+++ b/go/src/koding/klientctl/commands/auth/show.go
@@ -15,7 +15,7 @@ type showOptions struct {
 }
 
 // NewShowCommand creates a command that displays current session details.
-func NewShowCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewShowCommand(c *cli.CLI) *cobra.Command {
 	opts := &showOptions{}
 
 	cmd := &cobra.Command{
@@ -30,8 +30,7 @@ func NewShowCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.NoArgs, // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/bug/cmd.go
+++ b/go/src/koding/klientctl/commands/bug/cmd.go
@@ -10,7 +10,7 @@ import (
 type options struct{}
 
 // NewCommand creates a command that allows to report a bug.
-func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewCommand(c *cli.CLI) *cobra.Command {
 	opts := &options{}
 
 	cmd := &cobra.Command{
@@ -21,9 +21,8 @@ func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.NoArgs,         // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/cli/cli.go
+++ b/go/src/koding/klientctl/commands/cli/cli.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"sort"
-	"strings"
 
 	"koding/kites/metrics"
 	"koding/klientctl/config"
@@ -127,13 +126,11 @@ func (c *CLI) Middlewares() map[string][]string {
 	return all
 }
 
-func (c *CLI) registerMiddleware(name string, cmd *cobra.Command, aliasPath ...string) {
+func (c *CLI) registerMiddleware(name string, cmd *cobra.Command) {
 	f := func() (desc string) {
-		cmdAliasPath := ExtendAlias(cmd, aliasPath)
-
 		desc = cmd.CommandPath()
-		if len(cmdAliasPath) != 0 {
-			desc += " (alias: " + strings.Join(cmdAliasPath, " ") + ")"
+		if aliasPath := cmd.Annotations[AliasAnnotation]; len(aliasPath) != 0 {
+			desc += " (alias: " + aliasPath + ")"
 		}
 
 		return desc

--- a/go/src/koding/klientctl/commands/cli/cmd.go
+++ b/go/src/koding/klientctl/commands/cli/cmd.go
@@ -9,7 +9,7 @@ type options struct{}
 // NewCommand creates a command that displays debug information specific to
 // command line interface. It allows to examine requirements of all application
 // commands.
-func NewCommand(c *CLI, _ ...string) *cobra.Command {
+func NewCommand(c *CLI) *cobra.Command {
 	opts := &options{}
 
 	cmd := &cobra.Command{

--- a/go/src/koding/klientctl/commands/cli/metrics.go
+++ b/go/src/koding/klientctl/commands/cli/metrics.go
@@ -17,62 +17,60 @@ import (
 
 // WithMetrics allows to gather metrics for a given command. Command path can
 // be replaced with provided aliasPath.
-func WithMetrics(aliasPath ...string) CobraCmdMiddleware {
-	return func(cli *CLI, rootCmd *cobra.Command) {
-		cli.registerMiddleware("with_metrics", rootCmd, aliasPath...)
-		tail := rootCmd.RunE
-		if tail == nil {
-			panic("cannot insert middleware into empty function")
+func WithMetrics(cli *CLI, rootCmd *cobra.Command) {
+	cli.registerMiddleware("with_metrics", rootCmd)
+	tail := rootCmd.RunE
+	if tail == nil {
+		panic("cannot insert middleware into empty function")
+	}
+
+	// If metrics are disabled, do not add any middleware.
+	if cli.Metrics() == nil || cli.Metrics().Datadog == nil {
+		return
+	}
+
+	// Use aliased command path when provided.
+	cmdPath := strings.Split(rootCmd.CommandPath(), " ")
+	if aliasPath := rootCmd.Annotations[AliasAnnotation]; len(aliasPath) != 0 {
+		cmdPath = strings.Split(aliasPath, " ")
+	}
+
+	// Register command to metrics dashboard.
+	metrics.RegisterCLICommand(cli.Metrics(), cmdPath...)
+
+	rootCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		// rootCmd and invoked one should be the same. These values may
+		// differ for persistent command handlers.
+		if ccp, rcp := cmd.CommandPath(), rootCmd.CommandPath(); ccp != rcp {
+			panic(fmt.Sprintf("metric command mismatch: '%s' != '%s'", ccp, rcp))
 		}
 
-		// If metrics are disabled, do not add any middleware.
-		if cli.Metrics() == nil || cli.Metrics().Datadog == nil {
-			return
-		}
+		// Measure command execution time.
+		start := time.Now()
+		err := tail(cmd, args)
+		passed := time.Since(start)
 
-		// Use aliased command path when provided.
-		cmdPath := ExtendAlias(rootCmd, aliasPath)
-		if len(cmdPath) == 0 {
-			cmdPath = strings.Split(rootCmd.CommandPath(), " ")
-		}
+		// Generate command tags.
+		tags := append(CommandPathTags(cmdPath...), ApplicationInfoTags()...)
+		tags = metrics.AppendTag(tags, "success", err == nil)
+		tags = metrics.AppendTag(tags, "request_type", "cli")
 
-		// Register command to metrics dashboard.
-		metrics.RegisterCLICommand(cli.Metrics(), cmdPath...)
-
-		rootCmd.RunE = func(cmd *cobra.Command, args []string) error {
-			// rootCmd and invoked one should be the same. These values may
-			// differ for persistent command handlers.
-			if ccp, rcp := cmd.CommandPath(), rootCmd.CommandPath(); ccp != rcp {
-				panic(fmt.Sprintf("metric command mismatch: '%s' != '%s'", ccp, rcp))
+		// Shorten command error if it is too long.
+		const maxErrMsgLength = 20
+		if err != nil {
+			msg := err.Error()
+			if len(msg) > maxErrMsgLength {
+				msg = msg[:maxErrMsgLength]
 			}
-
-			// Measure command execution time.
-			start := time.Now()
-			err := tail(cmd, args)
-			passed := time.Since(start)
-
-			// Generate command tags.
-			tags := append(CommandPathTags(cmdPath...), ApplicationInfoTags()...)
-			tags = metrics.AppendTag(tags, "success", err == nil)
-			tags = metrics.AppendTag(tags, "request_type", "cli")
-
-			// Shorten command error if it is too long.
-			const maxErrMsgLength = 20
-			if err != nil {
-				msg := err.Error()
-				if len(msg) > maxErrMsgLength {
-					msg = msg[:maxErrMsgLength]
-				}
-				tags = metrics.AppendTag(tags, "err_message", msg)
-			}
-
-			// Send metrics to DataDog client.
-			var metricName = strings.Join(cmdPath, "_")
-			cli.Metrics().Datadog.Count(metricName+"_call_count", 1, tags, 1)
-			cli.Metrics().Datadog.Timing(metricName+"_timing", passed, tags, 1)
-
-			return err
+			tags = metrics.AppendTag(tags, "err_message", msg)
 		}
+
+		// Send metrics to DataDog client.
+		var metricName = strings.Join(cmdPath, "_")
+		cli.Metrics().Datadog.Count(metricName+"_call_count", 1, tags, 1)
+		cli.Metrics().Datadog.Timing(metricName+"_timing", passed, tags, 1)
+
+		return err
 	}
 }
 

--- a/go/src/koding/klientctl/commands/config/cmd.go
+++ b/go/src/koding/klientctl/commands/config/cmd.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NewCommand creates a command that manages KD configuration.
-func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewCommand(c *cli.CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Manage tool configuration",
@@ -16,12 +16,12 @@ func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Subcommands.
 	cmd.AddCommand(
-		NewListCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewResetCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewSetCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewShowCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewUnsetCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewUseCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
+		NewListCommand(c),
+		NewResetCommand(c),
+		NewSetCommand(c),
+		NewShowCommand(c),
+		NewUnsetCommand(c),
+		NewUseCommand(c),
 	)
 
 	// Middlewares.

--- a/go/src/koding/klientctl/commands/config/list.go
+++ b/go/src/koding/klientctl/commands/config/list.go
@@ -16,7 +16,7 @@ type listOptions struct {
 }
 
 // NewListCommand creates a command that shows all available configurations.
-func NewListCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewListCommand(c *cli.CLI) *cobra.Command {
 	opts := &listOptions{}
 
 	cmd := &cobra.Command{
@@ -32,8 +32,7 @@ func NewListCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.NoArgs, // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/config/reset.go
+++ b/go/src/koding/klientctl/commands/config/reset.go
@@ -16,7 +16,7 @@ type resetOptions struct {
 
 // NewResetCommand creates a command that resets configuration to the default
 // value fetched from Koding.
-func NewResetCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewResetCommand(c *cli.CLI) *cobra.Command {
 	opts := &resetOptions{}
 
 	cmd := &cobra.Command{
@@ -33,8 +33,7 @@ Koding service.`,
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.NoArgs, // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/config/set.go
+++ b/go/src/koding/klientctl/commands/config/set.go
@@ -12,7 +12,7 @@ import (
 type setOptions struct{}
 
 // NewSetCommand creates a command that allows to set configuration key value.
-func NewSetCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewSetCommand(c *cli.CLI) *cobra.Command {
 	opts := &setOptions{}
 
 	cmd := &cobra.Command{
@@ -23,8 +23,7 @@ func NewSetCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.ExactArgs(2),              // Two arguments are accepted.
+		cli.ExactArgs(2), // Two arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/config/show.go
+++ b/go/src/koding/klientctl/commands/config/show.go
@@ -19,7 +19,7 @@ type showOptions struct {
 }
 
 // NewShowCommand creates a command that displays configurations.
-func NewShowCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewShowCommand(c *cli.CLI) *cobra.Command {
 	opts := &showOptions{}
 
 	cmd := &cobra.Command{
@@ -35,8 +35,7 @@ func NewShowCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.NoArgs, // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/config/unset.go
+++ b/go/src/koding/klientctl/commands/config/unset.go
@@ -13,7 +13,7 @@ type unsetOptions struct{}
 
 // NewUnsetCommand creates a command that unsets configuration key, restoring
 // it to the default value.
-func NewUnsetCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewUnsetCommand(c *cli.CLI) *cobra.Command {
 	opts := &unsetOptions{}
 
 	cmd := &cobra.Command{
@@ -24,8 +24,7 @@ func NewUnsetCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.ExactArgs(1),              // One argument is accepted.
+		cli.ExactArgs(1), // One argument is accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/config/use.go
+++ b/go/src/koding/klientctl/commands/config/use.go
@@ -12,7 +12,7 @@ import (
 type useOptions struct{}
 
 // NewUseCommand creates a command that can change currently active configuration.
-func NewUseCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewUseCommand(c *cli.CLI) *cobra.Command {
 	opts := &useOptions{}
 
 	cmd := &cobra.Command{
@@ -23,8 +23,7 @@ func NewUseCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.ExactArgs(1),              // One argument is accepted.
+		cli.ExactArgs(1), // One argument is accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/cred/cmd.go
+++ b/go/src/koding/klientctl/commands/cred/cmd.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NewCommand creates a command that manages stack credentials.
-func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewCommand(c *cli.CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "credential",
 		Aliases: []string{"c"},
@@ -17,11 +17,11 @@ func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Subcommands.
 	cmd.AddCommand(
-		NewCreateCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewDescribeCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewInitCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewListCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewUseCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
+		NewCreateCommand(c),
+		NewDescribeCommand(c),
+		NewInitCommand(c),
+		NewListCommand(c),
+		NewUseCommand(c),
 	)
 
 	// Middlewares.

--- a/go/src/koding/klientctl/commands/cred/create.go
+++ b/go/src/koding/klientctl/commands/cred/create.go
@@ -26,7 +26,7 @@ type createOptions struct {
 
 // NewCreateCommand creates a command that can be used to create new stack
 // credential.
-func NewCreateCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewCreateCommand(c *cli.CLI) *cobra.Command {
 	opts := &createOptions{}
 
 	cmd := &cobra.Command{
@@ -45,9 +45,8 @@ func NewCreateCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.NoArgs,         // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/cred/describe.go
+++ b/go/src/koding/klientctl/commands/cred/describe.go
@@ -17,7 +17,7 @@ type describeOptions struct {
 }
 
 // NewDescribeCommand creates a command that describes credential documents.
-func NewDescribeCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewDescribeCommand(c *cli.CLI) *cobra.Command {
 	opts := &describeOptions{}
 
 	cmd := &cobra.Command{
@@ -33,9 +33,8 @@ func NewDescribeCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.NoArgs,         // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/cred/init.go
+++ b/go/src/koding/klientctl/commands/cred/init.go
@@ -18,7 +18,7 @@ type initOptions struct {
 }
 
 // NewInitCommand creates a command that creates a credential file.
-func NewInitCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewInitCommand(c *cli.CLI) *cobra.Command {
 	opts := &initOptions{}
 
 	cmd := &cobra.Command{
@@ -35,9 +35,8 @@ func NewInitCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.NoArgs,         // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/cred/list.go
+++ b/go/src/koding/klientctl/commands/cred/list.go
@@ -18,7 +18,7 @@ type listOptions struct {
 }
 
 // NewListCommand creates a command that displays imported stack credentials.
-func NewListCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewListCommand(c *cli.CLI) *cobra.Command {
 	opts := &listOptions{}
 
 	cmd := &cobra.Command{
@@ -36,9 +36,8 @@ func NewListCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.NoArgs,         // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/cred/use.go
+++ b/go/src/koding/klientctl/commands/cred/use.go
@@ -12,7 +12,7 @@ type useOptions struct{}
 
 // NewUseCommand creates a command that can change default credential per
 // provider.
-func NewUseCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewUseCommand(c *cli.CLI) *cobra.Command {
 	opts := &useOptions{}
 
 	cmd := &cobra.Command{
@@ -23,9 +23,8 @@ func NewUseCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.ExactArgs(1),              // One argument is accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.ExactArgs(1),   // One argument is accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/daemon/cmd.go
+++ b/go/src/koding/klientctl/commands/daemon/cmd.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NewCommand creates a command that manages deamon service.
-func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewCommand(c *cli.CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "daemon",
 		Short: "Manage deamon service",
@@ -16,12 +16,12 @@ func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Subcommands.
 	cmd.AddCommand(
-		NewInstallCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewRestartCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewStartCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewStopCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewUninstallCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewUpdateCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
+		NewInstallCommand(c),
+		NewRestartCommand(c),
+		NewStartCommand(c),
+		NewStopCommand(c),
+		NewUninstallCommand(c),
+		NewUpdateCommand(c),
 	)
 
 	// Middlewares.

--- a/go/src/koding/klientctl/commands/daemon/install.go
+++ b/go/src/koding/klientctl/commands/daemon/install.go
@@ -19,7 +19,7 @@ type installOptions struct {
 
 // NewInstallCommand creates a command that is used to install the deamon and
 // other KD dependencies.
-func NewInstallCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewInstallCommand(c *cli.CLI) *cobra.Command {
 	opts := &installOptions{}
 
 	cmd := &cobra.Command{
@@ -39,9 +39,8 @@ func NewInstallCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.AdminRequired,             // Root privileges are required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.AdminRequired, // Root privileges are required.
+		cli.NoArgs,        // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/daemon/restart.go
+++ b/go/src/koding/klientctl/commands/daemon/restart.go
@@ -10,7 +10,7 @@ import (
 type restartOptions struct{}
 
 // NewRestartCommand creates a command that is used to restart deamon service.
-func NewRestartCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewRestartCommand(c *cli.CLI) *cobra.Command {
 	opts := &restartOptions{}
 
 	cmd := &cobra.Command{
@@ -21,10 +21,9 @@ func NewRestartCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.AdminRequired,             // Root privileges are required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.AdminRequired,  // Root privileges are required.
+		cli.NoArgs,         // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/daemon/start.go
+++ b/go/src/koding/klientctl/commands/daemon/start.go
@@ -10,7 +10,7 @@ import (
 type startOptions struct{}
 
 // NewStartCommand creates a command that is used to start service deamon.
-func NewStartCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewStartCommand(c *cli.CLI) *cobra.Command {
 	opts := &startOptions{}
 
 	cmd := &cobra.Command{
@@ -21,10 +21,9 @@ func NewStartCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.AdminRequired,             // Root privileges are required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.AdminRequired,  // Root privileges are required.
+		cli.NoArgs,         // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/daemon/stop.go
+++ b/go/src/koding/klientctl/commands/daemon/stop.go
@@ -10,7 +10,7 @@ import (
 type stopOptions struct{}
 
 // NewStopCommand creates a command that is used to stop deamon service.
-func NewStopCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewStopCommand(c *cli.CLI) *cobra.Command {
 	opts := &stopOptions{}
 
 	cmd := &cobra.Command{
@@ -21,10 +21,9 @@ func NewStopCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.AdminRequired,             // Root privileges are required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.AdminRequired,  // Root privileges are required.
+		cli.NoArgs,         // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/daemon/uninstall.go
+++ b/go/src/koding/klientctl/commands/daemon/uninstall.go
@@ -13,7 +13,7 @@ type uninstallOptions struct {
 
 // NewUninstallCommand creates a command that is used to remove the deamon and
 // all other dependencies.
-func NewUninstallCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewUninstallCommand(c *cli.CLI) *cobra.Command {
 	opts := &uninstallOptions{}
 
 	cmd := &cobra.Command{
@@ -28,9 +28,8 @@ func NewUninstallCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.AdminRequired,             // Root privileges are required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.AdminRequired, // Root privileges are required.s
+		cli.NoArgs,        // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/daemon/update.go
+++ b/go/src/koding/klientctl/commands/daemon/update.go
@@ -14,7 +14,7 @@ type updateOptions struct {
 
 // NewUpdateCommand creates a command that can be used to update the service to
 // the latest version.
-func NewUpdateCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewUpdateCommand(c *cli.CLI) *cobra.Command {
 	opts := &updateOptions{}
 
 	cmd := &cobra.Command{
@@ -31,10 +31,9 @@ func NewUpdateCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.AdminRequired,             // Root privileges are required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.AdminRequired,  // Root privileges are required.
+		cli.NoArgs,         // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/initial/cmd.go
+++ b/go/src/koding/klientctl/commands/initial/cmd.go
@@ -28,7 +28,7 @@ import (
 type options struct{}
 
 // NewCommand creates a command that initializes new KD project.
-func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewCommand(c *cli.CLI) *cobra.Command {
 	opts := &options{}
 
 	cmd := &cobra.Command{
@@ -39,9 +39,8 @@ func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.NoArgs,         // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/kd.go
+++ b/go/src/koding/klientctl/commands/kd.go
@@ -40,26 +40,26 @@ func NewKdCommand(c *cli.CLI) *cobra.Command {
 		config.NewCommand(c),
 		cred.NewCommand(c),
 		daemon.NewCommand(c),
-		daemon.NewInstallCommand(c, "kd", "daemon"),
-		daemon.NewRestartCommand(c, "kd", "daemon"),
-		daemon.NewStartCommand(c, "kd", "daemon"),
-		daemon.NewStopCommand(c, "kd", "daemon"),
-		daemon.NewUninstallCommand(c, "kd", "daemon"),
-		daemon.NewUpdateCommand(c, "kd", "daemon"),
+		cli.Alias(daemon.NewInstallCommand(c), "kd daemon"),
+		cli.Alias(daemon.NewRestartCommand(c), "kd daemon"),
+		cli.Alias(daemon.NewStartCommand(c), "kd daemon"),
+		cli.Alias(daemon.NewStopCommand(c), "kd daemon"),
+		cli.Alias(daemon.NewUninstallCommand(c), "kd daemon"),
+		cli.Alias(daemon.NewUpdateCommand(c), "kd daemon"),
 		initial.NewCommand(c),
 		log.NewCommand(c),
 		machine.NewCommand(c),
-		machine.NewCpCommand(c, "kd", "machine"),
-		machine.NewExecCommand(c, "kd", "machine"),
-		machine.NewListCommand(c, "kd", "machine"),
-		machine.NewSSHCommand(c, "kd", "machine"),
-		machine.NewUmountCommand(c, "kd", "machine"),
+		cli.Alias(machine.NewCpCommand(c), "kd machine"),
+		cli.Alias(machine.NewExecCommand(c), "kd machine"),
+		cli.Alias(machine.NewListCommand(c), "kd machine"),
+		cli.Alias(machine.NewSSHCommand(c), "kd machine"),
+		cli.Alias(machine.NewUmountCommand(c), "kd machine"),
 		metrics.NewCommand(c),
-		mount.NewCommand(c, "kd", "machine"),
+		cli.Alias(mount.NewCommand(c), "kd machine"),
 		open.NewCommand(c),
 		stack.NewCommand(c),
 		status.NewCommand(c),
-		sync.NewCommand(c, "kd", "machine", "mount"),
+		cli.Alias(sync.NewCommand(c), "kd machine mount"),
 		team.NewCommand(c),
 		template.NewCommand(c),
 		version.NewCommand(c),
@@ -67,6 +67,7 @@ func NewKdCommand(c *cli.CLI) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
+		cli.ApplyForAll(cli.WithMetrics),          // Collect metrics for all commands.
 		cli.ApplyForAll(cli.CloseOnExitCtlCli),    // Run ctlcli.Close for all commands.
 		cli.ApplyForAll(cli.WithLoggedInfo),       // Log invocation and errors for all commands.
 		cli.ApplyForAll(cli.WithInitializedCache), // Use cache for all commands.

--- a/go/src/koding/klientctl/commands/log/cmd.go
+++ b/go/src/koding/klientctl/commands/log/cmd.go
@@ -20,7 +20,7 @@ type options struct {
 }
 
 // NewCommand creates a command that displays logs.
-func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewCommand(c *cli.CLI) *cobra.Command {
 	opts := &options{}
 
 	cmd := &cobra.Command{
@@ -31,7 +31,7 @@ func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Subcommands.
 	cmd.AddCommand(
-		NewUploadCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
+		NewUploadCommand(c),
 	)
 
 	// Flags.

--- a/go/src/koding/klientctl/commands/log/upload.go
+++ b/go/src/koding/klientctl/commands/log/upload.go
@@ -14,7 +14,7 @@ import (
 type uploadOptions struct{}
 
 // NewUploadCommand creates a command that uploads log files to Koding.
-func NewUploadCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewUploadCommand(c *cli.CLI) *cobra.Command {
 	opts := &uploadOptions{}
 
 	cmd := &cobra.Command{
@@ -25,8 +25,7 @@ func NewUploadCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.ExactArgs(1),              // One argument is accepted.
+		cli.ExactArgs(1), // One argument is accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/machine/cmd.go
+++ b/go/src/koding/klientctl/commands/machine/cmd.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NewCommand creates a command that manages remote machines.
-func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewCommand(c *cli.CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "machine",
 		Short: "Manage remote machines",
@@ -18,15 +18,15 @@ func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Subcommands.
 	cmd.AddCommand(
-		config.NewCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewCpCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewExecCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewListCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		mount.NewCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewSSHCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewStartCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewStopCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewUmountCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
+		config.NewCommand(c),
+		NewCpCommand(c),
+		NewExecCommand(c),
+		NewListCommand(c),
+		mount.NewCommand(c),
+		NewSSHCommand(c),
+		NewStartCommand(c),
+		NewStopCommand(c),
+		NewUmountCommand(c),
 	)
 
 	// Middlewares.

--- a/go/src/koding/klientctl/commands/machine/config/cmd.go
+++ b/go/src/koding/klientctl/commands/machine/config/cmd.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NewCommand creates a command that manages remote machine configuration.
-func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewCommand(c *cli.CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Manage remote machine configuration",
@@ -16,8 +16,8 @@ func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Subcommands.
 	cmd.AddCommand(
-		NewSetCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewShowCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
+		NewSetCommand(c),
+		NewShowCommand(c),
 	)
 
 	// Middlewares.

--- a/go/src/koding/klientctl/commands/machine/config/set.go
+++ b/go/src/koding/klientctl/commands/machine/config/set.go
@@ -10,7 +10,7 @@ import (
 type setOptions struct{}
 
 // NewSetCommand creates a command that allows to set configuration field.
-func NewSetCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewSetCommand(c *cli.CLI) *cobra.Command {
 	opts := &setOptions{}
 
 	cmd := &cobra.Command{
@@ -21,9 +21,8 @@ func NewSetCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.ExactArgs(3),              // Three arguments are accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.ExactArgs(3),   // Three arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/machine/config/show.go
+++ b/go/src/koding/klientctl/commands/machine/config/show.go
@@ -16,7 +16,7 @@ type showOptions struct {
 }
 
 // NewShowCommand creates a command that displays remote machine configuration.
-func NewShowCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewShowCommand(c *cli.CLI) *cobra.Command {
 	opts := &showOptions{}
 
 	cmd := &cobra.Command{
@@ -31,9 +31,8 @@ func NewShowCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.NoArgs,         // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/machine/cp.go
+++ b/go/src/koding/klientctl/commands/machine/cp.go
@@ -14,7 +14,7 @@ import (
 type cpOptions struct{}
 
 // NewCpCommand creates a command that allows to copy files between machines.
-func NewCpCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewCpCommand(c *cli.CLI) *cobra.Command {
 	opts := &cpOptions{}
 
 	cmd := &cobra.Command{
@@ -26,9 +26,8 @@ func NewCpCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.ExactArgs(2),              // Two arguments are required.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.ExactArgs(2),   // Two arguments are required.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/machine/exec.go
+++ b/go/src/koding/klientctl/commands/machine/exec.go
@@ -18,7 +18,7 @@ type execOptions struct{}
 
 // NewExecCommand creates a command that can run arbitrary command on remote
 // machine.
-func NewExecCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewExecCommand(c *cli.CLI) *cobra.Command {
 	opts := &execOptions{}
 
 	cmd := &cobra.Command{
@@ -31,9 +31,8 @@ func NewExecCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.MinArgs(2),                // At least two arguments are required.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.MinArgs(2),     // At least two arguments are required.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/machine/list.go
+++ b/go/src/koding/klientctl/commands/machine/list.go
@@ -19,7 +19,7 @@ type listOptions struct {
 
 // NewListCommand creates a command that displays remote machines which belong
 // to the user or that can be accessed by their.
-func NewListCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewListCommand(c *cli.CLI) *cobra.Command {
 	opts := &listOptions{}
 
 	cmd := &cobra.Command{
@@ -36,9 +36,8 @@ func NewListCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.NoArgs,         // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/machine/mount/cmd.go
+++ b/go/src/koding/klientctl/commands/machine/mount/cmd.go
@@ -16,7 +16,7 @@ type options struct{}
 
 // NewCommand creates a command that allows to create mounts and manage their
 // properties.
-func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewCommand(c *cli.CLI) *cobra.Command {
 	opts := &options{}
 
 	cmd := &cobra.Command{
@@ -28,16 +28,15 @@ func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Subcommands.
 	cmd.AddCommand(
-		NewInspectCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewListCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		msync.NewCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
+		NewInspectCommand(c),
+		NewListCommand(c),
+		msync.NewCommand(c),
 	)
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.RangeArgs(1, 2),           // One or two arguments are required.
+		cli.DaemonRequired,  // Deamon service is required.
+		cli.RangeArgs(1, 2), // One or two arguments are required.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/machine/mount/inspect.go
+++ b/go/src/koding/klientctl/commands/machine/mount/inspect.go
@@ -14,7 +14,7 @@ type inspectOptions struct {
 }
 
 // NewInspectCommand creates a command that allows to debug existing mount state.
-func NewInspectCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewInspectCommand(c *cli.CLI) *cobra.Command {
 	opts := &inspectOptions{}
 
 	cmd := &cobra.Command{
@@ -32,9 +32,8 @@ func NewInspectCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.ExactArgs(1),              // One argument is required.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.ExactArgs(1),   // One argument is required.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/machine/mount/list.go
+++ b/go/src/koding/klientctl/commands/machine/mount/list.go
@@ -20,7 +20,7 @@ type listOptions struct {
 }
 
 // NewListCommand creates a command that displays available mounts.
-func NewListCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewListCommand(c *cli.CLI) *cobra.Command {
 	opts := &listOptions{}
 
 	cmd := &cobra.Command{
@@ -37,9 +37,8 @@ func NewListCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.NoArgs,         // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/machine/mount/sync/cmd.go
+++ b/go/src/koding/klientctl/commands/machine/mount/sync/cmd.go
@@ -17,7 +17,7 @@ type options struct {
 }
 
 // NewCommand creates a command that manages mount file synchronization.
-func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewCommand(c *cli.CLI) *cobra.Command {
 	opts := &options{}
 
 	cmd := &cobra.Command{
@@ -28,8 +28,8 @@ func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Subcommands.
 	cmd.AddCommand(
-		NewPauseCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewResumeCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
+		NewPauseCommand(c),
+		NewResumeCommand(c),
 	)
 
 	// Flags.
@@ -38,9 +38,8 @@ func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.MaxArgs(1),                // At most one argument is accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.MaxArgs(1),     // At most one argument is accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/machine/mount/sync/pause.go
+++ b/go/src/koding/klientctl/commands/machine/mount/sync/pause.go
@@ -9,7 +9,7 @@ import (
 type pauseOptions struct{}
 
 // NewPauseCommand creates a command that allows to pause mount synchronization.
-func NewPauseCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewPauseCommand(c *cli.CLI) *cobra.Command {
 	opts := &pauseOptions{}
 
 	cmd := &cobra.Command{
@@ -20,9 +20,8 @@ func NewPauseCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.MaxArgs(1),                // At most one argument is accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.MaxArgs(1),     // At most one argument is accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/machine/mount/sync/resume.go
+++ b/go/src/koding/klientctl/commands/machine/mount/sync/resume.go
@@ -10,7 +10,7 @@ type resumeOptions struct{}
 
 // NewResumeCommand creates a command can resume file synchronization of
 // previously paused mount.
-func NewResumeCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewResumeCommand(c *cli.CLI) *cobra.Command {
 	opts := &resumeOptions{}
 
 	cmd := &cobra.Command{
@@ -21,9 +21,8 @@ func NewResumeCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.MaxArgs(1),                // At most one argument is accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.MaxArgs(1),     // At most one argument is accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/machine/ssh.go
+++ b/go/src/koding/klientctl/commands/machine/ssh.go
@@ -12,7 +12,7 @@ type sshOptions struct {
 }
 
 // NewSSHCommand creates a command that allows to SSH into remote machine.
-func NewSSHCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewSSHCommand(c *cli.CLI) *cobra.Command {
 	opts := &sshOptions{}
 
 	cmd := &cobra.Command{
@@ -28,9 +28,8 @@ func NewSSHCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.ExactArgs(1),              // One argument must be provided.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.ExactArgs(1),   // One argument must be provided.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/machine/start.go
+++ b/go/src/koding/klientctl/commands/machine/start.go
@@ -14,7 +14,7 @@ type startOptions struct {
 }
 
 // NewStartCommand creates a command that can start a remote machine.
-func NewStartCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewStartCommand(c *cli.CLI) *cobra.Command {
 	opts := &startOptions{}
 
 	cmd := &cobra.Command{
@@ -29,9 +29,8 @@ func NewStartCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.ExactArgs(1),              // One argument is required.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.ExactArgs(1),   // One argument is required.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/machine/stop.go
+++ b/go/src/koding/klientctl/commands/machine/stop.go
@@ -14,7 +14,7 @@ type stopOptions struct {
 }
 
 // NewStopCommand creates a command that can stop a remote machine.
-func NewStopCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewStopCommand(c *cli.CLI) *cobra.Command {
 	opts := &stopOptions{}
 
 	cmd := &cobra.Command{
@@ -29,9 +29,8 @@ func NewStopCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.ExactArgs(1),              // One argument is required.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.ExactArgs(1),   // One argument is required.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/machine/umount.go
+++ b/go/src/koding/klientctl/commands/machine/umount.go
@@ -15,7 +15,7 @@ type umountOptions struct {
 }
 
 // NewUmountCommand creates a command that unmounts mounted directory.
-func NewUmountCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewUmountCommand(c *cli.CLI) *cobra.Command {
 	opts := &umountOptions{}
 
 	cmd := &cobra.Command{
@@ -32,8 +32,7 @@ func NewUmountCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
+		cli.DaemonRequired, // Deamon service is required.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/metrics/add.go
+++ b/go/src/koding/klientctl/commands/metrics/add.go
@@ -14,7 +14,7 @@ type addOptions struct {
 }
 
 // NewAddCommand creates a command that allows to add new metric.
-func NewAddCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewAddCommand(c *cli.CLI) *cobra.Command {
 	opts := &addOptions{}
 
 	cmd := &cobra.Command{

--- a/go/src/koding/klientctl/commands/metrics/cmd.go
+++ b/go/src/koding/klientctl/commands/metrics/cmd.go
@@ -8,7 +8,7 @@ import (
 
 // NewCommand creates a command that allows to manually publish events from
 // external sources.
-func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewCommand(c *cli.CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "metrics",
 		Short:  "Publish events from external sources",
@@ -18,7 +18,7 @@ func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Subcommands.
 	cmd.AddCommand(
-		NewAddCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
+		NewAddCommand(c),
 	)
 
 	// Middlewares.

--- a/go/src/koding/klientctl/commands/open/cmd.go
+++ b/go/src/koding/klientctl/commands/open/cmd.go
@@ -16,7 +16,7 @@ type options struct {
 }
 
 // NewCommand creates a command that is used to open provided files in Koding UI.
-func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewCommand(c *cli.CLI) *cobra.Command {
 	opts := &options{}
 
 	cmd := &cobra.Command{
@@ -31,9 +31,8 @@ func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.MinArgs(1),                // At least 1 argument must be provided.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.MinArgs(1),     // At least 1 argument must be provided.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/stack/cmd.go
+++ b/go/src/koding/klientctl/commands/stack/cmd.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NewCommand creates a command that manages machine stacks.
-func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewCommand(c *cli.CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "stack",
 		Short: "Manage stacks",
@@ -16,8 +16,8 @@ func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Subcommands.
 	cmd.AddCommand(
-		NewCreateCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewListCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
+		NewCreateCommand(c),
+		NewListCommand(c),
 	)
 
 	// Middlewares.

--- a/go/src/koding/klientctl/commands/stack/create.go
+++ b/go/src/koding/klientctl/commands/stack/create.go
@@ -20,7 +20,7 @@ type createOptions struct {
 }
 
 // NewCreateCommand creates a command that can create stacks.
-func NewCreateCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewCreateCommand(c *cli.CLI) *cobra.Command {
 	opts := &createOptions{}
 
 	cmd := &cobra.Command{
@@ -39,9 +39,8 @@ func NewCreateCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.NoArgs,         // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/stack/list.go
+++ b/go/src/koding/klientctl/commands/stack/list.go
@@ -17,7 +17,7 @@ type listOptions struct {
 }
 
 // NewListCommand creates a command that can list stacks.
-func NewListCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewListCommand(c *cli.CLI) *cobra.Command {
 	opts := &listOptions{}
 
 	cmd := &cobra.Command{
@@ -34,9 +34,8 @@ func NewListCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.DaemonRequired, // Deamon service is required.s
+		cli.NoArgs,         // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/status/cmd.go
+++ b/go/src/koding/klientctl/commands/status/cmd.go
@@ -12,7 +12,7 @@ import (
 type options struct{}
 
 // NewCommand creates a command that can be used to check KD status.
-func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewCommand(c *cli.CLI) *cobra.Command {
 	opts := &options{}
 
 	cmd := &cobra.Command{

--- a/go/src/koding/klientctl/commands/team/cmd.go
+++ b/go/src/koding/klientctl/commands/team/cmd.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NewCommand creates a command that can list teams and set team context.
-func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewCommand(c *cli.CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "team",
 		Short: "List available teams and set their context",
@@ -16,10 +16,10 @@ func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Subcommands.
 	cmd.AddCommand(
-		NewListCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewShowCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewUseCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewWhoAmICommand(c, cli.ExtendAlias(cmd, aliasPath)...),
+		NewListCommand(c),
+		NewShowCommand(c),
+		NewUseCommand(c),
+		NewWhoAmICommand(c),
 	)
 
 	// Middlewares.

--- a/go/src/koding/klientctl/commands/team/list.go
+++ b/go/src/koding/klientctl/commands/team/list.go
@@ -17,7 +17,7 @@ type listOptions struct {
 }
 
 // NewListCommand creates a command that lists user's teams.
-func NewListCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewListCommand(c *cli.CLI) *cobra.Command {
 	opts := &listOptions{}
 
 	cmd := &cobra.Command{
@@ -34,9 +34,8 @@ func NewListCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.NoArgs,         // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/team/show.go
+++ b/go/src/koding/klientctl/commands/team/show.go
@@ -14,7 +14,7 @@ type showOptions struct {
 }
 
 // NewShowCommand creates a command that displays currently used team.
-func NewShowCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewShowCommand(c *cli.CLI) *cobra.Command {
 	opts := &showOptions{}
 
 	cmd := &cobra.Command{
@@ -29,9 +29,8 @@ func NewShowCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.NoArgs,         // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/team/use.go
+++ b/go/src/koding/klientctl/commands/team/use.go
@@ -12,7 +12,7 @@ import (
 type useOptions struct{}
 
 // NewUseCommand creates a command that can switch team context.
-func NewUseCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewUseCommand(c *cli.CLI) *cobra.Command {
 	opts := &useOptions{}
 
 	cmd := &cobra.Command{
@@ -23,9 +23,8 @@ func NewUseCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.ExactArgs(1),              // One argument is accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.ExactArgs(1),   // One argument is accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/team/whoami.go
+++ b/go/src/koding/klientctl/commands/team/whoami.go
@@ -17,7 +17,7 @@ type whoAmIOptions struct {
 }
 
 // NewWhoAmICommand creates a command that displays authentication details.
-func NewWhoAmICommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewWhoAmICommand(c *cli.CLI) *cobra.Command {
 	opts := &whoAmIOptions{}
 
 	cmd := &cobra.Command{
@@ -32,9 +32,8 @@ func NewWhoAmICommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.NoArgs,         // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/template/cmd.go
+++ b/go/src/koding/klientctl/commands/template/cmd.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NewCommand creates a command that manages stack templates.
-func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewCommand(c *cli.CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "template",
 		Short: "Manage stack templates",
@@ -16,10 +16,10 @@ func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Subcommands.
 	cmd.AddCommand(
-		NewDeleteCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewInitCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewListCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
-		NewShowCommand(c, cli.ExtendAlias(cmd, aliasPath)...),
+		NewDeleteCommand(c),
+		NewInitCommand(c),
+		NewListCommand(c),
+		NewShowCommand(c),
 	)
 
 	// Middlewares.

--- a/go/src/koding/klientctl/commands/template/delete.go
+++ b/go/src/koding/klientctl/commands/template/delete.go
@@ -17,7 +17,7 @@ type deleteOptions struct {
 }
 
 // NewDeleteCommand creates a command that is used to delete stack templates.
-func NewDeleteCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewDeleteCommand(c *cli.CLI) *cobra.Command {
 	opts := &deleteOptions{}
 
 	cmd := &cobra.Command{
@@ -34,9 +34,8 @@ func NewDeleteCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.NoArgs,         // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/template/init.go
+++ b/go/src/koding/klientctl/commands/template/init.go
@@ -27,7 +27,7 @@ type initOptions struct {
 }
 
 // NewInitCommand creates a command that generates a new stack template.
-func NewInitCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewInitCommand(c *cli.CLI) *cobra.Command {
 	opts := &initOptions{}
 
 	cmd := &cobra.Command{
@@ -44,9 +44,8 @@ func NewInitCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.NoArgs,         // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/template/list.go
+++ b/go/src/koding/klientctl/commands/template/list.go
@@ -19,7 +19,7 @@ type listOptions struct {
 }
 
 // NewListCommand creates a command that displays stack templates.
-func NewListCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewListCommand(c *cli.CLI) *cobra.Command {
 	opts := &listOptions{}
 
 	cmd := &cobra.Command{
@@ -37,9 +37,8 @@ func NewListCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.NoArgs,                    // No custom arguments are accepted.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.NoArgs,         // No custom arguments are accepted.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/template/show.go
+++ b/go/src/koding/klientctl/commands/template/show.go
@@ -21,7 +21,7 @@ type showOptions struct {
 }
 
 // NewShowCommand creates a command that shows details of a given stack template.
-func NewShowCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewShowCommand(c *cli.CLI) *cobra.Command {
 	opts := &showOptions{}
 
 	cmd := &cobra.Command{
@@ -38,9 +38,8 @@ func NewShowCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
 
 	// Middlewares.
 	cli.MultiCobraCmdMiddleware(
-		cli.DaemonRequired,            // Deamon service is required.
-		cli.WithMetrics(aliasPath...), // Gather statistics for this command.
-		cli.MaxArgs(1),                // No more than 1 arg.
+		cli.DaemonRequired, // Deamon service is required.
+		cli.MaxArgs(1),     // No more than 1 arg.
 	)(c, cmd)
 
 	return cmd

--- a/go/src/koding/klientctl/commands/version/cmd.go
+++ b/go/src/koding/klientctl/commands/version/cmd.go
@@ -14,7 +14,7 @@ type options struct {
 }
 
 // NewCommand creates a command that displays current version of this application.
-func NewCommand(c *cli.CLI, aliasPath ...string) *cobra.Command {
+func NewCommand(c *cli.CLI) *cobra.Command {
 	opts := &options{}
 
 	cmd := &cobra.Command{


### PR DESCRIPTION
This PR adds metrics for all kd commands. It also simplifies command aliasing logic.

Bonus point: it disables `auth register` subcommand.

## Motivation and Context
Measure everything

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):
#### Before:

<details>

```json
[
    "kd auth login",
    "kd auth register",
    "kd auth show",
    "kd bug",
    "kd config list",
    "kd config reset",
    "kd config set",
    "kd config show",
    "kd config unset",
    "kd config use",
    "kd cp (alias: kd machine cp)",
    "kd credential create",
    "kd credential describe",
    "kd credential init",
    "kd credential list",
    "kd credential use",
    "kd daemon install",
    "kd daemon restart",
    "kd daemon start",
    "kd daemon stop",
    "kd daemon uninstall",
    "kd daemon update",
    "kd exec (alias: kd machine exec)",
    "kd init",
    "kd install (alias: kd daemon install)",
    "kd list (alias: kd machine list)",
    "kd log upload",
    "kd machine config set",
    "kd machine config show",
    "kd machine cp",
    "kd machine exec",
    "kd machine list",
    "kd machine mount",
    "kd machine mount inspect",
    "kd machine mount list",
    "kd machine mount sync",
    "kd machine mount sync pause",
    "kd machine mount sync resume",
    "kd machine ssh",
    "kd machine start",
    "kd machine stop",
    "kd machine umount",
    "kd mount (alias: kd machine mount)",
    "kd mount inspect (alias: kd machine mount inspect)",
    "kd mount list (alias: kd machine mount list)",
    "kd mount sync (alias: kd machine mount sync)",
    "kd mount sync pause (alias: kd machine mount sync pause)",
    "kd mount sync resume (alias: kd machine mount sync resume)",
    "kd open",
    "kd restart (alias: kd daemon restart)",
    "kd ssh (alias: kd machine ssh)",
    "kd stack create",
    "kd stack list",
    "kd start (alias: kd daemon start)",
    "kd stop (alias: kd daemon stop)",
    "kd sync (alias: kd machine mount sync)",
    "kd sync pause (alias: kd machine mount sync pause)",
    "kd sync resume (alias: kd machine mount sync resume)",
    "kd team list",
    "kd team show",
    "kd team use",
    "kd team whoami",
    "kd template delete",
    "kd template init",
    "kd template list",
    "kd template show",
    "kd umount (alias: kd machine umount)",
    "kd uninstall (alias: kd daemon uninstall)",
    "kd update (alias: kd daemon update)"
]
```

</details>


#### After:

<details>

```json
[
    "kd",
    "kd auth",
    "kd auth login",
    "kd auth show",
    "kd bug",
    "kd cli",
    "kd config",
    "kd config list",
    "kd config reset",
    "kd config set",
    "kd config show",
    "kd config unset",
    "kd config use",
    "kd cp (alias: kd machine cp)",
    "kd credential",
    "kd credential create",
    "kd credential describe",
    "kd credential init",
    "kd credential list",
    "kd credential use",
    "kd daemon",
    "kd daemon install",
    "kd daemon restart",
    "kd daemon start",
    "kd daemon stop",
    "kd daemon uninstall",
    "kd daemon update",
    "kd exec (alias: kd machine exec)",
    "kd init",
    "kd install (alias: kd daemon install)",
    "kd list (alias: kd machine list)",
    "kd log",
    "kd log upload",
    "kd machine",
    "kd machine config",
    "kd machine config set",
    "kd machine config show",
    "kd machine cp",
    "kd machine exec",
    "kd machine list",
    "kd machine mount",
    "kd machine mount inspect",
    "kd machine mount list",
    "kd machine mount sync",
    "kd machine mount sync pause",
    "kd machine mount sync resume",
    "kd machine ssh",
    "kd machine start",
    "kd machine stop",
    "kd machine umount",
    "kd metrics",
    "kd metrics add",
    "kd mount (alias: kd machine mount)",
    "kd mount inspect (alias: kd machine mount inspect)",
    "kd mount list (alias: kd machine mount list)",
    "kd mount sync (alias: kd machine mount sync)",
    "kd mount sync pause (alias: kd machine mount sync pause)",
    "kd mount sync resume (alias: kd machine mount sync resume)",
    "kd open",
    "kd restart (alias: kd daemon restart)",
    "kd ssh (alias: kd machine ssh)",
    "kd stack",
    "kd stack create",
    "kd stack list",
    "kd start (alias: kd daemon start)",
    "kd status",
    "kd stop (alias: kd daemon stop)",
    "kd sync (alias: kd machine mount sync)",
    "kd sync pause (alias: kd machine mount sync pause)",
    "kd sync resume (alias: kd machine mount sync resume)",
    "kd team",
    "kd team list",
    "kd team show",
    "kd team use",
    "kd team whoami",
    "kd template",
    "kd template delete",
    "kd template init",
    "kd template list",
    "kd template show",
    "kd umount (alias: kd machine umount)",
    "kd uninstall (alias: kd daemon uninstall)",
    "kd update (alias: kd daemon update)",
    "kd version"
]
```

</details>

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

