### PR TITLE
Support for npm 5.x and node 8.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ elektron/node_modules
 
 .env.sh
 .env.json
+package-lock.json
 website/apidocs/lang
 
 credential

--- a/.npm-postinstall.sh
+++ b/.npm-postinstall.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+set -o errexit
+
+scripts/reset-node-modules.sh
 touch $(dirname $0)/node_modules/.npm-install.timestamp

--- a/.npm-preinstall.sh
+++ b/.npm-preinstall.sh
@@ -2,4 +2,4 @@
 
 set -o errexit
 
-scripts/reset-node-modules.sh
+scripts/de-reset-node-modules.sh

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "amqp": "0.2.6",
     "analytics-node": "2.1.0",
-    "appmetrics": "1.2.0",
+    "appmetrics": "3.0.2",
     "async": "1.5.0",
     "aws-sdk": "2.7.21",
     "backoff": "2.5.0",

--- a/scripts/check-node-version.sh
+++ b/scripts/check-node-version.sh
@@ -4,12 +4,12 @@ VERSION=$(node --version | sed -e 's/^v//')
 
 while IFS=".", read MAJOR MINOR REVISION; do
 	MISMATCH=1
-	if [[ $MAJOR -eq 6 ]]; then
+	if [[ $MAJOR -ge 6 ]]; then
 		MISMATCH=
 	fi
 done < <(echo $VERSION)
 
 if [[ -n "$MISMATCH" ]]; then
-	echo "error: node version must be 6"
+	echo "error: node version must be > 6"
 	exit 1
 fi

--- a/scripts/de-reset-node-modules.sh
+++ b/scripts/de-reset-node-modules.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+DIR=$(
+	cd $(dirname "${BASH_SOURCE[0]}")
+	pwd
+)
+NODE_MODULES=$DIR/./../node_modules
+MATCHES=$(ls "$NODE_MODULES"_koding)
+
+if [ -d $NODE_MODULES ]; then
+  for i in $MATCHES; do
+  	rm -r $NODE_MODULES/$i 2>/dev/null
+  done
+fi


### PR DESCRIPTION
Fixes npm5 issue with symlinked node modules, with current `node_modules_koding` and existing post/pre install scripts in package.json, `npm5` was deleting some of the packages after install. To be able to fix that I've reverted symlinks before installing packages then created them back after install.

Right now with following changes I can run koding with following;

```
(npm5) $ node -v
v8.2.1
(npm5) $ npm -v
5.3.0
```

ps. For now I've ignored the `package-lock.json` since there are still issues with it.