### PR TITLE
generate-bongo-schema: unsuccessful termination of schema generation

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -20,7 +20,7 @@ development: node_modules bongo_schema watch-dev
 dist: node_modules bongo_schema landing build-prod
 
 bongo_schema:
-	$(RUN) exec $(SCRIPTS)/generate-bongo-schema --file $(MKFILE_DIR).schema.json
+	$(RUN) exec $(SCRIPTS)/generate-bongo-schema --file $(MKFILE_DIR).schema.json || exit 1;
 
 node_modules:
 	$(SCRIPTS)/check-node_modules.sh $(CLIENT) || npm install


### PR DESCRIPTION
Changed the termination status of generate-bongo-schema script. With this fix, the script won't let a makefile, who utilizes this script, to proceed its execution if the given file for schema is invalid.