### PR TITLE
Define user proxy and tunnel URIs in the configuration

### DIFF
--- a/config/generateRuntimeConfig.coffee
+++ b/config/generateRuntimeConfig.coffee
@@ -14,6 +14,9 @@ module.exports = (KONFIG, credentials, options) ->
     socialApiUri         : '/xhr'
     apiUri               : '/'
     mainUri              : '/'
+    userProxyHost        : options.userProxyHost
+    userProxyUri         : options.userProxyUri
+    userTunnelUri        : options.userTunnelUri
     fileFetchTimeout     : 1000 * 15
     userIdleMs           : 1000 * 60 * 5
     kites                : require './kites.coffee'           # browser passes this version information to kontrol , so it connects to correct version of the kite.

--- a/config/main.default.coffee
+++ b/config/main.default.coffee
@@ -42,7 +42,9 @@ Configuration = (options = {}) ->
   options.credentialPath or= "$KONFIG_PROJECTROOT/config/credentials.#{options.environment}.coffee"
   options.clientUploadS3BucketName or= 'kodingdev-client'
   options.publicLogsS3BucketName or= 'kodingdev-publiclogs'
-  options.proxySubdomain or= 'dev-p'
+  options.userProxyHost or= options.hostname
+  options.userProxyUri or= "#{options.userProxyHost}/-/devproxy"
+  options.userTunnelUri or= "#{options.userProxyHost}/-/devtunnel"
 
   _port = if options.publicPort is '80' then '' else ":#{options.publicPort}"
   options.host or= "#{options.hostname}#{_port}"

--- a/config/main.dev.coffee
+++ b/config/main.dev.coffee
@@ -44,6 +44,9 @@ Configuration = (options = {}) ->
   options.clientUploadS3BucketName = 'kodingdev-client'
   options.publicLogsS3BucketName or= 'kodingdev-publiclogs'
   options.proxySubdomain or= 'dev-p'
+  options.userProxyHost or= "#{options.proxySubdomain}.koding.com"
+  options.userProxyUri or= "#{options.userProxyHost}/-/devproxy"
+  options.userTunnelUri or= "#{options.userProxyHost}/-/devtunnel"
   options.watchNode = yes
 
   try fs.lstatSync options.credentialPath

--- a/config/main.sandbox.coffee
+++ b/config/main.sandbox.coffee
@@ -42,6 +42,9 @@ Configuration = (options = {}) ->
   options.clientUploadS3BucketName = 'kodingdev-client'
   options.publicLogsS3BucketName or= 'kodingdev-publiclogs'
   options.proxySubdomain or= 'dev-p'
+  options.userProxyHost or= "#{options.proxySubdomain}.koding.com"
+  options.userProxyUri or= "#{options.userProxyHost}/-/devproxy"
+  options.userTunnelUri or= "#{options.userProxyHost}/-/devtunnel"
 
 
   try fs.lstatSync options.credentialPath


### PR DESCRIPTION
Signed-off-by: Sonmez Kartal <sonmez@koding.com>

## Description

Simplify setting of user proxy/tunnel URI.

## Motivation and Context

Proxifier module is computing the user proxy/tunnel URIs based on environment runtime.
I've simplified this process by setting the user proxy/tunnel URIs in the configuration of each environment. Proxifier module does not need to have conditional statement branches to figure out what endpoint to use.

## How Has This Been Tested?

- Built an AWS stack on sandbox environment
- Built a Vagrant stack on sandbox environment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
