### PR TITLE
Fallback to a generic error view when the card is declined

### DIFF
--- a/client/landing/site.landing/coffee/core/stripeerrors.coffee
+++ b/client/landing/site.landing/coffee/core/stripeerrors.coffee
@@ -1,0 +1,127 @@
+module.exports = StripeDeclineErrors =
+  approve_with_id:
+    message: 'The payment cannot be authorized.'
+    nextStep: "Please try again in a while. If the payment still can't be processed, you need to contact your bank."
+  call_issuer:
+    message: 'The card has been declined for an unknown reason.'
+    nextStep: 'You need to contact your bank for more information.'
+  card_not_supported:
+    message: 'The card does not support this type of purchase.'
+    nextStep: 'You need to contact your bank to make sure your card can be used to make this type of purchase.'
+  card_velocity_exceeded:
+    message: 'You has exceeded the balance or credit limit available on your card.'
+    nextStep: 'You should contact your bank for more information.'
+  currency_not_supported:
+    message: 'The card does not support the specified currency.'
+    nextStep: 'You need check with the issuer that the card can be used for the type of currency specified.'
+  do_not_honor:
+    message: 'The card has been declined for an unknown reason.'
+    nextStep: 'You need to contact your bank for more information.'
+  do_not_try_again:
+    message: 'The card has been declined for an unknown reason.'
+    nextStep: 'You should contact your bank for more information.'
+  duplicate_transaction:
+    message: 'A transaction with identical amount and credit card information was submitted very recently.'
+    nextStep: 'You should contact your bank for more information.'
+  expired_card:
+    message: 'The card has expired.'
+    nextStep: 'You should use another card.'
+  fraudulent:
+    message: 'The card has been declined for an unknown reason.'
+    nextStep: 'You need to contact your bank for more information.'
+  generic_decline:
+    message: 'The card has been declined for an unknown reason.'
+    nextStep: 'You need to contact your bank for more information.'
+  incorrect_number:
+    message: 'The card number is incorrect.'
+    nextStep: 'You should try again using the correct card number.'
+  incorrect_cvc:
+    message: 'The CVC number is incorrect.'
+    nextStep: 'You should try again using the correct CVC.'
+  incorrect_pin:
+    message: 'The PIN entered is incorrect.'
+    nextStep: 'You should try again using the correct PIN.'
+  incorrect_zip:
+    message: 'The ZIP/postal code is incorrect.'
+    nextStep: 'You should try again using the correct billing ZIP/postal code.'
+  insufficient_funds:
+    message: 'The card has insufficient funds to complete the purchase.'
+    nextStep: 'You should use an alternative payment method.'
+  invalid_account:
+    message: 'The card, or account the card is connected to, is invalid.'
+    nextStep: 'You need to contact your bank to check that the card is working correctly.'
+  invalid_amount:
+    message: 'The payment amount is invalid, or exceeds the amount that is allowed.'
+    nextStep: 'If the amount appears to be correct, you need to check with your bank that they can make purchases of that amount.'
+  invalid_cvc:
+    message: 'The CVC number is incorrect.'
+    nextStep: 'You should try again using the correct CVC.'
+  invalid_expiry_year:
+    message: 'The expiration year invalid.'
+    nextStep: 'You should try again using the correct expiration date.'
+  invalid_number:
+    message: 'The card number is incorrect.'
+    nextStep: 'You should try again using the correct card number.'
+  invalid_pin:
+    message: 'The PIN entered is incorrect. This decline code only applies to payments made with a card reader.'
+    nextStep: 'You should try again using the correct PIN.'
+  issuer_not_available:
+    message: 'The card issuer could not be reached, so the payment could not be authorized.'
+    nextStep: "Please try again in a while. If the payment still can't be processed, you need to contact your bank."
+  lost_card:
+    message: 'The card has been declined for an unknown reason.'
+    nextStep: 'You should contact your bank for more information.'
+  new_account_information_available:
+    message: 'The card, or account the card is connected to, is invalid.'
+    nextStep: 'You need to contact your bank for more information.'
+  no_action_taken:
+    message: 'The card has been declined for an unknown reason.'
+    nextStep: 'You should contact your bank for more information.'
+  not_permitted:
+    message: 'The payment is not permitted.'
+    nextStep: 'You need to contact your bank for more information.'
+  pickup_card:
+    message: 'The card has been declined for an unknown reason.'
+    nextStep: 'You need to contact your bank for more information.'
+  pin_try_exceeded:
+    message: 'The allowable number of PIN tries has been exceeded.'
+    nextStep: 'You must use another card or method of payment.'
+  processing_error:
+    message: 'An error occurred while processing the card.'
+    nextStep: 'The payment should be attempted again. If it still cannot be processed, try again later.'
+  reenter_transaction:
+    message: 'The payment could not be processed by the issuer for an unknown reason.'
+    nextStep: 'The payment should be attempted again. If it still cannot be processed, the customer needs to contact your bank.'
+  restricted_card:
+    message: 'The card has been declined for an unknown reason.'
+    nextStep: 'You need to contact your bank for more information.'
+  revocation_of_all_authorizations:
+    message: 'The card has been declined for an unknown reason.'
+    nextStep: 'You should contact your bank for more information.'
+  revocation_of_authorization:
+    message: 'The card has been declined for an unknown reason.'
+    nextStep: 'You should contact your bank for more information.'
+  security_violation:
+    message: 'The card has been declined for an unknown reason.'
+    nextStep: 'You need to contact your bank for more information.'
+  service_not_allowed:
+    message: 'The card has been declined for an unknown reason.'
+    nextStep: 'You should contact your bank for more information.'
+  stolen_card:
+    message: 'The card has been declined for an unknown reason.'
+    nextStep: 'You need to contact your bank for more information.'
+  stop_payment_order:
+    message: 'The card has been declined for an unknown reason.'
+    nextStep: 'You should contact your bank for more information.'
+  testmode_decline:
+    message: 'A Stripe test card number was used.'
+    nextStep: 'A genuine card must be used to make a payment.'
+  transaction_not_allowed:
+    message: 'The card has been declined for an unknown reason.'
+    nextStep: 'You need to contact your bank for more information.'
+  try_again_later:
+    message: 'The card has been declined for an unknown reason.'
+    nextStep: 'Please try again in a while.'
+  withdrawal_count_limit_exceeded:
+    message: 'You have exceeded the balance or credit limit available on your card.'
+    nextStep: 'You should use an alternative payment method.'

--- a/client/landing/site.landing/coffee/core/utils.coffee
+++ b/client/landing/site.landing/coffee/core/utils.coffee
@@ -522,7 +522,7 @@ module.exports = utils = {
       data: JSON.stringify { source: { token }, email }
       success: resolve
       error: (err) ->
-        reject JSON.parse err.responseText
+        reject JSON.parse err.responseJSON?.description
 
     $.ajax options
 

--- a/client/landing/site.landing/coffee/core/utils.coffee
+++ b/client/landing/site.landing/coffee/core/utils.coffee
@@ -522,7 +522,10 @@ module.exports = utils = {
       data: JSON.stringify { source: { token }, email }
       success: resolve
       error: (err) ->
-        reject JSON.parse err.responseJSON?.description
+        try
+          reject JSON.parse err.responseJSON?.description
+        catch err
+          reject err
 
     $.ajax options
 

--- a/client/landing/site.landing/coffee/team/forms/stripepaymenttabform.coffee
+++ b/client/landing/site.landing/coffee/team/forms/stripepaymenttabform.coffee
@@ -45,6 +45,7 @@ module.exports = class StripePaymentTabForm extends LoginViewInlineForm
 
     @backLink = @getButtonLink 'BACK', '/Team/Domain'
     @resetFormLink = @getResetFormLink()
+    @errorView = @getErrorView()
 
     @on [ 'FormSubmitFailed', 'FormValidationFailed' ], @button.bound 'hideLoader'
 
@@ -59,6 +60,21 @@ module.exports = class StripePaymentTabForm extends LoginViewInlineForm
 
     @forEachInputView (input) -> input.hide()
     @resetFormLink.show()
+
+
+  showFatalError: ({ message, nextStep }) ->
+
+    @showReset()
+    @errorView.show()
+
+    @errorView.destroySubViews()
+    @errorView.addSubView new kd.CustomHTMLView
+      tagName: 'h4'
+      partial: message
+
+    @errorView.addSubView new kd.CustomHTMLView
+      tagName: 'h5'
+      partial: nextStep
 
 
   forEachInputView: (callback) ->
@@ -188,9 +204,16 @@ module.exports = class StripePaymentTabForm extends LoginViewInlineForm
       click    : callback
 
 
+  getErrorView: ->
+
+    new kd.CustomHTMLView
+      cssClass: 'hidden cc-form-errorView'
+
+
   pistachio: ->
 
     """
+    {{> @errorView }}
     <div class='cc-form-resetLink'>
       {{> @resetFormLink}}
     </div>

--- a/client/landing/site.landing/coffee/team/forms/stripepaymenttabform.coffee
+++ b/client/landing/site.landing/coffee/team/forms/stripepaymenttabform.coffee
@@ -52,8 +52,13 @@ module.exports = class StripePaymentTabForm extends LoginViewInlineForm
 
       return  unless token = utils.getPayment().token
 
-      @resetFormLink.show()
-      @forEachInputView (input) -> input.hide()
+      @showReset()
+
+
+  showReset: ->
+
+    @forEachInputView (input) -> input.hide()
+    @resetFormLink.show()
 
 
   forEachInputView: (callback) ->

--- a/client/landing/site.landing/coffee/team/forms/stripepaymenttabform.coffee
+++ b/client/landing/site.landing/coffee/team/forms/stripepaymenttabform.coffee
@@ -189,7 +189,7 @@ module.exports = class StripePaymentTabForm extends LoginViewInlineForm
     new kd.CustomHTMLView
       tagName  : 'a'
       cssClass : 'hidden'
-      partial  : 'Use different card'
+      partial  : 'Use a different card'
       click    : ->
         Cookies.remove 'clientId'
         location.reload()

--- a/client/landing/site.landing/coffee/team/forms/stripepaymenttabform.coffee
+++ b/client/landing/site.landing/coffee/team/forms/stripepaymenttabform.coffee
@@ -156,10 +156,11 @@ module.exports = class StripePaymentTabForm extends LoginViewInlineForm
       .then (token) =>
         @button.hideLoader()
         @options.onSubmitSuccess token
+        grecaptcha?.reset()
       .catch (err) =>
         @button.hideLoader()
         @options.onSubmitError err
-
+        grecaptcha?.reset()
 
 
   getResetFormLink: ->

--- a/client/landing/site.landing/coffee/team/tabs/stripepaymenttab.coffee
+++ b/client/landing/site.landing/coffee/team/tabs/stripepaymenttab.coffee
@@ -4,10 +4,9 @@ kd = require 'kd'
 MainHeaderView = require '../../core/mainheaderview'
 StripePaymentTabForm = require '../forms/stripepaymenttabform'
 utils = require '../../core/utils'
+StripeDeclineErrors = require '../../core/stripeerrors'
 
 module.exports = class StripePaymentTab extends kd.TabPaneView
-
-
 
   constructor: (options = {}, data) ->
 
@@ -35,6 +34,8 @@ module.exports = class StripePaymentTab extends kd.TabPaneView
       @form.cvc.decorateValidation error.message
     else if /expiry/.test error?.code
       @form.expiration.decorateValidation error.message
+    else if error?.decline_code and StripeDeclineErrors[error.decline_code]
+      @form.showFatalError StripeDeclineErrors[error.decline_code]
     else
       @form.number.decorateValidation error.message
 
@@ -51,7 +52,7 @@ module.exports = class StripePaymentTab extends kd.TabPaneView
     {{> @header }}
     <div class="TeamsModal TeamsModal--groupCreation">
       <h4>Billing Information</h4>
-      <h5>We <strong>never charge you</strong> without asking first.</h5>
+      <h5 class="bordered">We <strong>never charge you</strong> without asking first.</h5>
       {{> @form}}
     </div>
     '''

--- a/client/landing/site.landing/styl/team.payment.styl
+++ b/client/landing/site.landing/styl/team.payment.styl
@@ -38,6 +38,22 @@ form.cc-form
     input.kdinput.text
       padding-left          38px
 
+.cc-form-errorView
+  margin                    -40px -40px 40px
+  color                     #989898
+  background-color          rgba(242, 119, 138, 0.05)
+  border-bottom             1px solid rgba(0,0,0,0.05)
+  padding                   15px 40px
+  line-height               1.4em
+  contentBox()
+
+  > h4
+    color                   rgba(242, 119, 138, 1)
+    font-weight             bold
+
+  > h5
+    font-size               12px
+
 .cc-form-resetLink a
   display                   block
   padding                   20px 0 40px

--- a/client/landing/site.landing/styl/team.payment.styl
+++ b/client/landing/site.landing/styl/team.payment.styl
@@ -40,7 +40,7 @@ form.cc-form
 
 .cc-form-resetLink a
   display                   block
-  padding                   0 0 20px
+  padding                   20px 0 40px
   font-size                 18px
 
 $disabledOpacity = .5

--- a/client/landing/site.landing/styl/team.styl
+++ b/client/landing/site.landing/styl/team.styl
@@ -172,6 +172,10 @@ body.teams #kdmaincontainer #main-tab-view
 
     &.full
       width                 100%
+    &.bordered
+      padding-bottom        10px
+      border-bottom         1px solid rgba(0, 0, 0, .05)
+      margin                0 -40px
     b
       color                 #3e4f55
       font-weight           600


### PR DESCRIPTION
fixes the problem of https://twitter.com/cdinu/status/901548830621040641

@sinan I hunted down the response he got in stripe, and recorded this video especially with the same error object which is:

```js
{
    "message": "Your card was declined.",
    "type": "card_error",
    "code": "card_declined",
    "decline_code": "do_not_honor"
}
```

![landing-billing-generic-errors](https://user-images.githubusercontent.com/1783869/30066761-88a882ce-9261-11e7-88e6-f2dff936ea8d.gif)

Also generic error messages are parsed from https://stripe.com/docs/declines/codes and replaced the sensitive error messages with generic ones.