### PR TITLE
Fix for inheritance of environment variables starting with KONFIG

### DIFF
--- a/config/inheritEnvVars.coffee
+++ b/config/inheritEnvVars.coffee
@@ -5,7 +5,7 @@ module.exports = (KONFIG) ->
   traverse.forEach KONFIG, (node) ->
     return  if typeof node is 'object'
 
-    if val = process.env["KONFIG_#{@path.join '_'}"]
+    if val = process.env["KONFIG_#{@path.join '_'}".toUpperCase()]
       try val = JSON.parse val
 
     return val or node


### PR DESCRIPTION
Path conversion fix for inheriting environment variables from ./configure input or from the host environment.