### PR TITLE
Fix environment inheritance of KONFIG in worker objects

### DIFF
--- a/config/main.default.coffee
+++ b/config/main.default.coffee
@@ -82,6 +82,7 @@ Configuration = (options = {}) ->
   ]
 
   KONFIG = require('./generateKonfig')(options, credentials)
+  (require './inheritEnvVars') KONFIG  if options.inheritEnvVars
   KONFIG.workers = require('./workers')(KONFIG, options, credentials)
   KONFIG.client.runtimeOptions = require('./generateRuntimeConfig')(KONFIG, credentials, options)
 
@@ -106,8 +107,6 @@ Configuration = (options = {}) ->
 
   KONFIG.supervisord.unix_http_server =
     file : "#{KONFIG.supervisord.rundir}/supervisor.sock"
-
-  (require './inheritEnvVars') KONFIG  if options.inheritEnvVars
 
   envFiles =
     sh: (require './generateShellEnv').create KONFIG, options

--- a/config/main.dev.coffee
+++ b/config/main.dev.coffee
@@ -83,6 +83,7 @@ Configuration = (options = {}) ->
     gitlab     : no
 
   KONFIG = require('./generateKonfig')(options, credentials)
+  (require './inheritEnvVars') KONFIG  if options.inheritEnvVars
   KONFIG.workers = require('./workers')(KONFIG, options, credentials)
   KONFIG.client.runtimeOptions = require('./generateRuntimeConfig')(KONFIG, credentials, options)
 
@@ -98,8 +99,6 @@ Configuration = (options = {}) ->
 
   KONFIG.supervisord.unix_http_server =
     file : "#{KONFIG.supervisord.rundir}/supervisor.sock"
-
-  (require './inheritEnvVars') KONFIG  if options.inheritEnvVars
 
   envFiles =
     sh: (require './generateShellEnv').create KONFIG, options

--- a/config/main.sandbox.coffee
+++ b/config/main.sandbox.coffee
@@ -81,6 +81,8 @@ Configuration = (options = {}) ->
 
   KONFIG = require('./generateKonfig')(options, credentials)
 
+  (require './inheritEnvVars') KONFIG  if options.inheritEnvVars
+
   workers = require('./workers')(KONFIG, options, credentials)
 
   KONFIG.workers = require('./customextend') workers,
@@ -115,8 +117,6 @@ Configuration = (options = {}) ->
   KONFIG.supervisord.memmon =
     limit: '1536MB'
     email: 'sysops+supervisord-sandbox@koding.com'
-
-  (require './inheritEnvVars') KONFIG  if options.inheritEnvVars
 
   envFiles =
     sh: (require './generateShellEnv').create KONFIG, options


### PR DESCRIPTION
Relocating `(require './inheritEnvVars') KONFIG  if options.inheritEnvVars` in all environments to pass the values from the input values to workers.coffee.