### PR TITLE
klient: add support for machine labels

### DIFF
--- a/go/src/koding/klient/machine/machine.go
+++ b/go/src/koding/klient/machine/machine.go
@@ -46,3 +46,9 @@ func (ids IDSlice) String() string {
 
 	return strings.Join(strs, ", ")
 }
+
+// Metadata stores additional information about single machine.
+type Metadata struct {
+	Owner string `json:"owner"`
+	Label string `json:"label"`
+}

--- a/go/src/koding/klient/machine/machine.go
+++ b/go/src/koding/klient/machine/machine.go
@@ -34,18 +34,25 @@ func (ids IDSlice) Less(i, j int) bool {
 	return string(ids[i]) < string(ids[j])
 }
 
-// String implements fmt.Stringer interface. It pretty prints machine IDs.
-func (ids IDSlice) String() string {
-	strs := make([]string, len(ids))
+// StringSlice converts ID to string slice.
+func (ids IDSlice) StringSlice() []string {
+	ss := make([]string, len(ids))
 	for i := range ids {
-		strs[i] = string(ids[i])
+		ss[i] = string(ids[i])
 	}
 
-	return strings.Join(strs, ", ")
+	return ss
+}
+
+// String implements fmt.Stringer interface. It pretty prints machine IDs.
+func (ids IDSlice) String() string {
+	return strings.Join(ids.StringSlice(), ", ")
 }
 
 // Metadata stores additional information about single machine.
 type Metadata struct {
 	Owner string `json:"owner"`
 	Label string `json:"label"`
+	Stack string `json:"stack"`
+	Team  string `json:"team"`
 }

--- a/go/src/koding/klient/machine/machine.go
+++ b/go/src/koding/klient/machine/machine.go
@@ -2,7 +2,6 @@ package machine
 
 import (
 	"errors"
-	"sort"
 	"strings"
 
 	"koding/klient/config"
@@ -30,11 +29,9 @@ type ID string
 // IDSlice represents a set of machine IDs.
 type IDSlice []ID
 
-// Sort sorts machine IDs in lexicographical order.
-func (ids IDSlice) Sort() {
-	sort.Slice(ids, func(i, j int) bool {
-		return string(ids[i]) < string(ids[j])
-	})
+// Less provides a comparator for lexicographical ordering.
+func (ids IDSlice) Less(i, j int) bool {
+	return string(ids[i]) < string(ids[j])
 }
 
 // String implements fmt.Stringer interface. It pretty prints machine IDs.

--- a/go/src/koding/klient/machine/machine.go
+++ b/go/src/koding/klient/machine/machine.go
@@ -2,6 +2,7 @@ package machine
 
 import (
 	"errors"
+	"sort"
 	"strings"
 
 	"koding/klient/config"
@@ -28,6 +29,13 @@ type ID string
 
 // IDSlice represents a set of machine IDs.
 type IDSlice []ID
+
+// Sort sorts machine IDs in lexicographical order.
+func (ids IDSlice) Sort() {
+	sort.Slice(ids, func(i, j int) bool {
+		return string(ids[i]) < string(ids[j])
+	})
+}
 
 // String implements fmt.Stringer interface. It pretty prints machine IDs.
 func (ids IDSlice) String() string {

--- a/go/src/koding/klient/machine/machinegroup/aliases/aliaser.go
+++ b/go/src/koding/klient/machine/machinegroup/aliases/aliaser.go
@@ -10,7 +10,7 @@ type Aliaser interface {
 	// Create generates a new alias for provided machine ID.
 	Create(machine.ID) (string, error)
 
-	// Drop removes alias which is binded to provided machine ID.
+	// Drop removes alias which is bound to provided machine ID.
 	Drop(machine.ID) error
 
 	// MachineID gets machine ID from provided alias.

--- a/go/src/koding/klient/machine/machinegroup/aliases/aliases.go
+++ b/go/src/koding/klient/machine/machinegroup/aliases/aliases.go
@@ -109,7 +109,7 @@ func (a *Aliases) Create(id machine.ID) (string, error) {
 	}
 }
 
-// Drop removes alias which is binded to provided machine ID.
+// Drop removes alias which is bound to provided machine ID.
 func (a *Aliases) Drop(id machine.ID) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -118,7 +118,7 @@ func (a *Aliases) Drop(id machine.ID) error {
 	return nil
 }
 
-// MachineID checks if there is a machine ID that is binded to provided alias.
+// MachineID checks if there is a machine ID that is bound to provided alias.
 // If yes, the machine ID is returned. machine.ErrMachineNotFound is returned
 // if there is no machine ID with provided alias.
 //

--- a/go/src/koding/klient/machine/machinegroup/aliases/cached.go
+++ b/go/src/koding/klient/machine/machinegroup/aliases/cached.go
@@ -50,13 +50,13 @@ func (c *Cached) Create(id machine.ID) (string, error) {
 	return c.aliases.Create(id)
 }
 
-// Drop removes alias which is binded to provided machine ID and updates
+// Drop removes alias which is bound to provided machine ID and updates
 // the cache.
 func (c *Cached) Drop(id machine.ID) error {
 	return c.aliases.Drop(id)
 }
 
-// MachineID checks if there is a machine ID that is binded to provided alias.
+// MachineID checks if there is a machine ID that is bound to provided alias.
 // If yes, the machine ID is returned. ErrAliasNotFound is be returned if there
 // is no machine ID with provided alias.
 func (c *Cached) MachineID(alias string) (machine.ID, error) {

--- a/go/src/koding/klient/machine/machinegroup/create_test.go
+++ b/go/src/koding/klient/machine/machinegroup/create_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -37,6 +38,10 @@ func TestCreate(t *testing.T) {
 		Addresses: map[machine.ID][]machine.Addr{
 			idA: {clienttest.TurnOffAddr()},
 			idB: {clienttest.TurnOnAddr()},
+		},
+		Metadata: map[machine.ID]*machine.Metadata{
+			idA: &machine.Metadata{Label: string(idA)},
+			idB: &machine.Metadata{Label: string(idB)},
 		},
 	}
 
@@ -170,11 +175,15 @@ func TestCreateBalanceStaleMount(t *testing.T) {
 func testCreateOn(g *Group, builder *clienttest.Builder, ids ...machine.ID) (aliases map[machine.ID]string, err error) {
 	req := &CreateRequest{
 		Addresses: make(map[machine.ID][]machine.Addr),
+		Metadata:  make(map[machine.ID]*machine.Metadata),
 	}
 
-	for _, id := range ids {
+	for n, id := range ids {
 		req.Addresses[id] = []machine.Addr{
 			clienttest.TurnOnAddr(),
+		}
+		req.Metadata[id] = &machine.Metadata{
+			Label: "ID_" + strconv.Itoa(n+1),
 		}
 	}
 

--- a/go/src/koding/klient/machine/machinegroup/id.go
+++ b/go/src/koding/klient/machine/machinegroup/id.go
@@ -29,12 +29,17 @@ func (res *IDResponse) IDSlice() (ids machine.IDSlice) {
 		ids = append(ids, id)
 	}
 
+	sort.Slice(ids, ids.Less)
+
 	return ids
 }
 
 // ItemDesc returns description string for each item stored in response.
 func (res *IDResponse) ItemDesc() (ds []string) {
-	for id, meta := range res.IDs {
+	ids := res.IDSlice()
+	for _, id := range ids {
+		meta := res.IDs[id]
+
 		d := fmt.Sprintf("%s(%s) - stack: %q, team: %q",
 			string(id), meta.Label, meta.Stack, meta.Team)
 

--- a/go/src/koding/klient/machine/machinegroup/id_test.go
+++ b/go/src/koding/klient/machine/machinegroup/id_test.go
@@ -17,6 +17,9 @@ func TestID(t *testing.T) {
 
 		ipA = machine.Addr{Network: "ip", Value: "52.24.123.32", UpdatedAt: time.Now()}
 		ipB = machine.Addr{Network: "ip", Value: "10.0.1.16", UpdatedAt: time.Now()}
+
+		metaA = machine.Metadata{Owner: "", Label: "machineA.0"}
+		metaB = machine.Metadata{Owner: "root", Label: "machineB.1"}
 	)
 
 	wd, err := ioutil.TempDir("", "id")
@@ -35,6 +38,10 @@ func TestID(t *testing.T) {
 		Addresses: map[machine.ID][]machine.Addr{
 			idA: {ipA},
 			idB: {ipB},
+		},
+		Metadata: map[machine.ID]*machine.Metadata{
+			idA: &metaA,
+			idB: &metaB,
 		},
 	}
 
@@ -61,6 +68,21 @@ func TestID(t *testing.T) {
 		"by IP": {
 			Identifier: ipA.Value,
 			ID:         idA,
+			Found:      true,
+		},
+		"by label": {
+			Identifier: metaA.Label,
+			ID:         idA,
+			Found:      true,
+		},
+		"by at with label": {
+			Identifier: "@" + metaA.Label,
+			ID:         idA,
+			Found:      true,
+		},
+		"by userlabel": {
+			Identifier: metaB.Owner + "@" + metaB.Label,
+			ID:         idB,
 			Found:      true,
 		},
 		"not found alias": {

--- a/go/src/koding/klient/machine/machinegroup/id_test.go
+++ b/go/src/koding/klient/machine/machinegroup/id_test.go
@@ -18,8 +18,18 @@ func TestID(t *testing.T) {
 		ipA = machine.Addr{Network: "ip", Value: "52.24.123.32", UpdatedAt: time.Now()}
 		ipB = machine.Addr{Network: "ip", Value: "10.0.1.16", UpdatedAt: time.Now()}
 
-		metaA = machine.Metadata{Owner: "", Label: "machineA.0"}
-		metaB = machine.Metadata{Owner: "root", Label: "machineB.1"}
+		metaA = machine.Metadata{
+			Owner: "",
+			Label: "machineA.0",
+			Stack: "stackA",
+			Team:  "teamA",
+		}
+		metaB = machine.Metadata{
+			Owner: "root",
+			Label: "machineB.1",
+			Stack: "stackB",
+			Team:  "teamB",
+		}
 	)
 
 	wd, err := ioutil.TempDir("", "id")
@@ -52,57 +62,57 @@ func TestID(t *testing.T) {
 
 	tests := map[string]struct {
 		Identifier string
-		ID         machine.ID
+		IDs        machine.IDSlice
 		Found      bool
 	}{
 		"by ID": {
 			Identifier: string(idA),
-			ID:         idA,
+			IDs:        machine.IDSlice{idA},
 			Found:      true,
 		},
 		"by (at) ID": {
 			Identifier: "@" + string(idA),
-			ID:         idA,
+			IDs:        machine.IDSlice{idA},
 			Found:      true,
 		},
 		"by alias": {
 			Identifier: res.Aliases[idB],
-			ID:         idB,
+			IDs:        machine.IDSlice{idB},
 			Found:      true,
 		},
 		"by IP": {
 			Identifier: ipA.Value,
-			ID:         idA,
+			IDs:        machine.IDSlice{idA},
 			Found:      true,
 		},
 		"by label": {
 			Identifier: metaA.Label,
-			ID:         idA,
+			IDs:        machine.IDSlice{idA},
 			Found:      true,
 		},
 		"by (at) label": {
 			Identifier: "@" + metaA.Label,
-			ID:         idA,
+			IDs:        machine.IDSlice{idA},
 			Found:      true,
 		},
 		"by userlabel": {
 			Identifier: metaB.Owner + "@" + metaB.Label,
-			ID:         idB,
+			IDs:        machine.IDSlice{idB},
 			Found:      true,
 		},
 		"not found alias": {
 			Identifier: "unknown_alias",
-			ID:         "",
+			IDs:        nil,
 			Found:      false,
 		},
 		"not found IP": {
 			Identifier: "127.0.0.12",
-			ID:         "",
+			IDs:        nil,
 			Found:      false,
 		},
 		"not found TCP": {
 			Identifier: ipB.Value + ":8080",
-			ID:         "",
+			IDs:        nil,
 			Found:      false,
 		},
 	}
@@ -124,8 +134,14 @@ func TestID(t *testing.T) {
 				return
 			}
 
-			if res.ID != test.ID {
-				t.Fatalf("want ID = %v; got %v", test.ID, res.ID)
+			if lr, lt := len(res.IDs), len(test.IDs); lr != lt {
+				t.Fatalf("want response length == %d; got %d", lt, lr)
+			}
+
+			for _, id := range test.IDs {
+				if _, ok := res.IDs[id]; !ok {
+					t.Fatalf("want id(%v) to be in response map; map: %v", id, res.IDs)
+				}
 			}
 		})
 	}

--- a/go/src/koding/klient/machine/machinegroup/id_test.go
+++ b/go/src/koding/klient/machine/machinegroup/id_test.go
@@ -60,6 +60,11 @@ func TestID(t *testing.T) {
 			ID:         idA,
 			Found:      true,
 		},
+		"by (at) ID": {
+			Identifier: "@" + string(idA),
+			ID:         idA,
+			Found:      true,
+		},
 		"by alias": {
 			Identifier: res.Aliases[idB],
 			ID:         idB,
@@ -75,7 +80,7 @@ func TestID(t *testing.T) {
 			ID:         idA,
 			Found:      true,
 		},
-		"by at with label": {
+		"by (at) label": {
 			Identifier: "@" + metaA.Label,
 			ID:         idA,
 			Found:      true,

--- a/go/src/koding/klient/machine/machinegroup/machinegroup_test.go
+++ b/go/src/koding/klient/machine/machinegroup/machinegroup_test.go
@@ -12,6 +12,7 @@ import (
 	"koding/klient/machine/client/clienttest"
 	"koding/klient/machine/machinegroup/addresses"
 	"koding/klient/machine/machinegroup/aliases"
+	"koding/klient/machine/machinegroup/metadata"
 	"koding/klient/machine/machinegroup/mounts"
 	"koding/klient/machine/mount"
 	"koding/klient/machine/mount/mounttest"
@@ -58,6 +59,15 @@ func TestMachineGroupFreshStart(t *testing.T) {
 	}
 	if len(alias.Registered()) != 0 {
 		t.Errorf("want no registered machines; got %v", alias.Registered())
+	}
+
+	// Nothing should be added to metadata storage.
+	meta, err := metadata.NewCached(st)
+	if err != nil {
+		t.Fatalf("want err = nil; got %v", err)
+	}
+	if len(meta.Registered()) != 0 {
+		t.Errorf("want no registered machines; got %v", meta.Registered())
 	}
 
 	// Nothing should be added to mounts storage.

--- a/go/src/koding/klient/machine/machinegroup/metadata/cached.go
+++ b/go/src/koding/klient/machine/machinegroup/metadata/cached.go
@@ -30,9 +30,9 @@ func NewCached(st storage.ValueInterface) (*Cached, error) {
 	}
 
 	// Drop inconsistent data.
-	empty := Entry{}
-	for id, entry := range c.metadata.m {
-		if entry == nil || *entry == empty {
+	empty := machine.Metadata{}
+	for id, meta := range c.metadata.m {
+		if meta == nil || *meta == empty {
 			delete(c.metadata.m, id)
 		}
 	}
@@ -41,8 +41,8 @@ func NewCached(st storage.ValueInterface) (*Cached, error) {
 }
 
 // Add binds metadata to provided machine
-func (c *Cached) Add(id machine.ID, entry *Entry) error {
-	return c.metadata.Add(id, entry)
+func (c *Cached) Add(id machine.ID, meta *machine.Metadata) error {
+	return c.metadata.Add(id, meta)
 }
 
 // Drop removes metadata bound to provided machine ID.

--- a/go/src/koding/klient/machine/machinegroup/metadata/cached.go
+++ b/go/src/koding/klient/machine/machinegroup/metadata/cached.go
@@ -1,0 +1,70 @@
+package metadata
+
+import (
+	"sync"
+
+	"koding/klient/machine"
+	"koding/klient/storage"
+)
+
+// storageKey is a database key used to store metadata.
+const storageKey = "metadata"
+
+// Cached is an Metadata object with additional storage layer.
+type Cached struct {
+	mu sync.Mutex
+	st storage.ValueInterface
+
+	metadata *Metadata
+}
+
+// NewCached creates a new Cached object backed by provided storage.
+func NewCached(st storage.ValueInterface) (*Cached, error) {
+	c := &Cached{
+		st:       st,
+		metadata: New(),
+	}
+
+	if err := c.st.GetValue(storageKey, &c.metadata.m); err != nil && err != storage.ErrKeyNotFound {
+		return nil, err
+	}
+
+	// Drop inconsistent data.
+	empty := Entry{}
+	for id, entry := range c.metadata.m {
+		if entry == nil || *entry == empty {
+			delete(c.metadata.m, id)
+		}
+	}
+
+	return c, nil
+}
+
+// Add binds metadata to provided machine
+func (c *Cached) Add(id machine.ID, entry *Entry) error {
+	return c.metadata.Add(id, entry)
+}
+
+// Drop removes metadata bound to provided machine ID.
+func (c *Cached) Drop(id machine.ID) error {
+	return c.metadata.Drop(id)
+}
+
+// MachineID checks if there is a machine ID that which has provided label and
+// belongs to provided owner.
+func (c *Cached) MachineID(owner, label string) (machine.IDSlice, error) {
+	return c.metadata.MachineID(owner, label)
+}
+
+// Registered returns all machines that are stored in this object.
+func (c *Cached) Registered() machine.IDSlice {
+	return c.metadata.Registered()
+}
+
+// Cache saves aliases data to underlying storage.
+func (c *Cached) Cache() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.st.SetValue(storageKey, c.metadata.all())
+}

--- a/go/src/koding/klient/machine/machinegroup/metadata/cached.go
+++ b/go/src/koding/klient/machine/machinegroup/metadata/cached.go
@@ -40,9 +40,14 @@ func NewCached(st storage.ValueInterface) (*Cached, error) {
 	return c, nil
 }
 
-// Add binds metadata to provided machine
+// Add binds metadata to provided machine.
 func (c *Cached) Add(id machine.ID, meta *machine.Metadata) error {
 	return c.metadata.Add(id, meta)
+}
+
+// Get gets metadata for provided machine.
+func (c *Cached) Get(id machine.ID) (*machine.Metadata, error) {
+	return c.metadata.Get(id)
 }
 
 // Drop removes metadata bound to provided machine ID.

--- a/go/src/koding/klient/machine/machinegroup/metadata/metadata.go
+++ b/go/src/koding/klient/machine/machinegroup/metadata/metadata.go
@@ -1,0 +1,97 @@
+package metadata
+
+import (
+	"errors"
+	"sync"
+
+	"koding/klient/machine"
+)
+
+// Metadata stores metadata of a group of unique machines.
+type Metadata struct {
+	mu sync.RWMutex
+	m  map[machine.ID]*Entry
+}
+
+// New creates an empty Metadata object.
+func New() *Metadata {
+	return &Metadata{
+		m: make(map[machine.ID]*Entry),
+	}
+}
+
+// Add binds metadata to provided machine.
+func (m *Metadata) Add(id machine.ID, entry *Entry) error {
+	if entry == nil {
+		return errors.New("nil metadata is not allowed")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.m[id] = entry
+
+	return nil
+}
+
+// Drop removes metadata entry bound to provided machine ID.
+func (m *Metadata) Drop(id machine.ID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.m, id)
+
+	return nil
+}
+
+// MachineID checks if there is a machine ID that which has provided label and
+// belongs to provided owner. Owner for current user should be empty. If there
+// is no machines with provided data, machine.ErrMachineNotFound is returned.
+func (m *Metadata) MachineID(owner, label string) (machine.IDSlice, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	ids := make(machine.IDSlice, 0)
+	for id, entry := range m.m {
+		if entry == nil {
+			continue
+		}
+
+		if entry.Owner == owner && entry.Label == label {
+			ids = append(ids, id)
+		}
+	}
+
+	if len(ids) != 0 {
+		return ids, nil
+	}
+
+	return nil, machine.ErrMachineNotFound
+}
+
+// Registered returns all machines that are stored in this object.
+func (m *Metadata) Registered() machine.IDSlice {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	registered := make(machine.IDSlice, 0, len(m.m))
+	for id := range m.m {
+		registered = append(registered, id)
+	}
+
+	return registered
+}
+
+// all returns all stored entry objects.
+func (m *Metadata) all() map[machine.ID]*Entry {
+	all := make(map[machine.ID]*Entry)
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for id, entry := range m.m {
+		all[id] = entry
+	}
+
+	return all
+}

--- a/go/src/koding/klient/machine/machinegroup/metadata/metadata.go
+++ b/go/src/koding/klient/machine/machinegroup/metadata/metadata.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	"errors"
+	"sort"
 	"sync"
 
 	"koding/klient/machine"
@@ -81,7 +82,7 @@ func (m *Metadata) MachineID(owner, label string) (machine.IDSlice, error) {
 		return nil, machine.ErrMachineNotFound
 	}
 
-	ids.Sort()
+	sort.Slice(ids, ids.Less)
 	return ids, nil
 }
 

--- a/go/src/koding/klient/machine/machinegroup/metadata/metadata.go
+++ b/go/src/koding/klient/machine/machinegroup/metadata/metadata.go
@@ -10,26 +10,26 @@ import (
 // Metadata stores metadata of a group of unique machines.
 type Metadata struct {
 	mu sync.RWMutex
-	m  map[machine.ID]*Entry
+	m  map[machine.ID]*machine.Metadata
 }
 
 // New creates an empty Metadata object.
 func New() *Metadata {
 	return &Metadata{
-		m: make(map[machine.ID]*Entry),
+		m: make(map[machine.ID]*machine.Metadata),
 	}
 }
 
 // Add binds metadata to provided machine.
-func (m *Metadata) Add(id machine.ID, entry *Entry) error {
-	if entry == nil {
+func (m *Metadata) Add(id machine.ID, meta *machine.Metadata) error {
+	if meta == nil {
 		return errors.New("nil metadata is not allowed")
 	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.m[id] = entry
+	m.m[id] = meta
 
 	return nil
 }
@@ -52,12 +52,12 @@ func (m *Metadata) MachineID(owner, label string) (machine.IDSlice, error) {
 	defer m.mu.RUnlock()
 
 	ids := make(machine.IDSlice, 0)
-	for id, entry := range m.m {
-		if entry == nil {
+	for id, meta := range m.m {
+		if meta == nil {
 			continue
 		}
 
-		if entry.Owner == owner && entry.Label == label {
+		if meta.Owner == owner && meta.Label == label {
 			ids = append(ids, id)
 		}
 	}
@@ -83,15 +83,15 @@ func (m *Metadata) Registered() machine.IDSlice {
 	return registered
 }
 
-// all returns all stored entry objects.
-func (m *Metadata) all() map[machine.ID]*Entry {
-	all := make(map[machine.ID]*Entry)
+// all returns all stored metadata objects.
+func (m *Metadata) all() map[machine.ID]*machine.Metadata {
+	all := make(map[machine.ID]*machine.Metadata)
 
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	for id, entry := range m.m {
-		all[id] = entry
+	for id, meta := range m.m {
+		all[id] = meta
 	}
 
 	return all

--- a/go/src/koding/klient/machine/machinegroup/metadata/metadata.go
+++ b/go/src/koding/klient/machine/machinegroup/metadata/metadata.go
@@ -62,11 +62,12 @@ func (m *Metadata) MachineID(owner, label string) (machine.IDSlice, error) {
 		}
 	}
 
-	if len(ids) != 0 {
-		return ids, nil
+	if len(ids) == 0 {
+		return nil, machine.ErrMachineNotFound
 	}
 
-	return nil, machine.ErrMachineNotFound
+	ids.Sort()
+	return ids, nil
 }
 
 // Registered returns all machines that are stored in this object.

--- a/go/src/koding/klient/machine/machinegroup/metadata/metadata.go
+++ b/go/src/koding/klient/machine/machinegroup/metadata/metadata.go
@@ -34,6 +34,21 @@ func (m *Metadata) Add(id machine.ID, meta *machine.Metadata) error {
 	return nil
 }
 
+// Get gets metadata for provided machine.
+func (m *Metadata) Get(id machine.ID) (*machine.Metadata, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	meta, ok := m.m[id]
+	if !ok || meta == nil {
+		return nil, machine.ErrMachineNotFound
+	}
+
+	metaCopy := *meta
+
+	return &metaCopy, nil
+}
+
 // Drop removes metadata entry bound to provided machine ID.
 func (m *Metadata) Drop(id machine.ID) error {
 	m.mu.Lock()

--- a/go/src/koding/klient/machine/machinegroup/metadata/metadata_test.go
+++ b/go/src/koding/klient/machine/machinegroup/metadata/metadata_test.go
@@ -1,0 +1,89 @@
+package metadata_test
+
+import (
+	"reflect"
+	"testing"
+
+	"koding/klient/machine"
+	"koding/klient/machine/machinegroup/metadata"
+)
+
+func TestMetadataMachineID(t *testing.T) {
+	m := map[machine.ID]*metadata.Entry{
+		"ID_1": &metadata.Entry{
+			Owner: "",
+			Label: "machineA",
+		},
+		"ID_2": &metadata.Entry{
+			Owner: "user",
+			Label: "machineA",
+		},
+		"ID_3": &metadata.Entry{
+			Owner: "",
+			Label: "machineA",
+		},
+		"ID_4": &metadata.Entry{
+			Owner: "",
+			Label: "machineB",
+		},
+		"ID_5": &metadata.Entry{
+			Owner: "",
+			Label: "machineC",
+		},
+	}
+
+	meta := metadata.New()
+	for id, entry := range m {
+		if err := meta.Add(id, entry); err != nil {
+			t.Fatalf("want err = nil; got %v", err)
+		}
+	}
+
+	tests := map[string]struct {
+		Owner    string
+		Label    string
+		Expected machine.IDSlice
+		NotFound bool
+	}{
+		"full meta": {
+			Owner:    "user",
+			Label:    "machineA",
+			Expected: machine.IDSlice{"ID_2"},
+			NotFound: false,
+		},
+		"two machines": {
+			Owner:    "",
+			Label:    "machineA",
+			Expected: machine.IDSlice{"ID_1", "ID_3"},
+			NotFound: false,
+		},
+		"empty owner": {
+			Owner:    "",
+			Label:    "machineC",
+			Expected: machine.IDSlice{"ID_5"},
+			NotFound: false,
+		},
+		"non existing machine": {
+			Owner:    "unknown",
+			Label:    "machineA",
+			Expected: nil,
+			NotFound: true,
+		},
+	}
+
+	for name, test := range tests {
+		// capture range variable here
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ids, err := meta.MachineID(test.Owner, test.Label)
+			if (err == machine.ErrMachineNotFound) != test.NotFound {
+				t.Fatalf("want err machine not found = %t; got %v", test.NotFound, err)
+			}
+
+			if !reflect.DeepEqual(ids, test.Expected) {
+				t.Fatalf("want ids = %v; got %v", test.Expected, ids)
+			}
+		})
+	}
+}

--- a/go/src/koding/klient/machine/machinegroup/metadata/metadata_test.go
+++ b/go/src/koding/klient/machine/machinegroup/metadata/metadata_test.go
@@ -9,24 +9,24 @@ import (
 )
 
 func TestMetadataMachineID(t *testing.T) {
-	m := map[machine.ID]*metadata.Entry{
-		"ID_1": &metadata.Entry{
+	m := map[machine.ID]*machine.Metadata{
+		"ID_1": &machine.Metadata{
 			Owner: "",
 			Label: "machineA",
 		},
-		"ID_2": &metadata.Entry{
+		"ID_2": &machine.Metadata{
 			Owner: "user",
 			Label: "machineA",
 		},
-		"ID_3": &metadata.Entry{
+		"ID_3": &machine.Metadata{
 			Owner: "",
 			Label: "machineA",
 		},
-		"ID_4": &metadata.Entry{
+		"ID_4": &machine.Metadata{
 			Owner: "",
 			Label: "machineB",
 		},
-		"ID_5": &metadata.Entry{
+		"ID_5": &machine.Metadata{
 			Owner: "",
 			Label: "machineC",
 		},

--- a/go/src/koding/klient/machine/machinegroup/metadata/metadater.go
+++ b/go/src/koding/klient/machine/machinegroup/metadata/metadater.go
@@ -11,7 +11,7 @@ type Entry struct {
 // Metadater is an interface used to manage machines' metadata.
 type Metadater interface {
 	// Add binds custom alias to provided machine.
-	Add(machine.ID, *Entry) error
+	Add(machine.ID, *machine.Metadata) error
 
 	// Drop removes machine metadata.
 	Drop(machine.ID) error

--- a/go/src/koding/klient/machine/machinegroup/metadata/metadater.go
+++ b/go/src/koding/klient/machine/machinegroup/metadata/metadater.go
@@ -1,0 +1,26 @@
+package metadata
+
+import "koding/klient/machine"
+
+// Entry stores additional information about single machine.
+type Entry struct {
+	Owner string `json:"owner"`
+	Label string `json:"label"`
+}
+
+// Metadater is an interface used to manage machines' metadata.
+type Metadater interface {
+	// Add binds custom alias to provided machine.
+	Add(machine.ID, *Entry) error
+
+	// Drop removes machine metadata.
+	Drop(machine.ID) error
+
+	// MachineID looks up machine ID based on provided owner and machine label.
+	// It may return more than one ID if there are machines with identical
+	// labels across different stacks.
+	MachineID(owner, label string) (machine.IDSlice, error)
+
+	// Registered returns all machines that are managed by metadater.
+	Registered() machine.IDSlice
+}

--- a/go/src/koding/klient/machine/machinegroup/metadata/metadater.go
+++ b/go/src/koding/klient/machine/machinegroup/metadata/metadater.go
@@ -2,16 +2,13 @@ package metadata
 
 import "koding/klient/machine"
 
-// Entry stores additional information about single machine.
-type Entry struct {
-	Owner string `json:"owner"`
-	Label string `json:"label"`
-}
-
 // Metadater is an interface used to manage machines' metadata.
 type Metadater interface {
 	// Add binds custom alias to provided machine.
 	Add(machine.ID, *machine.Metadata) error
+
+	// Get gets metadata for provided machine.
+	Get(machine.ID) (*machine.Metadata, error)
 
 	// Drop removes machine metadata.
 	Drop(machine.ID) error

--- a/go/src/koding/klientctl/commands/machine/config/set.go
+++ b/go/src/koding/klientctl/commands/machine/config/set.go
@@ -30,10 +30,11 @@ func NewSetCommand(c *cli.CLI) *cobra.Command {
 
 func setCommand(c *cli.CLI, opts *setOptions) cli.CobraFuncE {
 	return func(cmd *cobra.Command, args []string) error {
-		ident := args[0]
-		key := args[1]
-		value := args[2]
-
-		return machine.Set(ident, key, value)
+		return machine.Set(&machine.SetOptions{
+			Identifier: args[0],
+			Key:        args[1],
+			Value:      args[2],
+			AskList:    cli.AskList(c, cmd),
+		})
 	}
 }

--- a/go/src/koding/klientctl/commands/machine/config/show.go
+++ b/go/src/koding/klientctl/commands/machine/config/show.go
@@ -40,7 +40,10 @@ func NewShowCommand(c *cli.CLI) *cobra.Command {
 
 func showCommand(c *cli.CLI, opts *showOptions) cli.CobraFuncE {
 	return func(cmd *cobra.Command, args []string) error {
-		conf, err := machine.Show(args[0])
+		conf, err := machine.Show(&machine.ShowOptions{
+			Identifier: args[0],
+			AskList:    cli.AskList(c, cmd),
+		})
 		if err != nil {
 			return err
 		}

--- a/go/src/koding/klientctl/commands/machine/cp.go
+++ b/go/src/koding/klientctl/commands/machine/cp.go
@@ -52,6 +52,7 @@ func cpCommand(c *cli.CLI, opts *cpOptions) cli.CobraFuncE {
 			Identifier:      ident,
 			SourcePath:      source,
 			DestinationPath: dest,
+			AskList:         cli.AskList(c, cmd),
 		}
 
 		return machine.Cp(cpOpts)

--- a/go/src/koding/klientctl/commands/machine/list.go
+++ b/go/src/koding/klientctl/commands/machine/list.go
@@ -76,16 +76,15 @@ func tabListFormatter(w io.Writer, infos []*machine.Info) {
 	now := time.Now()
 	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
 
-	fmt.Fprintf(tw, "ID\tALIAS\tTEAM\tSTACK\tPROVIDER\tLABEL\tOWNER\tAGE\tIP\tSTATUS\n")
+	fmt.Fprintf(tw, "ID\tLABEL\tOWNER\tTEAM\tSTACK\tPROVIDER\tAGE\tIP\tSTATUS\n")
 	for _, info := range infos {
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			info.ID,
-			info.Alias,
+			info.Label,
+			info.Owner,
 			dashIfEmpty(info.Team),
 			dashIfEmpty(info.Stack),
 			dashIfEmpty(info.Provider),
-			info.Label,
-			info.Owner,
 			machine.ShortDuration(info.CreatedAt, now),
 			info.IP,
 			machine.PrettyStatus(info.Status, now),

--- a/go/src/koding/klientctl/commands/machine/mount/cmd.go
+++ b/go/src/koding/klientctl/commands/machine/mount/cmd.go
@@ -62,15 +62,12 @@ func command(c *cli.CLI, opts *options) cli.CobraFuncE {
 			Identifier: ident,
 			Path:       path,
 			RemotePath: remotePath,
+			AskList:    cli.AskList(c, cmd),
 		}
 
 		if err := machine.Mount(opts); err != nil {
 			return err
 		}
-
-		// Best-effort attempt of making the remote vm do not
-		// turn off after 1h.
-		_ = machine.Set(ident, "alwaysOn", "true")
 
 		return nil
 	}

--- a/go/src/koding/klientctl/commands/machine/ssh.go
+++ b/go/src/koding/klientctl/commands/machine/ssh.go
@@ -40,6 +40,7 @@ func sshCommand(c *cli.CLI, opts *sshOptions) cli.CobraFuncE {
 		sshOpts := &machine.SSHOptions{
 			Identifier: args[0],
 			Username:   opts.username,
+			AskList:    cli.AskList(c, cmd),
 		}
 
 		return machine.SSH(sshOpts)

--- a/go/src/koding/klientctl/commands/machine/start.go
+++ b/go/src/koding/klientctl/commands/machine/start.go
@@ -38,7 +38,10 @@ func NewStartCommand(c *cli.CLI) *cobra.Command {
 
 func startCommand(c *cli.CLI, opts *startOptions) cli.CobraFuncE {
 	return func(cmd *cobra.Command, args []string) error {
-		event, err := machine.Start(args[0])
+		event, err := machine.Start(&machine.StartOptions{
+			Identifier: args[0],
+			AskList:    cli.AskList(c, cmd),
+		})
 		if err != nil {
 			return err
 		}

--- a/go/src/koding/klientctl/commands/machine/stop.go
+++ b/go/src/koding/klientctl/commands/machine/stop.go
@@ -38,7 +38,10 @@ func NewStopCommand(c *cli.CLI) *cobra.Command {
 
 func stopCommand(c *cli.CLI, opts *stopOptions) cli.CobraFuncE {
 	return func(cmd *cobra.Command, args []string) error {
-		event, err := machine.Stop(args[0])
+		event, err := machine.Stop(&machine.StopOptions{
+			Identifier: args[0],
+			AskList:    cli.AskList(c, cmd),
+		})
 		if err != nil {
 			return err
 		}

--- a/go/src/koding/klientctl/endpoint/machine/cp.go
+++ b/go/src/koding/klientctl/endpoint/machine/cp.go
@@ -16,6 +16,8 @@ type CpOptions struct {
 	Identifier      string // Machine identifier.
 	SourcePath      string // Data source.
 	DestinationPath string // Data destination.
+
+	AskList func(is, ds []string) (string, error) // Ask for multiple choices.
 }
 
 // Cp transfers file(s) between remote and local machine.
@@ -25,18 +27,14 @@ func (c *Client) Cp(options *CpOptions) (err error) {
 	}
 
 	// Translate identifier to machine ID.
-	idReq := &machinegroup.IDRequest{
-		Identifier: options.Identifier,
-	}
-	var idRes machinegroup.IDResponse
-
-	if err := c.klient().Call("machine.id", idReq, &idRes); err != nil {
+	id, err := c.getMachineID(options.Identifier, options.AskList)
+	if err != nil {
 		return err
 	}
 
 	// Ensure connection to remote machine.
 	cpReq := &machinegroup.CpRequest{
-		ID:              idRes.ID,
+		ID:              id,
 		Download:        options.Download,
 		SourcePath:      options.SourcePath,
 		DestinationPath: options.DestinationPath,

--- a/go/src/koding/klientctl/endpoint/machine/list.go
+++ b/go/src/koding/klientctl/endpoint/machine/list.go
@@ -84,6 +84,8 @@ func (c *Client) List(options *ListOptions) ([]*Info, error) {
 		createReq.Metadata[kmachine.ID(m.ID)] = &kmachine.Metadata{
 			Owner: ownerFromUsers(m.Users),
 			Label: m.Label,
+			Stack: m.Stack,
+			Team:  m.Team,
 		}
 	}
 

--- a/go/src/koding/klientctl/endpoint/machine/list.go
+++ b/go/src/koding/klientctl/endpoint/machine/list.go
@@ -59,6 +59,7 @@ func (c *Client) List(options *ListOptions) ([]*Info, error) {
 	// Register machines to klient and get aliases.
 	createReq := &machinegroup.CreateRequest{
 		Addresses: make(map[kmachine.ID][]kmachine.Addr),
+		Metadata:  make(map[kmachine.ID]*kmachine.Metadata),
 	}
 	var createRes machinegroup.CreateResponse
 
@@ -79,6 +80,10 @@ func (c *Client) List(options *ListOptions) ([]*Info, error) {
 				Value:     m.RegisterURL,
 				UpdatedAt: time.Now(),
 			},
+		}
+		createReq.Metadata[kmachine.ID(m.ID)] = &kmachine.Metadata{
+			Owner: ownerFromUsers(m.Users),
+			Label: m.Label,
 		}
 	}
 


### PR DESCRIPTION
## Description
This PR adds support for machine labels as machine identifiers. The syntax: `[owner@]label`, where `owner` is specified as shown by `kd list` ( current user of kd is identified by empty string `""` ).

Machines which have the same label and the same user are not supported. Error in form:
```
identifier "identifier" is ambiguous (matches: machineID1, machineID2...)
```
will be returned in such cases.

Auto-completion support for labels was is also included in this PR.

Aliases are hidden in `kd list` response but are still supported and visible in `kd list --json`. They will be dropped later.

/cc @gokmen 

## Motivation and Context
Solves: #10961

## How Has This Been Tested?
Unit tests, manually

## Screenshots (if appropriate):
https://asciinema.org/a/nUsI8qoGqEScXyK3jb75bMQxK

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

