### PR TITLE
klient: fix updater url for default env

### DIFF
--- a/go/src/koding/klient/app/update.go
+++ b/go/src/koding/klient/app/update.go
@@ -170,8 +170,7 @@ func kd2klient(kdEnv string) string {
 	if klientEnv, ok := environments[kdEnv]; ok {
 		return klientEnv
 	}
-
-	return ""
+	return kdEnv
 }
 
 func (u *Updater) endpointVersion(env string) string {


### PR DESCRIPTION
Fixes: 

```
2017-09-22 17:52:24 [klient] INFO     Starting Updater with following options:
        interval of: 5m0s
        endpoint: defaulthdefaulttdefaulttdefaultpdefault:default/default/defaultddefaultcdefaultodefaultsdefault.defaultkdefaultodefaultddefaultidefaultndefaultgdefault.defaulttdefaultedefaultadefaultmdefault/defaultadefault/defaultkdefaultldefaultidefaultedefaultndefaulttdefault/defaultddefaultedefaultfdefaultadefaultudefaultldefaulttdefault/defaultldefaultadefaulttdefaultedefaultsdefaulttdefault-defaultvdefaultedefaultrdefaultsdefaultidefaultodefaultndefault.defaulttdefaultxdefaulttdefault
```