### PR TITLE
klient: improve opening boltdb / fix wrong team default

### DIFF
--- a/go/src/koding/klient/storage/bolt.go
+++ b/go/src/koding/klient/storage/bolt.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/boltdb/bolt"
 )
@@ -62,8 +63,11 @@ func (b *boltdb) Set(key, value string) error {
 func (b *boltdb) Get(key string) (string, error) {
 	var res string
 	if err := b.DB.View(func(tx *bolt.Tx) error {
-		b := tx.Bucket(b.bucket())
-		v := b.Get([]byte(key))
+		bkt := tx.Bucket(b.bucket())
+		if bkt == nil {
+			return fmt.Errorf("bucket %q does not exist", b.bucket())
+		}
+		v := bkt.Get([]byte(key))
 		res = string(v)
 		return nil
 	}); err != nil {

--- a/go/src/koding/klientctl/commands/daemon/install.go
+++ b/go/src/koding/klientctl/commands/daemon/install.go
@@ -33,7 +33,7 @@ func NewInstallCommand(c *cli.CLI) *cobra.Command {
 	flags.StringVar(&opts.prefix, "prefix", "", "overwrite installation directory")
 	flags.StringVar(&opts.baseURL, "baseurl", config.Konfig.Endpoints.Koding.Public.String(), "service login endpoint")
 	flags.StringVar(&opts.token, "token", "", "temporary authorization token")
-	flags.StringVar(&opts.team, "team", "kd.io", "team to login")
+	flags.StringVar(&opts.team, "team", "", "team to login")
 	flags.StringSliceVar(&opts.skip, "skip", nil, "steps to skip during installation")
 	flags.BoolVarP(&opts.force, "force", "f", false, "execute all install steps")
 

--- a/go/src/koding/klientctl/config/cache.go
+++ b/go/src/koding/klientctl/config/cache.go
@@ -62,7 +62,6 @@ func (c *Cache) ReadOnly() *config.Cache {
 	if c.rw != nil {
 		return c.rw
 	}
-
 	if c.ro == nil {
 		opts := configstore.CacheOptions("kd")
 		opts.BoltDB.Timeout = time.Duration(Konfig.LockTimeout) * time.Second

--- a/go/src/koding/klientctl/install-kd.sh
+++ b/go/src/koding/klientctl/install-kd.sh
@@ -355,10 +355,7 @@ if [ -n "$KONTROLURL" ]; then
   kontrolFlag="--baseurl=${KONTROLURL%/kontrol/kite}"
 fi
 
-# No need to print Creating foo... because kd install handles that.
-
-# Install klient, piping stdin (the tty) to kd
-if ! sudo /usr/local/bin/kd install $kontrolFlag --token "$1" < /dev/tty; then
+if ! sudo /usr/local/bin/kd install $kontrolFlag --token "$1"; then
   exit $err
 fi
 


### PR DESCRIPTION
This PR:

- fixes "invalid team name or user does not belong to the team", wrong default
- fixes "bad file descriptor" error, which is a regression; previously we ensured in kd's main that boltdb file exists; this is no longer true, that's why function which opens BoltDB now is responsible for ensuring the file exists, when database is being open in read mode.