### PR TITLE
mount: make mounts work on linux systems

### DIFF
--- a/go/src/koding/klient/machine/mount/notify/fuse/filesystem.go
+++ b/go/src/koding/klient/machine/mount/notify/fuse/filesystem.go
@@ -242,6 +242,12 @@ func (fs *Filesystem) fuseOptions() map[string]string {
 		}
 	}
 
+	if err := scanner.Err(); err != nil {
+		if fs.Log != nil {
+			fs.Log.Warning("Cannot parse FUSE configuration: %v", err)
+		}
+	}
+
 	return map[string]string{}
 }
 

--- a/go/src/koding/klientctl/ssh/ssh.go
+++ b/go/src/koding/klientctl/ssh/ssh.go
@@ -134,7 +134,7 @@ func PrivateKey(privPath string) (privKey interface{}, err error) {
 	return key, nil
 }
 
-// Keypaths generates a public and private keys paths from a given argument. If
+// KeyPaths generates a public and private keys paths from a given argument. If
 // argument path is a directory, paths will be created from DefaultKeyName.
 // If path point to either private or public key, its name will be used to
 // generate corresponding path.


### PR DESCRIPTION
## Description
Some FUSE options on Linux are either unavailable or depend on `/etc/fuse.conf` file. This PR dynamically creates FUSE options depending on OS and `/etc/fuse.conf` file allowing to create a mount without errors on Linux.

/cc @szkl 

## Motivation and Context
Make `kd mount` work on Linux.

## How Has This Been Tested?
Manually on Lubuntu 17.04

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
