### PR TITLE
NSE: remove Safari workaround since the issue fixed on upstream

### DIFF
--- a/client/new-stack-editor/lib/styl/main.styl
+++ b/client/new-stack-editor/lib/styl/main.styl
@@ -212,12 +212,6 @@ $stack-border-width         = 2px
       height                80px
       min-height            80px !important
 
-  .content
-    &.safari-flex-fix
-      // just because of a bug in safari
-      // https://bugs.webkit.org/show_bug.cgi?id=137730 ~ GG
-      height                calc(100% \- 70px)
-
   .mainview
     border-left             $stack-border-width solid $stack-border-color
     border-right            $stack-border-width solid $stack-border-color

--- a/client/new-stack-editor/lib/views/index.coffee
+++ b/client/new-stack-editor/lib/views/index.coffee
@@ -1,7 +1,6 @@
 debug = (require 'debug') 'nse:stackeditor'
 
 kd = require 'kd'
-bowser = require 'bowser'
 Encoder = require 'htmlencode'
 
 Events = require '../events'
@@ -299,5 +298,4 @@ module.exports = class StackEditor extends kd.View
           ]
       ]
 
-    contentView.setClass 'safari-flex-fix'  if bowser.safari
     contentView.addSubView @sideView


### PR DESCRIPTION
Flex usage fixed in Safari 11 which is the stable version of macOS now
https://bugs.webkit.org/show_bug.cgi?id=137730

## Screenshots (if appropriate):
<img width="1281" alt="screen shot 2017-10-25 at 15 39 51" src="https://user-images.githubusercontent.com/42368/32026851-cc04f678-b99a-11e7-9c74-121f2914e7e4.png">

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
