### PR TITLE
Fix "exec: command: not found"

### DIFF
--- a/scripts/bootstrap-container
+++ b/scripts/bootstrap-container
@@ -12,14 +12,14 @@ function configure() {
 function build() {
 	go/build.sh
 	make -C client dist
-	./run exec make klient
+	./run eval make klient
 }
 
 function run_backend() {
 	go/build.sh
 	./run is_ready || exit 255
 	./run migrations up
-	./run exec supervisord -c supervisord.conf
+	./run eval supervisord -c supervisord.conf
 	sleep 2
 	tail --follow --lines +0 --quiet .logs/*.log
 }
@@ -55,7 +55,7 @@ elif [ "$1" = "run" ]; then
 elif [ "$1" = "is_ready" ]; then
 	shift
 	is_ready
-	exec "$@"
+	eval "$@"
 else
-	exec "$@"
+	eval "$@"
 fi


### PR DESCRIPTION
## Description

This fixes docker-compose unable to build because of exec does not find any of the functions defined in scripts/bootstrap-container.
Root problem is that when calling exec it changes shell to that of the command and since the functions are not global functions it fails with the error above.

The solution is to change exec to eval which does the same thing but does not change shell.

## Motivation and Context
See above

## How Has This Been Tested?
Tested by successfully building the docker-compose containers.

## Screenshots (if appropriate):

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
