### PR TITLE
Updated documentation for kuburnetes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -24,6 +24,9 @@ git clone https://github.com/koding/docker-compose.git koding-docker-compose
 cd koding-docker-compose
 # Requires docker-compose version >= 1.6
 docker-compose up -d
+
+# Requires kubectl, minikube and kompose for kuburnetes
+kompose up
 ```
 
 Now you are able to access Koding via port `8090` (e.g. [localhost:8090](http://localhost:8090)) on your host.
@@ -50,8 +53,13 @@ You are now ready to run Koding.
 ```bash
 git clone https://github.com/koding/koding.git
 cd koding
+
+# With Docker Compose
 docker-compose -f docker-compose-init.yml run init
 docker-compose up
+
+# With Kuburnetes Kompose
+kompose up
 ```
 
 If you don't have a powerful computer, this may take a while at first, slow computers may take up to 15 minutes before they build the entire system. Please be patient. Once it is up and running, everything will be smooth and very fast.

--- a/scripts/bootstrap-container
+++ b/scripts/bootstrap-container
@@ -65,7 +65,7 @@ elif [ "$1" = "k8s_build" ]; then
 elif [ "$1" = "is_ready" ]; then
 	shift
 	is_ready
-	exec "$@"
+	"$@"
 else
-	exec "$@"
+	"$@"
 fi


### PR DESCRIPTION
## Description
As per the request from: https://github.com/koding/koding/issues/10776...
I've updated the documentation to support working with Kompose.

Please note that you need minikube running as well as kubectl and kompose for it to work.

## Motivation and Context
This was an issue sitting on koding for quite sometime.

## How Has This Been Tested?
I ran Kompose on Mac OS with the LTS of Docker and KubeCTL, Minikube and Kompose

## Types of changes
The changes made were merely made to reflect the latest versions of Kuburnetes that supports Docker Compose.

## Checklist:
I believe there were some problems with the Continuous Integration Unit Tests when I initially forked the repository. I am willing to investigate the problem(s).
